### PR TITLE
png_loader tvgPngLoader: Revert change to channel order

### DIFF
--- a/src/loaders/png/tvgLodePng.cpp
+++ b/src/loaders/png/tvgLodePng.cpp
@@ -2090,17 +2090,7 @@ static unsigned unfilterScanline(unsigned char* recon, const unsigned char* scan
     size_t i;
     switch (filterType) {
         case 0: {
-            if (bytewidth == 4) {
-                for (i = 0; i < length; i += 4) {
-                    //RGBA -> BGRA
-                    recon[i + 0] = scanline[i + 2];
-                    recon[i + 1] = scanline[i + 1];
-                    recon[i + 2] = scanline[i + 0];
-                    recon[i + 3] = scanline[i + 3];
-                }
-            } else {
-                for (i = 0; i != length; ++i) recon[i] = scanline[i];
-            }
+            for (i = 0; i < length; ++i) recon[i] = scanline[i];
             break;
         }
         case 1: {

--- a/src/loaders/png/tvgLodePng.cpp
+++ b/src/loaders/png/tvgLodePng.cpp
@@ -1762,11 +1762,7 @@ static void getPixelColorsRGBA8(unsigned char* LODEPNG_RESTRICT buffer, size_t n
     } else if (mode->colortype == LCT_RGB) {
         if (mode->bitdepth == 8) {
             for (i = 0; i != numpixels; ++i, buffer += num_channels) {
-                //lodepng_memcpy(buffer, &in[i * 3], 3);
-                //Convert colortype to LCT_BGR?
-                buffer[0] = in[i * 3 + 2];
-                buffer[1] = in[i * 3 + 1];
-                buffer[2] = in[i * 3 + 0];
+                lodepng_memcpy(buffer, &in[i * 3], 3);
                 buffer[3] = 255;
             }
             if (mode->key_defined) {


### PR DESCRIPTION
Revert an earlier change to store internal PNG channels as BGR (changed back to RGB).

- Reverts #1041
- Fixes #1112 (can be closed without merging)
- Reopens #1007 (needs to be fixed a different way)

PNGs now render correctly. I have tested this with 4 kinds of PNG, but not with grayscale PNGs yet.

However, please be aware that it doesn't matter if you target the buffer with ColorSpace ARGB8888 or ABGR8888, the PNG still appears the same both ways. i.e. the Picture renderer needs to be updated to swap the channels. This is likely the same bug as #1007 

```
// Changing the ColorSpace does not change the PNG channel order during drawing.
// Both of these result in the same drawing output.
canvas->target(buffer, width, width, height, tvg::SwCanvas::ARGB8888); // RGB
canvas->target(buffer, width, width, height, tvg::SwCanvas::ABGR8888); // BGR
```

