### PR TITLE
Enhance the Colorspace conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ builddir
 *.swp
 doc
 capi_test.tvg
+test.tvg
 .idea

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -123,10 +123,10 @@ bool GlRenderer::endComposite(TVG_UNUSED Compositor* cmp)
 }
 
 
-int32_t GlRenderer::colorSpace()
+ColorSpace GlRenderer::colorSpace()
 {
     //TODO: return a proper color space value.
-    return -1;
+    return ColorSpace::Unsupported;
 }
 
 

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -189,7 +189,7 @@ bool GlRenderer::dispose(RenderData data)
 }
 
 
-RenderData GlRenderer::prepare(TVG_UNUSED Surface* image, TVG_UNUSED const RenderMesh* mesh, TVG_UNUSED RenderData data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED uint32_t opacity, TVG_UNUSED Array<RenderData>& clips, TVG_UNUSED RenderUpdateFlag flags)
+RenderData GlRenderer::prepare(TVG_UNUSED Surface* surface, TVG_UNUSED const RenderMesh* mesh, TVG_UNUSED RenderData data, TVG_UNUSED const RenderTransform* transform, TVG_UNUSED uint32_t opacity, TVG_UNUSED Array<RenderData>& clips, TVG_UNUSED RenderUpdateFlag flags)
 {
     //TODO:
     return nullptr;

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -123,13 +123,6 @@ bool GlRenderer::endComposite(TVG_UNUSED Compositor* cmp)
 }
 
 
-ColorSpace GlRenderer::colorSpace()
-{
-    //TODO: return a proper color space value.
-    return ColorSpace::Unsupported;
-}
-
-
 bool GlRenderer::renderImage(TVG_UNUSED void* data)
 {
     //TODO: render requested images

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -50,7 +50,7 @@ public:
     bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) override;
     bool endComposite(Compositor* cmp) override;
 
-    uint32_t colorSpace() override;
+    ColorSpace colorSpace() override;
 
     static GlRenderer* gen();
     static int init(TVG_UNUSED uint32_t threads);

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -32,7 +32,7 @@ public:
 
     RenderData prepare(const RenderShape& rshape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags, bool clipper) override;
     RenderData prepare(const Array<RenderData>& scene, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
-    RenderData prepare(Surface* image, const RenderMesh* mesh, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
+    RenderData prepare(Surface* surface, const RenderMesh* mesh, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     bool preRender() override;
     bool renderShape(RenderData data) override;
     bool renderImage(RenderData data) override;

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -50,8 +50,6 @@ public:
     bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) override;
     bool endComposite(Compositor* cmp) override;
 
-    ColorSpace colorSpace() override;
-
     static GlRenderer* gen();
     static int init(TVG_UNUSED uint32_t threads);
     static int32_t init();

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -359,5 +359,6 @@ bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id);
 bool rasterClear(SwSurface* surface);
 void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len);
 void rasterUnpremultiply(SwSurface* surface);
+bool rasterConvertCS(Surface* surface, ColorSpace to);
 
 #endif /* _TVG_SW_COMMON_H_ */

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -1573,3 +1573,21 @@ bool rasterImage(SwSurface* surface, SwImage* image, const RenderMesh* mesh, con
     if (mesh && mesh->triangleCnt > 0) return _transformedRGBAImageMesh(surface, image, mesh, transform, &bbox, opacity);
     else return _rasterRGBAImage(surface, image, transform, bbox, opacity);
 }
