### PR TITLE
tests: fixing error on windows (mingw-64)

### DIFF
--- a/test/capi/capiLinearGradient.cpp
+++ b/test/capi/capiLinearGradient.cpp
@@ -162,7 +162,7 @@ TEST_CASE("Linear Gradient clear data", "[capiLinearGradient]")
 
     REQUIRE(tvg_gradient_set_color_stops(gradient, NULL, 0) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_gradient_get_color_stops(gradient, &color_stops_ret, &color_stops_count_ret) == TVG_RESULT_SUCCESS);
-    REQUIRE(color_stops_ret == NULL);
+    REQUIRE(color_stops_ret == nullptr);
     REQUIRE(color_stops_count_ret == 0);
 
     REQUIRE(tvg_gradient_del(gradient) == TVG_RESULT_SUCCESS);

--- a/test/capi/capiRadialGradient.cpp
+++ b/test/capi/capiRadialGradient.cpp
@@ -117,7 +117,7 @@ TEST_CASE("Clear gradient data", "[capiRadialGradient]")
 
     REQUIRE(tvg_gradient_set_color_stops(gradient, NULL, 0) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_gradient_get_color_stops(gradient, &color_stops_ret, &color_stops_count_ret) == TVG_RESULT_SUCCESS);
-    REQUIRE(color_stops_ret == NULL);
+    REQUIRE(color_stops_ret == nullptr);
     REQUIRE(color_stops_count_ret == 0);
 
     REQUIRE(tvg_gradient_del(gradient) == TVG_RESULT_SUCCESS);


### PR DESCRIPTION
Error while comparing a pointer and an integer.
Solved by using a null pointer const instead of
the NULL macro.

@issue: https://github.com/thorvg/thorvg/issues/1382