### PR TITLE
svg_loader: shape's bounds without a stroke

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -271,7 +271,17 @@ static void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float v
     if (style->fill.paint.none) {
         //Do nothing
     } else if (style->fill.paint.gradient) {
-        if (!style->fill.paint.gradient->userSpace) vg->bounds(&vx, &vy, &vw, &vh, false);
+        if (!style->fill.paint.gradient->userSpace) {
+            vg->bounds(&vx, &vy, &vw, &vh, false);
+            //According to: https://www.w3.org/TR/SVG11/coords.html#ObjectBoundingBoxUnits (the last paragraph)
+            //a stroke width should be ignored for bounding box calculations
+            if (auto strokeHalfW = 0.5f * vg->strokeWidth()) {
+                vx += strokeHalfW;
+                vy += strokeHalfW;
+                vw -= strokeHalfW;
+                vh -= strokeHalfW;
+            }
+        }
 
         if (style->fill.paint.gradient->type == SvgGradientType::Linear) {
              auto linear = _applyLinearGradientProperty(style->fill.paint.gradient, vg, vx, vy, vw, vh, style->fill.opacity);
@@ -310,7 +320,17 @@ static void _applyProperty(SvgNode* node, Shape* vg, float vx, float vy, float v
     if (style->stroke.paint.none) {
         //Do nothing
     } else if (style->stroke.paint.gradient) {
-        if (!style->stroke.paint.gradient->userSpace) vg->bounds(&vx, &vy, &vw, &vh, false);
+        if (!style->stroke.paint.gradient->userSpace) {
+            //According to: https://www.w3.org/TR/SVG11/coords.html#ObjectBoundingBoxUnits (the last paragraph)
+            //a stroke width should be ignored for bounding box calculations
+            vg->bounds(&vx, &vy, &vw, &vh, false);
+            if (auto strokeHalfW = 0.5f * vg->strokeWidth()) {
+                vx += strokeHalfW;
+                vy += strokeHalfW;
+                vw -= strokeHalfW;
+                vh -= strokeHalfW;
+            }
+        }
 
         if (style->stroke.paint.gradient->type == SvgGradientType::Linear) {
              auto linear = _applyLinearGradientProperty(style->stroke.paint.gradient, vg, vx, vy, vw, vh, style->stroke.opacity);


### PR DESCRIPTION
A shape's bounds used for a gradient transformation shouldn't take
a stroke into account.

before:
![42before](https://user-images.githubusercontent.com/67589014/139047982-587581eb-95bf-4a7f-9d8d-b428cdd5ae6d.PNG)

after:
![42after](https://user-images.githubusercontent.com/67589014/139047971-4335c7c6-f212-4c0a-b137-8ac78e4ef91c.PNG)

