### PR TITLE
svg_loader: fix zero width/height handling

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3212,8 +3212,8 @@ bool SvgLoader::header()
         //Return the brief resource info such as viewbox:
         vx = loaderData.doc->node.doc.vx;
         vy = loaderData.doc->node.doc.vy;
-        w = vw = loaderData.doc->node.doc.vw;
-        h = vh = loaderData.doc->node.doc.vh;
+        vw = loaderData.doc->node.doc.vw;
+        vh = loaderData.doc->node.doc.vh;
 
         //Override size
         if (loaderData.doc->node.doc.w > 0) {


### PR DESCRIPTION
Svgs with width/height attrib set to zero
were rendered although they shouldn't have
been.

sample svg file:
```
<svg viewBox="0 0 10 10" height="100" width="0">
    <path stroke="none" fill="red" d="M0 0 L 100 0 100 100 0 100 0 0"/>
    <path fill="none" stroke="#00ff00" stroke-width="4" d="M0 0 L 100 100"/>
</svg>
```

expected result - empty canvas
master branch result:
<img width="374" alt="Zrzut ekranu 2023-03-9 o 01 32 42" src="https://user-images.githubusercontent.com/67589014/223884568-8730bd61-e114-49fe-914f-ffea38862b5b.png">
