### PR TITLE
common: enhancement++ of the logging method

### DIFF
--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -67,9 +67,10 @@ enum class FileType { Tvg = 0, Svg, Raw, Png, Jpg, Unknown };
 #ifdef THORVG_LOG_ENABLED
     constexpr auto ErrorColor = "\033[31m";  //red
     constexpr auto LogColor = "\033[32m";    //green
+    constexpr auto GreyColor = "\033[90m";   //grey
     constexpr auto ResetColor = "\033[0m";   //default
-    #define TVGERR(tag, fmt, ...) fprintf(stderr, "%s" tag " (%s l.%d): " fmt "%s\n", ErrorColor, __FILE__, __LINE__, ##__VA_ARGS__, ResetColor)
-    #define TVGLOG(tag, fmt, ...) fprintf(stderr, "%s" tag " (%s l.%d): " fmt "%s\n", LogColor, __FILE__, __LINE__, ##__VA_ARGS__, ResetColor)
+    #define TVGERR(tag, fmt, ...) fprintf(stderr, "%s" tag "%s (%s l.%d): %s" fmt "\n", ErrorColor, GreyColor, __FILE__, __LINE__, ResetColor, ##__VA_ARGS__)
+    #define TVGLOG(tag, fmt, ...) fprintf(stderr, "%s" tag "%s (%s l.%d): %s" fmt "\n", LogColor, GreyColor, __FILE__, __LINE__, ResetColor, ##__VA_ARGS__)
 #else
     #define TVGERR(...)
     #define TVGLOG(...)


### PR DESCRIPTION
Logging tags are marked with the corresponding
log type color, the file and the line information
in gray, and the message content in the default
color.

@Issue: https://github.com/thorvg/thorvg/issues/1351

<img width="1440" alt="Zrzut ekranu 2023-04-12 o 16 50 06" src="https://user-images.githubusercontent.com/67589014/231499245-ee7c720d-1215-46ae-b4cc-12d42772416d.png">
