### PR TITLE
png_loader meson: Remove dependency check using find_library()

### DIFF
--- a/src/loaders/external_png/meson.build
+++ b/src/loaders/external_png/meson.build
@@ -5,10 +5,6 @@ source_file = [
 
 png_dep = dependency('libpng', required: false)
 
-if not png_dep.found()
-    png_dep = meson.get_compiler('cpp').find_library('libpng')
-endif
-
 if png_dep.found()
     subloader_dep += [declare_dependency(
         include_directories : include_directories('.'),


### PR DESCRIPTION
meson's find_library() throws an error when the package cannot be found.
png static library is added, so it should be passed when package is not found.
Therefore, delete unnecessary find_library.