### PR TITLE
svg_loader: fixing viewbox width/height

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -67,7 +67,7 @@ struct Box
 };
 
 static bool _appendShape(SvgNode* node, Shape* shape, const Box& vBox, const string& svgPath);
-static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox, const string& svgPath, bool mask, int depth, bool* isMaskWhite = nullptr);
+static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox, Box& bBox, const string& svgPath, bool mask, int depth, bool* isMaskWhite = nullptr);
 
 
 static inline bool _isGroupType(SvgNodeType type)
@@ -92,6 +92,21 @@ static Box _boundingBox(const Shape* shape)
     }
 
     return {x, y, w, h};
+}
+
+
+static void _mergeBoundingBox(Box& bBox, const Box& shapesBBox)
+{
+    float x2 = bBox.x + bBox.w;
+    float y2 = bBox.y + bBox.h;
+
+    if (shapesBBox.x < bBox.x) bBox.x = shapesBBox.x;
+    if (x2 < shapesBBox.x + shapesBBox.w) x2 = (shapesBBox.x + shapesBBox.w);
+    if (shapesBBox.y < bBox.y) bBox.y = shapesBBox.y;
+    if (y2 < shapesBBox.y + shapesBBox.h) y2 = (shapesBBox.y + shapesBBox.h);
+
+    bBox.w = x2 - bBox.x;
+    bBox.h = y2 - bBox.y;
 }
 
 
