### PR TITLE
svg_loader SvgLoader: Fix gradient default value

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2069,11 +2069,11 @@ static SvgStyleGradient* _createRadialGradient(SvgLoaderData* loader, const char
     /**
     * Default values of gradient transformed into global percentage
     */
-    grad->radial->cx = 0.5f / loader->svgParse->global.w;
-    grad->radial->cy = 0.5f / loader->svgParse->global.h;
-    grad->radial->fx = 0.5f / loader->svgParse->global.w;
-    grad->radial->fy = 0.5f / loader->svgParse->global.h;
-    grad->radial->r = 0.5f / (sqrtf(pow(loader->svgParse->global.h, 2) + pow(loader->svgParse->global.w, 2)) / sqrtf(2.0f));
+    grad->radial->cx = 0.5f;
+    grad->radial->cy = 0.5f;
+    grad->radial->fx = 0.5f;
+    grad->radial->fy = 0.5f;
+    grad->radial->r = 0.5f;
     grad->radial->isCxPercentage = true;
     grad->radial->isCyPercentage = true;
     grad->radial->isFxPercentage = true;
@@ -2258,7 +2258,7 @@ static SvgStyleGradient* _createLinearGradient(SvgLoaderData* loader, const char
     /**
     * Default value of x2 is 100% - transformed to the global percentage
     */
-    grad->linear->x2 = 1.0f / loader->svgParse->global.w;
+    grad->linear->x2 = 1.0f;
     grad->linear->isX2Percentage = true;
 
     simpleXmlParseAttributes(buf, bufLength, _attrParseLinearGradientNode, loader);


### PR DESCRIPTION
If isXXPercentage is true, then it is calculated accordingly.

refer to: https://github.com/Samsung/thorvg/pull/892

before:
![image](https://user-images.githubusercontent.com/7413838/138636205-1b6e6631-4b8a-43a0-8bed-f4e0b6497ce1.png)


after:
![image](https://user-images.githubusercontent.com/7413838/138636163-b783a27a-2bcc-4b6e-92ec-5f2dbe94c6ef.png)
