### PR TITLE
tvg_saver: fix the argument of the sizeof call

### DIFF
--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -524,7 +524,7 @@ TvgBinCounter TvgSaver::serializePath(const Shape* shape, const Matrix* transfor
 
     auto cnt = writeData(&cmdCnt, SIZE(cmdCnt));
     cnt += writeData(&ptsCnt, SIZE(ptsCnt));
-    cnt += writeData(outCmds, SIZE(outCmds));
+    cnt += writeData(outCmds, SIZE(TvgBinFlag) * cmdCnt);
 
     //transform?
     if (preTransform) {


### PR DESCRIPTION
We got the size of a pointer instead of the size of a whole table.
Fixed now