### PR TITLE
tests: fix stack overflow error in testPicture (windows)

### DIFF
--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -269,7 +269,7 @@ TEST_CASE("Load SVG file and render", "[tvgPicture]")
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
 
-    uint32_t* buffer = new uint32_t(1000*1000);
+    uint32_t* buffer = new uint32_t[1000*1000];
     REQUIRE(canvas->target(buffer, 1000, 1000, 1000, SwCanvas::Colorspace::ABGR8888) == Result::Success);
 
     auto picture = Picture::gen();
@@ -336,7 +336,7 @@ TEST_CASE("Load TVG file and render", "[tvgPicture]")
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
 
-    uint32_t* buffer = new uint32_t(1000*1000);
+    uint32_t* buffer = new uint32_t[1000*1000];
     REQUIRE(canvas->target(buffer, 1000, 1000, 1000, SwCanvas::Colorspace::ABGR8888) == Result::Success);
 
     auto pictureTag = Picture::gen();


### PR DESCRIPTION
The testPicture test was failing on windows in two places with MSVC.

This is because a 4MB buffer was being created on the stack (4b x 1000 x 1000), and the [default stack size on ARM, x86 and x64](https://docs.microsoft.com/en-us/cpp/build/reference/stack-stack-allocations?view=msvc-160) is only 1MB.  Have changed the large buffers to be created on the heap instead (using new/delete).

There are still many tests failing on windows, but at least this one is fixed :)

Relates to #881 