### PR TITLE
svg_loader: fixing viewBox clipping

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -548,7 +548,7 @@ unique_ptr<Scene> svgSceneBuild(SvgNode* node, float vx, float vy, float vw, flo
             Matrix m = {sx, 0, -tvx, 0, sy, -tvy, 0, 0, 1};
             docNode->transform(m);
         }
-    } else if (vx < 0 || vy < 0) {
+    } else if (fabs(vx) > FLT_EPSILON || fabs(vy) > FLT_EPSILON) {
         docNode->translate(-vx, -vy);
     }
 


### PR DESCRIPTION
For vw=width and vh=height, vx or vy > 0 had no effect. Fixed

before:
![35before](https://user-images.githubusercontent.com/67589014/137229856-0f558686-6174-43f3-982d-3cfe1f49ed48.PNG)

after:
![35after](https://user-images.githubusercontent.com/67589014/137229998-27471293-2d2c-4a11-833e-e5dd8b9e79d1.PNG)

code:
```
<svg viewBox="30 40 100 100">
<path d="M 0 100 h 100 v -100 z" fill="#f0f"/>
</svg>
```