### PR TITLE
svg_loader: gradient handling and recalculation changed

### DIFF
--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -216,10 +216,10 @@ struct SvgLinearGradient
     float y1;
     float x2;
     float y2;
-    uint8_t x1Pct;
-    uint8_t y1Pct;
-    uint8_t x2Pct;
-    uint8_t y2Pct;
+    bool isX1Percentage;
+    bool isY1Percentage;
+    bool isX2Percentage;
+    bool isY2Percentage;
 
 };
 
@@ -230,11 +230,11 @@ struct SvgRadialGradient
     float fx;
     float fy;
     float r;
-    uint8_t cxPct;
-    uint8_t cyPct;
-    uint8_t fxPct;
-    uint8_t fyPct;
-    uint8_t rPct;
+    bool isCxPercentage;
+    bool isCyPercentage;
+    bool isFxPercentage;
+    bool isFyPercentage;
+    bool isRPercentage;
 };
 
 struct SvgComposite


### PR DESCRIPTION
The need to convert the gradient values occurs only when they are given
as nominal values in the current user coordinate system (userSpaceOnUse).

before:
![33before](https://user-images.githubusercontent.com/67589014/136704626-f2bb37d8-5e54-4ccc-9be8-b3674d9f1938.PNG)

after:
![33after](https://user-images.githubusercontent.com/67589014/136704629-0394f349-5ca2-4155-985a-23d2ddcbdbc3.PNG)

svg:
```
<svg viewBox="0 0 400 300">
<defs>
<!-- Object bbox -->
<radialGradient id="radialGradient1" r="10%" cx="100%" cy="50%" gradientUnits="objectBoundingBox" spreadMethod="reflect">
<stop style="stop-color:#ff0000;stop-opacity:1;" offset="0"/>
<stop style="stop-color:#0000ff;stop-opacity:1;" offset="1"/>
</radialGradient>

<radialGradient id="radialGradient2" r="0.1" cx="1" cy="0.5" gradientUnits="objectBoundingBox" spreadMethod="reflect">
<stop style="stop-color:#ff0000;stop-opacity:1;" offset="0"/>
<stop style="stop-color:#0000ff;stop-opacity:1;" offset="1"/>
</radialGradient>

<!-- User space -->
<radialGradient id="radialGradient3" r="10%" cx="100%" cy="50%" gradientUnits="userSpaceOnUse" spreadMethod="reflect">
<stop style="stop-color:#ff0000;stop-opacity:1;" offset="0"/>
<stop style="stop-color:#0000ff;stop-opacity:1;" offset="1"/>
</radialGradient>

<radialGradient id="radialGradient4" r="10" cx="100" cy="50" gradientUnits="userSpaceOnUse" spreadMethod="reflect">
<stop style="stop-color:#ff0000;stop-opacity:1;" offset="0"/>
<stop style="stop-color:#0000ff;stop-opacity:1;" offset="1"/>
</radialGradient>
</defs>

<rect x="50" y="0" width="100" height="100" fill="url(#radialGradient1)"/>
<rect x="200" y="0" width="100" height="100" fill="url(#radialGradient2)"/>
<rect x="50" y="150" width="100" height="100" fill="url(#radialGradient3)"/>
<rect x="200" y="150" width="100" height="100" fill="url(#radialGradient4)"/>
</svg>
```