### PR TITLE
sw_engine: fix safety check

### DIFF
--- a/src/lib/sw_engine/tvgSwRasterTexmap.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmap.h
@@ -548,7 +548,7 @@ static bool _apply(SwSurface* surface, AASpans* aaSpans)
 static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint32_t (*blendMethod)(uint32_t))
 {
     //Exceptions: No dedicated drawing area?
-    if (!image->rle || (!region && image->rle->size == 0)) return false;
+    if ((!image->rle && !region) || (image->rle && image->rle->size == 0)) return false;
 
    /* Prepare vertices.
       shift XY coordinates to match the sub-pixeling technique. */
@@ -605,7 +605,7 @@ static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const
 static bool _rasterTexmapPolygonMesh(SwSurface* surface, const SwImage* image, const Polygon* triangles, const uint32_t triangleCount, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint32_t (*blendMethod)(uint32_t))
 {
     //Exceptions: No dedicated drawing area?
-    if (!image->rle || (!region && image->rle->size == 0)) return false;
+    if ((!image->rle && !region) || (image->rle && image->rle->size == 0)) return false;
 
     // Step polygons once to transform
     auto transformedTris = (Polygon*)malloc(sizeof(Polygon) * triangleCount);


### PR DESCRIPTION
An incorrect check introduced in bf07eb11f25909d2c73aa7e5baeb01a80af384d0 as a solution of the #1327 issue. As a consequence rotated images were not drawn. Fixed.