### PR TITLE
svg_loader: fixing parsing empty tags

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2976,6 +2976,7 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
         //Parse the empty tag
         attrs = content;
         while ((attrs != nullptr) && *attrs != '>') attrs++;
+        if (empty) attrs--;
     }
 
     if (attrs) {


### PR DESCRIPTION
Self-closing tags (empty elements) were parsed until
the appearance of the '>' character, causing the '/'
char to be appended to the tag name. The final '/'
char should be omitted.

sample:
```
<svg
  viewBox="0 0 10 10"
  xmlns="http://www.w3.org/2000/svg"
  xmlns:xlink="http://www.w3.org/1999/xlink">
<defs/>
  <defs>
    <linearGradient id="myGradient" gradientTransform="rotate(90)">
      <stop />
      <stop offset="95%" stop-color="red" />
    </linearGradient>
  </defs>

  <!-- using my linear gradient -->
  <circle cx="5" cy="5" r="4" fill="url('#myGradient')" />
</svg>
```

before:
<img width="376" alt="Zrzut ekranu 2023-04-16 o 13 42 59" src="https://user-images.githubusercontent.com/67589014/232307892-8f5e3111-59d9-46c9-aecc-7ea68ec74e1b.png">
<img width="913" alt="Zrzut ekranu 2023-04-16 o 13 43 20" src="https://user-images.githubusercontent.com/67589014/232307898-655eea0f-f4b8-4dde-9b92-93968f0c06fd.png">


after:
<img width="381" alt="Zrzut ekranu 2023-04-16 o 13 46 01" src="https://user-images.githubusercontent.com/67589014/232307904-a854b556-ee65-495a-aaa8-8093e953a18b.png">
