### PR TITLE
picture: remove unnecessary reloads

### DIFF
--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -98,7 +98,6 @@ Result Picture::size(float w, float h) noexcept
 Result Picture::size(float* w, float* h) const noexcept
 {
     if (!pImpl->loader) return Result::InsufficientCondition;
-    pImpl->reload();
     if (w) *w = pImpl->w;
     if (h) *h = pImpl->h;
     return Result::Success;

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -162,7 +162,6 @@ struct Picture::Impl
     bool viewbox(float* x, float* y, float* w, float* h)
     {
         if (!loader) return false;
-        reload();
         if (x) *x = loader->vx;
         if (y) *y = loader->vy;
         if (w) *w = loader->vw;


### PR DESCRIPTION
After #1338 is applied there is no need to reload
the pictures while aksing about its viewbox or its size.