### PR TITLE
jpg_loader: support multi-thread and header reading in prior to decoding

### DIFF
--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -22,9 +22,19 @@
 #ifndef _TVG_JPG_LOADER_H_
 #define _TVG_JPG_LOADER_H_
 
-//TODO: Use Task?
-class JpgLoader : public LoadModule
+#include "tvgTaskScheduler.h"
+#include "tvgJpgd.h"
+
+class JpgLoader : public LoadModule, public Task
 {
+private:
+    jpeg_decoder* decoder = nullptr;
+    char* data = nullptr;
+    unsigned char *image = nullptr;
+    bool freeData = false;
+
+    void clear();
+
 public:
     ~JpgLoader();
 
@@ -35,9 +45,7 @@ public:
     bool close() override;
 
     const uint32_t* pixels() override;
-
-private:
-    unsigned char *image = nullptr;
+    void run(unsigned tid) override;
 };
 
 #endif //_TVG_JPG_LOADER_H_

--- a/src/loaders/jpg/tvgJpgd.h
+++ b/src/loaders/jpg/tvgJpgd.h
@@ -25,12 +25,11 @@
 #ifndef _TVG_JPGD_H_
 #define _TVG_JPGD_H_
 
-// Loads a JPEG image from a memory buffer or a file.
-// req_comps can be 1 (grayscale), 3 (RGB), or 4 (RGBA).
-// On return, width/height will be set to the image's dimensions, and actual_comps will be set to the either 1 (grayscale) or 3 (RGB).
-// Notes: For more control over where and how the source data is read, see the decompress_jpeg_image_from_stream() function below, or call the jpeg_decoder class directly.
-// Requesting a 8 or 32bpp image is currently a little faster than 24bpp because the jpeg_decoder class itself currently always unpacks to either 8 or 32bpp.
-unsigned char *decompress_jpeg_image_from_memory(const unsigned char *pSrc_data, int src_data_size, int *width, int *height, int *actual_comps, int req_comps);
-unsigned char *decompress_jpeg_image_from_file(const char *pSrc_filename, int *width, int *height, int *actual_comps, int req_comps);
+class jpeg_decoder;
+
+jpeg_decoder* jpgdHeader(const char* data, int size, int* width, int* height);
+jpeg_decoder* jpgdHeader(const char* filename, int* width, int* height);
+unsigned char* jpgdDecompress(jpeg_decoder* decoder);
+void jpgdDelete(jpeg_decoder* decoder);
 
 #endif //_TVG_JPGD_H_

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -136,7 +136,6 @@ bool PngLoader::read()
 bool PngLoader::close()
 {
     this->done();
-
     clear();
     return true;
 }

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -48,7 +48,6 @@ public:
     bool close() override;
 
     const uint32_t* pixels() override;
-
     void run(unsigned tid) override;
 };
 


### PR DESCRIPTION
revise the code to support async loading of the static jpeg_loader,
also support header reading in prior to decoding.