### PR TITLE
common: polished the log message.

### DIFF
--- a/src/lib/tvgCommon.h
+++ b/src/lib/tvgCommon.h
@@ -71,8 +71,8 @@ enum class FileType { Tvg = 0, Svg, Raw, Png, Jpg, Unknown };
     constexpr auto LogBgColor = "\033[42m";  //bg green
     constexpr auto GreyColor = "\033[90m";   //grey
     constexpr auto ResetColors = "\033[0m";  //default
-    #define TVGERR(tag, fmt, ...) fprintf(stderr, "%s[E]%s %s" tag "%s (%s l.%d): %s" fmt "\n", ErrorBgColor, ResetColors, ErrorColor, GreyColor, __FILE__, __LINE__, ResetColors, ##__VA_ARGS__)
-    #define TVGLOG(tag, fmt, ...) fprintf(stderr, "%s[L]%s %s" tag "%s (%s l.%d): %s" fmt "\n", LogBgColor, ResetColors, LogColor, GreyColor, __FILE__, __LINE__, ResetColors, ##__VA_ARGS__)
+    #define TVGERR(tag, fmt, ...) fprintf(stderr, "%s[E]%s %s" tag "%s (%s %d): %s" fmt "\n", ErrorBgColor, ResetColors, ErrorColor, GreyColor, __FILE__, __LINE__, ResetColors, ##__VA_ARGS__)
+    #define TVGLOG(tag, fmt, ...) fprintf(stderr, "%s[L]%s %s" tag "%s (%s %d): %s" fmt "\n", LogBgColor, ResetColors, LogColor, GreyColor, __FILE__, __LINE__, ResetColors, ##__VA_ARGS__)
 #else
     #define TVGERR(...)
     #define TVGLOG(...)


### PR DESCRIPTION
Removed 'l.'. It just bothers in reading numbers.

example:
(../../filename.cpp l.231)
(../../filename.cpp 231)
