### PR TITLE
test Picture: Change file open of ifstream to binary(and readonly) type

### DIFF
--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -129,7 +129,7 @@ TEST_CASE("Load PNG file from data", "[tvgPicture]")
     REQUIRE(picture);
 
     //Open file
-    ifstream file(TEST_DIR"/test.png", std::ios::in | std::ios::binary);
+    ifstream file(TEST_DIR"/test.png", ios::in | ios::binary);
     REQUIRE(file.is_open());
     auto size = sizeof(uint32_t) * (1000*1000);
     auto data = (char*)malloc(size);
@@ -170,13 +170,13 @@ TEST_CASE("Load JPG file from data", "[tvgPicture]")
     REQUIRE(picture);
 
     //Open file
-    ifstream file(TEST_DIR"/test.jpg", std::ios::in | std::ios::binary);
+    ifstream file(TEST_DIR"/test.jpg", ios::in | ios::binary);
     REQUIRE(file.is_open());
     auto begin = file.tellg();
-    file.seekg(0, std::ios::end);
+    file.seekg(0, ios::end);
     auto size = file.tellg() - begin;
     auto data = (char*)malloc(size);
-    file.seekg(0, std::ios::beg);
+    file.seekg(0, ios::beg);
     file.read(data, size);
     file.close();
 
@@ -214,13 +214,13 @@ TEST_CASE("Load TVG file from data", "[tvgPicture]")
     REQUIRE(picture);
 
     //Open file
-    ifstream file(TEST_DIR"/tag.tvg", std::ios::in | std::ios::binary);
+    ifstream file(TEST_DIR"/tag.tvg", ios::in | ios::binary);
     REQUIRE(file.is_open());
     auto begin = file.tellg();
-    file.seekg(0, std::ios::end);
+    file.seekg(0, ios::end);
     auto size = file.tellg() - begin;
     auto data = (char*)malloc(size);
-    file.seekg(0, std::ios::beg);
+    file.seekg(0, ios::beg);
     file.read(data, size);
     file.close();
 


### PR DESCRIPTION
When opening a file using ifstream, a different problem occurs for each platform.
To fix this, change to binary, readonly type.

+)
In window build, problem occurred in lodepng's signature check

refer to:
https://stackoverflow.com/questions/9817806/why-does-my-program-produce-different-results-on-windows-and-linux-about-file-r