### PR TITLE
examples: preventing undef behavior

### DIFF
--- a/src/examples/ImageScaleDown.cpp
+++ b/src/examples/ImageScaleDown.cpp
@@ -40,8 +40,9 @@ void tvgDrawCmds(tvg::Canvas* canvas)
         cout << "The PNG file is not loaded correctly. Did you enable PNG Loader?" << endl;
         return;
     }
-    if (canvas->push(move(picture)) == tvg::Result::Success) {
-        pPicture = picture.get();
+    pPicture = picture.get();
+    if (canvas->push(move(picture)) != tvg::Result::Success) {
+        pPicture = nullptr;
     }
 }
 

--- a/src/examples/ImageScaleUp.cpp
+++ b/src/examples/ImageScaleUp.cpp
@@ -40,8 +40,9 @@ void tvgDrawCmds(tvg::Canvas* canvas)
         cout << "The PNG file is not loaded correctly. Did you enable PNG Loader?" << endl;
         return;
     }
-    if (canvas->push(move(picture)) == tvg::Result::Success) {
-        pPicture = picture.get();
+    pPicture = picture.get();
+    if (canvas->push(move(picture)) != tvg::Result::Success) {
+        pPicture = nullptr;
     }
 }
 


### PR DESCRIPTION
Calling get() on a unique pointer after
it has been moved is the undefined behavior.