@@ -280,7 +295,8 @@ static void _applyComposition(Paint* paint, const SvgNode* node, const Box& vBox
             node->style->mask.applying = true;
 
             bool isMaskWhite = true;
-            auto comp = _sceneBuildHelper(compNode, vBox, svgPath, true, 0, &isMaskWhite);
+            Box dummy;
+            auto comp = _sceneBuildHelper(compNode, vBox, dummy, svgPath, true, 0, &isMaskWhite);
             if (comp) {
                 if (node->transform) comp->transform(*node->transform);
 
@@ -372,10 +388,15 @@ static void _applyProperty(SvgNode* node, Shape* vg, const Box& vBox, const stri
 }
 
 
-static unique_ptr<Shape> _shapeBuildHelper(SvgNode* node, const Box& vBox, const string& svgPath)
+static unique_ptr<Shape> _shapeBuildHelper(SvgNode* node, const Box& vBox, Box& bBox, const string& svgPath)
 {
     auto shape = Shape::gen();
-    if (_appendShape(node, shape.get(), vBox, svgPath)) return shape;
+    if (_appendShape(node, shape.get(), vBox, svgPath)) {
+        float x, y, w, h;
+        shape->bounds(&x, &y, &w, &h, false);
+        _mergeBoundingBox(bBox, {x, y, w, h});
+        return shape;
+    }
     else return nullptr;
 }
 
@@ -508,7 +529,7 @@ static bool _isValidImageMimeTypeAndEncoding(const char** href, const char** mim
 }
 
 
-static unique_ptr<Picture> _imageBuildHelper(SvgNode* node, const Box& vBox, const string& svgPath)
+static unique_ptr<Picture> _imageBuildHelper(SvgNode* node, const Box& vBox, Box& bBox, const string& svgPath)
 {
     if (!node->node.image.href) return nullptr;
     auto picture = Picture::gen();
@@ -549,6 +570,7 @@ static unique_ptr<Picture> _imageBuildHelper(SvgNode* node, const Box& vBox, con
         auto sx = node->node.image.w / w;
         auto sy = node->node.image.h / h;
         m = {sx, 0, node->node.image.x, 0, sy, node->node.image.y, 0, 0, 1};
+        _mergeBoundingBox(bBox, {0.0f, 0.0f, w, h});
     }
     if (node->transform) m = mathMultiply(node->transform, &m);
     picture->transform(m);
@@ -632,10 +654,10 @@ static Matrix _calculateAspectRatioMatrix(AspectRatioAlign align, AspectRatioMee
 }
 
 
-static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, const string& svgPath, int depth, bool* isMaskWhite)
+static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, Box& bBox, const string& svgPath, int depth, bool* isMaskWhite)
 {
     unique_ptr<Scene> finalScene;
-    auto scene = _sceneBuildHelper(node, vBox, svgPath, false, depth + 1, isMaskWhite);
+    auto scene = _sceneBuildHelper(node, vBox, bBox, svgPath, false, depth + 1, isMaskWhite);
 
     // mUseTransform = mUseTransform * mTranslate
     Matrix mUseTransform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
@@ -702,7 +724,7 @@ static unique_ptr<Scene> _useBuildHelper(const SvgNode* node, const Box& vBox, c
 }
 
 
-static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox, const string& svgPath, bool mask, int depth, bool* isMaskWhite)
+static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox, Box& bBox, const string& svgPath, bool mask, int depth, bool* isMaskWhite)
 {
     /* Exception handling: Prevent invalid SVG data input.
        The size is the arbitrary value, we need an experimental size. */
@@ -721,17 +743,17 @@ static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox,
             for (uint32_t i = 0; i < node->child.count; ++i, ++child) {
                 if (_isGroupType((*child)->type)) {
                     if ((*child)->type == SvgNodeType::Use)
-                        scene->push(_useBuildHelper(*child, vBox, svgPath, depth + 1, isMaskWhite));
+                        scene->push(_useBuildHelper(*child, vBox, bBox, svgPath, depth + 1, isMaskWhite));
                     else
-                        scene->push(_sceneBuildHelper(*child, vBox, svgPath, false, depth + 1, isMaskWhite));
+                        scene->push(_sceneBuildHelper(*child, vBox, bBox, svgPath, false, depth + 1, isMaskWhite));
                 } else if ((*child)->type == SvgNodeType::Image) {
-                    auto image = _imageBuildHelper(*child, vBox, svgPath);
+                    auto image = _imageBuildHelper(*child, vBox, bBox, svgPath);
                     if (image) {
                         scene->push(move(image));
                         if (isMaskWhite) *isMaskWhite = false;
                     }
                 } else if ((*child)->type != SvgNodeType::Mask) {
-                    auto shape = _shapeBuildHelper(*child, vBox, svgPath);
+                    auto shape = _shapeBuildHelper(*child, vBox, bBox, svgPath);
                     if (shape) {
                         if (isMaskWhite) {
                             uint8_t r, g, b;
@@ -754,12 +776,11 @@ static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox,
 }
 
 
-static void _applySvgViewFlag(const Scene* scene, float& vx, float& vy, float& vw, float& vh, float& w, float& h, SvgViewFlag viewFlag)
+static void _applySvgViewFlag(const Scene* scene, float& vx, float& vy, float& vw, float& vh, float& w, float& h, Box& bBox, SvgViewFlag viewFlag)
 {
     if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Viewbox)) {
-        scene->bounds(&vx, &vy, &vw, &vh, false);
-        vw += vx;
-        vh += vy;
+        vw = bBox.w + bBox.x;
+        vh = bBox.h + bBox.y;
         vx = 0.0f;
         vy = 0.0f;
         if ((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width) vw = w;
@@ -780,8 +801,9 @@ unique_ptr<Scene> svgSceneBuild(SvgNode* node, float& vx, float& vy, float& vw, 
     if (!node || (node->type != SvgNodeType::Doc)) return nullptr;
 
     Box vBox = {vx, vy, vw, vh};
-    auto docNode = _sceneBuildHelper(node, vBox, svgPath, false, 0);
-    _applySvgViewFlag(docNode.get(), vx, vy, vw, vh, w, h, viewFlag);
+    Box bBox = {0.0f, 0.0f, 0.0f, 0.0f};
+    auto docNode = _sceneBuildHelper(node, vBox, bBox, svgPath, false, 0);
+    _applySvgViewFlag(docNode.get(), vx, vy, vw, vh, w, h, bBox, viewFlag);
 
     if (!mathEqual(w, vw) || !mathEqual(h, vh)) {
         Matrix m = _calculateAspectRatioMatrix(align, meetOrSlice, w, h, {vx, vy, vw, vh});

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -757,7 +757,9 @@ static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox,
 static void _applySvgViewFlag(const Scene* scene, float& vx, float& vy, float& vw, float& vh, float& w, float& h, SvgViewFlag viewFlag)
 {
     if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Viewbox)) {
-        scene->bounds(nullptr, nullptr, &vw, &vh, false);
+        scene->bounds(&vx, &vy, &vw, &vh, false);
+        vw += vx;
+        vh += vy;
         vx = 0.0f;
         vy = 0.0f;
         if ((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width) vw = w;


### PR DESCRIPTION
For svg without any viewbox and width/height
information the established width and height
values of the viewbox should be calculated
starting in the 0,0 point.