### PR TITLE
svg_loader: removed unused variable

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1661,7 +1661,6 @@ static SvgStyleGradient* _cloneGradient(SvgStyleGradient* from)
     grad->id = from->id ? _copyId(from->id->c_str()) : nullptr;
     grad->ref = from->ref ? _copyId(from->ref->c_str()) : nullptr;
     grad->spread = from->spread;
-    grad->usePercentage = from->usePercentage;
     grad->userSpace = from->userSpace;
 
     if (from->transform) {
@@ -2063,8 +2062,6 @@ static SvgStyleGradient* _createRadialGradient(SvgLoaderData* loader, const char
         radialTags[i].tagRecalc(loader, grad->radial, grad->userSpace);
     }
 
-    grad->usePercentage = true;
-
     return loader->svgParse->styleGrad;
 }
 
@@ -2240,8 +2237,6 @@ static SvgStyleGradient* _createLinearGradient(SvgLoaderData* loader, const char
     for (unsigned int i = 0; i < sizeof(linear_tags) / sizeof(linear_tags[0]); i++) {
         linear_tags[i].tagRecalc(loader, grad->linear, grad->userSpace);
     }
-
-    grad->usePercentage = true;
 
     return loader->svgParse->styleGrad;
 }

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -266,7 +266,6 @@ struct SvgStyleGradient
     Matrix* transform = nullptr;
     Array<Fill::ColorStop> stops;
     bool userSpace = false;
-    bool usePercentage = false;
 
     ~SvgStyleGradient()
     {

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -46,12 +46,10 @@ static unique_ptr<LinearGradient> _applyLinearGradientProperty(SvgStyleGradient*
     int stopCount = 0;
     auto fillGrad = LinearGradient::gen();
 
-    if (g->usePercentage) {
-        g->linear->x1 = g->linear->x1 * rw + rx;
-        g->linear->y1 = g->linear->y1 * rh + ry;
-        g->linear->x2 = g->linear->x2 * rw + rx;
-        g->linear->y2 = g->linear->y2 * rh + ry;
-    }
+    g->linear->x1 = g->linear->x1 * rw + rx;
+    g->linear->y1 = g->linear->y1 * rh + ry;
+    g->linear->x2 = g->linear->x2 * rw + rx;
+    g->linear->y2 = g->linear->y2 * rh + ry;
 
     if (g->transform) {
         //Calc start point
@@ -109,13 +107,11 @@ static unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient*
         radius = sqrtf(pow(min, 2) + pow(min, 2)) / sqrtf(2.0f);
     }
 
-    if (g->usePercentage) {
-        g->radial->cx = g->radial->cx * rw + rx;
-        g->radial->cy = g->radial->cy * rh + ry;
-        g->radial->r = g->radial->r * radius;
-        g->radial->fx = g->radial->fx * rw + rx;
-        g->radial->fy = g->radial->fy * rh + ry;
-    }
+    g->radial->cx = g->radial->cx * rw + rx;
+    g->radial->cy = g->radial->cy * rh + ry;
+    g->radial->r = g->radial->r * radius;
+    g->radial->fx = g->radial->fx * rw + rx;
+    g->radial->fy = g->radial->fy * rh + ry;
 
     //TODO: Radial gradient transformation - all tests possible after rx/ry implementation
     if (g->transform) {


### PR DESCRIPTION
The gradient values passed to the scene builder are always given as percentages,
so there is no need to mark/check that.