### PR TITLE
svg_loader: fix vx and vy

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -757,9 +757,15 @@ static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox,
 static void _applySvgViewFlag(const Scene* scene, float& vx, float& vy, float& vw, float& vh, float& w, float& h, SvgViewFlag viewFlag)
 {
     if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Viewbox)) {
-        scene->bounds(&vx, &vy, &vw, &vh, false);
-        if ((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width) vw = w;
-        if ((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Height) vh = h;
+        float x, y;
+        scene->bounds(&x, &y, &vw, &vh, false);
+        if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width) && !((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Height)) {
+            vx = x;
+            vy = y;
+        } else {
+            if ((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width) vw = w;
+            if ((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Height) vh = h;
+        }
     }
     if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width)) w = vw;
     if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Height)) h = vh;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -756,19 +756,23 @@ static unique_ptr<Scene> _sceneBuildHelper(const SvgNode* node, const Box& vBox,
 
 static void _applySvgViewFlag(const Scene* scene, float& vx, float& vy, float& vw, float& vh, float& w, float& h, SvgViewFlag viewFlag)
 {
-    if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Viewbox)) {
+    bool noViewbox = !((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Viewbox);
+    bool noWidth = !((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width);
+    bool noHeight = !((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Height);
+
+    if (noViewbox) {
         float x, y;
         scene->bounds(&x, &y, &vw, &vh, false);
-        if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width) && !((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Height)) {
+        if (noWidth && noHeight) {
             vx = x;
             vy = y;
         } else {
-            if ((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width) vw = w;
-            if ((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Height) vh = h;
+            vw = noWidth ? vw : w;
+            vh = noHeight ? vh : h;
         }
     }
-    if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Width)) w = vw;
-    if (!((uint32_t)viewFlag & (uint32_t)SvgViewFlag::Height)) h = vh;
+    w = noWidth ? vw : w;
+    h = noHeight ? vh : h;
 }
 
 /************************************************************************/


### PR DESCRIPTION
If no viewbox is given, vx and vy were set to values
corresponding to the svg's bounding box. This is now
applied only if no viewbox and no width/height information
is given. Otherwise, vx and vy are set to the default
values (0, 0).

@issue: https://github.com/thorvg/thorvg/issues/1368