+
+
+bool rasterConvertCS(Surface* surface, ColorSpace to)
+{
+    //TOOD: Support SIMD accelerations
+    auto from = surface->cs;
+
+    if ((from == ColorSpace::ABGR8888 && to == ColorSpace::ARGB8888) || (from == ColorSpace::ABGR8888S && to == ColorSpace::ARGB8888S)) {
+        return cRasterABGRtoARGB(surface);
+    }
+    if ((from == ColorSpace::ARGB8888 && to == ColorSpace::ABGR8888) || (from == ColorSpace::ARGB8888S && to == ColorSpace::ABGR8888S)) {
+        return cRasterARGBtoABGR(surface);
+    }
+
+    surface->cs = to;
+
+    return false;
+}

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -1452,10 +1452,10 @@ void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 
 bool rasterCompositor(SwSurface* surface)
 {
-    if (surface->cs == SwCanvas::ABGR8888 || surface->cs == SwCanvas::ABGR8888_STRAIGHT) {
+    if (surface->cs == ColorSpace::ABGR8888 || surface->cs == ColorSpace::ABGR8888S) {
         surface->blender.join = _abgrJoin;
         surface->blender.lumaValue = _abgrLumaValue;
-    } else if (surface->cs == SwCanvas::ARGB8888 || surface->cs == SwCanvas::ARGB8888_STRAIGHT) {
+    } else if (surface->cs == ColorSpace::ARGB8888 || surface->cs == ColorSpace::ARGB8888S) {
         surface->blender.join = _argbJoin;
         surface->blender.lumaValue = _argbLumaValue;
     } else {

--- a/src/lib/sw_engine/tvgSwRasterC.h
+++ b/src/lib/sw_engine/tvgSwRasterC.h
@@ -61,3 +61,27 @@ static bool inline cRasterTranslucentRect(SwSurface* surface, const SwBBox& regi
     }
     return true;
 }
+
+
+static bool inline cRasterABGRtoARGB(Surface* surface)
+{
+    TVGLOG("SW_ENGINE", "Convert ColorSpace ABGR - ARGB");
+
+    auto buffer = surface->buffer;
+    for (uint32_t y = 0; y < surface->h; ++y, buffer += surface->stride) {
+        auto dst = buffer;
+        for (uint32_t x = 0; x < surface->w; ++x, ++dst) {
+            auto c = *dst;
+            //flip Blue, Red channels
+            *dst = (c & 0xff000000) + ((c & 0x00ff0000) >> 16) + (c & 0x0000ff00) + ((c & 0x000000ff) << 16);
+        }
+    }
+    return true;
+}
+
+
+static bool inline cRasterARGBtoABGR(Surface* surface)
+{
+    //exactly same with ABGRtoARGB
+    return cRasterABGRtoARGB(surface);
+}

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -761,13 +761,6 @@ SwRenderer::SwRenderer():mpool(globalMpool)
 }
 
 
-ColorSpace SwRenderer::colorSpace()
-{
-    if (surface) return surface->cs;
-    return ColorSpace::Unsupported;
-}
-
-
 bool SwRenderer::init(uint32_t threads)
 {
     if ((initEngineCnt++) > 0) return true;

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -407,7 +407,7 @@ bool SwRenderer::viewport(const RenderRegion& vp)
 }
 
 
-bool SwRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, uint32_t colorSpace)
+bool SwRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs)
 {
     if (!buffer || stride == 0 || w == 0 || h == 0 || w > stride) return false;
 
@@ -417,7 +417,7 @@ bool SwRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     surface->stride = stride;
     surface->w = w;
     surface->h = h;
-    surface->cs = colorSpace;
+    surface->cs = cs;
 
     vport.x = vport.y = 0;
     vport.w = surface->w;
@@ -447,7 +447,7 @@ void SwRenderer::clearCompositors()
 bool SwRenderer::postRender()
 {
     //Unmultiply alpha if needed
-    if (surface->cs == SwCanvas::ABGR8888_STRAIGHT || surface->cs == SwCanvas::ARGB8888_STRAIGHT) {
+    if (surface->cs == ColorSpace::ABGR8888S || surface->cs == ColorSpace::ARGB8888S) {
         rasterUnpremultiply(surface);
     }
 
@@ -755,10 +755,10 @@ SwRenderer::SwRenderer():mpool(globalMpool)
 }
 
 
-uint32_t SwRenderer::colorSpace()
+ColorSpace SwRenderer::colorSpace()
 {
     if (surface) return surface->cs;
-    return tvg::SwCanvas::ARGB8888;
+    return ColorSpace::Unsupported;
 }
 
 

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -50,7 +50,7 @@ public:
 
     bool clear() override;
     bool sync() override;
-    bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, uint32_t colorSpace);
+    bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs);
     bool mempool(bool shared);
 
     Compositor* target(const RenderRegion& region) override;
