### PR TITLE
common Paint: Add name getter/setter API

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -427,6 +427,28 @@ public:
      */
     uint32_t identifier() const noexcept;
 
+    /**
+     * @brief Sets the name for the current instance.
+     *
+     * The name can be up to 127 characters long.
+     *
+     * @note The "id" attribute of the SVG format is set to name, and save/load is not yet supported in the case of the TVG format.
+     *
+     * @return Result::Success when succeed, Result::InvalidArguments in case the name length exceeded 128 characters.
+     *
+     * @BETA_API
+     */
+    Result name(std::string name) const noexcept;
+
+    /**
+     * @brief Returns the name set for the current instance.
+     *
+     * @return The name set on the current instance when succeed, otherwise an empty string.
+     *
+     * @BETA_API
+     */
+    std::string name() const noexcept;
+
     _TVG_DECLARE_PRIVATE(Paint);
 };
 

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -796,6 +796,7 @@ static unique_ptr<Scene> _sceneBuildHelper(SvgLoaderData& loaderData, const SvgN
                 } else if ((*child)->type == SvgNodeType::Image) {
                     auto image = _imageBuildHelper(loaderData, *child, vBox, svgPath);
                     if (image) {
+                        if ((*child)->id) image->name(std::string((*child)->id));
                         scene->push(std::move(image));
                         if (isMaskWhite) *isMaskWhite = false;
                     }
@@ -810,6 +811,7 @@ static unique_ptr<Scene> _sceneBuildHelper(SvgLoaderData& loaderData, const SvgN
                                 *isMaskWhite = false;
                             }
                         }
+                        if ((*child)->id) shape->name(std::string((*child)->id));
                         scene->push(std::move(shape));
                     }
                 }
@@ -817,6 +819,7 @@ static unique_ptr<Scene> _sceneBuildHelper(SvgLoaderData& loaderData, const SvgN
             _applyComposition(loaderData, scene.get(), node, vBox, svgPath);
             scene->opacity(node->style->opacity);
         }
+        if (node->id) scene->name(std::string(node->id));
         return scene;
     }
     return nullptr;

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -140,6 +140,7 @@ Paint* Paint::Impl::duplicate()
     }
 
     ret->pImpl->opacity = opacity;
+    ret->pImpl->name = name;
 
     if (compData) ret->pImpl->composite(ret, compData->target->duplicate(), compData->method);
 
@@ -458,7 +459,14 @@ Result Paint::blend(BlendMethod method) const noexcept
         pImpl->blendMethod = method;
         pImpl->renderFlag |= RenderUpdateFlag::Blend;
     }
+    return Result::Success;
+}
 
+
+Result Paint::name(std::string name) const noexcept
+{
+    if (name.length() > 128) return Result::InvalidArguments;
+    pImpl->name = name;
     return Result::Success;
 }
 
@@ -467,3 +475,10 @@ BlendMethod Paint::blend() const noexcept
 {
     return pImpl->blendMethod;
 }
+
+
+std::string Paint::name() const noexcept
+{
+    return pImpl->name;
+}
+

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -57,6 +57,7 @@ namespace tvg
         uint8_t id;
         uint8_t opacity = 255;
         uint8_t refCnt = 0;                              //reference count
+        std::string name = "";
 
         Impl(Paint* pnt) : paint(pnt) {}
 

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -115,6 +115,17 @@ TEST_CASE("Opacity", "[tvgPaint]")
     REQUIRE(shape->opacity() == 0);
 }
 
+TEST_CASE("Name", "[tvgPaint]")
+{
+    auto shape = Shape::gen();
+    REQUIRE(shape);
+
+    REQUIRE(shape->name().empty());
+
+    REQUIRE(shape->name("test") == Result::Success);
+    REQUIRE(shape->name() == "test");
+}
+
 TEST_CASE("Bounding Box", "[tvgPaint]")
 {
     auto shape = Shape::gen();
@@ -166,6 +177,7 @@ TEST_CASE("Duplication", "[tvgPaint]")
     REQUIRE(shape->translate(200.0f, 100.0f) == Result::Success);
     REQUIRE(shape->scale(2.2f) == Result::Success);
     REQUIRE(shape->rotate(90.0f) == Result::Success);
+    REQUIRE(shape->name("test") == Result::Success);
 
     auto comp = Shape::gen();
     REQUIRE(comp);
@@ -177,6 +189,8 @@ TEST_CASE("Duplication", "[tvgPaint]")
 
     //Compare properties
     REQUIRE(dup->opacity() == 0);
+
+    REQUIRE(dup->name() == "test");
 
     auto m = shape->transform();
     REQUIRE(m.e11 == Approx(0.0f).margin(0.000001));


### PR DESCRIPTION
Adds an API that can set/get string type name to tvgPaint.
This can be used when the user needs to traverse the scene tree or find a specific instance.
+) The SVG's "id" attribute is set to name when SVG is loaded.

Issue: 
- https://github.com/thorvg/thorvg/issues/1276
- https://github.com/thorvg/thorvg/issues/2055