### PR TITLE
infra github: bump up version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -35,7 +35,7 @@ jobs:
   examples:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -59,7 +59,7 @@ jobs:
   unit_test:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -89,7 +89,7 @@ jobs:
         cd build
         sudo ninja -C . install test
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: UnitTestReport
         path: build/meson-logs/testlog.txt

--- a/.github/workflows/actions_cpplint.yml
+++ b/.github/workflows/actions_cpplint.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Install Packages
       run: |
@@ -23,7 +23,7 @@ jobs:
         where link
         ninja -C build install
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: result
         path: build/src\thorvg*
@@ -31,7 +31,7 @@ jobs:
   build_loaders:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ilammy/msvc-dev-cmd@v1
     - name: Install Packages
       run: |


### PR DESCRIPTION
Node.js 12 actions were deprecated.
Updated the script to use a more recent version.