### PR TITLE
infra: Disable cpp lint checker

### DIFF
--- a/.github/workflows/actions_cpplint.yml
+++ b/.github/workflows/actions_cpplint.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   coding-style:
+    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
When we do 1.0 release, we clean up the coding style of all codes.
Currently, there are limitations in our coding style and lint settings.
This results in unnecessary bot comments.