### PR TITLE
png_loader(static): Fix the colorspace of an image with an alpha channel

### DIFF
--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -213,5 +213,7 @@ void PngLoader::run(unsigned tid)
 
     lodepng_decode(&image, &width, &height, &state, data, size);
 
+    if (state.info_png.color.colortype == LCT_RGBA) colorSpace = SwCanvas::ABGR8888;
+
     _premultiply((uint32_t*)(image), width, height);
 }

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -125,6 +125,8 @@ bool PngLoader::open(const string& path)
     h = static_cast<float>(height);
     ret = true;
 
+    if (state.info_png.color.colortype == LCT_RGBA) colorSpace = SwCanvas::ABGR8888;
+
     goto finalize;
 
 failure:
@@ -158,6 +160,8 @@ bool PngLoader::open(const char* data, uint32_t size, bool copy)
     w = static_cast<float>(width);
     h = static_cast<float>(height);
     this->size = size;
+
+    if (state.info_png.color.colortype == LCT_RGBA) colorSpace = SwCanvas::ABGR8888;
 
     return true;
 }
@@ -212,8 +216,6 @@ void PngLoader::run(unsigned tid)
     auto height = static_cast<unsigned>(h);
 
     lodepng_decode(&image, &width, &height, &state, data, size);
-
-    if (state.info_png.color.colortype == LCT_RGBA) colorSpace = SwCanvas::ABGR8888;
 
     _premultiply((uint32_t*)(image), width, height);
 }


### PR DESCRIPTION
Set colorspace to ABGR when colortype of lodepng is LCT_RGBA.
Since an image without an alpha channel becomes an ARGB colorspace with LCT_RGB,
it is the same as the default colorspace.

related issue : https://github.com/thorvg/thorvg/issues/1320