### PR TITLE
svg loader: correct clipper usage.

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -264,11 +264,8 @@ static void _applyComposition(Paint* paint, const SvgNode* node, const Box& vBox
                 if (_appendChildShape(*child, comp.get(), vBox, svgPath)) valid = true;
             }
 
-            if (valid) {
-                comp->fill(255, 255, 255, 255);
-                comp->opacity(255);
-                paint->composite(move(comp), CompositeMethod::ClipPath);
-            }
+            if (valid) paint->composite(move(comp), CompositeMethod::ClipPath);
+
             node->style->clipPath.applying = false;
         }
     }


### PR DESCRIPTION
that has been changed by 0de3872be33793d2c8db03d5b85da38670410626