### PR TITLE
sw_engine: Fixed rendering region calculation

### DIFF
--- a/src/lib/sw_engine/tvgSwMath.cpp
+++ b/src/lib/sw_engine/tvgSwMath.cpp
@@ -467,9 +467,9 @@ bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, S
         if (yMax < pt->y) yMax = pt->y;
     }
     renderRegion.min.x = xMin >> 6;
-    renderRegion.max.x = (xMax + 63) >> 6;
+    renderRegion.max.x = xMax >> 6;
     renderRegion.min.y = yMin >> 6;
-    renderRegion.max.y = (yMax + 63) >> 6;
+    renderRegion.max.y = yMax >> 6;
 
     renderRegion.max.x = (renderRegion.max.x < clipRegion.max.x) ? renderRegion.max.x : clipRegion.max.x;
     renderRegion.max.y = (renderRegion.max.y < clipRegion.max.y) ? renderRegion.max.y : clipRegion.max.y;

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -369,8 +369,10 @@ static bool _fastTrack(const SwOutline* outline)
     auto pt3 = outline->pts + 2;
     auto pt4 = outline->pts + 3;
 
-    auto a = SwPoint{pt1->x, pt3->y};
-    auto b = SwPoint{pt3->x, pt1->y};
+    //mathUpdateOutlineBBox shift rendering bbox. This shif should not be aplied to fastTrack method
+    //https://github.com/Samsung/thorvg/issues/916
+    auto a = SwPoint{pt1->x, pt3->y - 63};
+    auto b = SwPoint{pt3->x - 63, pt1->y};
 
     if ((*pt2 == a && *pt4 == b) || (*pt2 == b && *pt4 == a)) return true;
 


### PR DESCRIPTION
Changes: 

Removed unnecessary shift in max value of render region. In verification picture all letters should have 12px width. 
Before change: "P" letters has 11 px width nad "l" letter has 13 px witdth (tested on 800x800 viewport). After change width of the letters is the same.

Before:
![invalid](https://user-images.githubusercontent.com/4451022/138239932-537db604-0c99-46fe-9ed0-8a7e773fc168.png)
After: 
![valid](https://user-images.githubusercontent.com/4451022/138239913-1add4199-9b4c-4ce8-8f60-ff80d948773b.png)

Reference (inkscape)
![reference](https://user-images.githubusercontent.com/4451022/138239983-c8c6562c-701b-4d59-98d1-b6dd39412aae.png)


