### PR TITLE
wasm: fix compilation

### DIFF
--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -48,7 +48,7 @@ using namespace tvg;
     #define TVG_FALLTHROUGH
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && !defined(__EMSCRIPTEN__)
     #define strncpy strncpy_s
     #define strdup _strdup
 #endif

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -33,7 +33,7 @@
 
 static FILE* _fopen(const char* filename, const char* mode)
 {
-#ifdef __clang__
+#if defined(__clang__) && !defined(__EMSCRIPTEN__)
     FILE *fp;
     auto err = fopen_s(&fp, filename, mode);
     if (err != 0) return nullptr;


### PR DESCRIPTION
After 'all: fixing clang warnings' (e7c3a91) there was a problem with wasm compilation, as strncpy and strdup.
Disable define is __EMSCRIPTEN__.