### PR TITLE
tools svg2tvg: improve the usability.

### DIFF
--- a/src/bin/svg2tvg/svg2tvg.cpp
+++ b/src/bin/svg2tvg/svg2tvg.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 
     //Get tvg file.
     auto tvgName = svgName.substr(svgName.find_last_of("/\\") + 1);
-    tvgName.append(".tvg");
+    tvgName.replace(tvgName.length() - 3, 3, "tvg");
 
     //Convert!
     if (convert(svgName, tvgName)) {


### PR DESCRIPTION
Removed the .svg in the output name.

Before: tiger.svg -> tiger.svg.tvg
After:  tiger.svg -> tiger.tvg