### PR TITLE
svg_loader: invalid strokes' width set to zero

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -346,7 +346,7 @@ static void _applyProperty(SvgNode* node, Shape* vg, const Box& vBox, const stri
 
     //If stroke property is nullptr then do nothing
     if (style->stroke.paint.none) {
-        //Do nothing
+        vg->stroke(0.0f);
     } else if (style->stroke.paint.gradient) {
         Box bBox = vBox;
         if (!style->stroke.paint.gradient->userSpace) bBox = _boundingBox(vg);


### PR DESCRIPTION
In case the "stroke" attrib is set to "none",
the width of the stroke is set to zero. Thanks
to that it isn't taken into account while
establishing the viewbox boundaries for svgs
without a viewbox and width/height information.

```
<svg>
      <linearGradient id="Gradient" x1="0" x2="50%" y1="3" y2="1" gradientUnits="userSpaceOnUse">
      <stop offset="0%" stop-color="red" />
      <stop offset="50%" stop-color="black" stop-opacity="0" />
      <stop offset="100%" stop-color="green" />
    </linearGradient>

  <path fill="blue" d="M 0 0 h 400 v 400 z"/>
  <path stroke="pink" stroke-width="80" fill="green" d="M -100 400  h 400 v -300 z"/>
    <path stroke="none" fill="url(#Gradient)" d="M0 0 L100 0 100 100 0 100 0 0"/>
    <path fill="none" stroke="#00ff00" stroke-width="80" d="M0 0 L 100 100"/>
</svg>
```

before:
<img width="559" alt="Zrzut ekranu 2023-03-22 o 00 19 03" src="https://user-images.githubusercontent.com/67589014/226763308-e2ddb6c6-db43-4b7c-8f52-cad83fc6d582.png">


after:
<img width="421" alt="Zrzut ekranu 2023-03-22 o 00 20 10" src="https://user-images.githubusercontent.com/67589014/226763293-746aa22f-b3bf-4979-82e9-7e7e8653cc47.png">
