### PR TITLE
svg_loader: changed update order

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3483,10 +3483,10 @@ void SvgLoader::run(unsigned tid)
         _updateComposite(loaderData.doc, loaderData.doc);
         if (defs) _updateComposite(loaderData.doc, defs);
 
+        _updateStyle(loaderData.doc, nullptr);
+
         if (loaderData.gradients.count > 0) _updateGradient(&loaderData, loaderData.doc, &loaderData.gradients);
         if (defs) _updateGradient(&loaderData, loaderData.doc, &defs->node.defs.gradients);
-
-        _updateStyle(loaderData.doc, nullptr);
     }
     root = svgSceneBuild(loaderData.doc, vx, vy, vw, vh, w, h, align, meetOrSlice, svgPath, viewFlag);
 }


### PR DESCRIPTION
The gradient was updated before the style,
which resulted in only the URL tag being
inherited, but the gradient itself was not
applied to the node.

sample (modified logo):
```
<svg height="1000" viewBox="0 0 1000 1000" width="1000" xmlns="http://www.w3.org/2000/svg">
        <linearGradient id="grad1" gradientTransform="translate(0, 0)" x1="0" y1="0" x2="100%" y2="0">
            <stop offset="0%" stop-color="red"/>
            <stop offset="100%" stop-color="blue"/>
        </linearGradient>
<g stroke-width="2" stroke="black">
<path d="M-.01986229-.01483051 999.12603.51483051 999.95363 999.91554.07944915 999.94865Z" fill="#fff" stroke-width="3.910218"/><g fill="url(#grad1)"><g stroke-width="3.864492"><path d="M256.61221 100.51736H752.8963V386.99554H256.61221Z"/><path d="M201.875 100.51736H238.366478V386.99554H201.875Z"/><path d="M771.14203 100.51736H807.633508V386.99554H771.14203Z"/></g><path d="M420.82388 380H588.68467V422.805317H420.82388Z" stroke-width="3.227"/><path d="m420.82403 440.7101v63.94623l167.86079 25.5782V440.7101Z"/><path d="M420.82403 523.07258V673.47362L588.68482 612.59701V548.13942Z"/></g><g fill="url(#grad1)"><path d="M420.82403 691.37851 588.68482 630.5019 589 834H421Z"/><path d="m420.82403 852.52249h167.86079v28.64782H420.82403v-28.64782 0 0"/><path d="m439.06977 879.17031c0 0-14.90282 8.49429-18.24574 15.8161-4.3792 9.59153 0 31.63185 0 31.63185h167.86079c0 0 4.3792-22.04032 0-31.63185-3.34292-7.32181-18.24574-15.8161-18.24574-15.8161z"/></g><g fill="#fff"><path d="m280 140h15v55l8 10 8-10v-55h15v60l-23 25-23-25z"/><path d="m335 140v80h45v-50h-25v10h10v30h-15v-57h18v-13z"/></g>
</g>
</svg>
```

before:
<img width="493" alt="Zrzut ekranu 2023-04-24 o 02 56 54" src="https://user-images.githubusercontent.com/67589014/233877366-2ac868e6-f72d-41c9-bd29-a00e9371eee6.png">

after:
<img width="493" alt="Zrzut ekranu 2023-04-24 o 02 57 30" src="https://user-images.githubusercontent.com/67589014/233877384-38c44fbe-509a-4c8a-a9c1-31fca5f03add.png">
