### PR TITLE
Draft - Paint: Blending modes implementation

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -212,6 +212,28 @@ struct Polygon
 
 
 /**
+ * @brief Enumeration specifying the blending mode used for paint blending.
+ * 
+ * @BETA_API
+ */
+enum class BlendingMode
+{
+    Normal = 0,
+    Screen,
+    Multiply,
+    Overlay,
+    Darken,
+    Lighten,
+    ColorDodge,
+    ColorBurn,
+    HardLight,
+    SoftLight,
+    Difference,
+    Exclusion
+};
+
+
+/**
  * @class Paint
  *
  * @brief An abstract class for managing graphical elements.
@@ -302,6 +324,26 @@ public:
      * @return Result::Success when succeed, Result::InvalidArguments otherwise.
      */
     Result composite(std::unique_ptr<Paint> target, CompositeMethod method) noexcept;
+
+    /**
+     * @brief Sets the blending mode for paint.
+     *
+     * @param[in] blendingMode The blending mode for paint.
+     *
+     * @return Result::Success when succeed.
+     * 
+     * @BETA_API
+     */
+    Result blending(BlendingMode blendingMode) const noexcept;
+
+    /**
+     * @brief Gets the blending of the object.
+     *
+     * @return The blending mode
+     * 
+     * @BETA_API
+     */
+    BlendingMode blending() const noexcept;
 
     /**
      * @brief Gets the bounding box of the paint object before any transformation.

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -123,6 +123,12 @@ bool GlRenderer::endComposite(TVG_UNUSED Compositor* cmp)
 }
 
 
+void GlRenderer::blending(BlendingMode blendingMode)
+{
+    // TODO: Implement blending modes in GL
+}
+
+
 bool GlRenderer::renderImage(TVG_UNUSED void* data)
 {
     return false;

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -50,6 +50,8 @@ public:
     bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) override;
     bool endComposite(Compositor* cmp) override;
 
+    void blending(BlendingMode blendingMode) override;
+
     static GlRenderer* gen();
     static int init(TVG_UNUSED uint32_t threads);
     static int32_t init();

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -236,6 +236,7 @@ struct SwBlender
 {
     uint32_t (*join)(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
     uint32_t (*lumaValue)(uint32_t c);
+    uint32_t (*blend)(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
 };
 
 struct SwCompositor;
@@ -281,6 +282,28 @@ static inline uint32_t INTERPOLATE(uint32_t a, uint32_t c0, uint32_t c1)
 static inline SwCoord HALF_STROKE(float width)
 {
     return TO_SWCOORD(width * 0.5f);
+}
+
+static inline uint32_t LIMIT_BYTE(uint32_t b)
+{
+    return (b & 0xffffff00) ? 0xff : b;
+}
+
+static inline uint32_t LIMIT_BYTE_LOW(uint32_t b)
+{
+    return (b & 0xffffff00) ? 0x00 : b;
+}
+
+static inline uint32_t BLEND_COLORS(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha)
+{
+    // for each byte: (src * alpha + dst * ialpha + 0xff) >> 8
+    return ((((src >> 8) & 0x00ff00ff) * alpha + ((dst >> 8) & 0x00ff00ff) * ialpha + 0xff00ff) & 0xff00ff00)
+            | (((((src) & 0x00ff00ff) * alpha + ((dst) & 0x00ff00ff) * ialpha + 0xff00ff) >> 8) & 0x00ff00ff);
+}
+
+static inline uint32_t ABS_DIFFERENCE(uint32_t src, uint32_t dst)
+{
+    return (src >= dst) ? (src - dst) : (dst - src);
 }
 
 int64_t mathMultiply(int64_t a, int64_t b);
@@ -346,6 +369,19 @@ SwOutline* mpoolReqOutline(SwMpool* mpool, unsigned idx);
 void mpoolRetOutline(SwMpool* mpool, unsigned idx);
 SwOutline* mpoolReqStrokeOutline(SwMpool* mpool, unsigned idx);
 void mpoolRetStrokeOutline(SwMpool* mpool, unsigned idx);
+
+uint32_t blendNormal(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendScreen(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendMultiply(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendOverlay(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendDarken(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendLighten(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendColorDodge(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendColorBurn(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendHardLight(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendSoftLight(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendDifference(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
+uint32_t blendExclusion(uint32_t src, uint32_t dst, uint8_t alpha, uint8_t ialpha, uint32_t src_blended);
 
 bool rasterCompositor(SwSurface* surface);
 bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id);

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -580,6 +580,51 @@ bool SwRenderer::dispose(RenderData data)
 }
 
 
+void SwRenderer::blending(BlendingMode blendingMode)
+{
+    switch (blendingMode)
+    {
+        default:
+        case BlendingMode::Normal:
+            this->surface->blender.blend = &blendNormal;
+            break;
+        case BlendingMode::Screen:
+            this->surface->blender.blend = &blendScreen;
+            break;
+        case BlendingMode::Multiply:
+            this->surface->blender.blend = &blendMultiply;
+            break;
+        case BlendingMode::Overlay:
+            this->surface->blender.blend = &blendOverlay;
+            break;
+        case BlendingMode::Darken:
+            this->surface->blender.blend = &blendDarken;
+            break;
+        case BlendingMode::Lighten:
+            this->surface->blender.blend = &blendLighten;
+            break;
+        case BlendingMode::ColorDodge:
+            this->surface->blender.blend = &blendColorDodge;
+            break;
+        case BlendingMode::ColorBurn:
+            this->surface->blender.blend = &blendColorBurn;
+            break;
+        case BlendingMode::HardLight:
+            this->surface->blender.blend = &blendHardLight;
+            break;
+        case BlendingMode::SoftLight:
+            this->surface->blender.blend = &blendSoftLight;
+            break;
+        case BlendingMode::Difference:
+            this->surface->blender.blend = &blendDifference;
+            break;
+        case BlendingMode::Exclusion:
+            this->surface->blender.blend = &blendExclusion;
+            break;
+    }
+}
+
+
 void* SwRenderer::prepareCommon(SwTask* task, const RenderTransform* transform, uint32_t opacity, const Array<RenderData>& clips, RenderUpdateFlag flags)
 {
     if (!surface) return task;

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -57,6 +57,8 @@ public:
     bool endComposite(Compositor* cmp) override;
     void clearCompositors();
 
+    void blending(BlendingMode blendingMode) override;
+
     static SwRenderer* gen();
     static bool init(uint32_t threads);
     static int32_t init();

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -104,6 +104,7 @@ Paint* Paint::Impl::duplicate()
     }
 
     ret->pImpl->opacity = opacity;
+    ret->pImpl->blendingMode = blendingMode;
 
     if (compData) ret->pImpl->composite(ret, compData->target->duplicate(), compData->method);
 
@@ -175,6 +176,7 @@ bool Paint::Impl::render(RenderMethod& renderer)
 
     if (cmp) renderer.beginComposite(cmp, compData->method, compData->target->pImpl->opacity);
 
+    renderer.blending(blendingMode);
     auto ret = smethod->render(renderer);
 
     if (cmp) renderer.endComposite(cmp);
@@ -381,6 +383,23 @@ CompositeMethod Paint::composite(const Paint** target) const noexcept
         if (target) *target = nullptr;
         return CompositeMethod::None;
     }
+}
+
+
+Result Paint::blending(BlendingMode blendingMode) const noexcept
+{
+    if (pImpl->blendingMode == blendingMode) return Result::Success;
+
+    pImpl->blendingMode = blendingMode;
+    pImpl->renderFlag |= RenderUpdateFlag::Blending;
+
+    return Result::Success;
+}
+
+
+BlendingMode Paint::blending() const noexcept
+{
+    return pImpl->blendingMode;
 }
 
 

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -66,6 +66,7 @@ namespace tvg
         uint32_t ctxFlag = ContextFlag::Invalid;
         uint32_t id;
         uint8_t opacity = 255;
+        BlendingMode blendingMode = BlendingMode::Normal;
 
         ~Impl()
         {

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -28,7 +28,19 @@
 namespace tvg
 {
 
-enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, All = 255};
+enum RenderUpdateFlag
+{
+    None = 0,
+    Path = 1,
+    Color = 2,
+    Gradient = 4,
+    Stroke = 8,
+    Transform = 16,
+    Image = 32,
+    GradientStroke = 64,
+    Blending = 128,
+    All = 255
+};
 
 struct Surface
 {
@@ -107,6 +119,8 @@ public:
     virtual Compositor* target(const RenderRegion& region) = 0;
     virtual bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) = 0;
     virtual bool endComposite(Compositor* cmp) = 0;
+
+    virtual void blending(BlendingMode blendingMode) = 0;
 };
 
 }


### PR DESCRIPTION
@hermet @mmaciola I started from mmaciola's implementation, but made some changes.

The biggest change is that the blending mode is now added to the surface as a function pointer.

This implementation should be more performant because the switch statement has been removed for every pixel being drawn.  The blending function pointer is only set one time before the paint is rendered.

This is just a draft implementation - it builds and runs, but the resulting blending is not correct.

I would really appreciate your help and pointers on what I have done incorrectly!

Please refer to #401 