@@ -58,7 +58,7 @@ public:
     bool endComposite(Compositor* cmp) override;
     void clearCompositors();
 
-    uint32_t colorSpace() override;
+    ColorSpace colorSpace() override;
 
     static SwRenderer* gen();
     static bool init(uint32_t threads);

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -38,7 +38,7 @@ class SwRenderer : public RenderMethod
 public:
     RenderData prepare(const RenderShape& rshape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags, bool clipper) override;
     RenderData prepare(const Array<RenderData>& scene, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
-    RenderData prepare(Surface* image, const RenderMesh* mesh, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
+    RenderData prepare(Surface* surface, const RenderMesh* mesh, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;
     bool preRender() override;
     bool renderShape(RenderData data) override;
     bool renderImage(RenderData data) override;

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -58,8 +58,6 @@ public:
     bool endComposite(Compositor* cmp) override;
     void clearCompositors();
 
-    ColorSpace colorSpace() override;
-
     static SwRenderer* gen();
     static bool init(uint32_t threads);
     static int32_t init();

--- a/src/lib/tvgLoadModule.h
+++ b/src/lib/tvgLoadModule.h
@@ -36,8 +36,8 @@ public:
     float vy = 0;
     float vw = 0;
     float vh = 0;
-    float w = 0, h = 0;         //default image size
-    ColorSpace cs = ColorSpace::ARGB8888;
+    float w = 0, h = 0;                             //default image size
+    ColorSpace cs = ColorSpace::Unsupported;        //must be clarified at open()
 
     virtual ~LoadModule() {}
 
@@ -50,7 +50,7 @@ public:
 
     virtual bool read() = 0;
     virtual bool close() = 0;
-    virtual unique_ptr<Surface> bitmap(ColorSpace cs) { return nullptr; }
+    virtual unique_ptr<Surface> bitmap() { return nullptr; }
     virtual unique_ptr<Paint> paint() { return nullptr; }
 };
 

--- a/src/lib/tvgLoadModule.h
+++ b/src/lib/tvgLoadModule.h
@@ -37,7 +37,7 @@ public:
     float vw = 0;
     float vh = 0;
     float w = 0, h = 0;         //default image size
-    uint32_t colorSpace = SwCanvas::ARGB8888;
+    ColorSpace cs = ColorSpace::ARGB8888;
 
     virtual ~LoadModule() {}
 
@@ -50,7 +50,7 @@ public:
 
     virtual bool read() = 0;
     virtual bool close() = 0;
-    virtual unique_ptr<Surface> bitmap(uint32_t colorSpace) { return nullptr; }
+    virtual unique_ptr<Surface> bitmap(ColorSpace cs) { return nullptr; }
     virtual unique_ptr<Paint> paint() { return nullptr; }
 };
 

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -107,7 +107,7 @@ Result Picture::size(float* w, float* h) const noexcept
 const uint32_t* Picture::data(uint32_t* w, uint32_t* h) const noexcept
 {
     //Try it, If not loaded yet.
-    pImpl->reload();
+    pImpl->load();
 
     if (pImpl->loader) {
         if (w) *w = static_cast<uint32_t>(pImpl->loader->w);

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -66,7 +66,6 @@ struct Picture::Impl
     Surface* surface = nullptr;       //bitmap picture uses
     RenderData rd = nullptr;          //engine data
     float w = 0, h = 0;
-    ColorSpace rendererColorSpace = ColorSpace::Unsupported;
     RenderMesh rm;                    //mesh data
     bool resizing = false;
 
@@ -105,7 +104,7 @@ struct Picture::Impl
                 }
             }
             free(surface);
-            if ((surface = loader->bitmap(rendererColorSpace).release())) {
+            if ((surface = loader->bitmap().release())) {
                 loader->close();
                 return RenderUpdateFlag::Image;
             }
@@ -129,7 +128,6 @@ struct Picture::Impl
 
     RenderData update(RenderMethod &renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag pFlag, bool clipper)
     {
-        rendererColorSpace = renderer.colorSpace();
         auto flag = reload();
 
         if (surface) {

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -66,7 +66,7 @@ struct Picture::Impl
     Surface* surface = nullptr;       //bitmap picture uses
     RenderData rd = nullptr;          //engine data
     float w = 0, h = 0;
-    uint32_t rendererColorSpace = 0;
+    ColorSpace rendererColorSpace = ColorSpace::Unsupported;
     RenderMesh rm;                    //mesh data
     bool resizing = false;
 

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -85,7 +85,7 @@ struct Picture::Impl
         return ret;
     }
 
-    uint32_t reload()
+    uint32_t load()
     {
         if (loader) {
             if (!paint) {
@@ -103,10 +103,11 @@ struct Picture::Impl
                     if (paint) return RenderUpdateFlag::None;
                 }
             }
-            free(surface);
-            if ((surface = loader->bitmap().release())) {
-                loader->close();
-                return RenderUpdateFlag::Image;
+            if (!surface) {
+                if ((surface = loader->bitmap().release())) {
+                    loader->close();
+                    return RenderUpdateFlag::Image;
+                }
             }
         }
         return RenderUpdateFlag::None;
@@ -128,7 +129,7 @@ struct Picture::Impl
 
     RenderData update(RenderMethod &renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag pFlag, bool clipper)
     {
-        auto flag = reload();
+        auto flag = load();
 
         if (surface) {
             auto transform = resizeTransform(pTransform);
@@ -265,7 +266,7 @@ struct Picture::Impl
 
     Paint* duplicate()
     {
-        reload();
+        load();
 
         auto ret = Picture::gen();
 
@@ -297,7 +298,7 @@ struct Picture::Impl
 
     Iterator* iterator()
     {
-        reload();
+        load();
         return new PictureIterator(paint);
     }
 };

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -278,6 +278,11 @@ struct Picture::Impl
         if (surface) {
             dup->surface = static_cast<Surface*>(malloc(sizeof(Surface)));
             *dup->surface = *surface;
+            //TODO: It needs a better design...
+            //Backend engines might try to align the colorspace.
+            //Since it shares the bitmap, duplications should not touch the data.
+            //Only the owner could manage it.
+            dup->surface->cs = ColorSpace::Unsupported;
         }
         dup->w = w;
         dup->h = h;

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -29,7 +29,20 @@
 namespace tvg
 {
 
+using RenderData = void*;
+
 enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, All = 255};
+
+struct Surface;
+
+enum ColorSpace
+{
+    ABGR8888 = 0,      //The channels are joined in the order: alpha, blue, green, red. Colors are alpha-premultiplied.
+    ARGB8888,          //The channels are joined in the order: alpha, red, green, blue. Colors are alpha-premultiplied.
+    ABGR8888S,         //The channels are joined in the order: alpha, blue, green, red. Colors are un-alpha-premultiplied.
+    ARGB8888S,         //The channels are joined in the order: alpha, red, green, blue. Colors are un-alpha-premultiplied.
+    Unsupported        //TODO: Change to the default, At the moment, we put it in the last to align with SwCanvas::Colorspace.
+};
 
 struct Surface
 {
@@ -37,10 +50,8 @@ struct Surface
     uint32_t* buffer;
     uint32_t  stride;
     uint32_t  w, h;
-    uint32_t  cs;
+    ColorSpace  cs;
 };
-
-using RenderData = void*;
 
 struct Compositor
 {
@@ -216,7 +227,7 @@ public:
     virtual bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) = 0;
     virtual bool endComposite(Compositor* cmp) = 0;
 
-    virtual uint32_t colorSpace() = 0;
+    virtual ColorSpace colorSpace() = 0;
 };
 
 }

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -210,7 +210,7 @@ public:
     virtual ~RenderMethod() {}
     virtual RenderData prepare(const RenderShape& rshape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags, bool clipper) = 0;
     virtual RenderData prepare(const Array<RenderData>& scene, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
-    virtual RenderData prepare(Surface* image, const RenderMesh* mesh, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
+    virtual RenderData prepare(Surface* surface, const RenderMesh* mesh, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) = 0;
     virtual bool preRender() = 0;
     virtual bool renderShape(RenderData data) = 0;
     virtual bool renderImage(RenderData data) = 0;

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -226,8 +226,6 @@ public:
     virtual Compositor* target(const RenderRegion& region) = 0;
     virtual bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) = 0;
     virtual bool endComposite(Compositor* cmp) = 0;
-
-    virtual ColorSpace colorSpace() = 0;
 };
 
 }

--- a/src/lib/tvgSwCanvas.cpp
+++ b/src/lib/tvgSwCanvas.cpp
@@ -85,7 +85,7 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     auto renderer = static_cast<SwRenderer*>(Canvas::pImpl->renderer);
     if (!renderer) return Result::MemoryCorruption;
 
-    if (!renderer->target(buffer, stride, w, h, cs)) return Result::InvalidArguments;
+    if (!renderer->target(buffer, stride, w, h, static_cast<ColorSpace>(cs))) return Result::InvalidArguments;
 
     //Paints must be updated again with this new target.
     Canvas::pImpl->needRefresh();

--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -38,7 +38,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(uint32_t colorSpace) override;
+    unique_ptr<Surface> bitmap(ColorSpace cs) override;
 
 private:
     void clear();

--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -38,7 +38,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(ColorSpace cs) override;
+    unique_ptr<Surface> bitmap() override;
 
 private:
     void clear();

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -128,11 +128,11 @@ bool PngLoader::close()
     return true;
 }
 
-unique_ptr<Surface> PngLoader::bitmap(uint32_t colorSpace)
+unique_ptr<Surface> PngLoader::bitmap(ColorSpace cs)
 {
     if (!content) return nullptr;
-    if (this->colorSpace != colorSpace) {
-        this->colorSpace = colorSpace;
+    if (this->cs != cs) {
+        this->cs = cs;
         _changeColorSpace(content, w, h);
     }
 
@@ -141,7 +141,7 @@ unique_ptr<Surface> PngLoader::bitmap(uint32_t colorSpace)
     surface->stride = w;
     surface->w = w;
     surface->h = h;
-    surface->cs = colorSpace;
+    surface->cs = cs;
 
     return unique_ptr<Surface>(surface);
 }

--- a/src/loaders/external_png/tvgPngLoader.h
+++ b/src/loaders/external_png/tvgPngLoader.h
@@ -37,7 +37,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(ColorSpace cs) override;
+    unique_ptr<Surface> bitmap() override;
 
 private:
     png_imagep image = nullptr;

--- a/src/loaders/external_png/tvgPngLoader.h
+++ b/src/loaders/external_png/tvgPngLoader.h
@@ -37,7 +37,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(uint32_t colorSpace) override;
+    unique_ptr<Surface> bitmap(ColorSpace cs) override;
 
 private:
     png_imagep image = nullptr;

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -28,24 +28,6 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static inline uint32_t CHANGE_COLORSPACE(uint32_t c)
-{
-    return (c & 0xff000000) + ((c & 0x00ff0000)>>16) + (c & 0x0000ff00) + ((c & 0x000000ff)<<16);
-}
-
-
-static void _changeColorSpace(uint32_t* data, uint32_t w, uint32_t h)
-{
-    auto buffer = data;
-    for (uint32_t y = 0; y < h; ++y, buffer += w) {
-        auto src = buffer;
-        for (uint32_t x = 0; x < w; ++x, ++src) {
-            *src = CHANGE_COLORSPACE(*src);
-        }
-    }
-}
-
-
 void JpgLoader::clear()
 {
     jpgdDelete(decoder);
@@ -79,6 +61,7 @@ bool JpgLoader::open(const string& path)
 
     w = static_cast<float>(width);
     h = static_cast<float>(height);
+    cs = ColorSpace::ARGB8888;
 
     return true;
 }
@@ -104,6 +87,7 @@ bool JpgLoader::open(const char* data, uint32_t size, bool copy)
 
     w = static_cast<float>(width);
     h = static_cast<float>(height);
+    cs = ColorSpace::ARGB8888;
 
     return true;
 }
@@ -128,15 +112,11 @@ bool JpgLoader::close()
 }
 
 
-unique_ptr<Surface> JpgLoader::bitmap(ColorSpace cs)
+unique_ptr<Surface> JpgLoader::bitmap()
 {
     this->done();
 
     if (!image) return nullptr;
-    if (this->cs != cs) {
-        this->cs = cs;
-        _changeColorSpace(reinterpret_cast<uint32_t*>(image), static_cast<uint32_t>(w), static_cast<uint32_t>(h));
-    }
 
     auto surface = static_cast<Surface*>(malloc(sizeof(Surface)));
     surface->buffer = reinterpret_cast<uint32_t*>(image);

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -128,13 +128,13 @@ bool JpgLoader::close()
 }
 
 
-unique_ptr<Surface> JpgLoader::bitmap(uint32_t colorSpace)
+unique_ptr<Surface> JpgLoader::bitmap(ColorSpace cs)
 {
     this->done();
 
     if (!image) return nullptr;
-    if (this->colorSpace != colorSpace) {
-        this->colorSpace = colorSpace;
+    if (this->cs != cs) {
+        this->cs = cs;
         _changeColorSpace(reinterpret_cast<uint32_t*>(image), static_cast<uint32_t>(w), static_cast<uint32_t>(h));
     }
 
@@ -143,7 +143,7 @@ unique_ptr<Surface> JpgLoader::bitmap(uint32_t colorSpace)
     surface->stride = static_cast<uint32_t>(w);
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);
-    surface->cs = colorSpace;
+    surface->cs = cs;
 
     return unique_ptr<Surface>(surface);
 }

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -45,7 +45,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(ColorSpace cs) override;
+    unique_ptr<Surface> bitmap() override;
     void run(unsigned tid) override;
 };
 

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -45,7 +45,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(uint32_t colorSpace) override;
+    unique_ptr<Surface> bitmap(ColorSpace cs) override;
     void run(unsigned tid) override;
 };
 

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -125,7 +125,7 @@ bool PngLoader::open(const string& path)
     h = static_cast<float>(height);
     ret = true;
 
