### PR TITLE
svg_loader: removing setting the locale

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -52,7 +52,6 @@
 
 #include <cstring>
 #include <math.h>
-#include <clocale>
 #include <ctype.h>
 #include "tvgSvgLoaderCommon.h"
 #include "tvgSvgPath.h"
@@ -545,20 +544,12 @@ bool svgPathToTvgPath(const char* svgPath, Array<PathCommand>& cmds, Array<Point
     char cmd = 0;
     bool isQuadratic = false;
     char* path = (char*)svgPath;
-    char* curLocale;
-
-    curLocale = setlocale(LC_NUMERIC, NULL);
-    if (curLocale) curLocale = strdup(curLocale);
-    setlocale(LC_NUMERIC, "POSIX");
 
     while ((path[0] != '\0')) {
         path = _nextCommand(path, &cmd, numberArray, &numberCount);
         if (!path) break;
         if (!_processCommand(&cmds, &pts, cmd, numberArray, numberCount, &cur, &curCtl, &startPoint, &isQuadratic)) break;
     }
-
-    setlocale(LC_NUMERIC, curLocale);
-    if (curLocale) free(curLocale);
 
     return true;
 }


### PR DESCRIPTION
The locale was set while reading the path attr,
which could have caused race conditions between
threads and potentially led to crashes.
Now removed as unnecessary.

@Issue: https://github.com/thorvg/thorvg/issues/1389