### PR TITLE
svg_loader: forcing file loading completion

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3327,6 +3327,12 @@ bool SvgLoader::read()
 
     TaskScheduler::request(this);
 
+    //In case no viewbox and width/height data is provided the completion of loading
+    //has to be forced, in order to establish this data based on the whole picture bounding box.
+    if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Viewbox) &&
+        (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width) || !((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Height)))
+        this->done();
+
     return true;
 }
 


### PR DESCRIPTION
Svgs without any viewbox and width/height information have to be loaded before any other action is taken. This is necessary to get the valid sive/viewbox info.

I'd use this instead of #1335 and extra reload() calls added in the picture code