### PR TITLE
sw_engine clipping: allow scene for ClipPath

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -234,6 +234,13 @@ RenderData GlRenderer::prepare(const Shape& shape, RenderData data, const Render
 }
 
 
+RenderData GlRenderer::prepare(Array<RenderData>& array, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags)
+{
+    //TODO:
+    return nullptr;
+}
+
+
 RenderRegion GlRenderer::viewport()
 {
     return {0, 0, UINT32_MAX, UINT32_MAX};

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -32,6 +32,7 @@ public:
 
     RenderData prepare(const Shape& shape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     RenderData prepare(const Picture& picture, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
+    RenderData prepare(Array<RenderData>& array, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     bool preRender() override;
     bool renderShape(RenderData data) override;
     bool renderImage(RenderData data) override;

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -341,8 +341,11 @@ void fillFetchRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, 
 SwRleData* rleRender(SwRleData* rle, const SwOutline* outline, const SwBBox& renderRegion, bool antiAlias);
 void rleFree(SwRleData* rle);
 void rleReset(SwRleData* rle);
+
+SwRleData* rleRectRender(const SwBBox* bbox);
 void rleClipPath(SwRleData *rle, const SwRleData *clip);
 void rleClipRect(SwRleData *rle, const SwBBox* clip);
+void rleUnionSpans(SwRleData *rle, SwRleData *clip1, const SwRleData *clip2);
 
 SwMpool* mpoolInit(uint32_t threads);
 bool mpoolTerm(SwMpool* mpool);

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -67,13 +67,8 @@ struct SwSceneTask : SwTask
     Array<RenderData> array;
     SwRleData* rle = nullptr;
 
-    void run(unsigned tid) override
-    {
-        for (auto paint = array.data; paint < (array.data + array.count); ++paint) {
-            auto task = static_cast<SwTask*>(*paint);
-            task->done();
-        }
-    }
+    //nothing to do on the thread
+    void run(unsigned tid) override {}
 
     bool dispose() override
     {

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -102,10 +102,18 @@ struct SwSceneTask : SwTask
     }
 
     bool innerRect() {
+        if (array.count == 1) {
+            auto task = static_cast<SwTask*>(*array.data);
+            return task->innerRect();
+        }
         return false;
     }
 
     SwBBox* innerBBox() {
+        if (array.count == 1) {
+            auto task = static_cast<SwTask*>(*array.data);
+            return task->innerBBox();
+        }
         return nullptr;
     }
 };

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -37,6 +37,7 @@ class SwRenderer : public RenderMethod
 public:
     RenderData prepare(const Shape& shape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     RenderData prepare(const Picture& picture, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
+    RenderData prepare(Array<RenderData>& array, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     bool preRender() override;
     bool renderShape(RenderData data) override;
     bool renderImage(RenderData data) override;

--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -668,16 +668,8 @@ SwSpan* _unionSpansRegion(const SwRleData *clip1, const SwRleData *clip2, SwSpan
     auto end2 = clip2->spans + clip2->size;
 
     while (spanCnt > 0 && (spans1 < end1 || spans2 < end2)) {
-        if (spans2 >= end2 || (spans1->y < spans2->y && spans1 < end1)) {
-            out->x = spans1->x;
-            out->y = spans1->y;
-            out->len = spans1->len;
-            out->coverage = spans1->coverage;
-            ++out;
-            --spanCnt;
-            ++spans1;
-
-        } else {
+        //TODO: Create better union algorithm
+        if (spans1 >= end1 || (spans1->y > spans2->y && spans2 < end2)) {
             out->x = spans2->x;
             out->y = spans2->y;
             out->len = spans2->len;
@@ -685,6 +677,15 @@ SwSpan* _unionSpansRegion(const SwRleData *clip1, const SwRleData *clip2, SwSpan
             ++out;
             --spanCnt;
             ++spans2;
+
+        } else {
+            out->x = spans1->x;
+            out->y = spans1->y;
+            out->len = spans1->len;
+            out->coverage = spans1->coverage;
+            ++out;
+            --spanCnt;
+            ++spans1;
         }
     }
     return out;

--- a/src/lib/sw_engine/tvgSwRle.cpp
+++ b/src/lib/sw_engine/tvgSwRle.cpp
@@ -911,12 +911,11 @@ void rleClipPath(SwRleData *rle, const SwRleData *clip)
 {
     if (!rle || !clip || rle->size == 0 || clip->size == 0) return;
     auto spanCnt = rle->size > clip->size ? rle->size : clip->size;
-    auto spanSize = sizeof(SwSpan) * spanCnt;
-    auto spans = static_cast<SwSpan*>(malloc(spanSize));
+    auto spans = static_cast<SwSpan*>(malloc(sizeof(SwSpan) * spanCnt));
     if (!spans) return;
     auto spansEnd = _intersectSpansRegion(clip, rle, spans, spanCnt);
 
-    _replaceClipSpan(rle, spans, spansEnd - spans, spanSize);
+    _replaceClipSpan(rle, spans, spansEnd - spans, spanCnt);
 
     TVGLOG("SW_ENGINE", "Using ClipPath!");
 }
@@ -925,12 +924,11 @@ void rleClipPath(SwRleData *rle, const SwRleData *clip)
 void rleClipRect(SwRleData *rle, const SwBBox* clip)
 {
     if (!rle || !clip || rle->size == 0) return;
-    auto spanSize = sizeof(SwSpan) * rle->size;
-    auto spans = static_cast<SwSpan*>(malloc(spanSize));
+    auto spans = static_cast<SwSpan*>(malloc(sizeof(SwSpan) * rle->size));
     if (!spans) return;
     auto spansEnd = _intersectSpansRect(clip, rle, spans, rle->size);
 
-    _replaceClipSpan(rle, spans, spansEnd - spans, spanSize);
+    _replaceClipSpan(rle, spans, spansEnd - spans, rle->size);
 
     TVGLOG("SW_ENGINE", "Using ClipRect!");
 }
@@ -941,12 +939,11 @@ void rleUnionSpans(SwRleData *rle, SwRleData *clip1, const SwRleData *clip2)
     if (!rle || !clip1 || !clip2 || clip1->size == 0 || clip2->size == 0) return;
 
     auto spanCnt = clip1->size + clip2->size;
-    auto spanSize = sizeof(SwSpan) * spanCnt;
-    auto spans = static_cast<SwSpan*>(malloc(spanSize));
+    auto spans = static_cast<SwSpan*>(malloc(sizeof(SwSpan) * spanCnt));
     if (!spans) return;
 
     auto spansEnd = _unionSpansRegion(clip1, clip2, spans, spanCnt);
-    _replaceClipSpan(rle, spans, spansEnd - spans, spanSize);
+    _replaceClipSpan(rle, spans, spansEnd - spans, spanCnt);
 
     TVGLOG("SW_ENGINE", "Using rleUnionSpans!");
 }

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -36,6 +36,8 @@ static inline bool FLT_SAME(float a, float b)
 
 static bool _clipPathFastTrack(Paint* cmpTarget, const RenderTransform* pTransform, RenderTransform* rTransform, RenderRegion& viewport)
 {
+    if (cmpTarget->id() != TVG_CLASS_ID_SHAPE) return false;
+
     /* Access Shape class by Paint is bad... but it's ok still it's an internal usage. */
     auto shape = static_cast<Shape*>(cmpTarget);
 

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -85,6 +85,7 @@ public:
     virtual ~RenderMethod() {}
     virtual RenderData prepare(const Shape& shape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
     virtual RenderData prepare(const Picture& picture, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
+    virtual RenderData prepare(Array<RenderData>& array, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
     virtual bool preRender() = 0;
     virtual bool renderShape(RenderData data) = 0;
     virtual bool renderImage(RenderData data) = 0;


### PR DESCRIPTION
This patch changes the sw_engine, introducing SwSceneTask and allowing to use
scene for ClipPath. Union region of rle is being created.

@issue: #524