### PR TITLE
picture: paint and surface reloading separation

### DIFF
--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -98,7 +98,7 @@ Result Picture::size(float w, float h) noexcept
 Result Picture::size(float* w, float* h) const noexcept
 {
     if (!pImpl->loader) return Result::InsufficientCondition;
-    pImpl->reload();
+    pImpl->reloadPaint();
     if (w) *w = pImpl->w;
     if (h) *h = pImpl->h;
     return Result::Success;


### PR DESCRIPTION
I'd rather use https://github.com/thorvg/thorvg/pull/1338

For svg files without any viewbox and widht/height
information it has to be ensured, that the loading
process is finished before any api like size/viewbox/bounds
is called.