### PR TITLE
[WIP] infra style: Apply clang-format-11

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+---
+# We'll use defaults from the LLVM style, but with 4 columns indentation.
+BasedOnStyle: LLVM
+IndentWidth: 4
+---
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+AllowShortLambdasOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortFunctionsOnASingleLine: None
+ColumnLimit: 0
+AlignAfterOpenBracket: Align
+AllowShortLoopsOnASingleLine: true
+AlignConsecutiveMacros: true
+SortIncludes: false
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterEnum: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeElse: false
+  BeforeWhile: false
+  AfterControlStatement: Never
+...

--- a/src/lib/tvgArray.h
+++ b/src/lib/tvgArray.h
@@ -24,18 +24,15 @@
 
 #include <memory.h>
 
-namespace tvg
-{
+namespace tvg {
 
-template<class T>
-struct Array
-{
+template <class T>
+struct Array {
     T* data = nullptr;
     uint32_t count = 0;
     uint32_t reserved = 0;
 
-    void push(T element)
-    {
+    void push(T element) {
         if (count + 1 > reserved) {
             reserved = (count + 1) * 2;
             data = static_cast<T*>(realloc(data, sizeof(T) * reserved));
@@ -43,8 +40,7 @@ struct Array
         data[count++] = element;
     }
 
-    bool reserve(uint32_t size)
-    {
+    bool reserve(uint32_t size) {
         if (size > reserved) {
             reserved = size;
             data = static_cast<T*>(realloc(data, sizeof(T) * reserved));
@@ -53,23 +49,19 @@ struct Array
         return true;
     }
 
-    bool grow(uint32_t size)
-    {
+    bool grow(uint32_t size) {
         return reserve(count + size);
     }
 
-    T* ptr()
-    {
+    T* ptr() {
         return data + count;
     }
 
-    void pop()
-    {
+    void pop() {
         if (count > 0) --count;
     }
 
-    void reset()
-    {
+    void reset() {
         if (data) {
             free(data);
             data = nullptr;
@@ -77,24 +69,21 @@ struct Array
         count = reserved = 0;
     }
 
-    void clear()
-    {
+    void clear() {
         count = 0;
     }
 
-    void operator=(const Array& rhs)
-    {
+    void operator=(const Array& rhs) {
         reserve(rhs.count);
         if (rhs.count > 0) memcpy(data, rhs.data, sizeof(T) * reserved);
         count = rhs.count;
     }
 
-    ~Array()
-    {
+    ~Array() {
         if (data) free(data);
     }
 };
 
-}
+} // namespace tvg
 
 #endif //_TVG_ARRAY_H_

--- a/src/lib/tvgBezier.cpp
+++ b/src/lib/tvgBezier.cpp
@@ -27,8 +27,7 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static float _lineLength(const Point& pt1, const Point& pt2)
-{
+static float _lineLength(const Point& pt1, const Point& pt2) {
     /* approximate sqrt(x*x + y*y) using alpha max plus beta min algorithm.
        With alpha = 1, beta = 3/8, giving results with the largest error less
        than 7% compared to the exact value. */
@@ -38,16 +37,13 @@ static float _lineLength(const Point& pt1, const Point& pt2)
     return (diff.x > diff.y) ? (diff.x + diff.y * 0.375f) : (diff.y + diff.x * 0.375f);
 }
 
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
-namespace tvg
-{
+namespace tvg {
 
-void bezSplit(const Bezier&cur, Bezier& left, Bezier& right)
-{
+void bezSplit(const Bezier& cur, Bezier& left, Bezier& right) {
     auto c = (cur.ctrl1.x + cur.ctrl2.x) * 0.5f;
     left.ctrl1.x = (cur.start.x + cur.ctrl1.x) * 0.5f;
     right.ctrl2.x = (cur.ctrl2.x + cur.end.x) * 0.5f;
@@ -67,9 +63,7 @@ void bezSplit(const Bezier&cur, Bezier& left, Bezier& right)
     left.end.y = right.start.y = (left.ctrl2.y + right.ctrl1.y) * 0.5f;
 }
 
-
-float bezLength(const Bezier& cur)
-{
+float bezLength(const Bezier& cur) {
     Bezier left, right;
     auto len = _lineLength(cur.start, cur.ctrl1) + _lineLength(cur.ctrl1, cur.ctrl2) + _lineLength(cur.ctrl2, cur.end);
     auto chord = _lineLength(cur.start, cur.end);
@@ -81,9 +75,7 @@ float bezLength(const Bezier& cur)
     return len;
 }
 
-
-void bezSplitLeft(Bezier& cur, float at, Bezier& left)
-{
+void bezSplitLeft(Bezier& cur, float at, Bezier& left) {
     left.start = cur.start;
 
     left.ctrl1.x = cur.start.x + at * (cur.ctrl1.x - cur.start.x);
@@ -105,16 +97,14 @@ void bezSplitLeft(Bezier& cur, float at, Bezier& left)
     left.end.y = cur.start.y = left.ctrl2.y + at * (cur.ctrl1.y - left.ctrl2.y);
 }
 
-
-float bezAt(const Bezier& bz, float at)
-{
+float bezAt(const Bezier& bz, float at) {
     auto len = bezLength(bz);
     auto biggest = 1.0f;
     auto smallest = 0.0f;
     auto t = 0.5f;
 
     //just in case to prevent an infinite loop
-    if (at <= 0) return 0.0f; 
+    if (at <= 0) return 0.0f;
 
     if (at >= len) return 1.0f;
 
@@ -139,12 +129,10 @@ float bezAt(const Bezier& bz, float at)
     return t;
 }
 
-
-void bezSplitAt(const Bezier& cur, float at, Bezier& left, Bezier& right)
-{
+void bezSplitAt(const Bezier& cur, float at, Bezier& left, Bezier& right) {
     right = cur;
     auto t = bezAt(right, at);
     bezSplitLeft(right, t, left);
 }
 
-}
+} // namespace tvg

--- a/src/lib/tvgBezier.h
+++ b/src/lib/tvgBezier.h
@@ -24,25 +24,23 @@
 
 #include "tvgCommon.h"
 
-namespace tvg
-{
+namespace tvg {
 
 #define BEZIER_EPSILON 1e-4f
 
-struct Bezier
-{
+struct Bezier {
     Point start;
     Point ctrl1;
     Point ctrl2;
     Point end;
 };
 
-void bezSplit(const Bezier&cur, Bezier& left, Bezier& right);
+void bezSplit(const Bezier& cur, Bezier& left, Bezier& right);
 float bezLength(const Bezier& cur);
 void bezSplitLeft(Bezier& cur, float at, Bezier& left);
 float bezAt(const Bezier& bz, float at);
 void bezSplitAt(const Bezier& cur, float at, Bezier& left, Bezier& right);
 
-}
+} // namespace tvg
 
 #endif //_TVG_BEZIER_H_

--- a/src/lib/tvgBinaryDesc.h
+++ b/src/lib/tvgBinaryDesc.h
@@ -33,63 +33,57 @@ using TvgBinCounter = uint32_t;
 using TvgBinTag = TvgBinByte;
 using TvgBinFlag = TvgBinByte;
 
-
 //Header
-#define TVG_HEADER_SIZE 33                //TVG_HEADER_SIGNATURE_LENGTH + TVG_HEADER_VERSION_LENGTH + 2*SIZE(float) + TVG_HEADER_RESERVED_LENGTH + TVG_HEADER_COMPRESS_SIZE
-#define TVG_HEADER_SIGNATURE "ThorVG"
+#define TVG_HEADER_SIZE             33 //TVG_HEADER_SIGNATURE_LENGTH + TVG_HEADER_VERSION_LENGTH + 2*SIZE(float) + TVG_HEADER_RESERVED_LENGTH + TVG_HEADER_COMPRESS_SIZE
+#define TVG_HEADER_SIGNATURE        "ThorVG"
 #define TVG_HEADER_SIGNATURE_LENGTH 6
-#define TVG_HEADER_VERSION "000400"       //Major 00, Minor 04, Micro 00
-#define TVG_HEADER_VERSION_LENGTH 6
-#define TVG_HEADER_RESERVED_LENGTH 1      //Storing flags for extensions
-#define TVG_HEADER_COMPRESS_SIZE 12       //TVG_HEADER_UNCOMPRESSED_SIZE + TVG_HEADER_COMPRESSED_SIZE + TVG_HEADER_COMPRESSED_SIZE_BITS
-//Compress Size 
-#define TVG_HEADER_UNCOMPRESSED_SIZE 4     //SIZE (TvgBinCounter)
-#define TVG_HEADER_COMPRESSED_SIZE 4       //SIZE (TvgBinCounter)
-#define TVG_HEADER_COMPRESSED_SIZE_BITS 4  //SIZE (TvgBinCounter)
+#define TVG_HEADER_VERSION          "000400" //Major 00, Minor 04, Micro 00
+#define TVG_HEADER_VERSION_LENGTH   6
+#define TVG_HEADER_RESERVED_LENGTH  1  //Storing flags for extensions
+#define TVG_HEADER_COMPRESS_SIZE    12 //TVG_HEADER_UNCOMPRESSED_SIZE + TVG_HEADER_COMPRESSED_SIZE + TVG_HEADER_COMPRESSED_SIZE_BITS
+//Compress Size
+#define TVG_HEADER_UNCOMPRESSED_SIZE    4 //SIZE (TvgBinCounter)
+#define TVG_HEADER_COMPRESSED_SIZE      4 //SIZE (TvgBinCounter)
+#define TVG_HEADER_COMPRESSED_SIZE_BITS 4 //SIZE (TvgBinCounter)
 //Reserved Flag
-#define TVG_HEAD_FLAG_COMPRESSED                    0x01
+#define TVG_HEAD_FLAG_COMPRESSED 0x01
 
 //Paint Type
-#define TVG_TAG_CLASS_PICTURE                       (TvgBinTag)0xfc
-#define TVG_TAG_CLASS_SHAPE                         (TvgBinTag)0xfd
-#define TVG_TAG_CLASS_SCENE                         (TvgBinTag)0xfe
-
+#define TVG_TAG_CLASS_PICTURE (TvgBinTag)0xfc
+#define TVG_TAG_CLASS_SHAPE   (TvgBinTag)0xfd
+#define TVG_TAG_CLASS_SCENE   (TvgBinTag)0xfe
 
 //Paint
-#define TVG_TAG_PAINT_OPACITY                       (TvgBinTag)0x10
-#define TVG_TAG_PAINT_TRANSFORM                     (TvgBinTag)0x11
-#define TVG_TAG_PAINT_CMP_TARGET                    (TvgBinTag)0x01
-#define TVG_TAG_PAINT_CMP_METHOD                    (TvgBinTag)0x20
-
+#define TVG_TAG_PAINT_OPACITY    (TvgBinTag)0x10
+#define TVG_TAG_PAINT_TRANSFORM  (TvgBinTag)0x11
+#define TVG_TAG_PAINT_CMP_TARGET (TvgBinTag)0x01
+#define TVG_TAG_PAINT_CMP_METHOD (TvgBinTag)0x20
 
 //Scene
-#define TVG_TAG_SCENE_RESERVEDCNT                   (TvgBinTag)0x30
-
+#define TVG_TAG_SCENE_RESERVEDCNT (TvgBinTag)0x30
 
 //Shape
-#define TVG_TAG_SHAPE_PATH                          (TvgBinTag)0x40
-#define TVG_TAG_SHAPE_STROKE                        (TvgBinTag)0x41
-#define TVG_TAG_SHAPE_FILL                          (TvgBinTag)0x42
-#define TVG_TAG_SHAPE_COLOR                         (TvgBinTag)0x43
-#define TVG_TAG_SHAPE_FILLRULE                      (TvgBinTag)0x44
-#define TVG_TAG_SHAPE_STROKE_CAP                    (TvgBinTag)0x50
-#define TVG_TAG_SHAPE_STROKE_JOIN                   (TvgBinTag)0x51
+#define TVG_TAG_SHAPE_PATH        (TvgBinTag)0x40
+#define TVG_TAG_SHAPE_STROKE      (TvgBinTag)0x41
+#define TVG_TAG_SHAPE_FILL        (TvgBinTag)0x42
+#define TVG_TAG_SHAPE_COLOR       (TvgBinTag)0x43
+#define TVG_TAG_SHAPE_FILLRULE    (TvgBinTag)0x44
+#define TVG_TAG_SHAPE_STROKE_CAP  (TvgBinTag)0x50
+#define TVG_TAG_SHAPE_STROKE_JOIN (TvgBinTag)0x51
 
 //Stroke
-#define TVG_TAG_SHAPE_STROKE_WIDTH                  (TvgBinTag)0x52
-#define TVG_TAG_SHAPE_STROKE_COLOR                  (TvgBinTag)0x53
-#define TVG_TAG_SHAPE_STROKE_FILL                   (TvgBinTag)0x54
-#define TVG_TAG_SHAPE_STROKE_DASHPTRN               (TvgBinTag)0x55
-
+#define TVG_TAG_SHAPE_STROKE_WIDTH    (TvgBinTag)0x52
+#define TVG_TAG_SHAPE_STROKE_COLOR    (TvgBinTag)0x53
+#define TVG_TAG_SHAPE_STROKE_FILL     (TvgBinTag)0x54
+#define TVG_TAG_SHAPE_STROKE_DASHPTRN (TvgBinTag)0x55
 
 //Fill
-#define TVG_TAG_FILL_LINEAR_GRADIENT                (TvgBinTag)0x60
-#define TVG_TAG_FILL_RADIAL_GRADIENT                (TvgBinTag)0x61
-#define TVG_TAG_FILL_COLORSTOPS                     (TvgBinTag)0x62
-#define TVG_TAG_FILL_FILLSPREAD                     (TvgBinTag)0x63
-
+#define TVG_TAG_FILL_LINEAR_GRADIENT (TvgBinTag)0x60
+#define TVG_TAG_FILL_RADIAL_GRADIENT (TvgBinTag)0x61
+#define TVG_TAG_FILL_COLORSTOPS      (TvgBinTag)0x62
+#define TVG_TAG_FILL_FILLSPREAD      (TvgBinTag)0x63
 
 //Picture
-#define TVG_TAG_PICTURE_RAW_IMAGE                   (TvgBinTag)0x70
+#define TVG_TAG_PICTURE_RAW_IMAGE (TvgBinTag)0x70
 
 #endif //_TVG_BINARY_DESC_H_

--- a/src/lib/tvgCanvas.cpp
+++ b/src/lib/tvgCanvas.cpp
@@ -25,49 +25,35 @@
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Canvas::Canvas(RenderMethod *pRenderer):pImpl(new Impl(pRenderer))
-{
+Canvas::Canvas(RenderMethod* pRenderer)
+    : pImpl(new Impl(pRenderer)) {
 }
 
-
-Canvas::~Canvas()
-{
-    delete(pImpl);
+Canvas::~Canvas() {
+    delete (pImpl);
 }
 
-
-Result Canvas::reserve(uint32_t n) noexcept
-{
+Result Canvas::reserve(uint32_t n) noexcept {
     if (!pImpl->paints.reserve(n)) return Result::FailedAllocation;
     return Result::Success;
 }
 
-
-Result Canvas::push(unique_ptr<Paint> paint) noexcept
-{
+Result Canvas::push(unique_ptr<Paint> paint) noexcept {
     return pImpl->push(move(paint));
 }
 
-
-Result Canvas::clear(bool free) noexcept
-{
+Result Canvas::clear(bool free) noexcept {
     return pImpl->clear(free);
 }
 
-
-Result Canvas::draw() noexcept
-{
+Result Canvas::draw() noexcept {
     return pImpl->draw();
 }
 
-
-Result Canvas::update(Paint* paint) noexcept
-{
+Result Canvas::update(Paint* paint) noexcept {
     return pImpl->update(paint, false);
 }
 
-
-Result Canvas::sync() noexcept
-{
+Result Canvas::sync() noexcept {
     return pImpl->sync();
 }

--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -28,25 +28,22 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-struct Canvas::Impl
-{
+struct Canvas::Impl {
     Array<Paint*> paints;
     RenderMethod* renderer;
-    bool refresh = false;   //if all paints should be updated by force.
-    bool drawing = false;   //on drawing condition?
+    bool refresh = false; //if all paints should be updated by force.
+    bool drawing = false; //on drawing condition?
 
-    Impl(RenderMethod* pRenderer):renderer(pRenderer)
-    {
+    Impl(RenderMethod* pRenderer)
+        : renderer(pRenderer) {
     }
 
-    ~Impl()
-    {
+    ~Impl() {
         clear(true);
-        delete(renderer);
+        delete (renderer);
     }
 
-    Result push(unique_ptr<Paint> paint)
-    {
+    Result push(unique_ptr<Paint> paint) {
         //You can not push paints during rendering.
         if (drawing) return Result::InsufficientCondition;
 
@@ -57,15 +54,14 @@ struct Canvas::Impl
         return update(p, true);
     }
 
-    Result clear(bool free)
-    {
+    Result clear(bool free) {
         //Clear render target before drawing
         if (!renderer || !renderer->clear()) return Result::InsufficientCondition;
 
         //Free paints
         for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
             (*paint)->pImpl->dispose(*renderer);
-            if (free) delete(*paint);
+            if (free) delete (*paint);
         }
 
         paints.clear();
@@ -75,13 +71,11 @@ struct Canvas::Impl
         return Result::Success;
     }
 
-    void needRefresh()
-    {
+    void needRefresh() {
         refresh = true;
     }
 
-    Result update(Paint* paint, bool force)
-    {
+    Result update(Paint* paint, bool force) {
         if (paints.count == 0 || drawing || !renderer) return Result::InsufficientCondition;
 
         Array<RenderData> clips;
@@ -98,7 +92,7 @@ struct Canvas::Impl
                 }
             }
             return Result::InvalidArguments;
-        //Update all retained paint nodes
+            //Update all retained paint nodes
         } else {
             for (auto paint = paints.data; paint < (paints.data + paints.count); ++paint) {
                 (*paint)->pImpl->update(*renderer, nullptr, 255, clips, flag);
@@ -110,8 +104,7 @@ struct Canvas::Impl
         return Result::Success;
     }
 
-    Result draw()
-    {
+    Result draw() {
         if (drawing || paints.count == 0 || !renderer || !renderer->preRender()) return Result::InsufficientCondition;
 
         bool rendered = false;
@@ -126,8 +119,7 @@ struct Canvas::Impl
         return Result::Success;
     }
 
-    Result sync()
-    {
+    Result sync() {
         if (!drawing) return Result::InsufficientCondition;
 
         if (renderer->sync()) {

--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -30,27 +30,27 @@ using namespace tvg;
 
 //for MSVC Compat
 #ifdef _MSC_VER
-    #define TVG_UNUSED
-    #define strncasecmp _strnicmp
-    #define strcasecmp _stricmp
+#define TVG_UNUSED
+#define strncasecmp _strnicmp
+#define strcasecmp  _stricmp
 #else
-    #define TVG_UNUSED __attribute__ ((__unused__))
+#define TVG_UNUSED __attribute__((__unused__))
 #endif
 
 // Portable 'fallthrough' attribute
 #if __has_cpp_attribute(fallthrough)
-    #ifdef _MSC_VER
-        #define TVG_FALLTHROUGH [[fallthrough]];
-    #else
-        #define TVG_FALLTHROUGH __attribute__ ((fallthrough));
-    #endif
+#ifdef _MSC_VER
+#define TVG_FALLTHROUGH [[fallthrough]];
 #else
-    #define TVG_FALLTHROUGH
+#define TVG_FALLTHROUGH __attribute__((fallthrough));
+#endif
+#else
+#define TVG_FALLTHROUGH
 #endif
 
 #if defined(__clang__) && !defined(__EMSCRIPTEN__)
-    #define strncpy strncpy_s
-    #define strdup _strdup
+#define strncpy strncpy_s
+#define strdup  _strdup
 #endif
 
 //TVG class identifier values
@@ -61,14 +61,19 @@ using namespace tvg;
 #define TVG_CLASS_ID_LINEAR    4
 #define TVG_CLASS_ID_RADIAL    5
 
-enum class FileType { Tvg = 0, Svg, Raw, Png, Jpg, Unknown };
+enum class FileType { Tvg = 0,
+                      Svg,
+                      Raw,
+                      Png,
+                      Jpg,
+                      Unknown };
 
 #ifdef THORVG_LOG_ENABLED
-    #define TVGLOG(tag, fmt, ...) fprintf(stdout, tag ": " fmt "\n", ##__VA_ARGS__)  //Log Message for notifying user some useful info
-    #define TVGERR(tag, fmt, ...) fprintf(stderr, tag ": " fmt "\n", ##__VA_ARGS__)  //Error Message for us to fix it
+#define TVGLOG(tag, fmt, ...) fprintf(stdout, tag ": " fmt "\n", ##__VA_ARGS__) //Log Message for notifying user some useful info
+#define TVGERR(tag, fmt, ...) fprintf(stderr, tag ": " fmt "\n", ##__VA_ARGS__) //Error Message for us to fix it
 #else
-    #define TVGERR(...)
-    #define TVGLOG(...)
+#define TVGERR(...)
+#define TVGLOG(...)
 #endif
 
 uint16_t THORVG_VERSION_NUMBER();

--- a/src/lib/tvgFill.cpp
+++ b/src/lib/tvgFill.cpp
@@ -25,24 +25,19 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Fill::Fill():pImpl(new Impl())
-{
+Fill::Fill()
+    : pImpl(new Impl()) {
 }
 
-
-Fill::~Fill()
-{
-    delete(pImpl);
+Fill::~Fill() {
+    delete (pImpl);
 }
 
-
-Result Fill::colorStops(const ColorStop* colorStops, uint32_t cnt) noexcept
-{
+Result Fill::colorStops(const ColorStop* colorStops, uint32_t cnt) noexcept {
     if ((!colorStops && cnt > 0) || (colorStops && cnt == 0)) return Result::InvalidArguments;
 
     if (cnt == 0) {
@@ -64,45 +59,33 @@ Result Fill::colorStops(const ColorStop* colorStops, uint32_t cnt) noexcept
     return Result::Success;
 }
 
-
-uint32_t Fill::colorStops(const ColorStop** colorStops) const noexcept
-{
+uint32_t Fill::colorStops(const ColorStop** colorStops) const noexcept {
     if (colorStops) *colorStops = pImpl->colorStops;
 
     return pImpl->cnt;
 }
 
-
-Result Fill::spread(FillSpread s) noexcept
-{
+Result Fill::spread(FillSpread s) noexcept {
     pImpl->spread = s;
 
     return Result::Success;
 }
 
-
-FillSpread Fill::spread() const noexcept
-{
+FillSpread Fill::spread() const noexcept {
     return pImpl->spread;
 }
 
-
-Result Fill::transform(const Matrix& m) noexcept
-{
+Result Fill::transform(const Matrix& m) noexcept {
     if (!pImpl->transform) pImpl->transform = new Matrix();
     *pImpl->transform = m;
     return Result::Success;
 }
 
-
-Matrix Fill::transform() const noexcept
-{
+Matrix Fill::transform() const noexcept {
     if (pImpl->transform) return *pImpl->transform;
     return {1, 0, 0, 0, 1, 0, 0, 0, 1};
 }
 
-
-Fill* Fill::duplicate() const noexcept
-{
+Fill* Fill::duplicate() const noexcept {
     return pImpl->duplicate();
 }

--- a/src/lib/tvgFill.h
+++ b/src/lib/tvgFill.h
@@ -26,49 +26,46 @@
 #include <cstring>
 #include "tvgCommon.h"
 
-template<typename T>
-struct DuplicateMethod
-{
-    virtual ~DuplicateMethod() {}
+template <typename T>
+struct DuplicateMethod {
+    virtual ~DuplicateMethod() {
+    }
     virtual T* duplicate() = 0;
 };
 
-template<class T>
-struct FillDup : DuplicateMethod<Fill>
-{
+template <class T>
+struct FillDup : DuplicateMethod<Fill> {
     T* inst = nullptr;
 
-    FillDup(T* _inst) : inst(_inst) {}
-    ~FillDup() {}
+    FillDup(T* _inst)
+        : inst(_inst) {
+    }
+    ~FillDup() {
+    }
 
-    Fill* duplicate() override
-    {
+    Fill* duplicate() override {
         return inst->duplicate();
     }
 };
 
-struct Fill::Impl
-{
+struct Fill::Impl {
     ColorStop* colorStops = nullptr;
     Matrix* transform = nullptr;
     uint32_t cnt = 0;
     FillSpread spread;
     DuplicateMethod<Fill>* dup = nullptr;
 
-    ~Impl()
-    {
-        if (dup) delete(dup);
+    ~Impl() {
+        if (dup) delete (dup);
         if (colorStops) free(colorStops);
-        if (transform) delete(transform);
+        if (transform) delete (transform);
     }
 
-    void method(DuplicateMethod<Fill>* dup)
-    {
+    void method(DuplicateMethod<Fill>* dup) {
         this->dup = dup;
     }
 
-    Fill* duplicate()
-    {
+    Fill* duplicate() {
         auto ret = dup->duplicate();
         if (!ret) return nullptr;
 
@@ -84,4 +81,4 @@ struct Fill::Impl
     }
 };
 
-#endif  //_TVG_FILL_H_
+#endif //_TVG_FILL_H_

--- a/src/lib/tvgGlCanvas.cpp
+++ b/src/lib/tvgGlCanvas.cpp
@@ -22,45 +22,39 @@
 #include "tvgCanvasImpl.h"
 
 #ifdef THORVG_GL_RASTER_SUPPORT
-    #include "tvgGlRenderer.h"
+#include "tvgGlRenderer.h"
 #else
-    class GlRenderer : public RenderMethod
-    {
-        //Non Supported. Dummy Class */
-    };
+class GlRenderer : public RenderMethod {
+    //Non Supported. Dummy Class */
+};
 #endif
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-struct GlCanvas::Impl
-{
+struct GlCanvas::Impl {
 };
-
 
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
 #ifdef THORVG_GL_RASTER_SUPPORT
-GlCanvas::GlCanvas() : Canvas(GlRenderer::gen()), pImpl(new Impl)
+GlCanvas::GlCanvas()
+    : Canvas(GlRenderer::gen()), pImpl(new Impl)
 #else
-GlCanvas::GlCanvas() : Canvas(nullptr), pImpl(new Impl)
+GlCanvas::GlCanvas()
+    : Canvas(nullptr), pImpl(new Impl)
 #endif
 {
 }
 
-
-
-GlCanvas::~GlCanvas()
-{
-    delete(pImpl);
+GlCanvas::~GlCanvas() {
+    delete (pImpl);
 }
 
-
-Result GlCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h) noexcept
-{
+Result GlCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h) noexcept {
 #ifdef THORVG_GL_RASTER_SUPPORT
     //We know renderer type, avoid dynamic_cast for performance.
     auto renderer = static_cast<GlRenderer*>(Canvas::pImpl->renderer);
@@ -76,9 +70,7 @@ Result GlCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     return Result::NonSupport;
 }
 
-
-unique_ptr<GlCanvas> GlCanvas::gen() noexcept
-{
+unique_ptr<GlCanvas> GlCanvas::gen() noexcept {
 #ifdef THORVG_GL_RASTER_SUPPORT
     if (GlRenderer::init() <= 0) return nullptr;
     return unique_ptr<GlCanvas>(new GlCanvas);

--- a/src/lib/tvgInitializer.cpp
+++ b/src/lib/tvgInitializer.cpp
@@ -24,17 +24,16 @@
 #include "tvgLoader.h"
 
 #ifdef _WIN32
-    #include <cstring>
+#include <cstring>
 #endif
 
 #ifdef THORVG_SW_RASTER_SUPPORT
-    #include "tvgSwRenderer.h"
+#include "tvgSwRenderer.h"
 #endif
 
 #ifdef THORVG_GL_RASTER_SUPPORT
-    #include "tvgGlRenderer.h"
+#include "tvgGlRenderer.h"
 #endif
-
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -43,10 +42,8 @@
 static int _initCnt = 0;
 static uint16_t _version = 0;
 
-
-static bool _buildVersionInfo()
-{
-    auto SRC = THORVG_VERSION_STRING;   //ex) 0.3.99
+static bool _buildVersionInfo() {
+    auto SRC = THORVG_VERSION_STRING; //ex) 0.3.99
     auto p = SRC;
     const char* x;
 
@@ -77,25 +74,23 @@ static bool _buildVersionInfo()
     return true;
 }
 
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Result Initializer::init(CanvasEngine engine, uint32_t threads) noexcept
-{
+Result Initializer::init(CanvasEngine engine, uint32_t threads) noexcept {
     auto nonSupport = true;
 
     if (static_cast<uint32_t>(engine) & static_cast<uint32_t>(CanvasEngine::Sw)) {
-        #ifdef THORVG_SW_RASTER_SUPPORT
-            if (!SwRenderer::init(threads)) return Result::FailedAllocation;
-            nonSupport = false;
-        #endif
+#ifdef THORVG_SW_RASTER_SUPPORT
+        if (!SwRenderer::init(threads)) return Result::FailedAllocation;
+        nonSupport = false;
+#endif
     } else if (static_cast<uint32_t>(engine) & static_cast<uint32_t>(CanvasEngine::Gl)) {
-        #ifdef THORVG_GL_RASTER_SUPPORT
-            if (!GlRenderer::init(threads)) return Result::FailedAllocation;
-            nonSupport = false;
-        #endif
+#ifdef THORVG_GL_RASTER_SUPPORT
+        if (!GlRenderer::init(threads)) return Result::FailedAllocation;
+        nonSupport = false;
+#endif
     } else {
         return Result::InvalidArguments;
     }
@@ -113,23 +108,21 @@ Result Initializer::init(CanvasEngine engine, uint32_t threads) noexcept
     return Result::Success;
 }
 
-
-Result Initializer::term(CanvasEngine engine) noexcept
-{
+Result Initializer::term(CanvasEngine engine) noexcept {
     if (_initCnt == 0) return Result::InsufficientCondition;
 
     auto nonSupport = true;
 
     if (static_cast<uint32_t>(engine) & static_cast<uint32_t>(CanvasEngine::Sw)) {
-        #ifdef THORVG_SW_RASTER_SUPPORT
-            if (!SwRenderer::term()) return Result::InsufficientCondition;
-            nonSupport = false;
-        #endif
+#ifdef THORVG_SW_RASTER_SUPPORT
+        if (!SwRenderer::term()) return Result::InsufficientCondition;
+        nonSupport = false;
+#endif
     } else if (static_cast<uint32_t>(engine) & static_cast<uint32_t>(CanvasEngine::Gl)) {
-        #ifdef THORVG_GL_RASTER_SUPPORT
-            if (!GlRenderer::term()) return Result::InsufficientCondition;
-            nonSupport = false;
-        #endif
+#ifdef THORVG_GL_RASTER_SUPPORT
+        if (!GlRenderer::term()) return Result::InsufficientCondition;
+        nonSupport = false;
+#endif
     } else {
         return Result::InvalidArguments;
     }
@@ -145,8 +138,6 @@ Result Initializer::term(CanvasEngine engine) noexcept
     return Result::Success;
 }
 
-
-uint16_t THORVG_VERSION_NUMBER()
-{
+uint16_t THORVG_VERSION_NUMBER() {
     return _version;
 }

--- a/src/lib/tvgIteratorAccessor.h
+++ b/src/lib/tvgIteratorAccessor.h
@@ -24,19 +24,16 @@
 
 #include "tvgPaint.h"
 
-namespace tvg
-{
+namespace tvg {
 
-class IteratorAccessor
-{
-public:
+class IteratorAccessor {
+  public:
     //Utility Method: Iterator Accessor
-    Iterator* iterator(const Paint* paint)
-    {
+    Iterator* iterator(const Paint* paint) {
         return paint->pImpl->iterator();
     }
 };
 
-}
+} // namespace tvg
 
 #endif //_TVG_ITERATOR_ACCESSOR_H_

--- a/src/lib/tvgLinearGradient.cpp
+++ b/src/lib/tvgLinearGradient.cpp
@@ -27,15 +27,13 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-struct LinearGradient::Impl
-{
+struct LinearGradient::Impl {
     float x1 = 0;
     float y1 = 0;
     float x2 = 0;
     float y2 = 0;
 
-    Fill* duplicate()
-    {
+    Fill* duplicate() {
         auto ret = LinearGradient::gen();
         if (!ret) return nullptr;
 
@@ -52,21 +50,17 @@ struct LinearGradient::Impl
 /* External Class Implementation                                        */
 /************************************************************************/
 
-LinearGradient::LinearGradient():pImpl(new Impl())
-{
+LinearGradient::LinearGradient()
+    : pImpl(new Impl()) {
     _id = TVG_CLASS_ID_LINEAR;
     Fill::pImpl->method(new FillDup<LinearGradient::Impl>(pImpl));
 }
 
-
-LinearGradient::~LinearGradient()
-{
-    delete(pImpl);
+LinearGradient::~LinearGradient() {
+    delete (pImpl);
 }
 
-
-Result LinearGradient::linear(float x1, float y1, float x2, float y2) noexcept
-{
+Result LinearGradient::linear(float x1, float y1, float x2, float y2) noexcept {
     pImpl->x1 = x1;
     pImpl->y1 = y1;
     pImpl->x2 = x2;
@@ -75,9 +69,7 @@ Result LinearGradient::linear(float x1, float y1, float x2, float y2) noexcept
     return Result::Success;
 }
 
-
-Result LinearGradient::linear(float* x1, float* y1, float* x2, float* y2) const noexcept
-{
+Result LinearGradient::linear(float* x1, float* y1, float* x2, float* y2) const noexcept {
     if (x1) *x1 = pImpl->x1;
     if (x2) *x2 = pImpl->x2;
     if (y1) *y1 = pImpl->y1;
@@ -86,14 +78,10 @@ Result LinearGradient::linear(float* x1, float* y1, float* x2, float* y2) const 
     return Result::Success;
 }
 
-
-unique_ptr<LinearGradient> LinearGradient::gen() noexcept
-{
+unique_ptr<LinearGradient> LinearGradient::gen() noexcept {
     return unique_ptr<LinearGradient>(new LinearGradient);
 }
 
-
-uint32_t LinearGradient::identifier() noexcept
-{
+uint32_t LinearGradient::identifier() noexcept {
     return TVG_CLASS_ID_LINEAR;
 }

--- a/src/lib/tvgLoadModule.h
+++ b/src/lib/tvgLoadModule.h
@@ -24,12 +24,10 @@
 
 #include "tvgCommon.h"
 
-namespace tvg
-{
+namespace tvg {
 
-class LoadModule
-{
-public:
+class LoadModule {
+  public:
     //default view box, if any.
     float vx = 0;
     float vy = 0;
@@ -38,21 +36,34 @@ public:
     float w = 0, h = 0;         //default image size
     bool preserveAspect = true; //keep aspect ratio by default.
 
-    virtual ~LoadModule() {}
+    virtual ~LoadModule() {
+    }
 
-    virtual bool open(const string& path) { return false; };
-    virtual bool open(const char* data, uint32_t size, bool copy) { return false; };
-    virtual bool open(const uint32_t* data, uint32_t w, uint32_t h, bool copy) { return false; };
+    virtual bool open(const string& path) {
+        return false;
+    };
+    virtual bool open(const char* data, uint32_t size, bool copy) {
+        return false;
+    };
+    virtual bool open(const uint32_t* data, uint32_t w, uint32_t h, bool copy) {
+        return false;
+    };
 
     //Override this if the vector-format has own resizing policy.
-    virtual bool resize(Paint* paint, float w, float h) { return false; };
+    virtual bool resize(Paint* paint, float w, float h) {
+        return false;
+    };
 
     virtual bool read() = 0;
     virtual bool close() = 0;
-    virtual const uint32_t* pixels() { return nullptr; };
-    virtual unique_ptr<Paint> paint() { return nullptr; };
+    virtual const uint32_t* pixels() {
+        return nullptr;
+    };
+    virtual unique_ptr<Paint> paint() {
+        return nullptr;
+    };
 };
 
-}
+} // namespace tvg
 
 #endif //_TVG_LOAD_MODULE_H_

--- a/src/lib/tvgLoader.cpp
+++ b/src/lib/tvgLoader.cpp
@@ -22,19 +22,19 @@
 #include "tvgLoader.h"
 
 #ifdef THORVG_SVG_LOADER_SUPPORT
-    #include "tvgSvgLoader.h"
+#include "tvgSvgLoader.h"
 #endif
 
 #ifdef THORVG_PNG_LOADER_SUPPORT
-    #include "tvgPngLoader.h"
+#include "tvgPngLoader.h"
 #endif
 
 #ifdef THORVG_TVG_LOADER_SUPPORT
-    #include "tvgTvgLoader.h"
+#include "tvgTvgLoader.h"
 #endif
 
 #ifdef THORVG_JPG_LOADER_SUPPORT
-    #include "tvgJpgLoader.h"
+#include "tvgJpgLoader.h"
 #endif
 
 #include "tvgRawLoader.h"
@@ -43,78 +43,75 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static LoadModule* _find(FileType type)
-{
-    switch(type) {
-        case FileType::Tvg: {
+static LoadModule* _find(FileType type) {
+    switch (type) {
+    case FileType::Tvg: {
 #ifdef THORVG_TVG_LOADER_SUPPORT
-            return new TvgLoader;
+        return new TvgLoader;
 #endif
-            break;
-        }
-        case FileType::Svg: {
+        break;
+    }
+    case FileType::Svg: {
 #ifdef THORVG_SVG_LOADER_SUPPORT
-            return new SvgLoader;
+        return new SvgLoader;
 #endif
-            break;
-        }
-        case FileType::Raw: {
-            return new RawLoader;
-            break;
-        }
-        case FileType::Png: {
+        break;
+    }
+    case FileType::Raw: {
+        return new RawLoader;
+        break;
+    }
+    case FileType::Png: {
 #ifdef THORVG_PNG_LOADER_SUPPORT
-            return new PngLoader;
+        return new PngLoader;
 #endif
-            break;
-        }
-        case FileType::Jpg: {
+        break;
+    }
+    case FileType::Jpg: {
 #ifdef THORVG_JPG_LOADER_SUPPORT
-            return new JpgLoader;
+        return new JpgLoader;
 #endif
-            break;
-        }
-        default: {
-            break;
-        }
+        break;
+    }
+    default: {
+        break;
+    }
     }
 
 #ifdef THORVG_LOG_ENABLED
-    const char *format;
-    switch(type) {
-        case FileType::Tvg: {
-            format = "TVG";
-            break;
-        }
-        case FileType::Svg: {
-            format = "SVG";
-            break;
-        }
-        case FileType::Raw: {
-            format = "RAW";
-            break;
-        }
-        case FileType::Png: {
-            format = "PNG";
-            break;
-        }
-        case FileType::Jpg: {
-            format = "JPG";
-            break;
-        }
-        default: {
-            format = "???";
-            break;
-        }
+    const char* format;
+    switch (type) {
+    case FileType::Tvg: {
+        format = "TVG";
+        break;
+    }
+    case FileType::Svg: {
+        format = "SVG";
+        break;
+    }
+    case FileType::Raw: {
+        format = "RAW";
+        break;
+    }
+    case FileType::Png: {
+        format = "PNG";
+        break;
+    }
+    case FileType::Jpg: {
+        format = "JPG";
+        break;
+    }
+    default: {
+        format = "???";
+        break;
+    }
     }
     TVGLOG("LOADER", "%s format is not supported", format);
 #endif
     return nullptr;
 }
 
-
-static LoadModule* _findByPath(const string& path)
-{
+static LoadModule* _findByPath(const string& path) {
     auto ext = path.substr(path.find_last_of(".") + 1);
     if (!ext.compare("tvg")) return _find(FileType::Tvg);
     if (!ext.compare("svg")) return _find(FileType::Svg);
@@ -123,18 +120,20 @@ static LoadModule* _findByPath(const string& path)
     return nullptr;
 }
 
-
-static LoadModule* _findByType(const string& mimeType)
-{
+static LoadModule* _findByType(const string& mimeType) {
     if (mimeType.empty()) return nullptr;
 
     auto type = FileType::Unknown;
 
     if (mimeType == "tvg") type = FileType::Tvg;
-    else if (mimeType == "svg" || mimeType == "svg+xml") type = FileType::Svg;
-    else if (mimeType == "raw") type = FileType::Raw;
-    else if (mimeType == "png") type = FileType::Png;
-    else if (mimeType == "jpg" || mimeType == "jpeg") type = FileType::Jpg;
+    else if (mimeType == "svg" || mimeType == "svg+xml")
+        type = FileType::Svg;
+    else if (mimeType == "raw")
+        type = FileType::Raw;
+    else if (mimeType == "png")
+        type = FileType::Png;
+    else if (mimeType == "jpg" || mimeType == "jpeg")
+        type = FileType::Jpg;
     else {
         TVGLOG("LOADER", "Given mimetype is unknown = \"%s\".", mimeType.c_str());
         return nullptr;
@@ -143,50 +142,42 @@ static LoadModule* _findByType(const string& mimeType)
     return _find(type);
 }
 
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
-
-bool LoaderMgr::init()
-{
+bool LoaderMgr::init() {
     //TODO:
 
     return true;
 }
 
-
-bool LoaderMgr::term()
-{
+bool LoaderMgr::term() {
     //TODO:
 
     return true;
 }
 
-
-shared_ptr<LoadModule> LoaderMgr::loader(const string& path, bool* invalid)
-{
+shared_ptr<LoadModule> LoaderMgr::loader(const string& path, bool* invalid) {
     *invalid = false;
 
     if (auto loader = _findByPath(path)) {
         if (loader->open(path)) return shared_ptr<LoadModule>(loader);
-        else delete(loader);
+        else
+            delete (loader);
         *invalid = true;
     }
     return nullptr;
 }
 
-
-shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const string& mimeType, bool copy)
-{
+shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const string& mimeType, bool copy) {
     //Try first with the given MimeType
     if (auto loader = _findByType(mimeType)) {
         if (loader->open(data, size, copy)) {
             return shared_ptr<LoadModule>(loader);
         } else {
             TVGLOG("LOADER", "Given mimetype \"%s\" seems incorrect or not supported. Will try again with other types.", mimeType.c_str());
-            delete(loader);
+            delete (loader);
         }
     }
 
@@ -195,19 +186,19 @@ shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const 
         auto loader = _find(static_cast<FileType>(i));
         if (loader) {
             if (loader->open(data, size, copy)) return shared_ptr<LoadModule>(loader);
-            else delete(loader);
+            else
+                delete (loader);
         }
     }
     return nullptr;
 }
 
-
-shared_ptr<LoadModule> LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h, bool copy)
-{
+shared_ptr<LoadModule> LoaderMgr::loader(const uint32_t* data, uint32_t w, uint32_t h, bool copy) {
     //function is dedicated for raw images only
     auto loader = new RawLoader;
     if (loader->open(data, w, h, copy)) return shared_ptr<LoadModule>(loader);
-    else delete(loader);
+    else
+        delete (loader);
 
     return nullptr;
 }

--- a/src/lib/tvgLoader.h
+++ b/src/lib/tvgLoader.h
@@ -24,8 +24,7 @@
 
 #include "tvgLoadModule.h"
 
-struct LoaderMgr
-{
+struct LoaderMgr {
     static bool init();
     static bool term();
     static shared_ptr<LoadModule> loader(const string& path, bool* invalid);

--- a/src/lib/tvgLzw.cpp
+++ b/src/lib/tvgLzw.cpp
@@ -69,13 +69,11 @@
 constexpr int Nil = -1;
 constexpr int MaxDictBits = 12;
 constexpr int StartBits = 9;
-constexpr int FirstCode = (1 << (StartBits - 1)); // 256
-constexpr int MaxDictEntries = (1 << MaxDictBits);     // 4096
-
+constexpr int FirstCode = (1 << (StartBits - 1));  // 256
+constexpr int MaxDictEntries = (1 << MaxDictBits); // 4096
 
 //Round up to the next power-of-two number, e.g. 37 => 64
-static int nextPowerOfTwo(int num)
-{
+static int nextPowerOfTwo(int num) {
     --num;
     for (size_t i = 1; i < sizeof(num) * 8; i <<= 1) {
         num = num | num >> i;
@@ -83,18 +81,15 @@ static int nextPowerOfTwo(int num)
     return ++num;
 }
 
+struct BitStreamWriter {
+    uint8_t* stream;    //Growable buffer to store our bits. Heap allocated & owned by the class instance.
+    int bytesAllocated; //Current size of heap-allocated stream buffer *in bytes*.
+    int granularity;    //Amount bytesAllocated multiplies by when auto-resizing in appendBit().
+    int currBytePos;    //Current byte being written to, from 0 to bytesAllocated-1.
+    int nextBitPos;     //Bit position within the current byte to access next. 0 to 7.
+    int numBitsWritten; //Number of bits in use from the stream buffer, not including byte-rounding padding.
 
-struct BitStreamWriter
-{
-    uint8_t* stream;       //Growable buffer to store our bits. Heap allocated & owned by the class instance.
-    int bytesAllocated;    //Current size of heap-allocated stream buffer *in bytes*.
-    int granularity;       //Amount bytesAllocated multiplies by when auto-resizing in appendBit().
-    int currBytePos;       //Current byte being written to, from 0 to bytesAllocated-1.
-    int nextBitPos;        //Bit position within the current byte to access next. 0 to 7.
-    int numBitsWritten;    //Number of bits in use from the stream buffer, not including byte-rounding padding.
-
-    void internalInit()
-    {
+    void internalInit() {
         stream = nullptr;
         bytesAllocated = 0;
         granularity = 2;
@@ -103,9 +98,8 @@ struct BitStreamWriter
         numBitsWritten = 0;
     }
 
-    uint8_t* allocBytes(const int bytesWanted, uint8_t * oldPtr, const int oldSize)
-    {
-        auto newMemory = static_cast<uint8_t *>(malloc(bytesWanted));
+    uint8_t* allocBytes(const int bytesWanted, uint8_t* oldPtr, const int oldSize) {
+        auto newMemory = static_cast<uint8_t*>(malloc(bytesWanted));
         memset(newMemory, 0, bytesWanted);
 
         if (oldPtr) {
@@ -115,28 +109,24 @@ struct BitStreamWriter
         return newMemory;
     }
 
-    BitStreamWriter()
-    {
+    BitStreamWriter() {
         /* 8192 bits for a start (1024 bytes). It will resize if needed.
            Default granularity is 2. */
         internalInit();
         allocate(8192);
     }
 
-    BitStreamWriter(const int initialSizeInBits, const int growthGranularity = 2)
-    {
+    BitStreamWriter(const int initialSizeInBits, const int growthGranularity = 2) {
         internalInit();
         setGranularity(growthGranularity);
         allocate(initialSizeInBits);
     }
 
-    ~BitStreamWriter()
-    {
+    ~BitStreamWriter() {
         free(stream);
     }
 
-    void allocate(int bitsWanted)
-    {
+    void allocate(int bitsWanted) {
         //Require at least a byte.
         if (bitsWanted <= 0) bitsWanted = 8;
 
@@ -151,8 +141,7 @@ struct BitStreamWriter
         bytesAllocated = sizeInBytes;
     }
 
-    void appendBit(const int bit)
-    {
+    void appendBit(const int bit) {
         const uint32_t mask = uint32_t(1) << nextBitPos;
         stream[currBytePos] = (stream[currBytePos] & ~mask) | (-bit & mask);
         ++numBitsWritten;
@@ -163,8 +152,7 @@ struct BitStreamWriter
         }
     }
 
-    void appendBitsU64(const uint64_t num, const int bitCount)
-    {
+    void appendBitsU64(const uint64_t num, const int bitCount) {
         for (int b = 0; b < bitCount; ++b) {
             const uint64_t mask = uint64_t(1) << b;
             const int bit = !!(num & mask);
@@ -172,20 +160,17 @@ struct BitStreamWriter
         }
     }
 
-    uint8_t* release()
-    {
+    uint8_t* release() {
         auto oldPtr = stream;
         internalInit();
         return oldPtr;
     }
 
-    void setGranularity(const int growthGranularity)
-    {
+    void setGranularity(const int growthGranularity) {
         granularity = (growthGranularity >= 2) ? growthGranularity : 2;
     }
 
-    int getByteCount() const
-    {
+    int getByteCount() const {
         int usedBytes = numBitsWritten / 8;
         int leftovers = numBitsWritten % 8;
         if (leftovers != 0) ++usedBytes;
@@ -193,22 +178,19 @@ struct BitStreamWriter
     }
 };
 
+struct BitStreamReader {
+    const uint8_t* stream; // Pointer to the external bit stream. Not owned by the reader.
+    const int sizeInBytes; // Size of the stream *in bytes*. Might include padding.
+    const int sizeInBits;  // Size of the stream *in bits*, padding *not* include.
+    int currBytePos = 0;   // Current byte being read in the stream.
+    int nextBitPos = 0;    // Bit position within the current byte to access next. 0 to 7.
+    int numBitsRead = 0;   // Total bits read from the stream so far. Never includes byte-rounding padding.
 
-struct BitStreamReader
-{
-    const uint8_t* stream;       // Pointer to the external bit stream. Not owned by the reader.
-    const int sizeInBytes;       // Size of the stream *in bytes*. Might include padding.
-    const int sizeInBits;        // Size of the stream *in bits*, padding *not* include.
-    int currBytePos = 0;         // Current byte being read in the stream.
-    int nextBitPos = 0;          // Bit position within the current byte to access next. 0 to 7.
-    int numBitsRead = 0;         // Total bits read from the stream so far. Never includes byte-rounding padding.
-
-    BitStreamReader(const uint8_t* bitStream, const int byteCount, const int bitCount) : stream(bitStream), sizeInBytes(byteCount), sizeInBits(bitCount)
-    {
+    BitStreamReader(const uint8_t* bitStream, const int byteCount, const int bitCount)
+        : stream(bitStream), sizeInBytes(byteCount), sizeInBits(bitCount) {
     }
 
-    bool readNextBit(int& bitOut)
-    {
+    bool readNextBit(int& bitOut) {
         if (numBitsRead >= sizeInBits) return false; //We are done.
 
         const uint32_t mask = uint32_t(1) << nextBitPos;
@@ -222,8 +204,7 @@ struct BitStreamReader
         return true;
     }
 
-    uint64_t readBitsU64(const int bitCount)
-    {
+    uint64_t readBitsU64(const int bitCount) {
         uint64_t num = 0;
         for (int b = 0; b < bitCount; ++b) {
             int bit;
@@ -236,17 +217,13 @@ struct BitStreamReader
         return num;
     }
 
-    bool isEndOfStream() const
-    {
+    bool isEndOfStream() const {
         return numBitsRead >= sizeInBits;
     }
 };
 
-
-struct Dictionary
-{
-    struct Entry
-    {
+struct Dictionary {
+    struct Entry {
         int code;
         int value;
     };
@@ -255,21 +232,19 @@ struct Dictionary
     int size;
     Entry entries[MaxDictEntries];
 
-    Dictionary()
-    {
+    Dictionary() {
         /* First 256 dictionary entries are reserved to the byte/ASCII range. 
            Additional entries follow for the character sequences found in the input. 
            Up to 4096 - 256 (MaxDictEntries - FirstCode). */
         size = FirstCode;
 
         for (int i = 0; i < size; ++i) {
-            entries[i].code  = Nil;
+            entries[i].code = Nil;
             entries[i].value = i;
         }
     }
 
-    int findIndex(const int code, const int value) const
-    {
+    int findIndex(const int code, const int value) const {
         if (code == Nil) return value;
 
         //Linear search for now.
@@ -280,17 +255,15 @@ struct Dictionary
         return Nil;
     }
 
-    bool add(const int code, const int value)
-    {
+    bool add(const int code, const int value) {
         if (size == MaxDictEntries) return false;
-        entries[size].code  = code;
+        entries[size].code = code;
         entries[size].value = value;
         ++size;
         return true;
     }
 
-    bool flush(int & codeBitsWidth)
-    {
+    bool flush(int& codeBitsWidth) {
         if (size == (1 << codeBitsWidth)) {
             ++codeBitsWidth;
             if (codeBitsWidth > MaxDictBits) {
@@ -304,18 +277,14 @@ struct Dictionary
     }
 };
 
-
-static bool outputByte(int code, uint8_t*& output, int outputSizeBytes, int& bytesDecodedSoFar)
-{
+static bool outputByte(int code, uint8_t*& output, int outputSizeBytes, int& bytesDecodedSoFar) {
     if (bytesDecodedSoFar >= outputSizeBytes) return false;
     *output++ = static_cast<uint8_t>(code);
     ++bytesDecodedSoFar;
     return true;
 }
 
-
-static bool outputSequence(const Dictionary& dict, int code, uint8_t*& output, int outputSizeBytes, int& bytesDecodedSoFar, int& firstByte)
-{
+static bool outputSequence(const Dictionary& dict, int code, uint8_t*& output, int outputSizeBytes, int& bytesDecodedSoFar, int& firstByte) {
     /* A sequence is stored backwards, so we have to write
        it to a temp then output the buffer in reverse. */
     int i = 0;
@@ -334,22 +303,19 @@ static bool outputSequence(const Dictionary& dict, int code, uint8_t*& output, i
     return true;
 }
 
-
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
 namespace tvg {
 
-uint8_t* lzwDecode(const uint8_t* compressed, uint32_t compressedSizeBytes, uint32_t compressedSizeBits, uint32_t uncompressedSizeBytes)
-{
+uint8_t* lzwDecode(const uint8_t* compressed, uint32_t compressedSizeBytes, uint32_t compressedSizeBits, uint32_t uncompressedSizeBytes) {
     int code = Nil;
     int prevCode = Nil;
     int firstByte = 0;
     int bytesDecoded = 0;
     int codeBitsWidth = StartBits;
-    auto uncompressed = (uint8_t*) malloc(sizeof(uint8_t) * uncompressedSizeBytes);
+    auto uncompressed = (uint8_t*)malloc(sizeof(uint8_t) * uncompressedSizeBytes);
     auto ptr = uncompressed;
 
     /* We'll reconstruct the dictionary based on the bit stream codes.
@@ -365,25 +331,25 @@ uint8_t* lzwDecode(const uint8_t* compressed, uint32_t compressedSizeBytes, uint
         if (prevCode == Nil) {
             if (!outputByte(code, ptr, uncompressedSizeBytes, bytesDecoded)) break;
             firstByte = code;
-            prevCode  = code;
+            prevCode = code;
             continue;
         }
         if (code >= dictionary.size) {
             if (!outputSequence(dictionary, prevCode, ptr, uncompressedSizeBytes, bytesDecoded, firstByte)) break;
             if (!outputByte(firstByte, ptr, uncompressedSizeBytes, bytesDecoded)) break;
-        } else if (!outputSequence(dictionary, code, ptr, uncompressedSizeBytes, bytesDecoded, firstByte)) break;
+        } else if (!outputSequence(dictionary, code, ptr, uncompressedSizeBytes, bytesDecoded, firstByte))
+            break;
 
         dictionary.add(prevCode, firstByte);
         if (dictionary.flush(codeBitsWidth)) prevCode = Nil;
-        else prevCode = code;
+        else
+            prevCode = code;
     }
 
     return uncompressed;
 }
 
-
-uint8_t* lzwEncode(const uint8_t* uncompressed, uint32_t uncompressedSizeBytes, uint32_t* compressedSizeBytes, uint32_t* compressedSizeBits)
-{
+uint8_t* lzwEncode(const uint8_t* uncompressed, uint32_t uncompressedSizeBytes, uint32_t* compressedSizeBytes, uint32_t* compressedSizeBits) {
     //LZW encoding context:
     int code = Nil;
     int codeBitsWidth = StartBits;
@@ -422,6 +388,6 @@ uint8_t* lzwEncode(const uint8_t* uncompressed, uint32_t uncompressedSizeBytes, 
     return bitStream.release();
 }
 
-}
+} // namespace tvg
 
 #endif

--- a/src/lib/tvgLzw.h
+++ b/src/lib/tvgLzw.h
@@ -22,10 +22,9 @@
 #ifndef _TVG_LZW_H_
 #define _TVG_LZW_H_
 
-namespace tvg
-{
-    uint8_t* lzwEncode(const uint8_t* uncompressed, uint32_t uncompressedSizeBytes, uint32_t* compressedSizeBytes, uint32_t* compressedSizeBits);
-    uint8_t* lzwDecode(const uint8_t* compressed, uint32_t compressedSizeBytes, uint32_t compressedSizeBits, uint32_t uncompressedSizeBytes);
-}
+namespace tvg {
+uint8_t* lzwEncode(const uint8_t* uncompressed, uint32_t uncompressedSizeBytes, uint32_t* compressedSizeBytes, uint32_t* compressedSizeBits);
+uint8_t* lzwDecode(const uint8_t* compressed, uint32_t compressedSizeBytes, uint32_t compressedSizeBits, uint32_t uncompressedSizeBytes);
+} // namespace tvg
 
-#endif  //_TVG_LZW_H
+#endif //_TVG_LZW_H

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -27,20 +27,17 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static inline bool FLT_SAME(float a, float b)
-{
+static inline bool FLT_SAME(float a, float b) {
     return (fabsf(a - b) < FLT_EPSILON);
 }
 
-
-static bool _clipPathFastTrack(Paint* cmpTarget, const RenderTransform* pTransform, RenderTransform* rTransform, RenderRegion& viewport)
-{
+static bool _clipPathFastTrack(Paint* cmpTarget, const RenderTransform* pTransform, RenderTransform* rTransform, RenderRegion& viewport) {
     /* Access Shape class by Paint is bad... but it's ok still it's an internal usage. */
     auto shape = static_cast<Shape*>(cmpTarget);
 
     //Rectangle Candidates?
     const Point* pts;
-     if (shape->pathCoords(&pts) != 4) return false;
+    if (shape->pathCoords(&pts) != 4) return false;
 
     if (rTransform) rTransform->update();
 
@@ -90,9 +87,7 @@ static bool _clipPathFastTrack(Paint* cmpTarget, const RenderTransform* pTransfo
     return false;
 }
 
-
-Paint* Paint::Impl::duplicate()
-{
+Paint* Paint::Impl::duplicate() {
     auto ret = smethod->duplicate();
     if (!ret) return nullptr;
 
@@ -112,9 +107,7 @@ Paint* Paint::Impl::duplicate()
     return ret;
 }
 
-
-bool Paint::Impl::rotate(float degree)
-{
+bool Paint::Impl::rotate(float degree) {
     if (rTransform) {
         if (fabsf(degree - rTransform->degree) <= FLT_EPSILON) return true;
     } else {
@@ -127,9 +120,7 @@ bool Paint::Impl::rotate(float degree)
     return true;
 }
 
-
-bool Paint::Impl::scale(float factor)
-{
+bool Paint::Impl::scale(float factor) {
     if (rTransform) {
         if (fabsf(factor - rTransform->scale) <= FLT_EPSILON) return true;
     } else {
@@ -142,9 +133,7 @@ bool Paint::Impl::scale(float factor)
     return true;
 }
 
-
-bool Paint::Impl::translate(float x, float y)
-{
+bool Paint::Impl::translate(float x, float y) {
     if (rTransform) {
         if (fabsf(x - rTransform->x) <= FLT_EPSILON && fabsf(y - rTransform->y) <= FLT_EPSILON) return true;
     } else {
@@ -158,9 +147,7 @@ bool Paint::Impl::translate(float x, float y)
     return true;
 }
 
-
-bool Paint::Impl::render(RenderMethod& renderer)
-{
+bool Paint::Impl::render(RenderMethod& renderer) {
     Compositor* cmp = nullptr;
 
     /* Note: only ClipPath is processed in update() step.
@@ -182,19 +169,17 @@ bool Paint::Impl::render(RenderMethod& renderer)
     return ret;
 }
 
-
-void* Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, uint32_t pFlag)
-{
+void* Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, uint32_t pFlag) {
     if (flag & RenderUpdateFlag::Transform) {
         if (!rTransform) return nullptr;
         if (!rTransform->update()) {
-            delete(rTransform);
+            delete (rTransform);
             rTransform = nullptr;
         }
     }
 
     /* 1. Composition Pre Processing */
-    void *cmpData = nullptr;
+    void* cmpData = nullptr;
     RenderRegion viewport;
     bool cmpFastTrack = false;
 
@@ -217,7 +202,7 @@ void* Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransf
     }
 
     /* 2. Main Update */
-    void *edata = nullptr;
+    void* edata = nullptr;
     auto newFlag = static_cast<RenderUpdateFlag>(pFlag | flag);
     flag = RenderUpdateFlag::None;
     opacity = (opacity * this->opacity) / 255;
@@ -232,13 +217,13 @@ void* Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransf
 
     /* 3. Composition Post Processing */
     if (cmpFastTrack) renderer.viewport(viewport);
-    else if (cmpData && cmpMethod == CompositeMethod::ClipPath) clips.pop();
+    else if (cmpData && cmpMethod == CompositeMethod::ClipPath)
+        clips.pop();
 
     return edata;
 }
 
-bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transformed)
-{
+bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transformed) {
     Matrix* m = nullptr;
 
     //Case: No transformed, quick return!
@@ -287,94 +272,69 @@ bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transforme
     return ret;
 }
 
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Paint :: Paint() : pImpl(new Impl())
-{
+Paint ::Paint()
+    : pImpl(new Impl()) {
 }
 
-
-Paint :: ~Paint()
-{
-    delete(pImpl);
+Paint ::~Paint() {
+    delete (pImpl);
 }
 
-
-Result Paint::rotate(float degree) noexcept
-{
+Result Paint::rotate(float degree) noexcept {
     if (pImpl->rotate(degree)) return Result::Success;
     return Result::FailedAllocation;
 }
 
-
-Result Paint::scale(float factor) noexcept
-{
+Result Paint::scale(float factor) noexcept {
     if (pImpl->scale(factor)) return Result::Success;
     return Result::FailedAllocation;
 }
 
-
-Result Paint::translate(float x, float y) noexcept
-{
+Result Paint::translate(float x, float y) noexcept {
     if (pImpl->translate(x, y)) return Result::Success;
     return Result::FailedAllocation;
 }
 
-
-Result Paint::transform(const Matrix& m) noexcept
-{
+Result Paint::transform(const Matrix& m) noexcept {
     if (pImpl->transform(m)) return Result::Success;
     return Result::FailedAllocation;
 }
 
-
-Matrix Paint::transform() noexcept
-{
+Matrix Paint::transform() noexcept {
     auto pTransform = pImpl->transform();
     if (pTransform) return *pTransform;
     return {1, 0, 0, 0, 1, 0, 0, 0, 1};
 }
 
-
-TVG_DEPRECATED Result Paint::bounds(float* x, float* y, float* w, float* h) const noexcept
-{
+TVG_DEPRECATED Result Paint::bounds(float* x, float* y, float* w, float* h) const noexcept {
     return this->bounds(x, y, w, h, false);
 }
 
-
-Result Paint::bounds(float* x, float* y, float* w, float* h, bool transform) const noexcept
-{
+Result Paint::bounds(float* x, float* y, float* w, float* h, bool transform) const noexcept {
     if (pImpl->bounds(x, y, w, h, transform)) return Result::Success;
     return Result::InsufficientCondition;
 }
 
-
-Paint* Paint::duplicate() const noexcept
-{
+Paint* Paint::duplicate() const noexcept {
     return pImpl->duplicate();
 }
 
-
-Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) noexcept
-{
+Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) noexcept {
     if (pImpl->composite(target.release(), method)) return Result::Success;
     return Result::InvalidArguments;
 }
 
-
-CompositeMethod Paint::composite(const Paint** target) const noexcept
-{
+CompositeMethod Paint::composite(const Paint** target) const noexcept {
     if (target) *target = pImpl->cmpTarget;
 
     return pImpl->cmpMethod;
 }
 
-
-Result Paint::opacity(uint8_t o) noexcept
-{
+Result Paint::opacity(uint8_t o) noexcept {
     if (pImpl->opacity == o) return Result::Success;
 
     pImpl->opacity = o;
@@ -383,8 +343,6 @@ Result Paint::opacity(uint8_t o) noexcept
     return Result::Success;
 }
 
-
-uint8_t Paint::opacity() const noexcept
-{
+uint8_t Paint::opacity() const noexcept {
     return pImpl->opacity;
 }

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -26,86 +26,64 @@
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Picture::Picture() : pImpl(new Impl(this))
-{
+Picture::Picture()
+    : pImpl(new Impl(this)) {
     _id = TVG_CLASS_ID_PICTURE;
     Paint::pImpl->method(new PaintMethod<Picture::Impl>(pImpl));
 }
 
-
-Picture::~Picture()
-{
-    delete(pImpl);
+Picture::~Picture() {
+    delete (pImpl);
 }
 
-
-unique_ptr<Picture> Picture::gen() noexcept
-{
+unique_ptr<Picture> Picture::gen() noexcept {
     return unique_ptr<Picture>(new Picture);
 }
 
-
-uint32_t Picture::identifier() noexcept
-{
+uint32_t Picture::identifier() noexcept {
     return TVG_CLASS_ID_PICTURE;
 }
 
-
-Result Picture::load(const std::string& path) noexcept
-{
+Result Picture::load(const std::string& path) noexcept {
     if (path.empty()) return Result::InvalidArguments;
 
     return pImpl->load(path);
 }
 
-
-Result Picture::load(const char* data, uint32_t size, const string& mimeType, bool copy) noexcept
-{
+Result Picture::load(const char* data, uint32_t size, const string& mimeType, bool copy) noexcept {
     if (!data || size <= 0) return Result::InvalidArguments;
 
     return pImpl->load(data, size, mimeType, copy);
 }
 
-
-TVG_DEPRECATED Result Picture::load(const char* data, uint32_t size, bool copy) noexcept
-{
+TVG_DEPRECATED Result Picture::load(const char* data, uint32_t size, bool copy) noexcept {
     return load(data, size, "", copy);
 }
 
-
-Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept
-{
+Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept {
     if (!data || w <= 0 || h <= 0) return Result::InvalidArguments;
 
     return pImpl->load(data, w, h, copy);
 }
 
-
-Result Picture::viewbox(float* x, float* y, float* w, float* h) const noexcept
-{
+Result Picture::viewbox(float* x, float* y, float* w, float* h) const noexcept {
     if (pImpl->viewbox(x, y, w, h)) return Result::Success;
     return Result::InsufficientCondition;
 }
 
-
-Result Picture::size(float w, float h) noexcept
-{
+Result Picture::size(float w, float h) noexcept {
     if (pImpl->size(w, h)) return Result::Success;
     return Result::InsufficientCondition;
 }
 
-
-Result Picture::size(float* w, float* h) const noexcept
-{
+Result Picture::size(float* w, float* h) const noexcept {
     if (!pImpl->loader) return Result::InsufficientCondition;
     if (w) *w = pImpl->w;
     if (h) *h = pImpl->h;
     return Result::Success;
 }
 
-
-const uint32_t* Picture::data(uint32_t* w, uint32_t* h) const noexcept
-{
+const uint32_t* Picture::data(uint32_t* w, uint32_t* h) const noexcept {
     //Try it, If not loaded yet.
     pImpl->reload();
 

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -30,66 +30,61 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-struct PictureIterator : Iterator
-{
+struct PictureIterator : Iterator {
     Paint* paint = nullptr;
     Paint* ptr = nullptr;
 
-    PictureIterator(Paint* p) : paint(p) {}
+    PictureIterator(Paint* p)
+        : paint(p) {
+    }
 
-    const Paint* next() override
-    {
+    const Paint* next() override {
         if (!ptr) ptr = paint;
-        else ptr = nullptr;
+        else
+            ptr = nullptr;
         return ptr;
     }
 
-    uint32_t count() override
-    {
+    uint32_t count() override {
         if (paint) return 1;
-        else return 0;
+        else
+            return 0;
     }
 
-    void begin() override
-    {
+    void begin() override {
         ptr = nullptr;
     }
 };
 
-
-struct Picture::Impl
-{
+struct Picture::Impl {
     shared_ptr<LoadModule> loader = nullptr;
     Paint* paint = nullptr;
     uint32_t* pixels = nullptr;
     Picture* picture = nullptr;
-    void* rdata = nullptr;            //engine data
+    void* rdata = nullptr; //engine data
     float w = 0, h = 0;
     bool resizing = false;
 
-    Impl(Picture* p) : picture(p)
-    {
+    Impl(Picture* p)
+        : picture(p) {
     }
 
-    ~Impl()
-    {
-        if (paint) delete(paint);
+    ~Impl() {
+        if (paint) delete (paint);
     }
 
-    bool dispose(RenderMethod& renderer)
-    {
+    bool dispose(RenderMethod& renderer) {
         bool ret = true;
         if (paint) {
             ret = paint->pImpl->dispose(renderer);
         } else if (pixels) {
-            ret =  renderer.dispose(rdata);
+            ret = renderer.dispose(rdata);
             rdata = nullptr;
         }
         return ret;
     }
 
-    uint32_t reload()
-    {
+    uint32_t reload() {
         if (loader) {
             if (!paint) {
                 if (auto p = loader->paint()) {
@@ -111,8 +106,7 @@ struct Picture::Impl
         return RenderUpdateFlag::None;
     }
 
-    RenderTransform resizeTransform(const RenderTransform* pTransform)
-    {
+    RenderTransform resizeTransform(const RenderTransform* pTransform) {
         //Overriding Transformation by the desired image size
         auto sx = w / loader->w;
         auto sy = h / loader->h;
@@ -122,11 +116,11 @@ struct Picture::Impl
         tmp.m = {scale, 0, 0, 0, scale, 0, 0, 0, 1};
 
         if (!pTransform) return tmp;
-        else return RenderTransform(pTransform, &tmp);
+        else
+            return RenderTransform(pTransform, &tmp);
     }
 
-    void* update(RenderMethod &renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag pFlag)
-    {
+    void* update(RenderMethod& renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag pFlag) {
         auto flag = reload();
 
         if (pixels) {
@@ -142,15 +136,14 @@ struct Picture::Impl
         return rdata;
     }
 
-    bool render(RenderMethod &renderer)
-    {
+    bool render(RenderMethod& renderer) {
         if (pixels) return renderer.renderImage(rdata);
-        else if (paint) return paint->pImpl->render(renderer);
+        else if (paint)
+            return paint->pImpl->render(renderer);
         return false;
     }
 
-    bool viewbox(float* x, float* y, float* w, float* h) const
-    {
+    bool viewbox(float* x, float* y, float* w, float* h) const {
         if (!loader) return false;
         if (x) *x = loader->vx;
         if (y) *y = loader->vy;
@@ -159,36 +152,32 @@ struct Picture::Impl
         return true;
     }
 
-    bool size(float w, float h)
-    {
+    bool size(float w, float h) {
         this->w = w;
         this->h = h;
         resizing = true;
         return true;
     }
 
-    bool bounds(float* x, float* y, float* w, float* h)
-    {
+    bool bounds(float* x, float* y, float* w, float* h) {
         if (x) *x = 0;
         if (y) *y = 0;
         if (w) *w = this->w;
         if (h) *h = this->h;
- 
+
         return true;
     }
 
-    RenderRegion bounds(RenderMethod& renderer)
-    {
+    RenderRegion bounds(RenderMethod& renderer) {
         if (rdata) return renderer.region(rdata);
         if (paint) return paint->pImpl->bounds(renderer);
         return {0, 0, 0, 0};
     }
 
-    Result load(const string& path)
-    {
+    Result load(const string& path) {
         if (paint || pixels) return Result::InsufficientCondition;
         if (loader) loader->close();
-        bool invalid;  //Invalid Path
+        bool invalid; //Invalid Path
         loader = LoaderMgr::loader(path, &invalid);
         if (!loader) {
             if (invalid) return Result::InvalidArguments;
@@ -200,8 +189,7 @@ struct Picture::Impl
         return Result::Success;
     }
 
-    Result load(const char* data, uint32_t size, const string& mimeType, bool copy)
-    {
+    Result load(const char* data, uint32_t size, const string& mimeType, bool copy) {
         if (paint || pixels) return Result::InsufficientCondition;
         if (loader) loader->close();
         loader = LoaderMgr::loader(data, size, mimeType, copy);
@@ -212,8 +200,7 @@ struct Picture::Impl
         return Result::Success;
     }
 
-    Result load(uint32_t* data, uint32_t w, uint32_t h, bool copy)
-    {
+    Result load(uint32_t* data, uint32_t w, uint32_t h, bool copy) {
         if (paint || pixels) return Result::InsufficientCondition;
         if (loader) loader->close();
         loader = LoaderMgr::loader(data, w, h, copy);
@@ -223,8 +210,7 @@ struct Picture::Impl
         return Result::Success;
     }
 
-    Paint* duplicate()
-    {
+    Paint* duplicate() {
         reload();
 
         auto ret = Picture::gen();
@@ -242,8 +228,7 @@ struct Picture::Impl
         return ret.release();
     }
 
-    Iterator* iterator()
-    {
+    Iterator* iterator() {
         reload();
         return new PictureIterator(paint);
     }

--- a/src/lib/tvgRadialGradient.cpp
+++ b/src/lib/tvgRadialGradient.cpp
@@ -26,14 +26,12 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-struct RadialGradient::Impl
-{
+struct RadialGradient::Impl {
     float cx = 0;
     float cy = 0;
     float radius = 0;
 
-    Fill* duplicate()
-    {
+    Fill* duplicate() {
         auto ret = RadialGradient::gen();
         if (!ret) return nullptr;
 
@@ -45,26 +43,21 @@ struct RadialGradient::Impl
     }
 };
 
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
-RadialGradient::RadialGradient():pImpl(new Impl())
-{
+RadialGradient::RadialGradient()
+    : pImpl(new Impl()) {
     _id = TVG_CLASS_ID_RADIAL;
     Fill::pImpl->method(new FillDup<RadialGradient::Impl>(pImpl));
 }
 
-
-RadialGradient::~RadialGradient()
-{
-    delete(pImpl);
+RadialGradient::~RadialGradient() {
+    delete (pImpl);
 }
 
-
-Result RadialGradient::radial(float cx, float cy, float radius) noexcept
-{
+Result RadialGradient::radial(float cx, float cy, float radius) noexcept {
     if (radius < 0) return Result::InvalidArguments;
 
     pImpl->cx = cx;
@@ -74,9 +67,7 @@ Result RadialGradient::radial(float cx, float cy, float radius) noexcept
     return Result::Success;
 }
 
-
-Result RadialGradient::radial(float* cx, float* cy, float* radius) const noexcept
-{
+Result RadialGradient::radial(float* cx, float* cy, float* radius) const noexcept {
     if (cx) *cx = pImpl->cx;
     if (cy) *cy = pImpl->cy;
     if (radius) *radius = pImpl->radius;
@@ -84,14 +75,10 @@ Result RadialGradient::radial(float* cx, float* cy, float* radius) const noexcep
     return Result::Success;
 }
 
-
-unique_ptr<RadialGradient> RadialGradient::gen() noexcept
-{
+unique_ptr<RadialGradient> RadialGradient::gen() noexcept {
     return unique_ptr<RadialGradient>(new RadialGradient);
 }
 
-
-uint32_t RadialGradient::identifier() noexcept
-{
+uint32_t RadialGradient::identifier() noexcept {
     return TVG_CLASS_ID_RADIAL;
 }

--- a/src/lib/tvgRender.cpp
+++ b/src/lib/tvgRender.cpp
@@ -27,25 +27,22 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
-void RenderTransform::override(const Matrix& m)
-{
+void RenderTransform::override(const Matrix& m) {
     this->m = m;
 
     if (m.e11 == 0.0f && m.e12 == 0.0f && m.e13 == 0.0f &&
         m.e21 == 0.0f && m.e22 == 0.0f && m.e23 == 0.0f &&
         m.e31 == 0.0f && m.e32 == 0.0f && m.e33 == 0.0f) {
         overriding = false;
-    } else overriding = true;
+    } else
+        overriding = true;
 }
 
-
-bool RenderTransform::update()
-{
+bool RenderTransform::update() {
     constexpr auto PI = 3.141592f;
 
     if (overriding) return true;
@@ -89,14 +86,10 @@ bool RenderTransform::update()
     return true;
 }
 
-
-RenderTransform::RenderTransform()
-{
+RenderTransform::RenderTransform() {
 }
 
-
-RenderTransform::RenderTransform(const RenderTransform* lhs, const RenderTransform* rhs)
-{
+RenderTransform::RenderTransform(const RenderTransform* lhs, const RenderTransform* rhs) {
     m.e11 = lhs->m.e11 * rhs->m.e11 + lhs->m.e12 * rhs->m.e21 + lhs->m.e13 * rhs->m.e31;
     m.e12 = lhs->m.e11 * rhs->m.e12 + lhs->m.e12 * rhs->m.e22 + lhs->m.e13 * rhs->m.e32;
     m.e13 = lhs->m.e11 * rhs->m.e13 + lhs->m.e12 * rhs->m.e23 + lhs->m.e13 * rhs->m.e33;

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -25,32 +25,37 @@
 #include "tvgCommon.h"
 #include "tvgArray.h"
 
-namespace tvg
-{
+namespace tvg {
 
-enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, All = 127};
+enum RenderUpdateFlag { None = 0,
+                        Path = 1,
+                        Color = 2,
+                        Gradient = 4,
+                        Stroke = 8,
+                        Transform = 16,
+                        Image = 32,
+                        GradientStroke = 64,
+                        All = 127 };
 
-struct Surface
-{
+struct Surface {
     //TODO: Union for multiple types
     uint32_t* buffer;
-    uint32_t  stride;
-    uint32_t  w, h;
-    uint32_t  cs;
+    uint32_t stride;
+    uint32_t w, h;
+    uint32_t cs;
 };
 
 using RenderData = void*;
 
 struct Compositor {
     CompositeMethod method;
-    uint32_t        opacity;
+    uint32_t opacity;
 };
 
 struct RenderRegion {
     uint32_t x, y, w, h;
 
-    void intersect(const RenderRegion& rhs)
-    {
+    void intersect(const RenderRegion& rhs) {
         auto x1 = x + w;
         auto y1 = y + h;
         auto x2 = rhs.x + rhs.w;
@@ -63,14 +68,13 @@ struct RenderRegion {
     }
 };
 
-struct RenderTransform
-{
-    Matrix m;             //3x3 Matrix Elements
+struct RenderTransform {
+    Matrix m; //3x3 Matrix Elements
     float x = 0.0f;
     float y = 0.0f;
-    float degree = 0.0f;  //rotation degree
-    float scale = 1.0f;   //scale factor
-    bool overriding = false;  //user transform?
+    float degree = 0.0f;     //rotation degree
+    float scale = 1.0f;      //scale factor
+    bool overriding = false; //user transform?
 
     bool update();
     void override(const Matrix& m);
@@ -79,10 +83,10 @@ struct RenderTransform
     RenderTransform(const RenderTransform* lhs, const RenderTransform* rhs);
 };
 
-class RenderMethod
-{
-public:
-    virtual ~RenderMethod() {}
+class RenderMethod {
+  public:
+    virtual ~RenderMethod() {
+    }
     virtual RenderData prepare(const Shape& shape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
     virtual RenderData prepare(const Picture& picture, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
     virtual bool preRender() = 0;
@@ -102,6 +106,6 @@ public:
     virtual bool endComposite(Compositor* cmp) = 0;
 };
 
-}
+} // namespace tvg
 
 #endif //_TVG_RENDER_H_

--- a/src/lib/tvgSaveModule.h
+++ b/src/lib/tvgSaveModule.h
@@ -24,18 +24,17 @@
 
 #include "tvgIteratorAccessor.h"
 
-namespace tvg
-{
+namespace tvg {
 
-class SaveModule : public IteratorAccessor
-{
-public:
-    virtual ~SaveModule() {}
+class SaveModule : public IteratorAccessor {
+  public:
+    virtual ~SaveModule() {
+    }
 
     virtual bool save(Paint* paint, const string& path, bool compress) = 0;
     virtual bool close() = 0;
 };
 
-}
+} // namespace tvg
 
 #endif //_TVG_SAVE_MODULE_H_

--- a/src/lib/tvgSaver.cpp
+++ b/src/lib/tvgSaver.cpp
@@ -23,57 +23,51 @@
 #include "tvgSaveModule.h"
 
 #ifdef THORVG_TVG_SAVER_SUPPORT
-    #include "tvgTvgSaver.h"
+#include "tvgTvgSaver.h"
 #endif
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-struct Saver::Impl
-{
+struct Saver::Impl {
     SaveModule* saveModule = nullptr;
-    ~Impl()
-    {
-        if (saveModule) delete(saveModule);
+    ~Impl() {
+        if (saveModule) delete (saveModule);
     }
 };
 
-
-static SaveModule* _find(FileType type)
-{
-    switch(type) {
-        case FileType::Tvg: {
+static SaveModule* _find(FileType type) {
+    switch (type) {
+    case FileType::Tvg: {
 #ifdef THORVG_TVG_SAVER_SUPPORT
-            return new TvgSaver;
+        return new TvgSaver;
 #endif
-            break;
-        }
-        default: {
-            break;
-        }
+        break;
+    }
+    default: {
+        break;
+    }
     }
 
 #ifdef THORVG_LOG_ENABLED
-    const char *format;
-    switch(type) {
-        case FileType::Tvg: {
-            format = "TVG";
-            break;
-        }
-        default: {
-            format = "???";
-            break;
-        }
+    const char* format;
+    switch (type) {
+    case FileType::Tvg: {
+        format = "TVG";
+        break;
+    }
+    default: {
+        format = "???";
+        break;
+    }
     }
     TVGLOG("SAVER", "%s format is not supported", format);
 #endif
     return nullptr;
 }
 
-
-static SaveModule* _find(const string& path)
-{
+static SaveModule* _find(const string& path) {
     auto ext = path.substr(path.find_last_of(".") + 1);
     if (!ext.compare("tvg")) {
         return _find(FileType::Tvg);
@@ -81,24 +75,19 @@ static SaveModule* _find(const string& path)
     return nullptr;
 }
 
-
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Saver::Saver() : pImpl(new Impl())
-{
+Saver::Saver()
+    : pImpl(new Impl()) {
 }
 
-
-Saver::~Saver()
-{
-    delete(pImpl);
+Saver::~Saver() {
+    delete (pImpl);
 }
 
-
-Result Saver::save(std::unique_ptr<Paint> paint, const string& path, bool compress) noexcept
-{
+Result Saver::save(std::unique_ptr<Paint> paint, const string& path, bool compress) noexcept {
     //Already on saving an other resource.
     if (pImpl->saveModule) return Result::InsufficientCondition;
 
@@ -116,19 +105,15 @@ Result Saver::save(std::unique_ptr<Paint> paint, const string& path, bool compre
     return Result::NonSupport;
 }
 
-
-Result Saver::sync() noexcept
-{
+Result Saver::sync() noexcept {
     if (!pImpl->saveModule) return Result::InsufficientCondition;
     pImpl->saveModule->close();
-    delete(pImpl->saveModule);
+    delete (pImpl->saveModule);
     pImpl->saveModule = nullptr;
 
     return Result::Success;
 }
 
-
-unique_ptr<Saver> Saver::gen() noexcept
-{
+unique_ptr<Saver> Saver::gen() noexcept {
     return unique_ptr<Saver>(new Saver);
 }

--- a/src/lib/tvgScene.cpp
+++ b/src/lib/tvgScene.cpp
@@ -25,33 +25,25 @@
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Scene::Scene() : pImpl(new Impl())
-{
+Scene::Scene()
+    : pImpl(new Impl()) {
     _id = TVG_CLASS_ID_SCENE;
     Paint::pImpl->method(new PaintMethod<Scene::Impl>(pImpl));
 }
 
-
-Scene::~Scene()
-{
-    delete(pImpl);
+Scene::~Scene() {
+    delete (pImpl);
 }
 
-
-unique_ptr<Scene> Scene::gen() noexcept
-{
+unique_ptr<Scene> Scene::gen() noexcept {
     return unique_ptr<Scene>(new Scene);
 }
 
-
-uint32_t Scene::identifier() noexcept
-{
+uint32_t Scene::identifier() noexcept {
     return TVG_CLASS_ID_SCENE;
 }
 
-
-Result Scene::push(unique_ptr<Paint> paint) noexcept
-{
+Result Scene::push(unique_ptr<Paint> paint) noexcept {
     auto p = paint.release();
     if (!p) return Result::MemoryCorruption;
     pImpl->paints.push(p);
@@ -59,17 +51,13 @@ Result Scene::push(unique_ptr<Paint> paint) noexcept
     return Result::Success;
 }
 
-
-Result Scene::reserve(uint32_t size) noexcept
-{
+Result Scene::reserve(uint32_t size) noexcept {
     if (!pImpl->paints.reserve(size)) return Result::FailedAllocation;
 
     return Result::Success;
 }
 
-
-Result Scene::clear(bool free) noexcept
-{
+Result Scene::clear(bool free) noexcept {
     pImpl->clear(free);
 
     return Result::Success;

--- a/src/lib/tvgShape.cpp
+++ b/src/lib/tvgShape.cpp
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-#define _USE_MATH_DEFINES       //Math Constants are not defined in Standard C/C++.
+#define _USE_MATH_DEFINES //Math Constants are not defined in Standard C/C++.
 
 #include <limits>
 #include <float.h>
@@ -36,42 +36,32 @@ constexpr auto PATH_KAPPA = 0.552284f;
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Shape :: Shape() : pImpl(new Impl(this))
-{
+Shape ::Shape()
+    : pImpl(new Impl(this)) {
     _id = TVG_CLASS_ID_SHAPE;
     Paint::pImpl->method(new PaintMethod<Shape::Impl>(pImpl));
 }
 
-
-Shape :: ~Shape()
-{
-    delete(pImpl);
+Shape ::~Shape() {
+    delete (pImpl);
 }
 
-
-unique_ptr<Shape> Shape::gen() noexcept
-{
+unique_ptr<Shape> Shape::gen() noexcept {
     return unique_ptr<Shape>(new Shape);
 }
 
-
-uint32_t Shape::identifier() noexcept
-{
+uint32_t Shape::identifier() noexcept {
     return TVG_CLASS_ID_SHAPE;
 }
 
-
-Result Shape::reset() noexcept
-{
+Result Shape::reset() noexcept {
     pImpl->path.reset();
     pImpl->flag = RenderUpdateFlag::Path;
 
     return Result::Success;
 }
 
-
-uint32_t Shape::pathCommands(const PathCommand** cmds) const noexcept
-{
+uint32_t Shape::pathCommands(const PathCommand** cmds) const noexcept {
     if (!cmds) return 0;
 
     *cmds = pImpl->path.cmds;
@@ -79,9 +69,7 @@ uint32_t Shape::pathCommands(const PathCommand** cmds) const noexcept
     return pImpl->path.cmdCnt;
 }
 
-
-uint32_t Shape::pathCoords(const Point** pts) const noexcept
-{
+uint32_t Shape::pathCoords(const Point** pts) const noexcept {
     if (!pts) return 0;
 
     *pts = pImpl->path.pts;
@@ -89,9 +77,7 @@ uint32_t Shape::pathCoords(const Point** pts) const noexcept
     return pImpl->path.ptsCnt;
 }
 
-
-Result Shape::appendPath(const PathCommand *cmds, uint32_t cmdCnt, const Point* pts, uint32_t ptsCnt) noexcept
-{
+Result Shape::appendPath(const PathCommand* cmds, uint32_t cmdCnt, const Point* pts, uint32_t ptsCnt) noexcept {
     if (cmdCnt == 0 || ptsCnt == 0 || !cmds || !pts) return Result::InvalidArguments;
 
     pImpl->path.grow(cmdCnt, ptsCnt);
@@ -102,9 +88,7 @@ Result Shape::appendPath(const PathCommand *cmds, uint32_t cmdCnt, const Point* 
     return Result::Success;
 }
 
-
-Result Shape::moveTo(float x, float y) noexcept
-{
+Result Shape::moveTo(float x, float y) noexcept {
     pImpl->path.moveTo(x, y);
 
     pImpl->flag |= RenderUpdateFlag::Path;
@@ -112,9 +96,7 @@ Result Shape::moveTo(float x, float y) noexcept
     return Result::Success;
 }
 
-
-Result Shape::lineTo(float x, float y) noexcept
-{
+Result Shape::lineTo(float x, float y) noexcept {
     pImpl->path.lineTo(x, y);
 
     pImpl->flag |= RenderUpdateFlag::Path;
@@ -122,9 +104,7 @@ Result Shape::lineTo(float x, float y) noexcept
     return Result::Success;
 }
 
-
-Result Shape::cubicTo(float cx1, float cy1, float cx2, float cy2, float x, float y) noexcept
-{
+Result Shape::cubicTo(float cx1, float cy1, float cx2, float cy2, float x, float y) noexcept {
     pImpl->path.cubicTo(cx1, cy1, cx2, cy2, x, y);
 
     pImpl->flag |= RenderUpdateFlag::Path;
@@ -132,9 +112,7 @@ Result Shape::cubicTo(float cx1, float cy1, float cx2, float cy2, float x, float
     return Result::Success;
 }
 
-
-Result Shape::close() noexcept
-{
+Result Shape::close() noexcept {
     pImpl->path.close();
 
     pImpl->flag |= RenderUpdateFlag::Path;
@@ -142,9 +120,7 @@ Result Shape::close() noexcept
     return Result::Success;
 }
 
-
-Result Shape::appendCircle(float cx, float cy, float rx, float ry) noexcept
-{
+Result Shape::appendCircle(float cx, float cy, float rx, float ry) noexcept {
     auto rxKappa = rx * PATH_KAPPA;
     auto ryKappa = ry * PATH_KAPPA;
 
@@ -161,8 +137,7 @@ Result Shape::appendCircle(float cx, float cy, float rx, float ry) noexcept
     return Result::Success;
 }
 
-Result Shape::appendArc(float cx, float cy, float radius, float startAngle, float sweep, bool pie) noexcept
-{
+Result Shape::appendArc(float cx, float cy, float radius, float startAngle, float sweep, bool pie) noexcept {
     const float M_PI_HALF = (float)(M_PI * 0.5f);
 
     //just circle
@@ -200,7 +175,7 @@ Result Shape::appendArc(float cx, float cy, float radius, float startAngle, floa
         auto by = end.y;
         auto q1 = ax * ax + ay * ay;
         auto q2 = ax * bx + ay * by + q1;
-        auto k2 = (4.0f/3.0f) * ((sqrtf(2 * q1 * q2) - q2) / (ax * by - ay * bx));
+        auto k2 = (4.0f / 3.0f) * ((sqrtf(2 * q1 * q2) - q2) / (ax * by - ay * bx));
 
         start = end; //Next start point is the current end point
 
@@ -222,9 +197,7 @@ Result Shape::appendArc(float cx, float cy, float radius, float startAngle, floa
     return Result::Success;
 }
 
-
-Result Shape::appendRect(float x, float y, float w, float h, float rx, float ry) noexcept
-{
+Result Shape::appendRect(float x, float y, float w, float h, float rx, float ry) noexcept {
     auto halfW = w * 0.5f;
     auto halfH = h * 0.5f;
 
@@ -240,7 +213,7 @@ Result Shape::appendRect(float x, float y, float w, float h, float rx, float ry)
         pImpl->path.lineTo(x + w, y + h);
         pImpl->path.lineTo(x, y + h);
         pImpl->path.close();
-    //circle
+        //circle
     } else if (fabsf(rx - halfW) < FLT_EPSILON && fabsf(ry - halfH) < FLT_EPSILON) {
         return appendCircle(x + (w * 0.5f), y + (h * 0.5f), rx, ry);
     } else {
@@ -264,9 +237,7 @@ Result Shape::appendRect(float x, float y, float w, float h, float rx, float ry)
     return Result::Success;
 }
 
-
-Result Shape::fill(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept
-{
+Result Shape::fill(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept {
     pImpl->color[0] = r;
     pImpl->color[1] = g;
     pImpl->color[2] = b;
@@ -274,7 +245,7 @@ Result Shape::fill(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept
     pImpl->flag |= RenderUpdateFlag::Color;
 
     if (pImpl->fill) {
-        delete(pImpl->fill);
+        delete (pImpl->fill);
         pImpl->fill = nullptr;
         pImpl->flag |= RenderUpdateFlag::Gradient;
     }
@@ -282,22 +253,18 @@ Result Shape::fill(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept
     return Result::Success;
 }
 
-
-Result Shape::fill(unique_ptr<Fill> f) noexcept
-{
+Result Shape::fill(unique_ptr<Fill> f) noexcept {
     auto p = f.release();
     if (!p) return Result::MemoryCorruption;
 
-    if (pImpl->fill && pImpl->fill != p) delete(pImpl->fill);
+    if (pImpl->fill && pImpl->fill != p) delete (pImpl->fill);
     pImpl->fill = p;
     pImpl->flag |= RenderUpdateFlag::Gradient;
 
     return Result::Success;
 }
 
-
-Result Shape::fillColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept
-{
+Result Shape::fillColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept {
     if (r) *r = pImpl->color[0];
     if (g) *g = pImpl->color[1];
     if (b) *b = pImpl->color[2];
@@ -306,37 +273,28 @@ Result Shape::fillColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const no
     return Result::Success;
 }
 
-const Fill* Shape::fill() const noexcept
-{
+const Fill* Shape::fill() const noexcept {
     return pImpl->fill;
 }
 
-
-Result Shape::stroke(float width) noexcept
-{
+Result Shape::stroke(float width) noexcept {
     if (!pImpl->strokeWidth(width)) return Result::FailedAllocation;
 
     return Result::Success;
 }
 
-
-float Shape::strokeWidth() const noexcept
-{
+float Shape::strokeWidth() const noexcept {
     if (!pImpl->stroke) return 0;
     return pImpl->stroke->width;
 }
 
-
-Result Shape::stroke(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept
-{
+Result Shape::stroke(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept {
     if (!pImpl->strokeColor(r, g, b, a)) return Result::FailedAllocation;
 
     return Result::Success;
 }
 
-
-Result Shape::strokeColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept
-{
+Result Shape::strokeColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept {
     if (!pImpl->stroke) return Result::InsufficientCondition;
 
     if (r) *r = pImpl->stroke->color[0];
@@ -347,23 +305,17 @@ Result Shape::strokeColor(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const 
     return Result::Success;
 }
 
-
-Result Shape::stroke(unique_ptr<Fill> f) noexcept
-{
+Result Shape::stroke(unique_ptr<Fill> f) noexcept {
     return pImpl->strokeFill(move(f));
 }
 
-
-const Fill* Shape::strokeFill() const noexcept
-{
+const Fill* Shape::strokeFill() const noexcept {
     if (!pImpl->stroke) return nullptr;
 
     return pImpl->stroke->fill;
 }
 
-
-Result Shape::stroke(const float* dashPattern, uint32_t cnt) noexcept
-{
+Result Shape::stroke(const float* dashPattern, uint32_t cnt) noexcept {
     if ((cnt == 1) || (!dashPattern && cnt > 0) || (dashPattern && cnt == 0)) {
         return Result::InvalidArguments;
     }
@@ -376,9 +328,7 @@ Result Shape::stroke(const float* dashPattern, uint32_t cnt) noexcept
     return Result::Success;
 }
 
-
-uint32_t Shape::strokeDash(const float** dashPattern) const noexcept
-{
+uint32_t Shape::strokeDash(const float** dashPattern) const noexcept {
     if (!pImpl->stroke) return 0;
 
     if (dashPattern) *dashPattern = pImpl->stroke->dashPattern;
@@ -386,48 +336,36 @@ uint32_t Shape::strokeDash(const float** dashPattern) const noexcept
     return pImpl->stroke->dashCnt;
 }
 
-
-Result Shape::stroke(StrokeCap cap) noexcept
-{
+Result Shape::stroke(StrokeCap cap) noexcept {
     if (!pImpl->strokeCap(cap)) return Result::FailedAllocation;
 
     return Result::Success;
 }
 
-
-Result Shape::stroke(StrokeJoin join) noexcept
-{
+Result Shape::stroke(StrokeJoin join) noexcept {
     if (!pImpl->strokeJoin(join)) return Result::FailedAllocation;
 
     return Result::Success;
 }
 
-
-StrokeCap Shape::strokeCap() const noexcept
-{
+StrokeCap Shape::strokeCap() const noexcept {
     if (!pImpl->stroke) return StrokeCap::Square;
 
     return pImpl->stroke->cap;
 }
 
-
-StrokeJoin Shape::strokeJoin() const noexcept
-{
+StrokeJoin Shape::strokeJoin() const noexcept {
     if (!pImpl->stroke) return StrokeJoin::Bevel;
 
     return pImpl->stroke->join;
 }
 
-
-Result Shape::fill(FillRule r) noexcept
-{
+Result Shape::fill(FillRule r) noexcept {
     pImpl->rule = r;
 
     return Result::Success;
 }
 
-
-FillRule Shape::fillRule() const noexcept
-{
+FillRule Shape::fillRule() const noexcept {
     return pImpl->rule;
 }

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -29,24 +29,23 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-struct ShapeStroke
-{
+struct ShapeStroke {
     float width = 0;
     uint8_t color[4] = {0, 0, 0, 0};
-    Fill *fill = nullptr;
+    Fill* fill = nullptr;
     float* dashPattern = nullptr;
     uint32_t dashCnt = 0;
     StrokeCap cap = StrokeCap::Square;
     StrokeJoin join = StrokeJoin::Bevel;
 
-    ShapeStroke() {}
+    ShapeStroke() {
+    }
 
     ShapeStroke(const ShapeStroke* src)
-     : width(src->width),
-       dashCnt(src->dashCnt),
-       cap(src->cap),
-       join(src->join)
-    {
+        : width(src->width),
+          dashCnt(src->dashCnt),
+          cap(src->cap),
+          join(src->join) {
         memcpy(color, src->color, sizeof(color));
         if (dashCnt > 0) {
             dashPattern = static_cast<float*>(malloc(sizeof(float) * dashCnt));
@@ -55,36 +54,30 @@ struct ShapeStroke
         if (src->fill) fill = src->fill->duplicate();
     }
 
-    ~ShapeStroke()
-    {
+    ~ShapeStroke() {
         if (dashPattern) free(dashPattern);
-        if (fill) delete(fill);
+        if (fill) delete (fill);
     }
 };
 
-
-struct ShapePath
-{
+struct ShapePath {
     PathCommand* cmds = nullptr;
     uint32_t cmdCnt = 0;
     uint32_t reservedCmdCnt = 0;
 
-    Point *pts = nullptr;
+    Point* pts = nullptr;
     uint32_t ptsCnt = 0;
     uint32_t reservedPtsCnt = 0;
 
-    ~ShapePath()
-    {
+    ~ShapePath() {
         if (cmds) free(cmds);
         if (pts) free(pts);
     }
 
-    ShapePath()
-    {
+    ShapePath() {
     }
 
-    void duplicate(const ShapePath* src)
-    {
+    void duplicate(const ShapePath* src) {
         cmdCnt = src->cmdCnt;
         reservedCmdCnt = src->reservedCmdCnt;
         ptsCnt = src->ptsCnt;
@@ -102,42 +95,36 @@ struct ShapePath
         memcpy(pts, src->pts, sizeof(Point) * ptsCnt);
     }
 
-    void reserveCmd(uint32_t cmdCnt)
-    {
+    void reserveCmd(uint32_t cmdCnt) {
         if (cmdCnt <= reservedCmdCnt) return;
         reservedCmdCnt = cmdCnt;
         cmds = static_cast<PathCommand*>(realloc(cmds, sizeof(PathCommand) * reservedCmdCnt));
     }
 
-    void reservePts(uint32_t ptsCnt)
-    {
+    void reservePts(uint32_t ptsCnt) {
         if (ptsCnt <= reservedPtsCnt) return;
         reservedPtsCnt = ptsCnt;
         pts = static_cast<Point*>(realloc(pts, sizeof(Point) * reservedPtsCnt));
     }
 
-    void grow(uint32_t cmdCnt, uint32_t ptsCnt)
-    {
+    void grow(uint32_t cmdCnt, uint32_t ptsCnt) {
         reserveCmd(this->cmdCnt + cmdCnt);
         reservePts(this->ptsCnt + ptsCnt);
     }
 
-    void reset()
-    {
+    void reset() {
         cmdCnt = 0;
         ptsCnt = 0;
     }
 
-    void append(const PathCommand* cmds, uint32_t cmdCnt, const Point* pts, uint32_t ptsCnt)
-    {
+    void append(const PathCommand* cmds, uint32_t cmdCnt, const Point* pts, uint32_t ptsCnt) {
         memcpy(this->cmds + this->cmdCnt, cmds, sizeof(PathCommand) * cmdCnt);
         memcpy(this->pts + this->ptsCnt, pts, sizeof(Point) * ptsCnt);
         this->cmdCnt += cmdCnt;
         this->ptsCnt += ptsCnt;
     }
 
-    void moveTo(float x, float y)
-    {
+    void moveTo(float x, float y) {
         if (cmdCnt + 1 > reservedCmdCnt) reserveCmd((cmdCnt + 1) * 2);
         if (ptsCnt + 2 > reservedPtsCnt) reservePts((ptsCnt + 2) * 2);
 
@@ -145,8 +132,7 @@ struct ShapePath
         pts[ptsCnt++] = {x, y};
     }
 
-    void lineTo(float x, float y)
-    {
+    void lineTo(float x, float y) {
         if (cmdCnt + 1 > reservedCmdCnt) reserveCmd((cmdCnt + 1) * 2);
         if (ptsCnt + 2 > reservedPtsCnt) reservePts((ptsCnt + 2) * 2);
 
@@ -154,8 +140,7 @@ struct ShapePath
         pts[ptsCnt++] = {x, y};
     }
 
-    void cubicTo(float cx1, float cy1, float cx2, float cy2, float x, float y)
-    {
+    void cubicTo(float cx1, float cy1, float cx2, float cy2, float x, float y) {
         if (cmdCnt + 1 > reservedCmdCnt) reserveCmd((cmdCnt + 1) * 2);
         if (ptsCnt + 3 > reservedPtsCnt) reservePts((ptsCnt + 3) * 2);
 
@@ -165,20 +150,18 @@ struct ShapePath
         pts[ptsCnt++] = {x, y};
     }
 
-    void close()
-    {
+    void close() {
         if (cmdCnt > 0 && cmds[cmdCnt - 1] == PathCommand::Close) return;
 
         if (cmdCnt + 1 > reservedCmdCnt) reserveCmd((cmdCnt + 1) * 2);
         cmds[cmdCnt++] = PathCommand::Close;
     }
 
-    bool bounds(float* x, float* y, float* w, float* h) const
-    {
+    bool bounds(float* x, float* y, float* w, float* h) const {
         if (ptsCnt == 0) return false;
 
-        Point min = { pts[0].x, pts[0].y };
-        Point max = { pts[0].x, pts[0].y };
+        Point min = {pts[0].x, pts[0].y};
+        Point max = {pts[0].x, pts[0].y};
 
         for (uint32_t i = 1; i < ptsCnt; ++i) {
             if (pts[i].x < min.x) min.x = pts[i].x;
@@ -196,54 +179,46 @@ struct ShapePath
     }
 };
 
-
-struct Shape::Impl
-{
+struct Shape::Impl {
     ShapePath path;
-    Fill *fill = nullptr;
-    ShapeStroke *stroke = nullptr;
-    uint8_t color[4] = {0, 0, 0, 0};    //r, g, b, a
+    Fill* fill = nullptr;
+    ShapeStroke* stroke = nullptr;
+    uint8_t color[4] = {0, 0, 0, 0}; //r, g, b, a
     FillRule rule = FillRule::Winding;
-    RenderData rdata = nullptr;         //engine data
-    Shape *shape = nullptr;
+    RenderData rdata = nullptr; //engine data
+    Shape* shape = nullptr;
     uint32_t flag = RenderUpdateFlag::None;
 
-    Impl(Shape* s) : shape(s)
-    {
+    Impl(Shape* s)
+        : shape(s) {
     }
 
-    ~Impl()
-    {
-        if (fill) delete(fill);
-        if (stroke) delete(stroke);
+    ~Impl() {
+        if (fill) delete (fill);
+        if (stroke) delete (stroke);
     }
 
-    bool dispose(RenderMethod& renderer)
-    {
+    bool dispose(RenderMethod& renderer) {
         auto ret = renderer.dispose(rdata);
         rdata = nullptr;
         return ret;
     }
 
-    bool render(RenderMethod& renderer)
-    {
+    bool render(RenderMethod& renderer) {
         return renderer.renderShape(rdata);
     }
 
-    void* update(RenderMethod& renderer, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag pFlag)
-    {
+    void* update(RenderMethod& renderer, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag pFlag) {
         this->rdata = renderer.prepare(*shape, this->rdata, transform, opacity, clips, static_cast<RenderUpdateFlag>(pFlag | flag));
         flag = RenderUpdateFlag::None;
         return this->rdata;
     }
 
-    RenderRegion bounds(RenderMethod& renderer)
-    {
+    RenderRegion bounds(RenderMethod& renderer) {
         return renderer.region(rdata);
     }
 
-    bool bounds(float* x, float* y, float* w, float* h)
-    {
+    bool bounds(float* x, float* y, float* w, float* h) {
         auto ret = path.bounds(x, y, w, h);
 
         //Stroke feathering
@@ -256,8 +231,7 @@ struct Shape::Impl
         return ret;
     }
 
-    bool strokeWidth(float width)
-    {
+    bool strokeWidth(float width) {
         //TODO: Size Exception?
 
         if (!stroke) stroke = new ShapeStroke();
@@ -267,8 +241,7 @@ struct Shape::Impl
         return true;
     }
 
-    bool strokeCap(StrokeCap cap)
-    {
+    bool strokeCap(StrokeCap cap) {
         if (!stroke) stroke = new ShapeStroke();
         stroke->cap = cap;
         flag |= RenderUpdateFlag::Stroke;
@@ -276,8 +249,7 @@ struct Shape::Impl
         return true;
     }
 
-    bool strokeJoin(StrokeJoin join)
-    {
+    bool strokeJoin(StrokeJoin join) {
         if (!stroke) stroke = new ShapeStroke();
         stroke->join = join;
         flag |= RenderUpdateFlag::Stroke;
@@ -285,11 +257,10 @@ struct Shape::Impl
         return true;
     }
 
-    bool strokeColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-    {
+    bool strokeColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
         if (!stroke) stroke = new ShapeStroke();
         if (stroke->fill) {
-            delete(stroke->fill);
+            delete (stroke->fill);
             stroke->fill = nullptr;
             flag |= RenderUpdateFlag::GradientStroke;
         }
@@ -304,13 +275,12 @@ struct Shape::Impl
         return true;
     }
 
-    Result strokeFill(unique_ptr<Fill> f)
-    {
+    Result strokeFill(unique_ptr<Fill> f) {
         auto p = f.release();
         if (!p) return Result::MemoryCorruption;
 
         if (!stroke) stroke = new ShapeStroke();
-        if (stroke->fill && stroke->fill != p) delete(stroke->fill);
+        if (stroke->fill && stroke->fill != p) delete (stroke->fill);
         stroke->fill = p;
 
         flag |= RenderUpdateFlag::Stroke;
@@ -319,8 +289,7 @@ struct Shape::Impl
         return Result::Success;
     }
 
-    bool strokeDash(const float* pattern, uint32_t cnt)
-    {
+    bool strokeDash(const float* pattern, uint32_t cnt) {
         //Reset dash
         if (!pattern && cnt == 0) {
             free(stroke->dashPattern);
@@ -345,8 +314,7 @@ struct Shape::Impl
         return true;
     }
 
-    Paint* duplicate()
-    {
+    Paint* duplicate() {
         auto ret = Shape::gen();
         if (!ret) return nullptr;
 
@@ -379,8 +347,7 @@ struct Shape::Impl
         return ret.release();
     }
 
-    Iterator* iterator()
-    {
+    Iterator* iterator() {
         return nullptr;
     }
 };

--- a/src/lib/tvgSwCanvas.cpp
+++ b/src/lib/tvgSwCanvas.cpp
@@ -22,44 +22,39 @@
 #include "tvgCanvasImpl.h"
 
 #ifdef THORVG_SW_RASTER_SUPPORT
-    #include "tvgSwRenderer.h"
+#include "tvgSwRenderer.h"
 #else
-    class SwRenderer : public RenderMethod
-    {
-        //Non Supported. Dummy Class */
-    };
+class SwRenderer : public RenderMethod {
+    //Non Supported. Dummy Class */
+};
 #endif
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-struct SwCanvas::Impl
-{
+struct SwCanvas::Impl {
 };
-
 
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
 #ifdef THORVG_SW_RASTER_SUPPORT
-SwCanvas::SwCanvas() : Canvas(SwRenderer::gen()), pImpl(new Impl)
+SwCanvas::SwCanvas()
+    : Canvas(SwRenderer::gen()), pImpl(new Impl)
 #else
-SwCanvas::SwCanvas() : Canvas(nullptr), pImpl(new Impl)
+SwCanvas::SwCanvas()
+    : Canvas(nullptr), pImpl(new Impl)
 #endif
 {
 }
 
-
-SwCanvas::~SwCanvas()
-{
-    delete(pImpl);
+SwCanvas::~SwCanvas() {
+    delete (pImpl);
 }
 
-
-Result SwCanvas::mempool(MempoolPolicy policy) noexcept
-{
+Result SwCanvas::mempool(MempoolPolicy policy) noexcept {
 #ifdef THORVG_SW_RASTER_SUPPORT
     //We know renderer type, avoid dynamic_cast for performance.
     auto renderer = static_cast<SwRenderer*>(Canvas::pImpl->renderer);
@@ -69,16 +64,15 @@ Result SwCanvas::mempool(MempoolPolicy policy) noexcept
     if (Canvas::pImpl->paints.count > 0) return Result::InsufficientCondition;
 
     if (policy == MempoolPolicy::Individual) renderer->mempool(false);
-    else renderer->mempool(true);
+    else
+        renderer->mempool(true);
 
     return Result::Success;
 #endif
     return Result::NonSupport;
 }
 
-
-Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, Colorspace cs) noexcept
-{
+Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, Colorspace cs) noexcept {
 #ifdef THORVG_SW_RASTER_SUPPORT
     //We know renderer type, avoid dynamic_cast for performance.
     auto renderer = static_cast<SwRenderer*>(Canvas::pImpl->renderer);
@@ -94,9 +88,7 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     return Result::NonSupport;
 }
 
-
-unique_ptr<SwCanvas> SwCanvas::gen() noexcept
-{
+unique_ptr<SwCanvas> SwCanvas::gen() noexcept {
 #ifdef THORVG_SW_RASTER_SUPPORT
     if (SwRenderer::init() <= 0) return nullptr;
     return unique_ptr<SwCanvas>(new SwCanvas);

--- a/src/lib/tvgTaskScheduler.h
+++ b/src/lib/tvgTaskScheduler.h
@@ -26,32 +26,28 @@
 #include <condition_variable>
 #include "tvgCommon.h"
 
-namespace tvg
-{
+namespace tvg {
 
 struct Task;
 
-struct TaskScheduler
-{
+struct TaskScheduler {
     static unsigned threads();
     static void init(unsigned threads);
     static void term();
     static void request(Task* task);
 };
 
-struct Task
-{
-private:
-    mutex                   mtx;
-    condition_variable      cv;
-    bool                    ready{true};
-    bool                    pending{false};
+struct Task {
+  private:
+    mutex mtx;
+    condition_variable cv;
+    bool ready{true};
+    bool pending{false};
 
-public:
+  public:
     virtual ~Task() = default;
 
-    void done()
-    {
+    void done() {
         if (!pending) return;
 
         unique_lock<mutex> lock(mtx);
@@ -59,12 +55,11 @@ public:
         pending = false;
     }
 
-protected:
+  protected:
     virtual void run(unsigned tid) = 0;
 
-private:
-    void operator()(unsigned tid)
-    {
+  private:
+    void operator()(unsigned tid) {
         run(tid);
 
         lock_guard<mutex> lock(mtx);
@@ -72,8 +67,7 @@ private:
         cv.notify_one();
     }
 
-    void prepare()
-    {
+    void prepare() {
         ready = false;
         pending = true;
     }
@@ -81,8 +75,6 @@ private:
     friend class TaskSchedulerImpl;
 };
 
-
-
-}
+} // namespace tvg
 
 #endif //_TVG_TASK_SCHEDULER_H_


### PR DESCRIPTION
I want a coding style that can be standardized
and I wanted to check for conflicts with cpplint in github action.
This is just a test :)
```
---
BasedOnStyle: LLVM
IndentWidth: 4
---
Language: Cpp
DerivePointerAlignment: false
PointerAlignment: Left
AllowShortLambdasOnASingleLine: Empty
AllowShortIfStatementsOnASingleLine: Always
AllowShortFunctionsOnASingleLine: None
ColumnLimit: 0
AlignAfterOpenBracket: Align
AllowShortLoopsOnASingleLine: true
AlignConsecutiveMacros: true
SortIncludes: false
BraceWrapping:
  AfterCaseLabel: false
  AfterClass: false
  AfterEnum: false
  AfterNamespace: false
  AfterStruct: false
  AfterUnion: false
  BeforeElse: false
  BeforeWhile: false
  AfterControlStatement: Never
...
```