### PR TITLE
sw_engine: refactoring

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -298,7 +298,7 @@ SwFixed mathLength(const SwPoint& pt);
 bool mathSmallCubic(const SwPoint* base, SwFixed& angleIn, SwFixed& angleMid, SwFixed& angleOut);
 SwFixed mathMean(SwFixed angle1, SwFixed angle2);
 SwPoint mathTransform(const Point* to, const Matrix* transform);
-bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion);
+bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, bool rect);
 bool mathInverse(const Matrix* m, Matrix* invM);
 bool mathMultiply(const Matrix* lhs, Matrix* rhs);
 bool mathIdentity(const Matrix* m);

--- a/src/lib/sw_engine/tvgSwImage.cpp
+++ b/src/lib/sw_engine/tvgSwImage.cpp
@@ -75,7 +75,7 @@ static bool _genOutline(SwImage* image, const Matrix* transform, SwMpool* mpool,
 bool imagePrepare(SwImage* image, const Matrix* transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid)
 {
     if (!_genOutline(image, transform, mpool, tid)) return false;
-    return mathUpdateOutlineBBox(image->outline, clipRegion, renderRegion);
+    return mathUpdateOutlineBBox(image->outline, clipRegion, renderRegion, false);
 }
 
 


### PR DESCRIPTION
The rasterization region was rearranged in the case of fastTrack,
but its validation and boundaries weren't check, causing segf in some
cases. Fixed.