### PR TITLE
svg_loader: fixing grad overriding 

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3265,18 +3265,24 @@ static void _updateGradient(SvgLoaderData* loader, SvgNode* node, Array<SvgStyle
         }
     } else {
         if (node->style->fill.paint.url) {
-            if (node->style->fill.paint.gradient) {
-                node->style->fill.paint.gradient->clear();
-                free(node->style->fill.paint.gradient);
+            auto newGrad = _gradientDup(loader, gradients, node->style->fill.paint.url);
+            if (newGrad) {
+                if (node->style->fill.paint.gradient) {
+                    node->style->fill.paint.gradient->clear();
+                    free(node->style->fill.paint.gradient);
+                }
+                node->style->fill.paint.gradient = newGrad;
             }
-            node->style->fill.paint.gradient = _gradientDup(loader, gradients, node->style->fill.paint.url);
         }
         if (node->style->stroke.paint.url) {
-            if (node->style->stroke.paint.gradient) {
-                node->style->stroke.paint.gradient->clear();
-                free(node->style->stroke.paint.gradient);
+            auto newGrad = _gradientDup(loader, gradients, node->style->stroke.paint.url);
+            if (newGrad) {
+                if (node->style->stroke.paint.gradient) {
+                    node->style->stroke.paint.gradient->clear();
+                    free(node->style->stroke.paint.gradient);
+                }
+                node->style->stroke.paint.gradient = newGrad;
             }
-            node->style->stroke.paint.gradient = _gradientDup(loader, gradients, node->style->stroke.paint.url);
         }
     }
 }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3483,10 +3483,10 @@ void SvgLoader::run(unsigned tid)
         _updateComposite(loaderData.doc, loaderData.doc);
         if (defs) _updateComposite(loaderData.doc, defs);
 
+        _updateStyle(loaderData.doc, nullptr);
+
         if (loaderData.gradients.count > 0) _updateGradient(&loaderData, loaderData.doc, &loaderData.gradients);
         if (defs) _updateGradient(&loaderData, loaderData.doc, &defs->node.defs.gradients);
-
-        _updateStyle(loaderData.doc, nullptr);
     }
     root = svgSceneBuild(loaderData.doc, vx, vy, vw, vh, w, h, align, meetOrSlice, svgPath, viewFlag);
 }


### PR DESCRIPTION
Gradient was mistakenly overridden in
files in which the <def> section existed,
but grad was defined outside it.

contains #1396 

(results with #1396)
before:
<img width="402" alt="Zrzut ekranu 2023-04-25 o 01 25 40" src="https://user-images.githubusercontent.com/67589014/234138141-b6bcc1bd-c2b5-4fe9-b0e4-d28fdc1ebe49.png">

after:
<img width="402" alt="Zrzut ekranu 2023-04-25 o 01 26 17" src="https://user-images.githubusercontent.com/67589014/234138156-ef1acfca-1dd1-467e-80ea-acc4c954ef62.png">

sample:
```
<svg height="400" viewBox="0 0 400 400" width="400" xmlns="http://www.w3.org/2000/svg">

  <g fill="url(#grad1)">
    <path  d="M0 0 h 200 v 200 z"/>
  </g>
  <g fill="url(#grad2)">
    <path  d="M200 0 h 200 v 200 z"/>
  </g>
 
 <linearGradient id="grad1" gradientTransform="translate(0, 0)" x1="0" y1="0" x2="100%" y2="0">
   <stop offset="0%" stop-color="red"/>
   <stop offset="100%" stop-color="blue"/>
 </linearGradient>
 
 <defs>
   <linearGradient id="grad2" gradientTransform="translate(0, 0)" x1="0" y1="0" x2="100%" y2="0">
     <stop offset="0%" stop-color="green"/>
     <stop offset="100%" stop-color="yellow"/>
   </linearGradient>
 </defs>

 <g fill="url(#grad1)">
   <path d="M0 200 h 200 v 200 z"/>
 </g>
 <g fill="url(#grad2)">
   <path d="M200 200 h 200 v 200 z"/>
 </g>

</svg>
```