-    if (state.info_png.color.colortype == LCT_RGBA) colorSpace = SwCanvas::ABGR8888;
+    if (state.info_png.color.colortype == LCT_RGBA) cs = ColorSpace::ABGR8888;
 
     goto finalize;
 
@@ -161,7 +161,7 @@ bool PngLoader::open(const char* data, uint32_t size, bool copy)
     h = static_cast<float>(height);
     this->size = size;
 
-    if (state.info_png.color.colortype == LCT_RGBA) colorSpace = SwCanvas::ABGR8888;
+    if (state.info_png.color.colortype == LCT_RGBA) cs = ColorSpace::ABGR8888;
 
     return true;
 }
@@ -185,13 +185,13 @@ bool PngLoader::close()
 }
 
 
-unique_ptr<Surface> PngLoader::bitmap(uint32_t colorSpace)
+unique_ptr<Surface> PngLoader::bitmap(ColorSpace cs)
 {
     this->done();
 
     if (!image) return nullptr;
-    if (this->colorSpace != colorSpace) {
-        this->colorSpace = colorSpace;
+    if (this->cs != cs) {
+        this->cs = cs;
         _changeColorSpace(reinterpret_cast<uint32_t*>(image), static_cast<uint32_t>(w), static_cast<uint32_t>(h));
     }
 
@@ -200,7 +200,7 @@ unique_ptr<Surface> PngLoader::bitmap(uint32_t colorSpace)
     surface->stride = static_cast<uint32_t>(w);
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);
-    surface->cs = colorSpace;
+    surface->cs = cs;
 
     return unique_ptr<Surface>(surface);
 }

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -48,7 +48,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(ColorSpace cs) override;
+    unique_ptr<Surface> bitmap() override;
     void run(unsigned tid) override;
 };
 

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -48,7 +48,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(uint32_t colorSpace) override;
+    unique_ptr<Surface> bitmap(ColorSpace cs) override;
     void run(unsigned tid) override;
 };
 

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -90,11 +90,11 @@ bool RawLoader::close()
 }
 
 
