### PR TITLE
common taskscheduler: increase thread efficiency.

### DIFF
--- a/src/lib/tvgTaskScheduler.cpp
+++ b/src/lib/tvgTaskScheduler.cpp
@@ -100,13 +100,12 @@ struct TaskQueue {
 };
 
 
-class TaskSchedulerImpl
+struct TaskSchedulerImpl
 {
-public:
-    unsigned                       threadCnt;
+    uint32_t                       threadCnt;
     vector<thread>                 threads;
     vector<TaskQueue>              taskQueues;
-    atomic<unsigned>               idx{0};
+    uint32_t                       idx = 0;
 
     TaskSchedulerImpl(unsigned threadCnt) : threadCnt(threadCnt), taskQueues(threadCnt)
     {


### PR DESCRIPTION
Revise the logic to avoid potential blocking of the main thread. Move the clippers job completion to worker-threads to prevent main thread blocks and enhance maximum parallelization efficiency.