### PR TITLE
svg_loader: fixing clipper transformation

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -254,13 +254,18 @@ static void _applyComposition(Paint* paint, const SvgNode* node, const Box& vBox
             node->style->clipPath.applying = true;
 
             auto comp = Shape::gen();
-            if (node->transform) comp->transform(*node->transform);
 
             auto child = compNode->child.data;
             auto valid = false; //Composite only when valid shapes are existed
 
             for (uint32_t i = 0; i < compNode->child.count; ++i, ++child) {
                 if (_appendChildShape(*child, comp.get(), vBox, svgPath)) valid = true;
+            }
+
+            if (node->transform) {
+                auto m = comp->transform();
+                m = mathMultiply(node->transform, &m);
+                comp->transform(m);
             }
 
             if (valid) paint->composite(move(comp), CompositeMethod::ClipPath);


### PR DESCRIPTION
In a case where both the clipper and the clippee
are transformed, the final clipper transformation
matrix should be calculated as the multiplication
of both matrices.

@Issue: https://github.com/thorvg/thorvg/issues/1255

KOSZ_893:
before:
<img width="402" alt="Zrzut ekranu 2023-04-18 o 01 45 56" src="https://user-images.githubusercontent.com/67589014/232639695-418bbdbf-732b-474e-811e-c242e0071018.png">

after:
<img width="402" alt="Zrzut ekranu 2023-04-18 o 01 48 26" src="https://user-images.githubusercontent.com/67589014/232639708-25921b7d-9627-4b8b-a8a8-00275ec60319.png">


