### PR TITLE
svg_loader: fixing 'infinity' handling in svgUtilStrtof

### DIFF
--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -94,8 +94,8 @@ float svgUtilStrtof(const char *nPtr, char **endPtr)
         if ((tolower(*(iter + 1)) == 'n') && (tolower(*(iter + 2)) == 'f')) iter += 3;
         else goto error;
 
-        if (tolower(*(iter + 3)) == 'i') {
-            if ((tolower(*(iter + 4)) == 'n') && (tolower(*(iter + 5)) == 'i') && (tolower(*(iter + 6)) == 't') && (tolower(*(iter + 7)) == 'y')) iter += 5;
+        if (tolower(*(iter)) == 'i') {
+            if ((tolower(*(iter + 1)) == 'n') && (tolower(*(iter + 2)) == 'i') && (tolower(*(iter + 3)) == 't') && (tolower(*(iter + 4)) == 'y')) iter += 5;
             else goto error;
         }
         if (endPtr) *endPtr = (char *)(iter);


### PR DESCRIPTION
The word 'infinity' was not read to the end due to the pointer shifting.