### PR TITLE
svg_loader XMLParser: Refacotring simpleXmlParse()

### DIFF
--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -414,7 +414,7 @@ bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb
                     end = _unskipWhiteSpacesAndXmlEntities(end, start);
                 }
 
-                if (!func((void*)data, type, start, (size_t)(end - start))) return false;
+                if (!func((void*)data, type, start, (unsigned int)(end - start))) return false;
 
                 itr = p + 1;
             } else {
@@ -427,7 +427,7 @@ bool simpleXmlParse(const char* buf, unsigned bufLength, bool strip, simpleXMLCb
                 p = itr;
                 p = _skipWhiteSpacesAndXmlEntities(p, itrEnd);
                 if (p) {
-                    if (!func((void*)data, SimpleXMLType::Ignored, itr, (size_t)(p - itr))) return false;
+                    if (!func((void*)data, SimpleXMLType::Ignored, itr, (unsigned int)(p - itr))) return false;
                     itr = p;
                 }
             }

--- a/src/loaders/svg/tvgXmlParser.h
+++ b/src/loaders/svg/tvgXmlParser.h
@@ -44,7 +44,7 @@ enum class SimpleXMLType
     DoctypeChild //!< \<!doctype_child
 };
 
-typedef bool (*simpleXMLCb)(void* data, SimpleXMLType type, const char* content, unsigned length);
+typedef bool (*simpleXMLCb)(void* data, SimpleXMLType type, const char* content, unsigned int length);
 typedef bool (*simpleXMLAttributeCb)(void* data, const char* key, const char* value);
 
 bool simpleXmlParseAttributes(const char* buf, unsigned buflen, simpleXMLAttributeCb func, const void* data);


### PR DESCRIPTION
1.
Remove macro function. The existing macro function
was doing meaningless nested `return false`.

2.
Extract the logic to find the type as a function.

3.
The SimpleXMLType::Error case is not actually used,
and in case of invalid XML, Do 'return false' immediately.

+)
I have checked that SVG Example works properly.