### PR TITLE
external_jpg_loader: Fix crash when loader is reloaded

### DIFF
--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -55,6 +55,24 @@ uint32_t convertColorSpaceType(uint32_t colorSpace)
     return tjpfColorSpace;
 }
 
+
+static inline uint32_t CHANGE_COLORSPACE(uint32_t c)
+{
+    return (c & 0xff000000) + ((c & 0x00ff0000)>>16) + (c & 0x0000ff00) + ((c & 0x000000ff)<<16);
+}
+
+
+static void _changeColorSpace(uint32_t* data, uint32_t w, uint32_t h)
+{
+    auto buffer = data;
+    for (uint32_t y = 0; y < h; ++y, buffer += w) {
+        auto src = buffer;
+        for (uint32_t x = 0; x < w; ++x, ++src) {
+            *src = CHANGE_COLORSPACE(*src);
+        }
+    }
+}
+
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
@@ -172,7 +190,7 @@ unique_ptr<Surface> JpgLoader::bitmap(uint32_t colorSpace)
     if (!image) return nullptr;
     if (this->colorSpace != colorSpace) {
         this->colorSpace = colorSpace;
-        read();
+        _changeColorSpace(reinterpret_cast<uint32_t*>(image), w, h);
     }
 
     auto surface = static_cast<Surface*>(malloc(sizeof(Surface)));


### PR DESCRIPTION
When reload is called from tvgPicture, clear() of external_jpg loader is called and 'data' is freed.
In the past, there was no case where reload was called until bitmap() was called after load.
Currently I have to consider reload() for a none-viewbox svg case.
So change the color myself because loader can't call open() again.