### PR TITLE
tests capi: missing header added

### DIFF
--- a/test/capi/capiSwCanvas.cpp
+++ b/test/capi/capiSwCanvas.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <thorvg_capi.h>
+#include "config.h"
 #include "../catch.hpp"
 
 #ifdef THORVG_SW_RASTER_SUPPORT


### PR DESCRIPTION
Because of this tests for SwCanvas were
not performed.