### PR TITLE
test Scene/Canvas: Fix maximum size for big size test

### DIFF
--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -65,7 +65,7 @@ TEST_CASE("Scene Memory Reservation", "[tvgScene]")
     REQUIRE(scene->reserve(0) == Result::Success);
 
     //Too Big Size
-    REQUIRE(scene->reserve(-1) == Result::FailedAllocation);
+    REQUIRE(scene->reserve(UINT32_MAX) == Result::FailedAllocation);
 }
 
 TEST_CASE("Scene Clear", "[tvgScene]")

--- a/test/testSwCanvasBase.cpp
+++ b/test/testSwCanvasBase.cpp
@@ -40,7 +40,7 @@ TEST_CASE("Memory Reservation", "[tvgSwCanvasBase]")
     REQUIRE(canvas->reserve(0) == Result::Success);
 
     //Too big size
-    REQUIRE(canvas->reserve(-1) == Result::FailedAllocation);
+    REQUIRE(canvas->reserve(UINT32_MAX) == Result::FailedAllocation);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
 }


### PR DESCRIPTION
In some development environments, -1 of uint32_t may become 0.