### PR TITLE
sw_engine: building tvgSwRasterAvx as a library

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,10 @@ if get_option('savers').contains('tvg') == true
     config_h.set10('THORVG_TVG_SAVER_SUPPORT', true)
 endif
 
+if host_machine.system() == 'windows'
+    config_h.set10('HOST_SYSTEM_WINDOWS', true)
+endif
+
 simd_type = 'none'
 
 if get_option('vector') == true
@@ -66,6 +70,7 @@ configure_file(
 )
 
 headers = [include_directories('inc'), include_directories('.')]
+avx_headers = headers
 
 subdir('inc')
 subdir('src')

--- a/src/lib/meson.build
+++ b/src/lib/meson.build
@@ -1,3 +1,5 @@
+avx_headers +=  [include_directories('.')]
+
 engine_dep = []
 
 if get_option('engines').contains('sw') == true

--- a/src/lib/sw_engine/meson.build
+++ b/src/lib/sw_engine/meson.build
@@ -1,7 +1,6 @@
 source_file = [
    'tvgSwCommon.h',
    'tvgSwRasterC.h',
-   'tvgSwRasterAvx.h',
    'tvgSwRasterNeon.h',
    'tvgSwFill.cpp',
    'tvgSwImage.cpp',
@@ -15,7 +14,24 @@ source_file = [
    'tvgSwStroke.cpp',
 ]
 
+avx_source_file = [
+    'tvgSwRasterAvx.cpp',
+]
+
+avx_compiler_flags = compiler_flags + ['-mavx']
+avx_headers +=  [include_directories('.')]
+
+avx_raster_lib = library(
+    'tvgSwRasterAvx',
+    avx_source_file,
+    include_directories  : avx_headers,
+    cpp_args             : avx_compiler_flags,
+    install              : true
+)
+
+
 engine_dep += [declare_dependency(
-    include_directories : include_directories('.'),
-    sources : source_file
+    link_with            : avx_raster_lib,
+    include_directories  : include_directories('.'),
+    sources              : source_file
 )]

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -24,8 +24,11 @@
 #include "tvgSwCommon.h"
 #include "tvgRender.h"
 #include "tvgSwRasterC.h"
-#include "tvgSwRasterAvx.h"
 #include "tvgSwRasterNeon.h"
+
+#ifdef THORVG_AVX_VECTOR_SUPPORT
+#include "tvgSwRasterAvx.h"
+#endif
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -194,7 +197,10 @@ static bool _rasterTranslucentRect(SwSurface* surface, const SwBBox& region, uin
     }
 
 #if defined(THORVG_AVX_VECTOR_SUPPORT)
-    return avxRasterTranslucentRect(surface, region, color);
+//    if (THORVG_SIMD_SUPPORT() == SimdExtension::Avx || THORVG_SIMD_SUPPORT() == SimdExtension::Avx2)
+        return avxRasterTranslucentRect(surface, region, color);
+//    else
+//        return cRasterTranslucentRect(surface, region, color);
 #elif defined(THORVG_NEON_VECTOR_SUPPORT)
     return neonRasterTranslucentRect(surface, region, color);
 #else
@@ -1427,7 +1433,10 @@ static bool _rasterOpaqueRadialGradientRle(SwSurface* surface, const SwRleData* 
 void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 {
 #if defined(THORVG_AVX_VECTOR_SUPPORT)
-    avxRasterRGBA32(dst, val, offset, len);
+//    if (THORVG_SIMD_SUPPORT() == SimdExtension::Avx || THORVG_SIMD_SUPPORT() == SimdExtension::Avx2)
+        avxRasterRGBA32(dst, val, offset, len);
+//    else
+//        cRasterRGBA32(dst, val, offset, len);
 #elif defined(THORVG_NEON_VECTOR_SUPPORT)
     neonRasterRGBA32(dst, val, offset, len);
 #else

--- a/src/lib/sw_engine/tvgSwRasterAvx.cpp
+++ b/src/lib/sw_engine/tvgSwRasterAvx.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgSwRasterAvx.h"
+
+
+__m128i ALPHA_BLEND(__m128i c, __m128i a)
+{
+    //1. set the masks for the A/G and R/B channels
+    auto AG = _mm_set1_epi32(0xff00ff00);
+    auto RB = _mm_set1_epi32(0x00ff00ff);
+
+    //2. mask the alpha vector - originally quartet [a, a, a, a]
+    auto aAG = _mm_and_si128(a, AG);
+    auto aRB = _mm_and_si128(a, RB);
+
+    //3. calculate the alpha blending of the 2nd and 4th channel
+    //- mask the color vector
+    //- multiply it by the masked alpha vector
+    //- add the correction to compensate bit shifting used instead of dividing by 255
+    //- shift bits - corresponding to division by 256
+    auto even = _mm_and_si128(c, RB);
+    even = _mm_mullo_epi16(even, aRB);
+    even =_mm_add_epi16(even, RB);
+    even = _mm_srli_epi16(even, 8);
+
+    //4. calculate the alpha blending of the 1st and 3rd channel:
+    //- mask the color vector
+    //- multiply it by the corresponding masked alpha vector and store the high bits of the result
+    //- add the correction to compensate division by 256 instead of by 255 (next step)
+    //- remove the low 8 bits to mimic the division by 256
+    auto odd = _mm_and_si128(c, AG);
+    odd = _mm_mulhi_epu16(odd, aAG);
+    odd = _mm_add_epi16(odd, RB);
+    odd = _mm_and_si128(odd, AG);
+
+    //5. the final result
+    return _mm_or_si128(odd, even);
+}
+
+
+void avxRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
+{
+    //1. calculate how many iterations we need to cover the length
+    uint32_t iterations = len / N_32BITS_IN_256REG;
+    uint32_t avxFilled = iterations * N_32BITS_IN_256REG;
+
+    //2. set the beginning of the array
+    dst += offset;
+
+    //3. fill the octets
+    for (uint32_t i = 0; i < iterations; ++i, dst += N_32BITS_IN_256REG) {
+        _mm256_storeu_si256((__m256i*)dst, _mm256_set1_epi32(val));
+    }
+
+    //4. fill leftovers (in the first step we have to set the pointer to the place where the avx job is done)
+    int32_t leftovers = len - avxFilled;
+    while (leftovers--) *dst++ = val;
+}
+
+
+bool avxRasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint32_t color)
+{
+    auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
+    auto h = static_cast<uint32_t>(region.max.y - region.min.y);
+    auto w = static_cast<uint32_t>(region.max.x - region.min.x);
+
+    auto ialpha = 255 - static_cast<uint8_t>(surface->blender.alpha(color));
+
+    auto avxColor = _mm_set1_epi32(color);
+    auto avxIalpha = _mm_set1_epi8(ialpha);
+
+    for (uint32_t y = 0; y < h; ++y) {
+        auto dst = &buffer[y * surface->stride];
+
+        //1. fill the not aligned memory (for 128-bit registers a 16-bytes alignment is required)
+        auto notAligned = ((uintptr_t)dst & 0xf) / 4;
+        if (notAligned) {
+            notAligned = (N_32BITS_IN_128REG - notAligned > w ? w : N_32BITS_IN_128REG - notAligned);
+            for (uint32_t x = 0; x < notAligned; ++x, ++dst) {
+                *dst = color + ALPHA_BLEND(*dst, ialpha);
+            }
+        }
+
+        //2. fill the aligned memory - N_32BITS_IN_128REG pixels processed at once
+        uint32_t iterations = (w - notAligned) / N_32BITS_IN_128REG;
+        uint32_t avxFilled = iterations * N_32BITS_IN_128REG;
+        auto avxDst = (__m128i*)dst;
+        for (uint32_t x = 0; x < iterations; ++x, ++avxDst) {
+            *avxDst = _mm_add_epi32(avxColor, ALPHA_BLEND(*avxDst, avxIalpha));
+        }
+
+        //3. fill the remaining pixels
+        int32_t leftovers = w - notAligned - avxFilled;
+        dst += avxFilled;
+        while (leftovers--) {
+            *dst = color + ALPHA_BLEND(*dst, ialpha);
+            dst++;
+        }
+    }
+    return true;
+}

--- a/src/lib/sw_engine/tvgSwRasterAvx.h
+++ b/src/lib/sw_engine/tvgSwRasterAvx.h
@@ -20,108 +20,12 @@
  * SOFTWARE.
  */
 
-#ifdef THORVG_AVX_VECTOR_SUPPORT
-
 #include <immintrin.h>
+#include "tvgSwCommon.h"
 
 #define N_32BITS_IN_128REG 4
 #define N_32BITS_IN_256REG 8
 
-static inline __m128i ALPHA_BLEND(__m128i c, __m128i a)
-{
-    //1. set the masks for the A/G and R/B channels
-    auto AG = _mm_set1_epi32(0xff00ff00);
-    auto RB = _mm_set1_epi32(0x00ff00ff);
-
-    //2. mask the alpha vector - originally quartet [a, a, a, a]
-    auto aAG = _mm_and_si128(a, AG);
-    auto aRB = _mm_and_si128(a, RB);
-
-    //3. calculate the alpha blending of the 2nd and 4th channel
-    //- mask the color vector
-    //- multiply it by the masked alpha vector
-    //- add the correction to compensate bit shifting used instead of dividing by 255
-    //- shift bits - corresponding to division by 256
-    auto even = _mm_and_si128(c, RB);
-    even = _mm_mullo_epi16(even, aRB);
-    even =_mm_add_epi16(even, RB);
-    even = _mm_srli_epi16(even, 8);
-
-    //4. calculate the alpha blending of the 1st and 3rd channel:
-    //- mask the color vector
-    //- multiply it by the corresponding masked alpha vector and store the high bits of the result
-    //- add the correction to compensate division by 256 instead of by 255 (next step)
-    //- remove the low 8 bits to mimic the division by 256
-    auto odd = _mm_and_si128(c, AG);
-    odd = _mm_mulhi_epu16(odd, aAG);
-    odd = _mm_add_epi16(odd, RB);
-    odd = _mm_and_si128(odd, AG);
-
-    //5. the final result
-    return _mm_or_si128(odd, even);
-}
-
-
-static inline void avxRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
-{
-    //1. calculate how many iterations we need to cover the length
-    uint32_t iterations = len / N_32BITS_IN_256REG;
-    uint32_t avxFilled = iterations * N_32BITS_IN_256REG;
-
-    //2. set the beginning of the array
-    dst += offset;
-
-    //3. fill the octets
-    for (uint32_t i = 0; i < iterations; ++i, dst += N_32BITS_IN_256REG) {
-        _mm256_storeu_si256((__m256i*)dst, _mm256_set1_epi32(val));
-    }
-
-    //4. fill leftovers (in the first step we have to set the pointer to the place where the avx job is done)
-    int32_t leftovers = len - avxFilled;
-    while (leftovers--) *dst++ = val;
-}
-
-
-static inline bool avxRasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint32_t color)
-{
-    auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
-    auto h = static_cast<uint32_t>(region.max.y - region.min.y);
-    auto w = static_cast<uint32_t>(region.max.x - region.min.x);
-
-    auto ialpha = 255 - static_cast<uint8_t>(surface->blender.alpha(color));
-
-    auto avxColor = _mm_set1_epi32(color);
-    auto avxIalpha = _mm_set1_epi8(ialpha);
-
-    for (uint32_t y = 0; y < h; ++y) {
-        auto dst = &buffer[y * surface->stride];
-
-        //1. fill the not aligned memory (for 128-bit registers a 16-bytes alignment is required)
-        auto notAligned = ((uintptr_t)dst & 0xf) / 4;
-        if (notAligned) {
-            notAligned = (N_32BITS_IN_128REG - notAligned > w ? w : N_32BITS_IN_128REG - notAligned);
-            for (uint32_t x = 0; x < notAligned; ++x, ++dst) {
-                *dst = color + ALPHA_BLEND(*dst, ialpha);
-            }
-        }
-
-        //2. fill the aligned memory - N_32BITS_IN_128REG pixels processed at once
-        uint32_t iterations = (w - notAligned) / N_32BITS_IN_128REG;
-        uint32_t avxFilled = iterations * N_32BITS_IN_128REG;
-        auto avxDst = (__m128i*)dst;
-        for (uint32_t x = 0; x < iterations; ++x, ++avxDst) {
-            *avxDst = _mm_add_epi32(avxColor, ALPHA_BLEND(*avxDst, avxIalpha));
-        }
-
-        //3. fill the remaining pixels
-        int32_t leftovers = w - notAligned - avxFilled;
-        dst += avxFilled;
-        while (leftovers--) {
-            *dst = color + ALPHA_BLEND(*dst, ialpha);
-            dst++;
-        }
-    }
-    return true;
-}
-
-#endif
+__m128i ALPHA_BLEND(__m128i c, __m128i a);
+void avxRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len);
+bool avxRasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint32_t color);

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,9 +2,6 @@ compiler_flags = ['-DTVG_BUILD']
 
 cc = meson.get_compiler('cpp')
 if (cc.get_id() != 'msvc')
-    if simd_type == 'avx'
-        compiler_flags += ['-mavx']
-    endif
     if simd_type == 'neon'
         compiler_flags += ['-mfpu=neon']
     endif


### PR DESCRIPTION
it's a draft, since in `src/lib/sw_engine/tvgSwRaster.cpp` the changes are made only for testing purposes. 
I want to use function pointers, but not to each raster function, rather only to the external ones. but to do this we need to implement more avx functions.


issue #29 