### PR TITLE
engine/loaders: Migrate alpha premultiplying to the engine side.

### DIFF
--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -28,7 +28,7 @@
 class GlRenderer : public RenderMethod
 {
 public:
-    Surface surface = {nullptr, 0, 0, 0};
+    Surface surface = {nullptr, 0, 0, 0, ColorSpace::Unsupported, true};
 
     RenderData prepare(const RenderShape& rshape, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags, bool clipper) override;
     RenderData prepare(const Array<RenderData>& scene, RenderData data, const RenderTransform* transform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag flags) override;

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -358,7 +358,8 @@ bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint
 bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id);
 bool rasterClear(SwSurface* surface);
 void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len);
-void rasterUnpremultiply(SwSurface* surface);
+void rasterUnpremultiply(Surface* surface);
+void rasterPremultiply(Surface* surface);
 bool rasterConvertCS(Surface* surface, ColorSpace to);
 
 #endif /* _TVG_SW_COMMON_H_ */

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -1481,8 +1481,10 @@ bool rasterClear(SwSurface* surface)
 }
 
 
-void rasterUnpremultiply(SwSurface* surface)
+void rasterUnpremultiply(Surface* surface)
 {
+    TVGLOG("SW_ENGINE", "Unpremultiply [Size: %d x %d]", surface->w, surface->h);
+
     //OPTIMIZE_ME: +SIMD
     for (uint32_t y = 0; y < surface->h; y++) {
         auto buffer = surface->buffer + surface->stride * y;
@@ -1503,6 +1505,25 @@ void rasterUnpremultiply(SwSurface* surface)
             }
         }
     }
+    surface->premultiplied = false;
+}
+
+
+void rasterPremultiply(Surface* surface)
+{
+    TVGLOG("SW_ENGINE", "Premultiply [Size: %d x %d]", surface->w, surface->h);
+
+    //OPTIMIZE_ME: +SIMD
+    auto buffer = surface->buffer;
+    for (uint32_t y = 0; y < surface->h; ++y, buffer += surface->stride) {
+        auto dst = buffer;
+        for (uint32_t x = 0; x < surface->w; ++x, ++dst) {
+            auto c = *dst;
+            auto a = (c >> 24);
+            *dst = (c & 0xff000000) + ((((c >> 8) & 0xff) * a) & 0xff00) + ((((c & 0x00ff00ff) * a) >> 8) & 0x00ff00ff);
+        }
+    }
+    surface->premultiplied = true;
 }
 
 

--- a/src/lib/sw_engine/tvgSwRasterC.h
+++ b/src/lib/sw_engine/tvgSwRasterC.h
@@ -65,7 +65,7 @@ static bool inline cRasterTranslucentRect(SwSurface* surface, const SwBBox& regi
 
 static bool inline cRasterABGRtoARGB(Surface* surface)
 {
-    TVGLOG("SW_ENGINE", "Convert ColorSpace ABGR - ARGB");
+    TVGLOG("SW_ENGINE", "Convert ColorSpace ABGR - ARGB [Size: %d x %d]", surface->w, surface->h);
 
     auto buffer = surface->buffer;
     for (uint32_t y = 0; y < surface->h; ++y, buffer += surface->stride) {

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -278,7 +278,10 @@ struct SwImageTask : SwTask
         auto clipRegion = bbox;
 
         //Convert colorspace if it's not aligned.
-        if (surface->cs != source->cs) rasterConvertCS(source, surface->cs);
+        if (source->owner) {
+            if (source->cs != surface->cs) rasterConvertCS(source, surface->cs);
+            if (!source->premultiplied) rasterPremultiply(source);
+        }
 
         image.data = source->buffer;
         image.w = source->w;
@@ -427,6 +430,8 @@ bool SwRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     surface->w = w;
     surface->h = h;
     surface->cs = cs;
+    surface->premultiplied = true;
+    surface->owner = true;
 
     vport.x = vport.y = 0;
     vport.w = surface->w;

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -72,7 +72,7 @@ struct Picture::Impl
     ~Impl()
     {
         if (paint) delete(paint);
-        free(surface);
+        delete(surface);
     }
 
     bool dispose(RenderMethod& renderer)
@@ -275,13 +275,10 @@ struct Picture::Impl
 
         dup->loader = loader;
         if (surface) {
-            dup->surface = static_cast<Surface*>(malloc(sizeof(Surface)));
+            dup->surface = new Surface;
             *dup->surface = *surface;
-            //TODO: It needs a better design...
-            //Backend engines might try to align the colorspace.
-            //Since it shares the bitmap, duplications should not touch the data.
-            //Only the owner could manage it.
-            dup->surface->cs = ColorSpace::Unsupported;
+            //TODO: A dupilcation is not a proxy... it needs copy of the pixel data?
+            dup->surface->owner = false;
         }
         dup->w = w;
         dup->h = h;

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -46,11 +46,13 @@ enum ColorSpace
 
 struct Surface
 {
-    //TODO: Union for multiple types
     uint32_t* buffer;
-    uint32_t  stride;
-    uint32_t  w, h;
+    uint32_t stride;
+    uint32_t w, h;
     ColorSpace  cs;
+
+    bool premultiplied;      //Alpha-premultiplied
+    bool owner;              //Only owner could modify the buffer
 };
 
 struct Compositor

--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -158,12 +158,15 @@ unique_ptr<Surface> JpgLoader::bitmap()
 {
     if (!image) return nullptr;
 
-    auto surface = static_cast<Surface*>(malloc(sizeof(Surface)));
+    //TODO: It's better to keep this surface instance in the loader side
+    auto surface = new Surface;
     surface->buffer = (uint32_t*)(image);
     surface->stride = w;
     surface->w = w;
     surface->h = h;
     surface->cs = cs;
+    surface->premultiplied = true;
+    surface->owner = true;
 
     return unique_ptr<Surface>(surface);
 }

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -118,12 +118,15 @@ unique_ptr<Surface> JpgLoader::bitmap()
 
     if (!image) return nullptr;
 
-    auto surface = static_cast<Surface*>(malloc(sizeof(Surface)));
+    //TODO: It's better to keep this surface instance in the loader side
+    auto surface = new Surface;
     surface->buffer = reinterpret_cast<uint32_t*>(image);
     surface->stride = static_cast<uint32_t>(w);
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);
     surface->cs = cs;
+    surface->premultiplied = true;
+    surface->owner = true;
 
     return unique_ptr<Surface>(surface);
 }

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -80,12 +80,15 @@ unique_ptr<Surface> RawLoader::bitmap()
 {
     if (!content) return nullptr;
 
-    auto surface = static_cast<Surface*>(malloc(sizeof(Surface)));
+    //TODO: It's better to keep this surface instance in the loader side
+    auto surface = new Surface;
     surface->buffer = content;
     surface->stride = static_cast<uint32_t>(w);
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);
     surface->cs = cs;
+    surface->premultiplied = true;
+    surface->owner = true;
 
     return unique_ptr<Surface>(surface);
 }


### PR DESCRIPTION
It's not efficient to handle alpha premultiplying in every loader. The backend engine should be responsible for it.
Now, we can remove duplicate code.