### PR TITLE
sw_engine: fastTracking turned off for small outlines

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -45,6 +45,8 @@ static double timeStamp()
 using SwCoord = signed long;
 using SwFixed = signed long long;
 
+static inline SwCoord TO_SWCOORD(float val);
+
 struct SwPoint
 {
     SwCoord x, y;
@@ -89,6 +91,12 @@ struct SwPoint
         else return false;
     }
 
+    bool big() const
+    {
+        //20 is big enough
+        if (abs(x) > TO_SWCOORD(20.0f) && abs(y) > TO_SWCOORD(20.0f)) return true;
+        else return false;
+    }
 };
 
 struct SwSize

--- a/src/lib/sw_engine/tvgSwShape.cpp
+++ b/src/lib/sw_engine/tvgSwShape.cpp
@@ -371,8 +371,9 @@ static bool _fastTrack(const SwOutline* outline)
 
     auto a = SwPoint{pt1->x, pt3->y};
     auto b = SwPoint{pt3->x, pt1->y};
+    auto rectSize = *pt3 - *pt1;
 
-    if ((*pt2 == a && *pt4 == b) || (*pt2 == b && *pt4 == a)) return true;
+    if (((*pt2 == a && *pt4 == b) || (*pt2 == b && *pt4 == a)) && rectSize.big()) return true;
 
     return false;
 }


### PR DESCRIPTION
For shapes with small outlines, the lack of anti-aliasing in the case
of fast tracking caused visual differences (issue #916).
The size limitation is introduced - fastTracking is applied for
outlines larger than an arbitrary chosen value of width and height.

the case when we are close to the limit (rectSize.x is close to 20*64):
![pip_por](https://user-images.githubusercontent.com/67589014/138530816-4caaff64-ec0a-4faf-a72d-5abd925441c8.PNG)

the same - zoomed
![pip_por2](https://user-images.githubusercontent.com/67589014/138530825-e9000628-24a0-4e07-9f8b-0e244ebcea87.PNG)

very small shape - zoomed:
![pip_fin2](https://user-images.githubusercontent.com/67589014/138530830-5f61ed2d-1aa9-42c4-8a5d-af7d8695c1bd.PNG)

