### PR TITLE
example: correct clipper usage.

### DIFF
--- a/src/examples/PictureRaw.cpp
+++ b/src/examples/PictureRaw.cpp
@@ -61,7 +61,6 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     auto circle = tvg::Shape::gen();
     circle->appendCircle(350, 350, 200,200);
-    circle->fill(255, 255, 255, 255);
 
     picture2->composite(move(circle), tvg::CompositeMethod::ClipPath);
 


### PR DESCRIPTION
it has been changed by 0de3872be33793d2c8db03d5b85da38670410626