-unique_ptr<Surface> RawLoader::bitmap(uint32_t colorSpace)
+unique_ptr<Surface> RawLoader::bitmap(ColorSpace cs)
 {
     if (!content) return nullptr;
-    if (this->colorSpace != colorSpace) {
-        this->colorSpace = colorSpace;
+    if (this->cs != cs) {
+        this->cs = cs;
         _changeColorSpace(content, static_cast<uint32_t>(w), static_cast<uint32_t>(h));
     }
 
@@ -103,7 +103,7 @@ unique_ptr<Surface> RawLoader::bitmap(uint32_t colorSpace)
     surface->stride = static_cast<uint32_t>(w);
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);
-    surface->cs = colorSpace;
+    surface->cs = cs;
 
     return unique_ptr<Surface>(surface);
 }

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -29,22 +29,6 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static inline uint32_t CHANGE_COLORSPACE(uint32_t c)
-{
-    return (c & 0xff000000) + ((c & 0x00ff0000)>>16) + (c & 0x0000ff00) + ((c & 0x000000ff)<<16);
-}
-
-
-static void _changeColorSpace(uint32_t* data, uint32_t w, uint32_t h)
-{
-    auto buffer = data;
-    for (uint32_t y = 0; y < h; ++y, buffer += w) {
-        auto src = buffer;
-        for (uint32_t x = 0; x < w; ++x, ++src) {
-            *src = CHANGE_COLORSPACE(*src);
-        }
-    }
-}
 
 /************************************************************************/
 /* External Class Implementation                                        */
