### PR TITLE
svg_loader: handling svg width/height in percentages

### DIFF
--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -260,6 +260,8 @@ struct SvgDocNode
     float vy;
     float vw;
     float vh;
+    float sw;
+    float sh;
     SvgViewFlag viewFlag;
     SvgNode* defs;
     SvgNode* style;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -796,7 +796,10 @@ unique_ptr<Scene> svgSceneBuild(SvgNode* node, float& vx, float& vy, float& vw, 
 
     Box vBox = {vx, vy, vw, vh};
     auto docNode = _sceneBuildHelper(node, vBox, svgPath, false, 0);
+
     _applySvgViewFlag(docNode.get(), vx, vy, vw, vh, w, h, viewFlag);
+    w *= node->node.doc.sw;
+    h *= node->node.doc.sh;
 
     if (!mathEqual(w, vw) || !mathEqual(h, vh)) {
         Matrix m = _calculateAspectRatioMatrix(align, meetOrSlice, w, h, {vx, vy, vw, vh});


### PR DESCRIPTION
The percentages should refer to the size of the viewbox. This was not the case for not knowing the viewbox before reading the width/height.

@Issue: https://github.com/thorvg/thorvg/issues/1409