### PR TITLE
common: defining macro with the overloaded new operator

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -16,6 +16,9 @@
 
 #include <memory>
 #include <string>
+#include <new>
+
+#define NEWT new(std::nothrow)
 
 #ifdef TVG_BUILD
     #if defined(_MSC_VER) && !defined(__clang__)

--- a/src/lib/gl_engine/tvgGlProgram.cpp
+++ b/src/lib/gl_engine/tvgGlProgram.cpp
@@ -163,7 +163,7 @@ void GlProgram::linkProgram(std::shared_ptr<GlShader> shader)
         glGetProgramiv(progObj, GL_INFO_LOG_LENGTH, &infoLen);
         if (infoLen > 0)
         {
-            char* infoLog = new char[infoLen];
+            char* infoLog = NEWT char[infoLen];
             glGetProgramInfoLog(progObj, infoLen, NULL, infoLog);
             TVGERR("GL_ENGINE", "Error linking shader: %s", infoLog);
             delete[] infoLog;

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -196,7 +196,7 @@ RenderData GlRenderer::prepare(const Shape& shape, RenderData data, const Render
     //prepare shape data
     GlShape* sdata = static_cast<GlShape*>(data);
     if (!sdata) {
-        sdata = new GlShape;
+        sdata = NEWT GlShape;
         if (!sdata) return nullptr;
         sdata->shape = &shape;
     }
@@ -277,7 +277,7 @@ int GlRenderer::term()
 
 GlRenderer* GlRenderer::gen()
 {
-    return new GlRenderer();
+    return NEWT GlRenderer();
 }
 
 

--- a/src/lib/gl_engine/tvgGlShader.cpp
+++ b/src/lib/gl_engine/tvgGlShader.cpp
@@ -84,7 +84,7 @@ uint32_t GlShader::complileShader(uint32_t type, char* shaderSrc)
 
         if (infoLen > 0)
         {
-            char* infoLog = new char[infoLen];
+            char* infoLog = NEWT char[infoLen];
             glGetShaderInfoLog(shader, infoLen, NULL, infoLog);
             TVGERR("GL_ENGINE", "Error compiling shader: %s", infoLog);
             delete[] infoLog;

--- a/src/lib/sw_engine/tvgSwMemPool.cpp
+++ b/src/lib/sw_engine/tvgSwMemPool.cpp
@@ -59,7 +59,7 @@ void mpoolRetStrokeOutline(SwMpool* mpool, unsigned idx)
 
 SwMpool* mpoolInit(unsigned threads)
 {
-    auto mpool = new SwMpool;
+    auto mpool = NEWT SwMpool;
     if (!mpool) return nullptr;
 
     if (threads == 0) threads = 1;

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -284,7 +284,7 @@ bool SwRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     if (!buffer || stride == 0 || w == 0 || h == 0 || w > stride) return false;
 
     if (!surface) {
-        surface = new SwSurface;
+        surface = NEWT SwSurface;
         if (!surface) return false;
     }
 
@@ -452,13 +452,13 @@ Compositor* SwRenderer::target(const RenderRegion& region)
 
     //New Composition
     if (!cmp) {
-        cmp = new SwSurface;
+        cmp = NEWT SwSurface;
         if (!cmp) goto err;
 
         //Inherits attributes from main surface
         *cmp = *surface;
 
-        cmp->compositor = new SwCompositor;
+        cmp->compositor = NEWT SwCompositor;
         if (!cmp->compositor) goto err;
 
         //SwImage, Optimize Me: Surface size from MainSurface(WxH) to Parameter W x H
@@ -589,7 +589,7 @@ RenderData SwRenderer::prepare(const Picture& pdata, RenderData data, const Rend
     //prepare task
     auto task = static_cast<SwImageTask*>(data);
     if (!task) {
-        task = new SwImageTask;
+        task = NEWT SwImageTask;
         if (!task) return nullptr;
         task->pdata = &pdata;
     }
@@ -602,7 +602,7 @@ RenderData SwRenderer::prepare(const Shape& sdata, RenderData data, const Render
     //prepare task
     auto task = static_cast<SwShapeTask*>(data);
     if (!task) {
-        task = new SwShapeTask;
+        task = NEWT SwShapeTask;
         if (!task) return nullptr;
         task->sdata = &sdata;
     }
@@ -652,5 +652,5 @@ bool SwRenderer::term()
 SwRenderer* SwRenderer::gen()
 {
     ++rendererCnt;
-    return new SwRenderer();
+    return NEWT SwRenderer();
 }

--- a/src/lib/tvgCanvas.cpp
+++ b/src/lib/tvgCanvas.cpp
@@ -25,7 +25,7 @@
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Canvas::Canvas(RenderMethod *pRenderer):pImpl(new Impl(pRenderer))
+Canvas::Canvas(RenderMethod *pRenderer):pImpl(NEWT Impl(pRenderer))
 {
 }
 

--- a/src/lib/tvgFill.cpp
+++ b/src/lib/tvgFill.cpp
@@ -30,7 +30,7 @@
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Fill::Fill():pImpl(new Impl())
+Fill::Fill():pImpl(NEWT Impl())
 {
 }
 

--- a/src/lib/tvgGlCanvas.cpp
+++ b/src/lib/tvgGlCanvas.cpp
@@ -44,9 +44,9 @@ struct GlCanvas::Impl
 /************************************************************************/
 
 #ifdef THORVG_GL_RASTER_SUPPORT
-GlCanvas::GlCanvas() : Canvas(GlRenderer::gen()), pImpl(new Impl)
+GlCanvas::GlCanvas() : Canvas(GlRenderer::gen()), pImpl(NEWT Impl)
 #else
-GlCanvas::GlCanvas() : Canvas(nullptr), pImpl(new Impl)
+GlCanvas::GlCanvas() : Canvas(nullptr), pImpl(NEWT Impl)
 #endif
 {
 }
@@ -81,7 +81,7 @@ unique_ptr<GlCanvas> GlCanvas::gen() noexcept
 {
 #ifdef THORVG_GL_RASTER_SUPPORT
     if (GlRenderer::init() <= 0) return nullptr;
-    return unique_ptr<GlCanvas>(new GlCanvas);
+    return unique_ptr<GlCanvas>(NEWT GlCanvas);
 #endif
     return nullptr;
 }

--- a/src/lib/tvgLinearGradient.cpp
+++ b/src/lib/tvgLinearGradient.cpp
@@ -52,10 +52,10 @@ struct LinearGradient::Impl
 /* External Class Implementation                                        */
 /************************************************************************/
 
-LinearGradient::LinearGradient():pImpl(new Impl())
+LinearGradient::LinearGradient():pImpl(NEWT Impl())
 {
     _id = TVG_CLASS_ID_LINEAR;
-    Fill::pImpl->method(new FillDup<LinearGradient::Impl>(pImpl));
+    Fill::pImpl->method(NEWT FillDup<LinearGradient::Impl>(pImpl));
 }
 
 
@@ -89,5 +89,5 @@ Result LinearGradient::linear(float* x1, float* y1, float* x2, float* y2) const 
 
 unique_ptr<LinearGradient> LinearGradient::gen() noexcept
 {
-    return unique_ptr<LinearGradient>(new LinearGradient);
+    return unique_ptr<LinearGradient>(NEWT LinearGradient);
 }

--- a/src/lib/tvgLoader.cpp
+++ b/src/lib/tvgLoader.cpp
@@ -48,29 +48,29 @@ static LoadModule* _find(FileType type)
     switch(type) {
         case FileType::Tvg: {
 #ifdef THORVG_TVG_LOADER_SUPPORT
-            return new TvgLoader;
+            return NEWT TvgLoader;
 #endif
             break;
         }
         case FileType::Svg: {
 #ifdef THORVG_SVG_LOADER_SUPPORT
-            return new SvgLoader;
+            return NEWT SvgLoader;
 #endif
             break;
         }
         case FileType::Raw: {
-            return new RawLoader;
+            return NEWT RawLoader;
             break;
         }
         case FileType::Png: {
 #ifdef THORVG_PNG_LOADER_SUPPORT
-            return new PngLoader;
+            return NEWT PngLoader;
 #endif
             break;
         }
         case FileType::Jpg: {
 #ifdef THORVG_JPG_LOADER_SUPPORT
-            return new JpgLoader;
+            return NEWT JpgLoader;
 #endif
             break;
         }
@@ -205,7 +205,7 @@ shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const 
 shared_ptr<LoadModule> LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h, bool copy)
 {
     //function is dedicated for raw images only
-    auto loader = new RawLoader;
+    auto loader = NEWT RawLoader;
     if (loader) {
         if (loader->open(data, w, h, copy)) return shared_ptr<LoadModule>(loader);
         else delete(loader);

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -98,7 +98,7 @@ Paint* Paint::Impl::duplicate()
 
     //duplicate Transform
     if (rTransform) {
-        ret->pImpl->rTransform = new RenderTransform();
+        ret->pImpl->rTransform = NEWT RenderTransform();
         if (ret->pImpl->rTransform) {
             *ret->pImpl->rTransform = *rTransform;
             ret->pImpl->flag |= RenderUpdateFlag::Transform;
@@ -121,7 +121,7 @@ bool Paint::Impl::rotate(float degree)
         if (fabsf(degree - rTransform->degree) <= FLT_EPSILON) return true;
     } else {
         if (fabsf(degree) <= FLT_EPSILON) return true;
-        rTransform = new RenderTransform();
+        rTransform = NEWT RenderTransform();
         if (!rTransform) return false;
     }
     rTransform->degree = degree;
@@ -137,7 +137,7 @@ bool Paint::Impl::scale(float factor)
         if (fabsf(factor - rTransform->scale) <= FLT_EPSILON) return true;
     } else {
         if (fabsf(factor) <= FLT_EPSILON) return true;
-        rTransform = new RenderTransform();
+        rTransform = NEWT RenderTransform();
         if (!rTransform) return false;
     }
     rTransform->scale = factor;
@@ -153,7 +153,7 @@ bool Paint::Impl::translate(float x, float y)
         if (fabsf(x - rTransform->x) <= FLT_EPSILON && fabsf(y - rTransform->y) <= FLT_EPSILON) return true;
     } else {
         if (fabsf(x) <= FLT_EPSILON && fabsf(y) <= FLT_EPSILON) return true;
-        rTransform = new RenderTransform();
+        rTransform = NEWT RenderTransform();
         if (!rTransform) return false;
     }
     rTransform->x = x;
@@ -297,7 +297,7 @@ bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transforme
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Paint :: Paint() : pImpl(new Impl())
+Paint :: Paint() : pImpl(NEWT Impl())
 {
 }
 

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -71,7 +71,7 @@ namespace tvg
         bool transform(const Matrix& m)
         {
             if (!rTransform) {
-                rTransform = new RenderTransform();
+                rTransform = NEWT RenderTransform();
                 if (!rTransform) return false;
             }
             rTransform->override(m);

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -26,10 +26,10 @@
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Picture::Picture() : pImpl(new Impl(this))
+Picture::Picture() : pImpl(NEWT Impl(this))
 {
     _id = TVG_CLASS_ID_PICTURE;
-    Paint::pImpl->method(new PaintMethod<Picture::Impl>(pImpl));
+    Paint::pImpl->method(NEWT PaintMethod<Picture::Impl>(pImpl));
 }
 
 
@@ -41,7 +41,7 @@ Picture::~Picture()
 
 unique_ptr<Picture> Picture::gen() noexcept
 {
-    return unique_ptr<Picture>(new Picture);
+    return unique_ptr<Picture>(NEWT Picture);
 }
 
 

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -245,7 +245,7 @@ struct Picture::Impl
     Iterator* iterator()
     {
         reload();
-        return new PictureIterator(paint);
+        return NEWT PictureIterator(paint);
     }
 };
 

--- a/src/lib/tvgRadialGradient.cpp
+++ b/src/lib/tvgRadialGradient.cpp
@@ -50,10 +50,10 @@ struct RadialGradient::Impl
 /* External Class Implementation                                        */
 /************************************************************************/
 
-RadialGradient::RadialGradient():pImpl(new Impl())
+RadialGradient::RadialGradient():pImpl(NEWT Impl())
 {
     _id = TVG_CLASS_ID_RADIAL;
-    Fill::pImpl->method(new FillDup<RadialGradient::Impl>(pImpl));
+    Fill::pImpl->method(NEWT FillDup<RadialGradient::Impl>(pImpl));
 }
 
 
@@ -87,5 +87,5 @@ Result RadialGradient::radial(float* cx, float* cy, float* radius) const noexcep
 
 unique_ptr<RadialGradient> RadialGradient::gen() noexcept
 {
-    return unique_ptr<RadialGradient>(new RadialGradient);
+    return unique_ptr<RadialGradient>(NEWT RadialGradient);
 }

--- a/src/lib/tvgSaver.cpp
+++ b/src/lib/tvgSaver.cpp
@@ -45,7 +45,7 @@ static SaveModule* _find(FileType type)
     switch(type) {
         case FileType::Tvg: {
 #ifdef THORVG_TVG_SAVER_SUPPORT
-            return new TvgSaver;
+            return NEWT TvgSaver;
 #endif
             break;
         }
@@ -86,7 +86,7 @@ static SaveModule* _find(const string& path)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Saver::Saver() : pImpl(new Impl())
+Saver::Saver() : pImpl(NEWT Impl())
 {
 }
 
@@ -130,5 +130,5 @@ Result Saver::sync() noexcept
 
 unique_ptr<Saver> Saver::gen() noexcept
 {
-    return unique_ptr<Saver>(new Saver);
+    return unique_ptr<Saver>(NEWT Saver);
 }

--- a/src/lib/tvgScene.cpp
+++ b/src/lib/tvgScene.cpp
@@ -25,10 +25,10 @@
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Scene::Scene() : pImpl(new Impl())
+Scene::Scene() : pImpl(NEWT Impl())
 {
     _id = TVG_CLASS_ID_SCENE;
-    Paint::pImpl->method(new PaintMethod<Scene::Impl>(pImpl));
+    Paint::pImpl->method(NEWT PaintMethod<Scene::Impl>(pImpl));
 }
 
 
@@ -40,7 +40,7 @@ Scene::~Scene()
 
 unique_ptr<Scene> Scene::gen() noexcept
 {
-    return unique_ptr<Scene>(new Scene);
+    return unique_ptr<Scene>(NEWT Scene);
 }
 
 

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -210,7 +210,7 @@ struct Scene::Impl
 
     Iterator* iterator()
     {
-        return new SceneIterator(&paints);
+        return NEWT SceneIterator(&paints);
     }
 };
 

--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -36,10 +36,10 @@ constexpr auto PATH_KAPPA = 0.552284f;
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Shape :: Shape() : pImpl(new Impl(this))
+Shape :: Shape() : pImpl(NEWT Impl(this))
 {
     _id = TVG_CLASS_ID_SHAPE;
-    Paint::pImpl->method(new PaintMethod<Shape::Impl>(pImpl));
+    Paint::pImpl->method(NEWT PaintMethod<Shape::Impl>(pImpl));
 }
 
 
@@ -51,7 +51,7 @@ Shape :: ~Shape()
 
 unique_ptr<Shape> Shape::gen() noexcept
 {
-    return unique_ptr<Shape>(new Shape);
+    return unique_ptr<Shape>(NEWT Shape);
 }
 
 

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -260,7 +260,7 @@ struct Shape::Impl
     {
         //TODO: Size Exception?
 
-        if (!stroke) stroke = new ShapeStroke();
+        if (!stroke) stroke = NEWT ShapeStroke();
         if (!stroke) return false;
 
         stroke->width = width;
@@ -271,7 +271,7 @@ struct Shape::Impl
 
     bool strokeCap(StrokeCap cap)
     {
-        if (!stroke) stroke = new ShapeStroke();
+        if (!stroke) stroke = NEWT ShapeStroke();
         if (!stroke) return false;
 
         stroke->cap = cap;
@@ -282,7 +282,7 @@ struct Shape::Impl
 
     bool strokeJoin(StrokeJoin join)
     {
-        if (!stroke) stroke = new ShapeStroke();
+        if (!stroke) stroke = NEWT ShapeStroke();
         if (!stroke) return false;
 
         stroke->join = join;
@@ -293,7 +293,7 @@ struct Shape::Impl
 
     bool strokeColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
     {
-        if (!stroke) stroke = new ShapeStroke();
+        if (!stroke) stroke = NEWT ShapeStroke();
         if (!stroke) return false;
 
         if (stroke->fill) {
@@ -317,7 +317,7 @@ struct Shape::Impl
         auto p = f.release();
         if (!p) return Result::MemoryCorruption;
 
-        if (!stroke) stroke = new ShapeStroke();
+        if (!stroke) stroke = NEWT ShapeStroke();
         if (!stroke) return Result::FailedAllocation;
 
         if (stroke->fill && stroke->fill != p) delete(stroke->fill);
@@ -336,7 +336,7 @@ struct Shape::Impl
             free(stroke->dashPattern);
             stroke->dashPattern = nullptr;
         } else {
-            if (!stroke) stroke = new ShapeStroke();
+            if (!stroke) stroke = NEWT ShapeStroke();
             if (!stroke) return false;
 
             if (stroke->dashCnt != cnt) {
@@ -375,7 +375,7 @@ struct Shape::Impl
 
         //Stroke
         if (stroke) {
-            dup->stroke = new ShapeStroke(stroke);
+            dup->stroke = NEWT ShapeStroke(stroke);
             dup->flag |= RenderUpdateFlag::Stroke;
 
             if (stroke->fill)

--- a/src/lib/tvgSwCanvas.cpp
+++ b/src/lib/tvgSwCanvas.cpp
@@ -44,9 +44,9 @@ struct SwCanvas::Impl
 /************************************************************************/
 
 #ifdef THORVG_SW_RASTER_SUPPORT
-SwCanvas::SwCanvas() : Canvas(SwRenderer::gen()), pImpl(new Impl)
+SwCanvas::SwCanvas() : Canvas(SwRenderer::gen()), pImpl(NEWT Impl)
 #else
-SwCanvas::SwCanvas() : Canvas(nullptr), pImpl(new Impl)
+SwCanvas::SwCanvas() : Canvas(nullptr), pImpl(NEWT Impl)
 #endif
 {
 }
@@ -99,7 +99,7 @@ unique_ptr<SwCanvas> SwCanvas::gen() noexcept
 {
 #ifdef THORVG_SW_RASTER_SUPPORT
     if (SwRenderer::init() <= 0) return nullptr;
-    return unique_ptr<SwCanvas>(new SwCanvas);
+    return unique_ptr<SwCanvas>(NEWT SwCanvas);
 #endif
     return nullptr;
 }

--- a/src/lib/tvgTaskScheduler.cpp
+++ b/src/lib/tvgTaskScheduler.cpp
@@ -167,7 +167,7 @@ static TaskSchedulerImpl* inst = nullptr;
 void TaskScheduler::init(unsigned threads)
 {
     if (inst) return;
-    inst = new TaskSchedulerImpl(threads);
+    inst = NEWT TaskSchedulerImpl(threads);
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -52,7 +52,7 @@ static string* _copyId(const char* str)
 {
     if (!str) return nullptr;
 
-    return new string(str);
+    return NEWT string(str);
 }
 
 
@@ -289,7 +289,7 @@ static string* _idFromUrl(const char* url)
     }
     tmp[i] = '\0';
 
-    return new string(tmp);
+    return NEWT string(tmp);
 }
 
 
@@ -1536,7 +1536,7 @@ static string* _idFromHref(const char* href)
 {
     href = _skipSpace(href, nullptr);
     if ((*href) == '#') href++;
-    return new string(href);
+    return NEWT string(href);
 }
 
 
@@ -1654,7 +1654,7 @@ static SvgStyleGradient* _cloneGradient(SvgStyleGradient* from)
 {
     if (!from) return nullptr;
 
-    auto grad = new SvgStyleGradient;
+    auto grad = NEWT SvgStyleGradient;
     if (!grad) return nullptr;
 
     grad->type = from->type;
@@ -1697,10 +1697,10 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
     }
     //Copy style attribute
     *to->style = *from->style;
-    if (from->style->fill.paint.url) to->style->fill.paint.url = new string(from->style->fill.paint.url->c_str());
-    if (from->style->stroke.paint.url) to->style->stroke.paint.url = new string(from->style->stroke.paint.url->c_str());
-    if (from->style->clipPath.url) to->style->clipPath.url = new string(from->style->clipPath.url->c_str());
-    if (from->style->mask.url) to->style->mask.url = new string(from->style->mask.url->c_str());
+    if (from->style->fill.paint.url) to->style->fill.paint.url = NEWT string(from->style->fill.paint.url->c_str());
+    if (from->style->stroke.paint.url) to->style->stroke.paint.url = NEWT string(from->style->stroke.paint.url->c_str());
+    if (from->style->clipPath.url) to->style->clipPath.url = NEWT string(from->style->clipPath.url->c_str());
+    if (from->style->mask.url) to->style->mask.url = NEWT string(from->style->mask.url->c_str());
 
     //Copy node attribute
     switch (from->type) {
@@ -1736,7 +1736,7 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             break;
         }
         case SvgNodeType::Path: {
-            if (from->node.path.path) to->node.path.path = new string(from->node.path.path->c_str());
+            if (from->node.path.path) to->node.path.path = NEWT string(from->node.path.path->c_str());
             break;
         }
         case SvgNodeType::Polygon: {
@@ -1756,7 +1756,7 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             to->node.image.y = from->node.image.y;
             to->node.image.w = from->node.image.w;
             to->node.image.h = from->node.image.h;
-            if (from->node.image.href) to->node.image.href = new string(from->node.image.href->c_str());
+            if (from->node.image.href) to->node.image.href = NEWT string(from->node.image.href->c_str());
             break;
         }
         default: {
@@ -2032,7 +2032,7 @@ static bool _attrParseRadialGradientNode(void* data, const char* key, const char
 
 static SvgStyleGradient* _createRadialGradient(SvgLoaderData* loader, const char* buf, unsigned bufLength)
 {
-    auto grad = new SvgStyleGradient;
+    auto grad = NEWT SvgStyleGradient;
     if (!grad) return nullptr;
 
     loader->svgParse->styleGrad = grad;
@@ -2216,7 +2216,7 @@ static bool _attrParseLinearGradientNode(void* data, const char* key, const char
 
 static SvgStyleGradient* _createLinearGradient(SvgLoaderData* loader, const char* buf, unsigned bufLength)
 {
-    auto grad = new SvgStyleGradient;
+    auto grad = NEWT SvgStyleGradient;
     if (!grad) return nullptr;
 
     loader->svgParse->styleGrad = grad;

--- a/src/loaders/tvg/tvgTvgLoader.cpp
+++ b/src/loaders/tvg/tvgTvgLoader.cpp
@@ -96,7 +96,7 @@ bool TvgLoader::readHeader()
     ptr += TVG_HEADER_COMPRESS_SIZE;
 
     //Decide the proper Tvg Binary Interpreter based on the current file version
-    if (this->version >= 0) interpreter = new TvgBinInterpreter;
+    if (this->version >= 0) interpreter = NEWT TvgBinInterpreter;
 
     return true;
 }


### PR DESCRIPTION
New throws a bad_alloc exception. To get a nullptr we have to call
its overloaded version new(std::nothrow).

I've changed new -> NEW_NOTHROW only in some places to show how it will look. 
If we agree to apply this approach I'll change it everywhere of course.