### PR TITLE
common: adding [E]/[L] markers to errors/logs

### DIFF
--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -66,11 +66,13 @@ enum class FileType { Tvg = 0, Svg, Raw, Png, Jpg, Unknown };
 
 #ifdef THORVG_LOG_ENABLED
     constexpr auto ErrorColor = "\033[31m";  //red
+    constexpr auto ErrorBgColor = "\033[41m";//bg red
     constexpr auto LogColor = "\033[32m";    //green
+    constexpr auto LogBgColor = "\033[42m";  //bg green
     constexpr auto GreyColor = "\033[90m";   //grey
-    constexpr auto ResetColor = "\033[0m";   //default
-    #define TVGERR(tag, fmt, ...) fprintf(stderr, "%s" tag "%s (%s l.%d): %s" fmt "\n", ErrorColor, GreyColor, __FILE__, __LINE__, ResetColor, ##__VA_ARGS__)
-    #define TVGLOG(tag, fmt, ...) fprintf(stderr, "%s" tag "%s (%s l.%d): %s" fmt "\n", LogColor, GreyColor, __FILE__, __LINE__, ResetColor, ##__VA_ARGS__)
+    constexpr auto ResetColors = "\033[0m";  //default
+    #define TVGERR(tag, fmt, ...) fprintf(stderr, "%s[E]%s %s" tag "%s (%s l.%d): %s" fmt "\n", ErrorBgColor, ResetColors, ErrorColor, GreyColor, __FILE__, __LINE__, ResetColors, ##__VA_ARGS__)
+    #define TVGLOG(tag, fmt, ...) fprintf(stderr, "%s[L]%s %s" tag "%s (%s l.%d): %s" fmt "\n", LogBgColor, ResetColors, LogColor, GreyColor, __FILE__, __LINE__, ResetColors, ##__VA_ARGS__)
 #else
     #define TVGERR(...)
     #define TVGLOG(...)

--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -67,9 +67,10 @@ enum class FileType { Tvg = 0, Svg, Raw, Png, Jpg, Unknown };
 #ifdef THORVG_LOG_ENABLED
     constexpr auto ErrorColor = "\033[31m";  //red
     constexpr auto LogColor = "\033[32m";    //green
+    constexpr auto GreyColor = "\033[90m";   //grey
     constexpr auto ResetColor = "\033[0m";   //default
-    #define TVGERR(tag, fmt, ...) fprintf(stderr, "%s" tag " (%s l.%d): " fmt "%s\n", ErrorColor, __FILE__, __LINE__, ##__VA_ARGS__, ResetColor)
-    #define TVGLOG(tag, fmt, ...) fprintf(stderr, "%s" tag " (%s l.%d): " fmt "%s\n", LogColor, __FILE__, __LINE__, ##__VA_ARGS__, ResetColor)
+    #define TVGERR(tag, fmt, ...) fprintf(stderr, "%s" tag "%s (%s l.%d): %s" fmt "\n", ErrorColor, GreyColor, __FILE__, __LINE__, ResetColor, ##__VA_ARGS__)
+    #define TVGLOG(tag, fmt, ...) fprintf(stderr, "%s" tag "%s (%s l.%d): %s" fmt "\n", LogColor, GreyColor, __FILE__, __LINE__, ResetColor, ##__VA_ARGS__)
 #else
     #define TVGERR(...)
     #define TVGLOG(...)


### PR DESCRIPTION
@issue: https://github.com/thorvg/thorvg/issues/1351

contains #1363 

logs:
<img width="1187" alt="Zrzut ekranu 2023-04-13 o 23 07 04" src="https://user-images.githubusercontent.com/67589014/231884225-fd51ca04-9235-4111-bb88-af548713f6dc.png">

errors (these are logs, just force to be printed as errors):
<img width="1187" alt="Zrzut ekranu 2023-04-13 o 23 06 44" src="https://user-images.githubusercontent.com/67589014/231884297-79da0f4b-f7da-4a17-b2ec-ef52b8282f5b.png">
