### PR TITLE
common: code refactoring for the IteractorAccessor.

### DIFF
--- a/src/lib/tvgAccessor.cpp
+++ b/src/lib/tvgAccessor.cpp
@@ -26,15 +26,15 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static bool accessChildren(Iterator* it, IteratorAccessor& itrAccessor, function<bool(const Paint* paint)> func)
+static bool accessChildren(Iterator* it, function<bool(const Paint* paint)> func)
 {
     while (auto child = it->next()) {
         //Access the child
         if (!func(child)) return false;
 
         //Access the children of the child
-        if (auto it2 = itrAccessor.iterator(child)) {
-            if (!accessChildren(it2, itrAccessor, func)) {
+        if (auto it2 = IteratorAccessor::iterator(child)) {
+            if (!accessChildren(it2, func)) {
                 delete(it2);
                 return false;
             }
@@ -59,9 +59,8 @@ unique_ptr<Picture> Accessor::set(unique_ptr<Picture> picture, function<bool(con
     if (!func(p)) return picture;
 
     //Children
-    IteratorAccessor itrAccessor;
-    if (auto it = itrAccessor.iterator(p)) {
-        accessChildren(it, itrAccessor, func);
+    if (auto it = IteratorAccessor::iterator(p)) {
+        accessChildren(it, func);
         delete(it);
     }
     return picture;

--- a/src/lib/tvgIteratorAccessor.h
+++ b/src/lib/tvgIteratorAccessor.h
@@ -32,7 +32,7 @@ class IteratorAccessor
 {
 public:
     //Utility Method: Iterator Accessor
-    Iterator* iterator(const Paint* paint)
+    static Iterator* iterator(const Paint* paint)
     {
         return paint->pImpl->iterator();
     }

--- a/src/lib/tvgSaveModule.h
+++ b/src/lib/tvgSaveModule.h
@@ -28,7 +28,7 @@
 namespace tvg
 {
 
-class SaveModule : public IteratorAccessor
+class SaveModule
 {
 public:
     virtual ~SaveModule() {}

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -356,7 +356,7 @@ TvgBinCounter TvgSaver::serializeChild(const Paint* parent, const Paint* child, 
 
 TvgBinCounter TvgSaver::serializeScene(const Scene* scene, const Matrix* pTransform, const Matrix* cTransform)
 {
-    auto it = this->iterator(scene);
+    auto it = IteratorAccessor::iterator(scene);
     if (it->count() == 0) {
         delete(it);
         return 0;
@@ -568,7 +568,7 @@ TvgBinCounter TvgSaver::serializeShape(const Shape* shape, const Matrix* pTransf
 /* Picture has either a vector scene or a bitmap. */
 TvgBinCounter TvgSaver::serializePicture(const Picture* picture, const Matrix* pTransform, const Matrix* cTransform)
 {
-    auto it = this->iterator(picture);
+    auto it = IteratorAccessor::iterator(picture);
 
     //Case - Vector Scene:
     if (it->count() == 1) {

--- a/src/wasm/thorvgwasm.cpp
+++ b/src/wasm/thorvgwasm.cpp
@@ -29,7 +29,7 @@ using namespace emscripten;
 using namespace std;
 using namespace tvg;
 
-class __attribute__((visibility("default"))) ThorvgWasm : public IteratorAccessor
+class __attribute__((visibility("default"))) ThorvgWasm
 {
 public:
     static unique_ptr<ThorvgWasm> create()
@@ -282,7 +282,7 @@ private:
     {
         //paint
         if (paint->identifier() != Shape::identifier()) {
-            auto it = this->iterator(paint);
+            auto it = IteratorAccessor::iterator(paint);
             if (it->count() > 0) {
                 layers->reserve(layers->count + it->count());
                 it->begin();
@@ -313,7 +313,7 @@ private:
         }
         //paint
         if (parent->identifier() != Shape::identifier()) {
-            auto it = this->iterator(parent);
+            auto it = IteratorAccessor::iterator(parent);
             if (it->count() > 0) {
                 it->begin();
                 while (auto child = it->next()) {


### PR DESCRIPTION
The instantiation of the accessor is unnecessary
as it does not require any internal context.

Simplifying its usage would be beneficial.