@@ -74,6 +58,8 @@ bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, bool copy)
     }
     else content = const_cast<uint32_t*>(data);
 
+    cs = ColorSpace::ARGB8888;
+
     return true;
 }
 
@@ -90,13 +76,9 @@ bool RawLoader::close()
 }
 
 
-unique_ptr<Surface> RawLoader::bitmap(ColorSpace cs)
+unique_ptr<Surface> RawLoader::bitmap()
 {
     if (!content) return nullptr;
-    if (this->cs != cs) {
-        this->cs = cs;
-        _changeColorSpace(content, static_cast<uint32_t>(w), static_cast<uint32_t>(h));
-    }
 
     auto surface = static_cast<Surface*>(malloc(sizeof(Surface)));
     surface->buffer = content;

--- a/src/loaders/raw/tvgRawLoader.h
+++ b/src/loaders/raw/tvgRawLoader.h
@@ -36,7 +36,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(ColorSpace cs) override;
+    unique_ptr<Surface> bitmap() override;
 };
 
 

--- a/src/loaders/raw/tvgRawLoader.h
+++ b/src/loaders/raw/tvgRawLoader.h
@@ -36,7 +36,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap(uint32_t colorSpace) override;
+    unique_ptr<Surface> bitmap(ColorSpace cs) override;
 };
 
 


### PR DESCRIPTION
Migrated the color space conversion to the backend engine side. This would increase the chances of performance acceleration (via threading and SIMD), and also remove duplicated conversion logic.