### PR TITLE
Masking feature optimization

### DIFF
--- a/src/examples/AnimateMasking.cpp
+++ b/src/examples/AnimateMasking.cpp
@@ -44,16 +44,17 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto picture1 = tvg::Picture::gen();
     picture1->load(EXAMPLE_DIR"/cartman.svg");
     picture1->size(400, 400);
+    canvas->push(move(picture1));
+
     auto picture2 = tvg::Picture::gen();
     picture2->load(EXAMPLE_DIR"/logo.svg");
     picture2->size(400, 400);
-    canvas->push(move(picture1));
 
     //mask
     auto maskShape = tvg::Shape::gen();
     pMaskShape = maskShape.get();
     maskShape->appendCircle(180, 180, 75, 75);
-    maskShape->fill(0, 0, 0, 125);
+    maskShape->fill(125, 125, 125, 255);
     maskShape->stroke(25, 25, 25, 255);
     maskShape->stroke(tvg::StrokeJoin::Round);
     maskShape->stroke(10);
@@ -62,7 +63,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto mask = tvg::Shape::gen();
     pMask = mask.get();
     mask->appendCircle(180, 180, 75, 75);
-    mask->fill(255, 0, 0, 255);
+    mask->fill(255, 255, 255, 255);    //AlphaMask RGB channels are unused.
 
     picture2->composite(move(mask), tvg::CompositeMethod::AlphaMask);
     if (canvas->push(move(picture2)) != tvg::Result::Success) return;

--- a/src/examples/InvMasking.cpp
+++ b/src/examples/InvMasking.cpp
@@ -39,7 +39,14 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Mask
     auto mask = tvg::Shape::gen();
     mask->appendCircle(200, 200, 125, 125);
-    mask->fill(255, 0, 0, 255);
+    mask->fill(255, 255, 255, 255);     //InvAlphaMask RGB channels are unused.
+
+    //Nested Mask
+    auto nMask = tvg::Shape::gen();
+    nMask->appendCircle(220, 220, 125, 125);
+    nMask->fill(255, 255, 255, 255);     //InvAlphaMask RGB channels are unused.
+
+    mask->composite(move(nMask), tvg::CompositeMethod::InvAlphaMask);
     shape->composite(move(mask), tvg::CompositeMethod::InvAlphaMask);
     canvas->push(move(shape));
 
@@ -54,7 +61,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto mask2 = tvg::Shape::gen();
     mask2->appendCircle(150, 500, 75, 75);
     mask2->appendRect(150, 500, 200, 200, 30, 30);
-    mask2->fill(255, 255, 255, 255);
+    mask2->fill(255, 255, 255, 255);    //InvAlphaMask RGB channels are unused.
     svg->composite(move(mask2), tvg::CompositeMethod::InvAlphaMask);
     if (canvas->push(move(svg)) != tvg::Result::Success) return;
 
@@ -78,7 +85,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Mask3
     auto mask3 = tvg::Shape::gen();
     mask3->appendCircle(600, 200, 125, 125);
-    mask3->fill(255, 255, 255, 255);
+    mask3->fill(255, 255, 255, 255);    //InvAlphaMask RGB channels are unused.
     star->composite(move(mask3), tvg::CompositeMethod::InvAlphaMask);
     if (canvas->push(move(star)) != tvg::Result::Success) return;
 
@@ -108,7 +115,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     mask4->lineTo(426, 511);
     mask4->lineTo(546, 493);
     mask4->close();
-    mask4->fill(255, 255, 255, 70);
+    mask4->fill(255, 255, 255, 70);     //InvAlphaMask RGB channels are unused.
     image->composite(move(mask4), tvg::CompositeMethod::InvAlphaMask);
     if (canvas->push(move(image)) != tvg::Result::Success) return;
 }

--- a/src/examples/LumaMasking.cpp
+++ b/src/examples/LumaMasking.cpp
@@ -39,7 +39,14 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Mask
     auto mask = tvg::Shape::gen();
     mask->appendCircle(200, 200, 125, 125);
-    mask->fill(255, 0, 0, 255);
+    mask->fill(255, 100, 255, 255);
+
+    //Nested Mask
+    auto nMask = tvg::Shape::gen();
+    nMask->appendCircle(220, 220, 125, 125);
+    nMask->fill(255, 200, 255, 255);
+
+    mask->composite(move(nMask), tvg::CompositeMethod::LumaMask);
     shape->composite(move(mask), tvg::CompositeMethod::LumaMask);
     canvas->push(move(shape));
 

--- a/src/examples/Masking.cpp
+++ b/src/examples/Masking.cpp
@@ -39,7 +39,14 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Mask
     auto mask = tvg::Shape::gen();
     mask->appendCircle(200, 200, 125, 125);
-    mask->fill(255, 0, 0, 255);
+    mask->fill(255, 255, 255, 255);     //AlphaMask RGB channels are unused.
+
+    //Nested Mask
+    auto nMask = tvg::Shape::gen();
+    nMask->appendCircle(220, 220, 125, 125);
+    nMask->fill(255, 255, 255, 255);     //AlphaMask RGB channels are unused.
+
+    mask->composite(move(nMask), tvg::CompositeMethod::AlphaMask);
     shape->composite(move(mask), tvg::CompositeMethod::AlphaMask);
     canvas->push(move(shape));
 
@@ -54,7 +61,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto mask2 = tvg::Shape::gen();
     mask2->appendCircle(150, 500, 75, 75);
     mask2->appendRect(150, 500, 200, 200, 30, 30);
-    mask2->fill(255, 255, 255, 255);
+    mask2->fill(255, 255, 255, 255);    //AlphaMask RGB channels are unused.
     svg->composite(move(mask2), tvg::CompositeMethod::AlphaMask);
     if (canvas->push(move(svg)) != tvg::Result::Success) return;
 
@@ -78,7 +85,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Mask3
     auto mask3 = tvg::Shape::gen();
     mask3->appendCircle(600, 200, 125, 125);
-    mask3->fill(255, 255, 255, 255);
+    mask3->fill(255, 255, 255, 255);    //AlphaMask RGB channels are unused.
     star->composite(move(mask3), tvg::CompositeMethod::AlphaMask);
     if (canvas->push(move(star)) != tvg::Result::Success) return;
 
@@ -86,7 +93,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw");
     if (!file.is_open()) return;
     auto data = (uint32_t*) malloc(sizeof(uint32_t) * (200 * 300));
-    file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
+    file.read(reinterpret_cast<char*>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
 
     auto image = tvg::Picture::gen();
@@ -106,7 +113,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     mask4->lineTo(426, 511);
     mask4->lineTo(546, 493);
     mask4->close();
-    mask4->fill(255, 255, 255, 70);
+    mask4->fill(255, 255, 255, 70);     //AlphaMask RGB channels are unused.
     image->composite(move(mask4), tvg::CompositeMethod::AlphaMask);
     if (canvas->push(move(image)) != tvg::Result::Success) return;
 

--- a/src/examples/Performance.cpp
+++ b/src/examples/Performance.cpp
@@ -35,10 +35,14 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 {
     if (!canvas) return;
 
-    auto picture = tvg::Picture::gen();
+    auto mask = tvg::Shape::gen();
+    mask->appendCircle(WIDTH/2, HEIGHT/2, WIDTH/2, HEIGHT/2);
+    mask->fill(255, 255, 255, 100);
 
+    auto picture = tvg::Picture::gen();
     picture->load(EXAMPLE_DIR"/tiger.svg");
     picture->size(WIDTH, HEIGHT);
+    picture->composite(move(mask), tvg::CompositeMethod::AlphaMask);
     pPicture = picture.get();
     canvas->push(move(picture));
 }

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -102,7 +102,7 @@ bool GlRenderer::postRender()
 }
 
 
-Compositor* GlRenderer::target(TVG_UNUSED const RenderRegion& region)
+Compositor* GlRenderer::target(TVG_UNUSED const RenderRegion& region, TVG_UNUSED ColorSpace cs)
 {
     //TODO: Prepare frameBuffer & Setup render target for composition
     return nullptr;

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -123,6 +123,12 @@ bool GlRenderer::endComposite(TVG_UNUSED Compositor* cmp)
 }
 
 
+ColorSpace GlRenderer::SwRenderer::colorSpace()
+{
+    return surface->cs;
+}
+
+
 bool GlRenderer::renderImage(TVG_UNUSED void* data)
 {
     //TODO: render requested images

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -41,6 +41,7 @@ public:
     RenderRegion region(RenderData data) override;
     RenderRegion viewport() override;
     bool viewport(const RenderRegion& vp) override;
+    ColorSpace colorSpace() override;
 
     bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h);
     bool sync() override;

--- a/src/lib/gl_engine/tvgGlRenderer.h
+++ b/src/lib/gl_engine/tvgGlRenderer.h
@@ -47,7 +47,7 @@ public:
     bool sync() override;
     bool clear() override;
 
-    Compositor* target(const RenderRegion& region) override;
+    Compositor* target(const RenderRegion& region, ColorSpace cs) override;
     bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) override;
     bool endComposite(Compositor* cmp) override;
 

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -223,7 +223,11 @@ struct SwImage
 {
     SwOutline*   outline = nullptr;
     SwRleData*   rle = nullptr;
-    uint32_t*    data = nullptr;
+    union {
+        pixel_t*  data;      //system based data pointer
+        uint32_t* buf32;     //for explicit 32bits channels
+        uint8_t*  buf8;      //for explicit 8bits grayscale
+    };
     uint32_t     w, h, stride;
     int32_t      ox = 0;         //offset x
     int32_t      oy = 0;         //offset y

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -241,7 +241,7 @@ struct SwImage
 struct SwBlender
 {
     uint32_t (*join)(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-    uint32_t (*lumaValue)(uint32_t c);
+    uint8_t (*luma)(uint8_t* c);
 };
 
 struct SwCompositor;

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -357,7 +357,7 @@ bool rasterShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8
 bool rasterImage(SwSurface* surface, SwImage* image, const RenderMesh* mesh, const Matrix* transform, const SwBBox& bbox, uint32_t opacity);
 bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id);
-bool rasterClear(SwSurface* surface);
+bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
 void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len);
 void rasterUnpremultiply(Surface* surface);
 void rasterPremultiply(Surface* surface);

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -228,6 +228,7 @@ struct SwImage
     int32_t      ox = 0;         //offset x
     int32_t      oy = 0;         //offset y
     float        scale;
+    uint8_t      channelSize;
 
     bool         direct = false;  //draw image directly (with offset)
     bool         scaled = false;  //draw scaled image

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -1466,15 +1466,18 @@ bool rasterCompositor(SwSurface* surface)
 }
 
 
-bool rasterClear(SwSurface* surface)
+bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_t h)
 {
-    if (!surface || !surface->buffer || surface->stride <= 0 || surface->w <= 0 || surface->h <= 0) return false;
+    if (!surface || !surface->buffer || surface->stride == 0 || surface->w == 0 || surface->h == 0) return false;
 
+    //full clear
     if (surface->w == surface->stride) {
-        rasterRGBA32(surface->buffer, 0x00000000, 0, surface->w * surface->h);
+        rasterRGBA32(surface->buffer + (surface->stride * y + x), 0x00000000, x, w * h);
+    //partial clear
     } else {
-        for (uint32_t i = 0; i < surface->h; i++) {
-            rasterRGBA32(surface->buffer + surface->stride * i, 0x00000000, 0, surface->w);
+        auto offset = surface->stride * y + x;
+        for (uint32_t i = 0; i < h; i++) {
+            rasterRGBA32(surface->buffer + (offset * i), 0x00000000, x, w);
         }
     }
     return true;

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -154,11 +154,11 @@ static uint32_t _interpDownScaler(const uint32_t *img, uint32_t stride, uint32_t
 
 static bool _rasterMaskedRect(SwSurface* surface, const SwBBox& region, uint32_t color, uint32_t (*blendMethod)(uint32_t))
 {
-    TVGLOG("SW_ENGINE", "Masked Rect");
-
     auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
+
+    TVGLOG("SW_ENGINE", "Masked Rect [Region: %lu %lu %u %u]", region.min.x, region.min.y, w, h);
 
     auto cbuffer = surface->compositor->image.data + (region.min.y * surface->compositor->image.stride) + region.min.x; //compositor buffer
 

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -37,8 +37,8 @@
 /************************************************************************/
 constexpr auto DOWN_SCALE_TOLERANCE = 0.5f;
 
-
-static inline uint32_t _multiplyAlpha(uint32_t c, uint32_t a)
+template<typename T>
+static inline T _multiply(T c, T a)
 {
     return ((c * a + 0xff) >> 8);
 }
@@ -56,15 +56,29 @@ static inline uint32_t _ialpha(uint32_t c)
 }
 
 
-static inline uint32_t _abgrLumaValue(uint32_t c)
+static inline uint8_t _alpha(uint8_t* a)
 {
-    return ((((c&0xff)*54) + (((c>>8)&0xff)*183) + (((c>>16)&0xff)*19))) >> 8; //0.2125*R + 0.7154*G + 0.0721*B
+    return *a;
 }
 
 
-static inline uint32_t _argbLumaValue(uint32_t c)
+static inline uint8_t _ialpha(uint8_t* a)
 {
-    return ((((c&0xff)*19) + (((c>>8)&0xff)*183) + (((c>>16)&0xff)*54))) >> 8; //0.0721*B + 0.7154*G + 0.2125*R
+    return ~(*a);
+}
+
+
+static inline uint8_t _abgrLuma(uint8_t* c)
+{
+    auto v = *(uint32_t*)c;
+    return ((((v&0xff)*54) + (((v>>8)&0xff)*183) + (((v>>16)&0xff)*19))) >> 8; //0.2125*R + 0.7154*G + 0.0721*B
+}
+
+
+static inline uint8_t _argbLuma(uint8_t* c)
+{
+    auto v = *(uint32_t*)c;
+    return ((((v&0xff)*19) + (((v>>8)&0xff)*183) + (((v>>16)&0xff)*54))) >> 8; //0.0721*B + 0.7154*G + 0.2125*R
 }
 
 
@@ -148,65 +162,95 @@ static uint32_t _interpDownScaler(const uint32_t *img, uint32_t stride, uint32_t
 }
 
 
+void _rasterGrayscale8(uint8_t *dst, uint32_t val, uint32_t offset, int32_t len)
+{
+    cRasterPixels<uint8_t>(dst, val, offset, len);
+}
+
 /************************************************************************/
 /* Rect                                                                 */
 /************************************************************************/
 
-static bool _rasterMaskedRect(SwSurface* surface, const SwBBox& region, uint32_t color, uint32_t (*blender)(uint32_t))
+static bool _rasterMaskedRect(SwSurface* surface, const SwBBox& region, uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t(*blender)(uint8_t*))
 {
-    auto buffer = surface->buf32 + (region.min.y * surface->stride) + region.min.x;
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
+    auto csize = surface->compositor->image.channelSize;
+    auto cbuffer = surface->compositor->image.buf8 + ((region.min.y * surface->compositor->image.stride + region.min.x) * csize);   //compositor buffer
 
     TVGLOG("SW_ENGINE", "Masked Rect [Region: %lu %lu %u %u]", region.min.x, region.min.y, w, h);
-
-    auto cbuffer = surface->compositor->image.buf32 + (region.min.y * surface->compositor->image.stride) + region.min.x; //compositor buffer
-
-    for (uint32_t y = 0; y < h; ++y) {
-        auto dst = &buffer[y * surface->stride];
-        auto cmp = &cbuffer[y * surface->stride];
-        for (uint32_t x = 0; x < w; ++x, ++dst, ++cmp) {
-            auto tmp = ALPHA_BLEND(color, blender(*cmp));
-            *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
+    
+    //32bits channels
+    if (surface->channelSize == sizeof(uint32_t)) {
+        auto color = surface->blender.join(r, g, b, a);
+        auto buffer = surface->buf32 + (region.min.y * surface->stride) + region.min.x;
+        for (uint32_t y = 0; y < h; ++y) {
+            auto dst = &buffer[y * surface->stride];
+            auto cmp = &cbuffer[y * surface->stride * csize];
+            for (uint32_t x = 0; x < w; ++x, ++dst, cmp += csize) {
+                auto tmp = ALPHA_BLEND(color, blender(cmp));
+                *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
+            }
+        }
+    //8bits grayscale
+    } else if (surface->channelSize == sizeof(uint8_t)) {
+        auto buffer = surface->buf8 + (region.min.y * surface->stride) + region.min.x;
+        for (uint32_t y = 0; y < h; ++y) {
+            auto dst = &buffer[y * surface->stride];
+            auto cmp = &cbuffer[y * surface->stride * csize];
+            for (uint32_t x = 0; x < w; ++x, ++dst, cmp += csize) {
+                auto tmp = _multiply<uint8_t>(a, blender(cmp));
+                *dst = tmp + _multiply<uint8_t>(*dst, _ialpha(tmp));
+            }
         }
     }
     return true;
 }
 
 
-static bool _rasterSolidRect(SwSurface* surface, const SwBBox& region, uint32_t color)
+static bool _rasterSolidRect(SwSurface* surface, const SwBBox& region, uint8_t r, uint8_t g, uint8_t b)
 {
-    auto buffer = surface->buf32 + (region.min.y * surface->stride);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
 
-    for (uint32_t y = 0; y < h; ++y) {
-        rasterRGBA32(buffer + y * surface->stride, color, region.min.x, w);
+    //32bits channels
+    if (surface->channelSize == sizeof(uint32_t)) {
+        auto color = surface->blender.join(r, g, b, 255);
+        auto buffer = surface->buf32 + (region.min.y * surface->stride);
+        for (uint32_t y = 0; y < h; ++y) {
+            rasterRGBA32(buffer + y * surface->stride, color, region.min.x, w);
+        }
+    //8bits grayscale
+    } else if (surface->channelSize == sizeof(uint8_t)) {
+        auto buffer = surface->buf8 + (region.min.y * surface->stride);
+        for (uint32_t y = 0; y < h; ++y) {
+            _rasterGrayscale8(buffer + y * surface->stride, 255, region.min.x, w);
+        }
     }
     return true;
 }
 
 
-static bool _rasterRect(SwSurface* surface, const SwBBox& region, uint32_t color, uint8_t opacity)
+static bool _rasterRect(SwSurface* surface, const SwBBox& region, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
     if (_compositing(surface)) {
         if (surface->compositor->method == CompositeMethod::AlphaMask) {
-            return _rasterMaskedRect(surface, region, color, _alpha);
+            return _rasterMaskedRect(surface, region, r, g, b, a, _alpha);
         } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
-            return _rasterMaskedRect(surface, region, color, _ialpha);
+            return _rasterMaskedRect(surface, region, r, g, b, a, _ialpha);
         } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-            return _rasterMaskedRect(surface, region, color, surface->blender.lumaValue);
+            return _rasterMaskedRect(surface, region, r, g, b, a, surface->blender.luma);
         }
     } else {
-        if (opacity == 255) {
-            return _rasterSolidRect(surface, region, color);
+        if (a == 255) {
+            return _rasterSolidRect(surface, region, r, g, b);
         } else {
 #if defined(THORVG_AVX_VECTOR_SUPPORT)
-            return avxRasterTranslucentRect(surface, region, color);
+            return avxRasterTranslucentRect(surface, region, r, g, b, a);
 #elif defined(THORVG_NEON_VECTOR_SUPPORT)
-            return neonRasterTranslucentRect(surface, region, color);
+            return neonRasterTranslucentRect(surface, region, r, g, b, a);
 #else
-            return cRasterTranslucentRect(surface, region, color);
+            return cRasterTranslucentRect(surface, region, r, g, b, a);
 #endif
         }
     }
@@ -218,41 +262,38 @@ static bool _rasterRect(SwSurface* surface, const SwBBox& region, uint32_t color
 /* Rle                                                                  */
 /************************************************************************/
 
-static bool _rasterMaskedRle(SwSurface* surface, SwRleData* rle, uint32_t color, uint32_t (*blender)(uint32_t))
+static bool _rasterMaskedRle(SwSurface* surface, SwRleData* rle, uint8_t r, uint8_t g, uint8_t b, uint8_t a, uint8_t(*blender)(uint8_t*))
 {
     TVGLOG("SW_ENGINE", "Masked Rle");
 
     auto span = rle->spans;
     uint32_t src;
-    auto cbuffer = surface->compositor->image.buf32;
+    auto cbuffer = surface->compositor->image.buf8;
+    auto csize = surface->compositor->image.channelSize;
 
-    for (uint32_t i = 0; i < rle->size; ++i, ++span) {
-        auto dst = &surface->buf32[span->y * surface->stride + span->x];
-        auto cmp = &cbuffer[span->y * surface->compositor->image.stride + span->x];
-        if (span->coverage == 255) src = color;
-        else src = ALPHA_BLEND(color, span->coverage);
-        for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp) {
-            auto tmp = ALPHA_BLEND(src, blender(*cmp));
-            *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
-        }
-    }
-    return true;
-}
-
-
-static bool _rasterSolidRle(SwSurface* surface, const SwRleData* rle, uint32_t color)
-{
-    auto span = rle->spans;
-
-    for (uint32_t i = 0; i < rle->size; ++i, ++span) {
-        if (span->coverage == 255) {
-            rasterRGBA32(surface->buf32 + span->y * surface->stride, color, span->x, span->len);
-        } else {
+    //32bit channels
+    if (surface->channelSize == sizeof(uint32_t)) {
+        auto color = surface->blender.join(r, g, b, a);
+        for (uint32_t i = 0; i < rle->size; ++i, ++span) {
             auto dst = &surface->buf32[span->y * surface->stride + span->x];
-            auto src = ALPHA_BLEND(color, span->coverage);
-            auto ialpha = 255 - span->coverage;
-            for (uint32_t x = 0; x < span->len; ++x, ++dst) {
-                *dst = src + ALPHA_BLEND(*dst, ialpha);
+            auto cmp = &cbuffer[(span->y * surface->compositor->image.stride + span->x) * csize];
+            if (span->coverage == 255) src = color;
+            else src = ALPHA_BLEND(color, span->coverage);
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, cmp += csize) {
+                auto tmp = ALPHA_BLEND(src, blender(cmp));
+                *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
+            }
+        }
+    //8bit grayscale
+    } else if (surface->channelSize == sizeof(uint8_t)) {
+        for (uint32_t i = 0; i < rle->size; ++i, ++span) {
+            auto dst = &surface->buf8[span->y * surface->stride + span->x];
+            auto cmp = &cbuffer[(span->y * surface->compositor->image.stride + span->x) * csize];
+            if (span->coverage == 255) src = a;
+            else src = _multiply<uint8_t>(a, span->coverage);
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, cmp += csize) {
+                auto tmp = _multiply<uint8_t>(src, blender(cmp));
+                *dst = tmp + _multiply<uint8_t>(*dst, _ialpha(tmp));
             }
         }
     }
@@ -260,28 +301,64 @@ static bool _rasterSolidRle(SwSurface* surface, const SwRleData* rle, uint32_t c
 }
 
 
-static bool _rasterRle(SwSurface* surface, SwRleData* rle, uint32_t color, uint8_t opacity)
+static bool _rasterSolidRle(SwSurface* surface, const SwRleData* rle, uint8_t r, uint8_t g, uint8_t b)
+{
+    auto span = rle->spans;
+
+    //32bit channels
+    if (surface->channelSize == sizeof(uint32_t)) {
+        auto color = surface->blender.join(r, g, b, 255);
+        for (uint32_t i = 0; i < rle->size; ++i, ++span) {
+            if (span->coverage == 255) {
+                rasterRGBA32(surface->buf32 + span->y * surface->stride, color, span->x, span->len);
+            } else {
+                auto dst = &surface->buf32[span->y * surface->stride + span->x];
+                auto src = ALPHA_BLEND(color, span->coverage);
+                auto ialpha = 255 - span->coverage;
+                for (uint32_t x = 0; x < span->len; ++x, ++dst) {
+                    *dst = src + ALPHA_BLEND(*dst, ialpha);
+                }
+            }
+        }
+    //8bit grayscale
+    } else if (surface->channelSize == sizeof(uint8_t)) {
+        for (uint32_t i = 0; i < rle->size; ++i, ++span) {
+            if (span->coverage == 255) {
+                _rasterGrayscale8(surface->buf8 + span->y * surface->stride, 255, span->x, span->len);
+            } else {
+                auto dst = &surface->buf8[span->y * surface->stride + span->x];
+                for (uint32_t x = 0; x < span->len; ++x, ++dst) {
+                    *dst = span->coverage;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+
+static bool _rasterRle(SwSurface* surface, SwRleData* rle, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
     if (!rle) return false;
 
     if (_compositing(surface)) {
         if (surface->compositor->method == CompositeMethod::AlphaMask) {
-            return _rasterMaskedRle(surface, rle, color, _alpha);
+            return _rasterMaskedRle(surface, rle, r, g, b, a, _alpha);
         } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
-            return _rasterMaskedRle(surface, rle, color, _ialpha);
+            return _rasterMaskedRle(surface, rle, r, g, b, a, _ialpha);
         } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-            return _rasterMaskedRle(surface, rle, color, surface->blender.lumaValue);
+            return _rasterMaskedRle(surface, rle, r, g, b, a, surface->blender.luma);
         }
     } else {
-        if (opacity == 255) {
-            return _rasterSolidRle(surface, rle, color);
+        if (a == 255) {
+            return _rasterSolidRle(surface, rle, r, g, b);
         } else {
 #if defined(THORVG_AVX_VECTOR_SUPPORT)
-            return avxRasterTranslucentRle(surface, rle, color);
+            return avxRasterTranslucentRle(surface, rle, r, g, b, a);
 #elif defined(THORVG_NEON_VECTOR_SUPPORT)
-            return neonRasterTranslucentRle(surface, rle, color);
+            return neonRasterTranslucentRle(surface, rle, r, g, b, a);
 #else
-            return cRasterTranslucentRle(surface, rle, color);
+            return cRasterTranslucentRle(surface, rle, r, g, b, a);
 #endif
         }
     }
@@ -301,7 +378,7 @@ static bool _transformedRleRGBAImage(SwSurface* surface, const SwImage* image, c
         } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _rasterTexmapPolygon(surface, image, transform, nullptr, opacity, _ialpha);
         } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-            return _rasterTexmapPolygon(surface, image, transform, nullptr, opacity, surface->blender.lumaValue);
+            return _rasterTexmapPolygon(surface, image, transform, nullptr, opacity, surface->blender.luma);
         }
     } else {
         return _rasterTexmapPolygon(surface, image, transform, nullptr, opacity, nullptr);
@@ -313,11 +390,12 @@ static bool _transformedRleRGBAImage(SwSurface* surface, const SwImage* image, c
 /* RLE Scaled RGBA Image                                                */
 /************************************************************************/
 
-static bool _rasterScaledMaskedTranslucentRleRGBAImage(SwSurface* surface, const SwImage* image, const Matrix* itransform, const SwBBox& region, uint32_t opacity, uint32_t halfScale, uint32_t (*blender)(uint32_t))
+static bool _rasterScaledMaskedTranslucentRleRGBAImage(SwSurface* surface, const SwImage* image, const Matrix* itransform, const SwBBox& region, uint32_t opacity, uint32_t halfScale, uint8_t(*blender)(uint8_t*))
 {
     TVGLOG("SW_ENGINE", "Scaled Masked Translucent Rle Image");
 
     auto span = image->rle->spans;
+    auto csize = surface->compositor->image.channelSize;
 
     //Center (Down-Scaled)
     if (image->scale < DOWN_SCALE_TOLERANCE) {
@@ -325,13 +403,13 @@ static bool _rasterScaledMaskedTranslucentRleRGBAImage(SwSurface* surface, const
             auto sy = (uint32_t)(span->y * itransform->e22 + itransform->e23);
             if (sy >= image->h) continue;
             auto dst = &surface->buf32[span->y * surface->stride + span->x];
-            auto cmp = &surface->compositor->image.buf32[span->y * surface->compositor->image.stride + span->x];
-            auto alpha = _multiplyAlpha(span->coverage, opacity);
-            for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, ++cmp) {
+            auto cmp = &surface->compositor->image.buf8[(span->y * surface->compositor->image.stride + span->x) * csize];
+            auto alpha = _multiply<uint32_t>(span->coverage, opacity);
+            for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, cmp += csize) {
                 auto sx = (uint32_t)(x * itransform->e11 + itransform->e13);
                 if (sx >= image->w) continue;
                 auto src = ALPHA_BLEND(_interpDownScaler(image->buf32, image->stride, image->w, image->h, sx, sy, halfScale), alpha);
-                auto tmp = ALPHA_BLEND(src, blender(*cmp));
+                auto tmp = ALPHA_BLEND(src, blender(cmp));
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
         }
@@ -341,13 +419,13 @@ static bool _rasterScaledMaskedTranslucentRleRGBAImage(SwSurface* surface, const
             auto sy = span->y * itransform->e22 + itransform->e23;
             if ((uint32_t)sy >= image->h) continue;
             auto dst = &surface->buf32[span->y * surface->stride + span->x];
-            auto cmp = &surface->compositor->image.buf32[span->y * surface->compositor->image.stride + span->x];
-            auto alpha = _multiplyAlpha(span->coverage, opacity);
-            for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, ++cmp) {
+            auto cmp = &surface->compositor->image.buf8[(span->y * surface->compositor->image.stride + span->x) * csize];
+            auto alpha = _multiply<uint32_t>(span->coverage, opacity);
+            for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, cmp += csize) {
                 auto sx = x * itransform->e11 + itransform->e13;
                 if ((uint32_t)sx >= image->w) continue;
                 auto src = ALPHA_BLEND(_interpUpScaler(image->buf32, image->w, image->h, sx, sy), alpha);
-                auto tmp = ALPHA_BLEND(src, blender(*cmp));
+                auto tmp = ALPHA_BLEND(src, blender(cmp));
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
         }
@@ -356,11 +434,12 @@ static bool _rasterScaledMaskedTranslucentRleRGBAImage(SwSurface* surface, const
 }
 
 
-static bool _rasterScaledMaskedRleRGBAImage(SwSurface* surface, const SwImage* image, const Matrix* itransform, const SwBBox& region, uint32_t halfScale, uint32_t(*blender)(uint32_t))
+static bool _rasterScaledMaskedRleRGBAImage(SwSurface* surface, const SwImage* image, const Matrix* itransform, const SwBBox& region, uint32_t halfScale, uint8_t(*blender)(uint8_t*))
 {
     TVGLOG("SW_ENGINE", "Scaled Masked Rle Image");
 
     auto span = image->rle->spans;
+    auto csize = surface->compositor->image.channelSize;
 
     //Center (Down-Scaled)
     if (image->scale < DOWN_SCALE_TOLERANCE) {
@@ -368,20 +447,20 @@ static bool _rasterScaledMaskedRleRGBAImage(SwSurface* surface, const SwImage* i
             auto sy = (uint32_t)(span->y * itransform->e22 + itransform->e23);
             if (sy >= image->h) continue;
             auto dst = &surface->buf32[span->y * surface->stride + span->x];
-            auto cmp = &surface->compositor->image.buf32[span->y * surface->compositor->image.stride + span->x];
+            auto cmp = &surface->compositor->image.buf8[(span->y * surface->compositor->image.stride + span->x) * csize];
             if (span->coverage == 255) {
-                for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, ++cmp) {
+                for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, cmp += csize) {
                     auto sx = (uint32_t)(x * itransform->e11 + itransform->e13);
                     if (sx >= image->w) continue;
-                    auto tmp = ALPHA_BLEND(_interpDownScaler(image->buf32, image->stride, image->w, image->h, sx, sy, halfScale), blender(*cmp));
+                    auto tmp = ALPHA_BLEND(_interpDownScaler(image->buf32, image->stride, image->w, image->h, sx, sy, halfScale), blender(cmp));
                     *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
                 }
             } else {
-                for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, ++cmp) {
+                for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, cmp += csize) {
                     auto sx = (uint32_t)(x * itransform->e11 + itransform->e13);
                     if (sx >= image->w) continue;
                     auto src = ALPHA_BLEND(_interpDownScaler(image->buf32, image->stride, image->w, image->h, sx, sy, halfScale), span->coverage);
-                    auto tmp = ALPHA_BLEND(src, blender(*cmp));
+                    auto tmp = ALPHA_BLEND(src, blender(cmp));
                     *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
                 }
             }
@@ -392,20 +471,20 @@ static bool _rasterScaledMaskedRleRGBAImage(SwSurface* surface, const SwImage* i
             auto sy = span->y * itransform->e22 + itransform->e23;
             if ((uint32_t)sy >= image->h) continue;
             auto dst = &surface->buf32[span->y * surface->stride + span->x];
-            auto cmp = &surface->compositor->image.buf32[span->y * surface->compositor->image.stride + span->x];
+            auto cmp = &surface->compositor->image.buf8[(span->y * surface->compositor->image.stride + span->x) * csize];
             if (span->coverage == 255) {
-                for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, ++cmp) {
+                for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, cmp += csize) {
                     auto sx = x * itransform->e11 + itransform->e13;
                     if ((uint32_t)sx >= image->w) continue;
-                    auto tmp = ALPHA_BLEND(_interpUpScaler(image->buf32, image->w, image->h, sx, sy), blender(*cmp));
+                    auto tmp = ALPHA_BLEND(_interpUpScaler(image->buf32, image->w, image->h, sx, sy), blender(cmp));
                     *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
                 }
             } else {
-                for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, ++cmp) {
+                for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, cmp += csize) {
                     auto sx = x * itransform->e11 + itransform->e13;
                     if ((uint32_t)sx >= image->w) continue;
                     auto src = ALPHA_BLEND(_interpUpScaler(image->buf32, image->w, image->h, sx, sy), span->coverage);
-                    auto tmp = ALPHA_BLEND(src, blender(*cmp));
+                    auto tmp = ALPHA_BLEND(src, blender(cmp));
                     *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
                 }
             }
@@ -425,7 +504,7 @@ static bool _rasterScaledTranslucentRleRGBAImage(SwSurface* surface, const SwIma
             auto sy = (uint32_t)(span->y * itransform->e22 + itransform->e23);
             if (sy >= image->h) continue;
             auto dst = &surface->buf32[span->y * surface->stride + span->x];
-            auto alpha = _multiplyAlpha(span->coverage, opacity);
+            auto alpha = _multiply<uint32_t>(span->coverage, opacity);
             for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst) {
                 auto sx = (uint32_t)(x * itransform->e11 + itransform->e13);
                 if (sx >= image->w) continue;
@@ -439,7 +518,7 @@ static bool _rasterScaledTranslucentRleRGBAImage(SwSurface* surface, const SwIma
             auto sy = span->y * itransform->e22 + itransform->e23;
             if ((uint32_t)sy >= image->h) continue;
             auto dst = &surface->buf32[span->y * surface->stride + span->x];
-            auto alpha = _multiplyAlpha(span->coverage, opacity);
+            auto alpha = _multiply<uint32_t>(span->coverage, opacity);
             for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst) {
                 auto sx = x * itransform->e11 + itransform->e13;
                 if ((uint32_t)sx >= image->w) continue;
@@ -522,7 +601,7 @@ static bool _scaledRleRGBAImage(SwSurface* surface, const SwImage* image, const 
             } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
                 return _rasterScaledMaskedRleRGBAImage(surface, image, &itransform, region, halfScale, _ialpha);
             } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-                return _rasterScaledMaskedRleRGBAImage(surface, image, &itransform, region, halfScale, surface->blender.lumaValue);
+                return _rasterScaledMaskedRleRGBAImage(surface, image, &itransform, region, halfScale, surface->blender.luma);
             }
         } else {
             if (surface->compositor->method == CompositeMethod::AlphaMask) {
@@ -530,7 +609,7 @@ static bool _scaledRleRGBAImage(SwSurface* surface, const SwImage* image, const 
             } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
                 return _rasterScaledMaskedTranslucentRleRGBAImage(surface, image, &itransform, region, opacity, halfScale, _ialpha);
             } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-                return _rasterScaledMaskedTranslucentRleRGBAImage(surface, image, &itransform, region, opacity, halfScale, surface->blender.lumaValue);
+                return _rasterScaledMaskedTranslucentRleRGBAImage(surface, image, &itransform, region, opacity, halfScale, surface->blender.luma);
             }
         }
     } else {
@@ -545,26 +624,27 @@ static bool _scaledRleRGBAImage(SwSurface* surface, const SwImage* image, const 
 /* RLE Direct RGBA Image                                                */
 /************************************************************************/
 
-static bool _rasterDirectMaskedTranslucentRleRGBAImage(SwSurface* surface, const SwImage* image, uint32_t opacity, uint32_t(*blender)(uint32_t))
+static bool _rasterDirectMaskedTranslucentRleRGBAImage(SwSurface* surface, const SwImage* image, uint32_t opacity, uint8_t(*blender)(uint8_t*))
 {
     TVGLOG("SW_ENGINE", "Direct Masked Rle Image");
 
     auto span = image->rle->spans;
-    auto cbuffer = surface->compositor->image.buf32;
+    auto csize = surface->compositor->image.channelSize;
+    auto cbuffer = surface->compositor->image.buf8;
 
     for (uint32_t i = 0; i < image->rle->size; ++i, ++span) {
         auto dst = &surface->buf32[span->y * surface->stride + span->x];
-        auto cmp = &cbuffer[span->y * surface->compositor->image.stride + span->x];
+        auto cmp = &cbuffer[(span->y * surface->compositor->image.stride + span->x) * csize];
         auto img = image->buf32 + (span->y + image->oy) * image->stride + (span->x + image->ox);
-        auto alpha = _multiplyAlpha(span->coverage, opacity);
+        auto alpha = _multiply<uint32_t>(span->coverage, opacity);
         if (alpha == 255) {
-            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++img) {
-                auto tmp = ALPHA_BLEND(*img, blender(*cmp));
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++img, cmp += csize) {
+                auto tmp = ALPHA_BLEND(*img, blender(cmp));
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
         } else {
-            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++img) {
-                auto tmp = ALPHA_BLEND(*img, _multiplyAlpha(alpha, blender(*cmp)));
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++img, cmp += csize) {
+                auto tmp = ALPHA_BLEND(*img, _multiply<uint32_t>(alpha, blender(cmp)));
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
         }
@@ -573,25 +653,26 @@ static bool _rasterDirectMaskedTranslucentRleRGBAImage(SwSurface* surface, const
 }
 
 
-static bool _rasterDirectMaskedRleRGBAImage(SwSurface* surface, const SwImage* image, uint32_t(*blender)(uint32_t))
+static bool _rasterDirectMaskedRleRGBAImage(SwSurface* surface, const SwImage* image, uint8_t(*blender)(uint8_t*))
 {
     TVGLOG("SW_ENGINE", "Direct Masked Rle Image");
 
     auto span = image->rle->spans;
-    auto cbuffer = surface->compositor->image.buf32;
+    auto csize = surface->compositor->image.channelSize;
+    auto cbuffer = surface->compositor->image.buf8;
 
     for (uint32_t i = 0; i < image->rle->size; ++i, ++span) {
         auto dst = &surface->buf32[span->y * surface->stride + span->x];
-        auto cmp = &cbuffer[span->y * surface->compositor->image.stride + span->x];
+        auto cmp = &cbuffer[(span->y * surface->compositor->image.stride + span->x) * csize];
         auto img = image->buf32 + (span->y + image->oy) * image->stride + (span->x + image->ox);
         if (span->coverage == 255) {
-            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++img) {
-                auto tmp = ALPHA_BLEND(*img, blender(*cmp));
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++img, cmp += csize) {
+                auto tmp = ALPHA_BLEND(*img, blender(cmp));
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
         } else {
-            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++img) {
-                auto tmp = ALPHA_BLEND(*img, _multiplyAlpha(span->coverage, blender(*cmp)));
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++img, cmp += csize) {
+                auto tmp = ALPHA_BLEND(*img, _multiply<uint32_t>(span->coverage, blender(cmp)));
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
         }
@@ -607,7 +688,7 @@ static bool _rasterDirectTranslucentRleRGBAImage(SwSurface* surface, const SwIma
     for (uint32_t i = 0; i < image->rle->size; ++i, ++span) {
         auto dst = &surface->buf32[span->y * surface->stride + span->x];
         auto img = image->buf32 + (span->y + image->oy) * image->stride + (span->x + image->ox);
-        auto alpha = _multiplyAlpha(span->coverage, opacity);
+        auto alpha = _multiply<uint32_t>(span->coverage, opacity);
         for (uint32_t x = 0; x < span->len; ++x, ++dst, ++img) {
             auto src = ALPHA_BLEND(*img, alpha);
             *dst = src + ALPHA_BLEND(*dst, _ialpha(src));
@@ -648,7 +729,7 @@ static bool _directRleRGBAImage(SwSurface* surface, const SwImage* image, uint32
             } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
                 return _rasterDirectMaskedRleRGBAImage(surface, image, _ialpha);
             } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-                return _rasterDirectMaskedRleRGBAImage(surface, image, surface->blender.lumaValue);
+                return _rasterDirectMaskedRleRGBAImage(surface, image, surface->blender.luma);
             }
         } else {
             if (surface->compositor->method == CompositeMethod::AlphaMask) {
@@ -656,7 +737,7 @@ static bool _directRleRGBAImage(SwSurface* surface, const SwImage* image, uint32
             } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
                 return _rasterDirectMaskedTranslucentRleRGBAImage(surface, image, opacity, _ialpha);
             } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-                return _rasterDirectMaskedTranslucentRleRGBAImage(surface, image, opacity, surface->blender.lumaValue);
+                return _rasterDirectMaskedTranslucentRleRGBAImage(surface, image, opacity, surface->blender.luma);
             }
         }
     } else {
@@ -679,7 +760,7 @@ static bool _transformedRGBAImage(SwSurface* surface, const SwImage* image, cons
         } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _rasterTexmapPolygon(surface, image, transform, &region, opacity, _ialpha);
         } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-            return _rasterTexmapPolygon(surface, image, transform, &region, opacity, surface->blender.lumaValue);
+            return _rasterTexmapPolygon(surface, image, transform, &region, opacity, surface->blender.luma);
         }
     } else {
         return _rasterTexmapPolygon(surface, image, transform, &region, opacity, nullptr);
@@ -695,7 +776,7 @@ static bool _transformedRGBAImageMesh(SwSurface* surface, const SwImage* image, 
         } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _rasterTexmapPolygonMesh(surface, image, mesh, transform, region, opacity, _ialpha);
         } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-            return _rasterTexmapPolygonMesh(surface, image, mesh, transform, region, opacity, surface->blender.lumaValue);
+            return _rasterTexmapPolygonMesh(surface, image, mesh, transform, region, opacity, surface->blender.luma);
         }
     } else {
         return _rasterTexmapPolygonMesh(surface, image, mesh, transform, region, opacity, nullptr);
@@ -708,12 +789,13 @@ static bool _transformedRGBAImageMesh(SwSurface* surface, const SwImage* image, 
 /*Scaled RGBA Image                                                     */
 /************************************************************************/
 
-static bool _rasterScaledMaskedTranslucentRGBAImage(SwSurface* surface, const SwImage* image, const Matrix* itransform, const SwBBox& region, uint32_t opacity, uint32_t halfScale, uint32_t (*blender)(uint32_t))
+static bool _rasterScaledMaskedTranslucentRGBAImage(SwSurface* surface, const SwImage* image, const Matrix* itransform, const SwBBox& region, uint32_t opacity, uint32_t halfScale, uint8_t(*blender)(uint8_t*))
 {
     TVGLOG("SW_ENGINE", "Scaled Masked Image");
 
     auto dbuffer = surface->buf32 + (region.min.y * surface->stride + region.min.x);
-    auto cbuffer = surface->compositor->image.buf32 + (region.min.y * surface->compositor->image.stride + region.min.x);
+    auto csize = surface->compositor->image.channelSize;
+    auto cbuffer = surface->compositor->image.buf8 + (region.min.y * surface->compositor->image.stride + region.min.x) * csize;
 
     // Down-Scaled
     if (image->scale < DOWN_SCALE_TOLERANCE) {
@@ -722,15 +804,15 @@ static bool _rasterScaledMaskedTranslucentRGBAImage(SwSurface* surface, const Sw
             if (sy >= image->h) continue;
             auto dst = dbuffer;
             auto cmp = cbuffer;
-            for (auto x = region.min.x; x < region.max.x; ++x, ++dst, ++cmp) {
+            for (auto x = region.min.x; x < region.max.x; ++x, ++dst, cmp += csize) {
                 auto sx = (uint32_t)(x * itransform->e11 + itransform->e13);
                 if (sx >= image->w) continue;
-                auto alpha = _multiplyAlpha(opacity, blender(*cmp));
+                auto alpha = _multiply<uint32_t>(opacity, blender(cmp));
                 auto src = ALPHA_BLEND(_interpDownScaler(image->buf32, image->stride, image->w, image->h, sx, sy, halfScale), alpha);
                 *dst = src + ALPHA_BLEND(*dst, _ialpha(src));
             }
             dbuffer += surface->stride;
-            cbuffer += surface->compositor->image.stride;
+            cbuffer += surface->compositor->image.stride * csize;
         }
     // Up-Scaled
     } else {
@@ -739,27 +821,28 @@ static bool _rasterScaledMaskedTranslucentRGBAImage(SwSurface* surface, const Sw
             if ((uint32_t)sy >= image->h) continue;
             auto dst = dbuffer;
             auto cmp = cbuffer;
-            for (auto x = region.min.x; x < region.max.x; ++x, ++dst, ++cmp) {
+            for (auto x = region.min.x; x < region.max.x; ++x, ++dst, cmp += csize) {
                 auto sx = x * itransform->e11 + itransform->e13;
                 if ((uint32_t)sx >= image->w) continue;
-                auto alpha = _multiplyAlpha(opacity, blender(*cmp));
+                auto alpha = _multiply<uint32_t>(opacity, blender(cmp));
                 auto src = ALPHA_BLEND(_interpUpScaler(image->buf32, image->w, image->h, sx, sy), alpha);
                 *dst = src + ALPHA_BLEND(*dst, _ialpha(src));
             }
             dbuffer += surface->stride;
-            cbuffer += surface->compositor->image.stride;
+            cbuffer += surface->compositor->image.stride * csize;
         }
     }
     return true;
 }
 
 
-static bool _rasterScaledMaskedRGBAImage(SwSurface* surface, const SwImage* image, const Matrix* itransform, const SwBBox& region, uint32_t halfScale, uint32_t (*blender)(uint32_t))
+static bool _rasterScaledMaskedRGBAImage(SwSurface* surface, const SwImage* image, const Matrix* itransform, const SwBBox& region, uint32_t halfScale, uint8_t (*blender)(uint8_t*))
 {
     TVGLOG("SW_ENGINE", "Scaled Masked Image");
 
     auto dbuffer = surface->buf32 + (region.min.y * surface->stride + region.min.x);
-    auto cbuffer = surface->compositor->image.buf32 + (region.min.y * surface->compositor->image.stride + region.min.x);
+    auto csize = surface->compositor->image.channelSize;
+    auto cbuffer = surface->compositor->image.buf8 + (region.min.y * surface->compositor->image.stride + region.min.x) * csize;
 
     // Down-Scaled
     if (image->scale < DOWN_SCALE_TOLERANCE) {
@@ -768,14 +851,14 @@ static bool _rasterScaledMaskedRGBAImage(SwSurface* surface, const SwImage* imag
             if (sy >= image->h) continue;
             auto dst = dbuffer;
             auto cmp = cbuffer;
-            for (auto x = region.min.x; x < region.max.x; ++x, ++dst, ++cmp) {
+            for (auto x = region.min.x; x < region.max.x; ++x, ++dst, cmp += csize) {
                 auto sx = (uint32_t)(x * itransform->e11 + itransform->e13);
                 if (sx >= image->w) continue;
-                auto src = ALPHA_BLEND(_interpDownScaler(image->buf32, image->stride, image->w, image->h, sx, sy, halfScale), blender(*cmp));
+                auto src = ALPHA_BLEND(_interpDownScaler(image->buf32, image->stride, image->w, image->h, sx, sy, halfScale), blender(cmp));
                 *dst = src + ALPHA_BLEND(*dst, _ialpha(src));
             }
             dbuffer += surface->stride;
-            cbuffer += surface->compositor->image.stride;
+            cbuffer += surface->compositor->image.stride * csize;
         }
     // Up-Scaled
     } else {
@@ -784,14 +867,14 @@ static bool _rasterScaledMaskedRGBAImage(SwSurface* surface, const SwImage* imag
             if ((uint32_t)sy >= image->h) continue;
             auto dst = dbuffer;
             auto cmp = cbuffer;
-            for (auto x = region.min.x; x < region.max.x; ++x, ++dst, ++cmp) {
+            for (auto x = region.min.x; x < region.max.x; ++x, ++dst, cmp += csize) {
                 auto sx = x * itransform->e11 + itransform->e13;
                 if ((uint32_t)sx >= image->w) continue;
-                auto src = ALPHA_BLEND(_interpUpScaler(image->buf32, image->w, image->h, sx, sy), blender(*cmp));
+                auto src = ALPHA_BLEND(_interpUpScaler(image->buf32, image->w, image->h, sx, sy), blender(cmp));
                 *dst = src + ALPHA_BLEND(*dst, _ialpha(src));
             }
             dbuffer += surface->stride;
-            cbuffer += surface->compositor->image.stride;
+            cbuffer += surface->compositor->image.stride * csize;
         }
     }
     return true;
@@ -885,7 +968,7 @@ static bool _scaledRGBAImage(SwSurface* surface, const SwImage* image, const Mat
             } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
                 return _rasterScaledMaskedRGBAImage(surface, image, &itransform, region, halfScale, _ialpha);
             } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-                return _rasterScaledMaskedRGBAImage(surface, image, &itransform, region, halfScale, surface->blender.lumaValue);
+                return _rasterScaledMaskedRGBAImage(surface, image, &itransform, region, halfScale, surface->blender.luma);
             }
         } else {
             if (surface->compositor->method == CompositeMethod::AlphaMask) {
@@ -893,7 +976,7 @@ static bool _scaledRGBAImage(SwSurface* surface, const SwImage* image, const Mat
             } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
                 return _rasterScaledMaskedTranslucentRGBAImage(surface, image, &itransform, region, opacity, halfScale, _ialpha);
             } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-                return _rasterScaledMaskedTranslucentRGBAImage(surface, image, &itransform, region, opacity, halfScale, surface->blender.lumaValue);
+                return _rasterScaledMaskedTranslucentRGBAImage(surface, image, &itransform, region, opacity, halfScale, surface->blender.luma);
             }
         }
     } else {
@@ -908,54 +991,56 @@ static bool _scaledRGBAImage(SwSurface* surface, const SwImage* image, const Mat
 /* Direct RGBA Image                                                    */
 /************************************************************************/
 
-static bool _rasterDirectMaskedRGBAImage(SwSurface* surface, const SwImage* image, const SwBBox& region, uint32_t (*blender)(uint32_t))
+static bool _rasterDirectMaskedRGBAImage(SwSurface* surface, const SwImage* image, const SwBBox& region, uint8_t (*blender)(uint8_t*))
 {
     TVGLOG("SW_ENGINE", "Direct Masked Image");
 
     auto buffer = surface->buf32 + (region.min.y * surface->stride) + region.min.x;
     auto h2 = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w2 = static_cast<uint32_t>(region.max.x - region.min.x);
+    auto csize = surface->compositor->image.channelSize;
 
     auto sbuffer = image->buf32 + (region.min.y + image->oy) * image->stride + (region.min.x + image->ox);
-    auto cbuffer = surface->compositor->image.buf32 + (region.min.y * surface->compositor->image.stride) + region.min.x; //compositor buffer
+    auto cbuffer = surface->compositor->image.buf8 + (region.min.y * surface->compositor->image.stride + region.min.x) * csize; //compositor buffer
 
     for (uint32_t y = 0; y < h2; ++y) {
         auto dst = buffer;
         auto cmp = cbuffer;
         auto src = sbuffer;
-        for (uint32_t x = 0; x < w2; ++x, ++dst, ++src, ++cmp) {
-            auto tmp = ALPHA_BLEND(*src, blender(*cmp));
+        for (uint32_t x = 0; x < w2; ++x, ++dst, ++src, cmp += csize) {
+            auto tmp = ALPHA_BLEND(*src, blender(cmp));
             *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
         }
         buffer += surface->stride;
-        cbuffer += surface->compositor->image.stride;
+        cbuffer += surface->compositor->image.stride * csize;
         sbuffer += image->stride;
     }
     return true;
 }
 
 
-static bool _rasterDirectMaskedTranslucentRGBAImage(SwSurface* surface, const SwImage* image, const SwBBox& region, uint32_t opacity, uint32_t (*blender)(uint32_t))
+static bool _rasterDirectMaskedTranslucentRGBAImage(SwSurface* surface, const SwImage* image, const SwBBox& region, uint32_t opacity, uint8_t (*blender)(uint8_t*))
 {
     TVGLOG("SW_ENGINE", "Direct Masked Translucent Image");
 
     auto buffer = surface->buf32 + (region.min.y * surface->stride) + region.min.x;
     auto h2 = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w2 = static_cast<uint32_t>(region.max.x - region.min.x);
+    auto csize = surface->compositor->image.channelSize;
 
     auto sbuffer = image->buf32 + (region.min.y + image->oy) * image->stride + (region.min.x + image->ox);
-    auto cbuffer = surface->compositor->image.buf32 + (region.min.y * surface->compositor->image.stride) + region.min.x; //compositor buffer
+    auto cbuffer = surface->compositor->image.buf8 + (region.min.y * surface->compositor->image.stride + region.min.x) * csize; //compositor buffer
 
     for (uint32_t y = 0; y < h2; ++y) {
         auto dst = buffer;
         auto cmp = cbuffer;
         auto src = sbuffer;
-        for (uint32_t x = 0; x < w2; ++x, ++dst, ++src, ++cmp) {
-            auto tmp = ALPHA_BLEND(*src, _multiplyAlpha(opacity, blender(*cmp)));
+        for (uint32_t x = 0; x < w2; ++x, ++dst, ++src, cmp += csize) {
+            auto tmp = ALPHA_BLEND(*src, _multiply<uint32_t>(opacity, blender(cmp)));
             *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
         }
         buffer += surface->stride;
-        cbuffer += surface->compositor->image.stride;
+        cbuffer += surface->compositor->image.stride * csize;
         sbuffer += image->stride;
     }
     return true;
@@ -1009,7 +1094,7 @@ static bool _directRGBAImage(SwSurface* surface, const SwImage* image, const SwB
             } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
                 return _rasterDirectMaskedRGBAImage(surface, image, region, _ialpha);
             } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-                return _rasterDirectMaskedRGBAImage(surface, image, region, surface->blender.lumaValue);
+                return _rasterDirectMaskedRGBAImage(surface, image, region, surface->blender.luma);
             }
         } else {
             if (surface->compositor->method == CompositeMethod::AlphaMask) {
@@ -1017,7 +1102,7 @@ static bool _directRGBAImage(SwSurface* surface, const SwImage* image, const SwB
             } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
                 return _rasterDirectMaskedTranslucentRGBAImage(surface, image, region, opacity, _ialpha);
             } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-                return _rasterDirectMaskedTranslucentRGBAImage(surface, image, region, opacity, surface->blender.lumaValue);
+                return _rasterDirectMaskedTranslucentRGBAImage(surface, image, region, opacity, surface->blender.luma);
             }
         }
     } else {
@@ -1049,14 +1134,15 @@ static bool _rasterRGBAImage(SwSurface* surface, SwImage* image, const Matrix* t
 /* Rect Linear Gradient                                                 */
 /************************************************************************/
 
-static bool _rasterLinearGradientMaskedRect(SwSurface* surface, const SwBBox& region, const SwFill* fill, uint32_t (*blender)(uint32_t))
+static bool _rasterLinearGradientMaskedRect(SwSurface* surface, const SwBBox& region, const SwFill* fill, uint8_t (*blender)(uint8_t*))
 {
     if (fill->linear.len < FLT_EPSILON) return false;
 
     auto buffer = surface->buf32 + (region.min.y * surface->stride) + region.min.x;
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
-    auto cbuffer = surface->compositor->image.buf32 + (region.min.y * surface->compositor->image.stride) + region.min.x;
+    auto csize = surface->compositor->image.channelSize;
+    auto cbuffer = surface->compositor->image.buf8 + (region.min.y * surface->compositor->image.stride + region.min.x) * csize;
 
     auto sbuffer = static_cast<uint32_t*>(alloca(w * sizeof(uint32_t)));
     if (!sbuffer) return false;
@@ -1066,12 +1152,12 @@ static bool _rasterLinearGradientMaskedRect(SwSurface* surface, const SwBBox& re
         auto dst = buffer;
         auto cmp = cbuffer;
         auto src = sbuffer;
-        for (uint32_t x = 0; x < w; ++x, ++dst, ++cmp, ++src) {
-            auto tmp = ALPHA_BLEND(*src, blender(*cmp));
+        for (uint32_t x = 0; x < w; ++x, ++dst, ++src, cmp += csize) {
+            auto tmp = ALPHA_BLEND(*src, blender(cmp));
             *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
         }
         buffer += surface->stride;
-        cbuffer += surface->stride;
+        cbuffer += surface->stride * csize;
     }
     return true;
 }
@@ -1123,7 +1209,7 @@ static bool _rasterLinearGradientRect(SwSurface* surface, const SwBBox& region, 
         } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _rasterLinearGradientMaskedRect(surface, region, fill, _ialpha);
         } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-            return _rasterLinearGradientMaskedRect(surface, region, fill, surface->blender.lumaValue);
+            return _rasterLinearGradientMaskedRect(surface, region, fill, surface->blender.luma);
         }
     } else {
         if (fill->translucent) return _rasterTranslucentLinearGradientRect(surface, region, fill);
@@ -1137,29 +1223,30 @@ static bool _rasterLinearGradientRect(SwSurface* surface, const SwBBox& region, 
 /* Rle Linear Gradient                                                  */
 /************************************************************************/
 
-static bool _rasterLinearGradientMaskedRle(SwSurface* surface, const SwRleData* rle, const SwFill* fill, uint32_t (*blender)(uint32_t))
+static bool _rasterLinearGradientMaskedRle(SwSurface* surface, const SwRleData* rle, const SwFill* fill, uint8_t (*blender)(uint8_t*))
 {
     if (fill->linear.len < FLT_EPSILON) return false;
 
     auto span = rle->spans;
-    auto cbuffer = surface->compositor->image.buf32;
+    auto csize = surface->compositor->image.channelSize;
+    auto cbuffer = surface->compositor->image.buf8;
     auto buffer = static_cast<uint32_t*>(alloca(surface->w * sizeof(uint32_t)));
     if (!buffer) return false;
 
     for (uint32_t i = 0; i < rle->size; ++i, ++span) {
         fillFetchLinear(fill, buffer, span->y, span->x, span->len);
         auto dst = &surface->buf32[span->y * surface->stride + span->x];
-        auto cmp = &cbuffer[span->y * surface->compositor->image.stride + span->x];
+        auto cmp = &cbuffer[(span->y * surface->compositor->image.stride + span->x) * csize];
         auto src = buffer;
         if (span->coverage == 255) {
-            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
-                auto tmp = ALPHA_BLEND(*src, blender(*cmp));
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++src, cmp += csize) {
+                auto tmp = ALPHA_BLEND(*src, blender(cmp));
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
         } else {
             auto ialpha = 255 - span->coverage;
-            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
-                auto tmp = ALPHA_BLEND(*src, blender(*cmp));
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++src, cmp += csize) {
+                auto tmp = ALPHA_BLEND(*src, blender(cmp));
                 tmp = ALPHA_BLEND(tmp, span->coverage) + ALPHA_BLEND(*dst, ialpha);
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
@@ -1229,7 +1316,7 @@ static bool _rasterLinearGradientRle(SwSurface* surface, const SwRleData* rle, c
         } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _rasterLinearGradientMaskedRle(surface, rle, fill, _ialpha);
         } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-            return _rasterLinearGradientMaskedRle(surface, rle, fill, surface->blender.lumaValue);
+            return _rasterLinearGradientMaskedRle(surface, rle, fill, surface->blender.luma);
         }
     } else {
         if (fill->translucent) return _rasterTranslucentLinearGradientRle(surface, rle, fill);
@@ -1243,14 +1330,15 @@ static bool _rasterLinearGradientRle(SwSurface* surface, const SwRleData* rle, c
 /* Rect Radial Gradient                                                 */
 /************************************************************************/
 
-static bool _rasterRadialGradientMaskedRect(SwSurface* surface, const SwBBox& region, const SwFill* fill, uint32_t (*blender)(uint32_t))
+static bool _rasterRadialGradientMaskedRect(SwSurface* surface, const SwBBox& region, const SwFill* fill, uint8_t(*blender)(uint8_t*))
 {
     if (fill->radial.a < FLT_EPSILON) return false;
 
     auto buffer = surface->buf32 + (region.min.y * surface->stride) + region.min.x;
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
-    auto cbuffer = surface->compositor->image.buf32 + (region.min.y * surface->compositor->image.stride) + region.min.x;
+    auto csize = surface->compositor->image.channelSize;
+    auto cbuffer = surface->compositor->image.buf8 + (region.min.y * surface->compositor->image.stride + region.min.x) * csize;
 
     auto sbuffer = static_cast<uint32_t*>(alloca(w * sizeof(uint32_t)));
     if (!sbuffer) return false;
@@ -1260,12 +1348,12 @@ static bool _rasterRadialGradientMaskedRect(SwSurface* surface, const SwBBox& re
         auto dst = buffer;
         auto cmp = cbuffer;
         auto src = sbuffer;
-        for (uint32_t x = 0; x < w; ++x, ++dst, ++cmp, ++src) {
-             auto tmp = ALPHA_BLEND(*src, blender(*cmp));
+        for (uint32_t x = 0; x < w; ++x, ++dst, ++src, cmp += csize) {
+             auto tmp = ALPHA_BLEND(*src, blender(cmp));
              *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
         }
         buffer += surface->stride;
-        cbuffer += surface->stride;
+        cbuffer += surface->stride * csize;
     }
     return true;
 }
@@ -1318,7 +1406,7 @@ static bool _rasterRadialGradientRect(SwSurface* surface, const SwBBox& region, 
         } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _rasterRadialGradientMaskedRect(surface, region, fill, _ialpha);
         } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-            return _rasterRadialGradientMaskedRect(surface, region, fill, surface->blender.lumaValue);
+            return _rasterRadialGradientMaskedRect(surface, region, fill, surface->blender.luma);
         }
     } else {
         if (fill->translucent) return _rasterTranslucentRadialGradientRect(surface, region, fill);
@@ -1332,28 +1420,29 @@ static bool _rasterRadialGradientRect(SwSurface* surface, const SwBBox& region, 
 /* RLE Radial Gradient                                                  */
 /************************************************************************/
 
-static bool _rasterRadialGradientMaskedRle(SwSurface* surface, const SwRleData* rle, const SwFill* fill, uint32_t (*blender)(uint32_t))
+static bool _rasterRadialGradientMaskedRle(SwSurface* surface, const SwRleData* rle, const SwFill* fill, uint8_t(*blender)(uint8_t*))
 {
     if (fill->radial.a < FLT_EPSILON) return false;
 
     auto span = rle->spans;
-    auto cbuffer = surface->compositor->image.buf32;
+    auto csize = surface->compositor->image.channelSize;
+    auto cbuffer = surface->compositor->image.buf8;
     auto buffer = static_cast<uint32_t*>(alloca(surface->w * sizeof(uint32_t)));
     if (!buffer) return false;
 
     for (uint32_t i = 0; i < rle->size; ++i, ++span) {
         fillFetchRadial(fill, buffer, span->y, span->x, span->len);
         auto dst = &surface->buf32[span->y * surface->stride + span->x];
-        auto cmp = &cbuffer[span->y * surface->compositor->image.stride + span->x];
+        auto cmp = &cbuffer[(span->y * surface->compositor->image.stride + span->x) * csize];
         auto src = buffer;
         if (span->coverage == 255) {
-            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
-                auto tmp = ALPHA_BLEND(*src, blender(*cmp));
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++src, cmp += csize) {
+                auto tmp = ALPHA_BLEND(*src, blender(cmp));
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
         } else {
-            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++cmp, ++src) {
-                auto tmp = INTERPOLATE(span->coverage, ALPHA_BLEND(*src, blender(*cmp)), *dst);
+            for (uint32_t x = 0; x < span->len; ++x, ++dst, ++src, cmp += csize) {
+                auto tmp = INTERPOLATE(span->coverage, ALPHA_BLEND(*src, blender(cmp)), *dst);
                 *dst = tmp + ALPHA_BLEND(*dst, _ialpha(tmp));
             }
         }
@@ -1423,7 +1512,7 @@ static bool _rasterRadialGradientRle(SwSurface* surface, const SwRleData* rle, c
         } else if (surface->compositor->method == CompositeMethod::InvAlphaMask) {
             return _rasterRadialGradientMaskedRle(surface, rle, fill, _ialpha);
         } else if (surface->compositor->method == CompositeMethod::LumaMask) {
-            return _rasterRadialGradientMaskedRle(surface, rle, fill, surface->blender.lumaValue);
+            return _rasterRadialGradientMaskedRle(surface, rle, fill, surface->blender.luma);
         }
     } else {
         if (fill->translucent) _rasterTranslucentRadialGradientRle(surface, rle, fill);
@@ -1431,7 +1520,6 @@ static bool _rasterRadialGradientRle(SwSurface* surface, const SwRleData* rle, c
     }
     return false;
 }
-
 
 /************************************************************************/
 /* External Class Implementation                                        */
@@ -1444,7 +1532,7 @@ void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 #elif defined(THORVG_NEON_VECTOR_SUPPORT)
     neonRasterRGBA32(dst, val, offset, len);
 #else
-    cRasterRGBA32(dst, val, offset, len);
+    cRasterPixels<uint32_t>(dst, val, offset, len);
 #endif
 }
 
@@ -1453,12 +1541,12 @@ bool rasterCompositor(SwSurface* surface)
 {
     if (surface->cs == ColorSpace::ABGR8888 || surface->cs == ColorSpace::ABGR8888S) {
         surface->blender.join = _abgrJoin;
-        surface->blender.lumaValue = _abgrLumaValue;
+        surface->blender.luma = _abgrLuma;
     } else if (surface->cs == ColorSpace::ARGB8888 || surface->cs == ColorSpace::ARGB8888S) {
         surface->blender.join = _argbJoin;
-        surface->blender.lumaValue = _argbLumaValue;
+        surface->blender.luma = _argbLuma;
     } else {
-        //What Color Space ???
+        TVGERR("SW_ENGINE", "Unsupported Colorspace(%d) is expected!", surface->cs);
         return false;
     }
     return true;
@@ -1470,21 +1558,34 @@ bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_
     if (!surface || !surface->buf32 || surface->stride == 0 || surface->w == 0 || surface->h == 0) return false;
 
     //full clear
-    if (surface->w == surface->stride) {
-        rasterRGBA32(surface->buf32 + (surface->stride * y + x), 0x00000000, x, w * h);
-    } else {
-        auto offset = surface->stride * y + x;
-        for (uint32_t i = 0; i < h; i++) {
-            rasterRGBA32(surface->buf32 + (offset * i), 0x00000000, x, w);
+    if (surface->channelSize == sizeof(uint32_t)) {
+        if (w == surface->stride) {
+            rasterRGBA32(surface->buf32 + (surface->stride * y), 0x00000000, 0, w * h);
+        } else {
+            auto buffer = surface->buf32 + (surface->stride * y + x);
+            for (uint32_t i = 0; i < h; i++) {
+                rasterRGBA32(buffer + (surface->stride * i), 0x00000000, 0, w);
+            }
+        }
+    //partial clear
+    } else if (surface->channelSize == sizeof(uint8_t)) {
+        if (w == surface->stride) {
+            _rasterGrayscale8(surface->buf8 + (surface->stride * y), 0x00, 0, w * h);
+        } else {
+            auto buffer = surface->buf8 + (surface->stride * y + x);
+            for (uint32_t i = 0; i < h; i++) {
+                _rasterGrayscale8(buffer + (surface->stride * i), 0x00, 0, w);
+            }
         }
     }
-
     return true;
 }
 
 
 void rasterUnpremultiply(Surface* surface)
 {
+    if (surface->channelSize != sizeof(uint32_t)) return;
+
     TVGLOG("SW_ENGINE", "Unpremultiply [Size: %d x %d]", surface->w, surface->h);
 
     //OPTIMIZE_ME: +SIMD
@@ -1513,6 +1614,8 @@ void rasterUnpremultiply(Surface* surface)
 
 void rasterPremultiply(Surface* surface)
 {
+    if (surface->channelSize != sizeof(uint32_t)) return;
+
     TVGLOG("SW_ENGINE", "Premultiply [Size: %d x %d]", surface->w, surface->h);
 
     //OPTIMIZE_ME: +SIMD
@@ -1531,6 +1634,11 @@ void rasterPremultiply(Surface* surface)
 
 bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id)
 {
+    if (surface->channelSize == sizeof(uint8_t)) {
+        TVGERR("SW_ENGINE", "Not supported grayscale gradient!");
+        return false;
+    }
+
     if (!shape->fill) return false;
 
     if (shape->fastTrack) {
@@ -1546,6 +1654,11 @@ bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id)
 
 bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id)
 {
+    if (surface->channelSize == sizeof(uint8_t)) {
+        TVGERR("SW_ENGINE", "Not supported grayscale gradient!");
+        return false;
+    }
+
     if (!shape->stroke || !shape->stroke->fill || !shape->strokeRle) return false;
 
     if (id == TVG_CLASS_ID_LINEAR) return _rasterLinearGradientRle(surface, shape->strokeRle, shape->stroke->fill);
@@ -1558,34 +1671,35 @@ bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id)
 bool rasterShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
     if (a < 255) {
-        r = _multiplyAlpha(r, a);
-        g = _multiplyAlpha(g, a);
-        b = _multiplyAlpha(b, a);
+        r = _multiply<uint32_t>(r, a);
+        g = _multiply<uint32_t>(g, a);
+        b = _multiply<uint32_t>(b, a);
     }
 
-    auto color = surface->blender.join(r, g, b, a);
-
-    if (shape->fastTrack) return _rasterRect(surface, shape->bbox, color, a);
-    else return _rasterRle(surface, shape->rle, color, a);
+    if (shape->fastTrack) return _rasterRect(surface, shape->bbox, r, g, b, a);
+    else return _rasterRle(surface, shape->rle, r, g, b, a);
 }
 
 
 bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
     if (a < 255) {
-        r = _multiplyAlpha(r, a);
-        g = _multiplyAlpha(g, a);
-        b = _multiplyAlpha(b, a);
+        r = _multiply<uint32_t>(r, a);
+        g = _multiply<uint32_t>(g, a);
+        b = _multiply<uint32_t>(b, a);
     }
 
-    auto color = surface->blender.join(r, g, b, a);
-
-    return _rasterRle(surface, shape->strokeRle, color, a);
+    return _rasterRle(surface, shape->strokeRle, r, g, b, a);
 }
 
 
 bool rasterImage(SwSurface* surface, SwImage* image, const RenderMesh* mesh, const Matrix* transform, const SwBBox& bbox, uint32_t opacity)
 {
+    if (surface->channelSize == sizeof(uint8_t)) {
+        TVGERR("SW_ENGINE", "Not supported grayscale image!");
+        return false;
+    }
+
     //Verify Boundary
     if (bbox.max.x < 0 || bbox.max.y < 0 || bbox.min.x >= static_cast<SwCoord>(surface->w) || bbox.min.y >= static_cast<SwCoord>(surface->h)) return false;
 

--- a/src/lib/sw_engine/tvgSwRasterAvx.h
+++ b/src/lib/sw_engine/tvgSwRasterAvx.h
@@ -82,8 +82,14 @@ static void avxRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_
 }
 
 
-static bool avxRasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint32_t color)
+static bool avxRasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
+    if (surface->channelSize != sizeof(uint32_t)) {
+        TVGERR("SW_ENGINE", "Unsupported Channel Size = %d", surface->channelSize);
+        return false;
+    }
+
+    auto color = surface->blender.join(r, g, b, a);
     auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
@@ -125,8 +131,14 @@ static bool avxRasterTranslucentRect(SwSurface* surface, const SwBBox& region, u
 }
 
 
-static bool avxRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, uint32_t color)
+static bool avxRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
+    if (surface->channelSize != sizeof(uint32_t)) {
+        TVGERR("SW_ENGINE", "Unsupported Channel Size = %d", surface->channelSize);
+        return false;
+    }
+
+    auto color = surface->blender.join(r, g, b, a);
     auto span = rle->spans;
     uint32_t src;
 

--- a/src/lib/sw_engine/tvgSwRasterC.h
+++ b/src/lib/sw_engine/tvgSwRasterC.h
@@ -33,7 +33,7 @@ static bool inline cRasterTranslucentRle(SwSurface* surface, const SwRleData* rl
     uint32_t src;
 
     for (uint32_t i = 0; i < rle->size; ++i, ++span) {
-        auto dst = &surface->buffer[span->y * surface->stride + span->x];
+        auto dst = &surface->buf32[span->y * surface->stride + span->x];
 
         if (span->coverage < 255) src = ALPHA_BLEND(color, span->coverage);
         else src = color;
@@ -48,7 +48,7 @@ static bool inline cRasterTranslucentRle(SwSurface* surface, const SwRleData* rl
 
 static bool inline cRasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint32_t color)
 {
-    auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
+    auto buffer = surface->buf32 + (region.min.y * surface->stride) + region.min.x;
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
     auto ialpha = _ialpha(color);
@@ -67,7 +67,7 @@ static bool inline cRasterABGRtoARGB(Surface* surface)
 {
     TVGLOG("SW_ENGINE", "Convert ColorSpace ABGR - ARGB [Size: %d x %d]", surface->w, surface->h);
 
-    auto buffer = surface->buffer;
+    auto buffer = surface->buf32;
     for (uint32_t y = 0; y < surface->h; ++y, buffer += surface->stride) {
         auto dst = buffer;
         for (uint32_t x = 0; x < surface->w; ++x, ++dst) {

--- a/src/lib/sw_engine/tvgSwRasterNeon.h
+++ b/src/lib/sw_engine/tvgSwRasterNeon.h
@@ -49,8 +49,14 @@ static void neonRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32
 }
 
 
-static bool neonRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, uint32_t color)
+static bool neonRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
+    if (surface->channelSize != sizeof(uint32_t)) {
+        TVGERR("SW_ENGINE", "Unsupported Channel Size = %d", surface->channelSize);
+        return false;
+    }
+
+    auto color = surface->blender.join(r, g, b, a);
     auto span = rle->spans;
     uint32_t src;
     uint8x8_t *vDst = nullptr;
@@ -88,8 +94,14 @@ static bool neonRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, u
 }
 
 
-static bool neonRasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint32_t color)
+static bool neonRasterTranslucentRect(SwSurface* surface, const SwBBox& region, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
+    if (surface->channelSize != sizeof(uint32_t)) {
+        TVGERR("SW_ENGINE", "Unsupported Channel Size = %d", surface->channelSize);
+        return false;
+    }
+
+    auto color = surface->blender.join(r, g, b, a);
     auto buffer = surface->buffer + (region.min.y * surface->stride) + region.min.x;
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);

--- a/src/lib/sw_engine/tvgSwRasterTexmap.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmap.h
@@ -69,7 +69,7 @@ static bool _arrange(const SwImage* image, const SwBBox* region, int& yStart, in
 }
 
 
-static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image, const SwBBox* region, int yStart, int yEnd, uint32_t opacity, uint32_t (*blender)(uint32_t), AASpans* aaSpans)
+static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image, const SwBBox* region, int yStart, int yEnd, uint32_t opacity, uint8_t(*blender)(uint8_t*), AASpans* aaSpans)
 {
 #define TEXMAP_TRANSLUCENT
 #define TEXMAP_MASKING
@@ -79,7 +79,7 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
 }
 
 
-static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image, const SwBBox* region, int yStart, int yEnd, uint32_t (*blender)(uint32_t), AASpans* aaSpans)
+static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image, const SwBBox* region, int yStart, int yEnd, uint8_t(*blender)(uint8_t*), AASpans* aaSpans)
 {
 #define TEXMAP_MASKING
     #include "tvgSwRasterTexmapInternal.h"
@@ -102,7 +102,7 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
 
 
 /* This mapping algorithm is based on Mikael Kalms's. */
-static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const SwBBox* region, uint32_t opacity, Polygon& polygon, uint32_t (*blender)(uint32_t), AASpans* aaSpans)
+static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const SwBBox* region, uint32_t opacity, Polygon& polygon, uint8_t(*blender)(uint8_t*), AASpans* aaSpans)
 {
     float x[3] = {polygon.vertex[0].pt.x, polygon.vertex[1].pt.x, polygon.vertex[2].pt.x};
     float y[3] = {polygon.vertex[0].pt.y, polygon.vertex[1].pt.y, polygon.vertex[2].pt.y};
@@ -545,7 +545,7 @@ static bool _apply(SwSurface* surface, AASpans* aaSpans)
     | /  |
     3 -- 2
 */
-static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint32_t (*blender)(uint32_t))
+static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint8_t(*blender)(uint8_t*))
 {
     //Exceptions: No dedicated drawing area?
     if ((!image->rle && !region) || (image->rle && image->rle->size == 0)) return false;
@@ -602,7 +602,7 @@ static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const
       Should provide two Polygons, one for each triangle.
       // TODO: region?
 */
-static bool _rasterTexmapPolygonMesh(SwSurface* surface, const SwImage* image, const RenderMesh* mesh, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint32_t (*blender)(uint32_t))
+static bool _rasterTexmapPolygonMesh(SwSurface* surface, const SwImage* image, const RenderMesh* mesh, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint8_t(*blender)(uint8_t*))
 {
     //Exceptions: No dedicated drawing area?
     if ((!image->rle && !region) || (image->rle && image->rle->size == 0)) return false;

--- a/src/lib/sw_engine/tvgSwRasterTexmap.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmap.h
@@ -502,7 +502,7 @@ static bool _apply(SwSurface* surface, AASpans* aaSpans)
             auto offset = y * surface->stride;
 
             //Left edge
-            dst = surface->buffer + (offset + line->x[0]);
+            dst = surface->buf32 + (offset + line->x[0]);
             if (line->x[0] > 1) pixel = *(dst - 1);
             else pixel = *dst;
 
@@ -514,7 +514,7 @@ static bool _apply(SwSurface* surface, AASpans* aaSpans)
             }
 
             //Right edge
-            dst = surface->buffer + (offset + line->x[1] - 1);
+            dst = surface->buf32 + (offset + line->x[1] - 1);
             if (line->x[1] < (int32_t)(surface->w - 1)) pixel = *(dst + 1);
             else pixel = *dst;
 

--- a/src/lib/sw_engine/tvgSwRasterTexmap.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmap.h
@@ -69,7 +69,7 @@ static bool _arrange(const SwImage* image, const SwBBox* region, int& yStart, in
 }
 
 
-static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image, const SwBBox* region, int yStart, int yEnd, uint32_t opacity, uint32_t (*blendMethod)(uint32_t), AASpans* aaSpans)
+static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image, const SwBBox* region, int yStart, int yEnd, uint32_t opacity, uint32_t (*blender)(uint32_t), AASpans* aaSpans)
 {
 #define TEXMAP_TRANSLUCENT
 #define TEXMAP_MASKING
@@ -79,7 +79,7 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
 }
 
 
-static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image, const SwBBox* region, int yStart, int yEnd, uint32_t (*blendMethod)(uint32_t), AASpans* aaSpans)
+static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image, const SwBBox* region, int yStart, int yEnd, uint32_t (*blender)(uint32_t), AASpans* aaSpans)
 {
 #define TEXMAP_MASKING
     #include "tvgSwRasterTexmapInternal.h"
@@ -102,7 +102,7 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
 
 
 /* This mapping algorithm is based on Mikael Kalms's. */
-static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const SwBBox* region, uint32_t opacity, Polygon& polygon, uint32_t (*blendMethod)(uint32_t), AASpans* aaSpans)
+static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const SwBBox* region, uint32_t opacity, Polygon& polygon, uint32_t (*blender)(uint32_t), AASpans* aaSpans)
 {
     float x[3] = {polygon.vertex[0].pt.x, polygon.vertex[1].pt.x, polygon.vertex[2].pt.x};
     float y[3] = {polygon.vertex[0].pt.y, polygon.vertex[1].pt.y, polygon.vertex[2].pt.y};
@@ -190,9 +190,9 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const 
             dxdyb = dxdy[0];
             xb = x[0] + dy * dxdyb + (off_y * dxdyb);
 
-            if (blendMethod) {
-                if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], blendMethod, aaSpans);
-                else _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], opacity, blendMethod, aaSpans);
+            if (blender) {
+                if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], blender, aaSpans);
+                else _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], opacity, blender, aaSpans);
             } else {
                 if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], aaSpans);
                 else _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], opacity, aaSpans);
@@ -211,9 +211,9 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const 
             // Set right edge X-slope and perform subpixel pre-stepping
             dxdyb = dxdy[2];
             xb = x[1] + (1 - (y[1] - yi[1])) * dxdyb + (off_y * dxdyb);
-            if (blendMethod) {
-                if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], blendMethod, aaSpans);
-                else _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], opacity, blendMethod, aaSpans);
+            if (blender) {
+                if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], blender, aaSpans);
+                else _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], opacity, blender, aaSpans);
             } else {
                 if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], aaSpans);
                 else _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], opacity, aaSpans);
@@ -240,9 +240,9 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const 
             ua = u[0] + dy * dudya + (off_y * dudya);
             va = v[0] + dy * dvdya + (off_y * dvdya);
 
-            if (blendMethod) {
-                if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], blendMethod, aaSpans);
-                else _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], opacity, blendMethod, aaSpans);
+            if (blender) {
+                if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], blender, aaSpans);
+                else _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], opacity, blender, aaSpans);
             } else {
                 if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], aaSpans);
                 else _rasterPolygonImageSegment(surface, image, region, yi[0], yi[1], opacity, aaSpans);
@@ -264,9 +264,9 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const 
             ua = u[1] + dy * dudya + (off_y * dudya);
             va = v[1] + dy * dvdya + (off_y * dvdya);
 
-            if (blendMethod) {
-                if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], blendMethod, aaSpans);
-                else _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], opacity, blendMethod, aaSpans);
+            if (blender) {
+                if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], blender, aaSpans);
+                else _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], opacity, blender, aaSpans);
             } else {
                 if (opacity == 255) _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], aaSpans);
                 else _rasterPolygonImageSegment(surface, image, region, yi[1], yi[2], opacity, aaSpans);
@@ -545,7 +545,7 @@ static bool _apply(SwSurface* surface, AASpans* aaSpans)
     | /  |
     3 -- 2
 */
-static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint32_t (*blendMethod)(uint32_t))
+static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint32_t (*blender)(uint32_t))
 {
     //Exceptions: No dedicated drawing area?
     if ((!image->rle && !region) || (image->rle && image->rle->size == 0)) return false;
@@ -576,14 +576,14 @@ static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const
     polygon.vertex[1] = vertices[1];
     polygon.vertex[2] = vertices[3];
 
-    _rasterPolygonImage(surface, image, region, opacity, polygon, blendMethod, aaSpans);
+    _rasterPolygonImage(surface, image, region, opacity, polygon, blender, aaSpans);
 
     //Draw the second polygon
     polygon.vertex[0] = vertices[1];
     polygon.vertex[1] = vertices[2];
     polygon.vertex[2] = vertices[3];
 
-    _rasterPolygonImage(surface, image, region, opacity, polygon, blendMethod, aaSpans);
+    _rasterPolygonImage(surface, image, region, opacity, polygon, blender, aaSpans);
 
     return _apply(surface, aaSpans);
 }
@@ -602,7 +602,7 @@ static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const
       Should provide two Polygons, one for each triangle.
       // TODO: region?
 */
-static bool _rasterTexmapPolygonMesh(SwSurface* surface, const SwImage* image, const RenderMesh* mesh, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint32_t (*blendMethod)(uint32_t))
+static bool _rasterTexmapPolygonMesh(SwSurface* surface, const SwImage* image, const RenderMesh* mesh, const Matrix* transform, const SwBBox* region, uint32_t opacity, uint32_t (*blender)(uint32_t))
 {
     //Exceptions: No dedicated drawing area?
     if ((!image->rle && !region) || (image->rle && image->rle->size == 0)) return false;
@@ -636,7 +636,7 @@ static bool _rasterTexmapPolygonMesh(SwSurface* surface, const SwImage* image, c
     auto aaSpans = _AASpans(ys, ye, image, region);
     if (aaSpans) {
         for (uint32_t i = 0; i < mesh->triangleCnt; i++) {
-            _rasterPolygonImage(surface, image, region, opacity, transformedTris[i], blendMethod, aaSpans);
+            _rasterPolygonImage(surface, image, region, opacity, transformedTris[i], blender, aaSpans);
         }
         // Apply to surface (note: frees the AA spans)
         _apply(surface, aaSpans);

--- a/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
@@ -24,8 +24,8 @@
     float _dudx = dudx, _dvdx = dvdx;
     float _dxdya = dxdya, _dxdyb = dxdyb, _dudya = dudya, _dvdya = dvdya;
     float _xa = xa, _xb = xb, _ua = ua, _va = va;
-    auto sbuf = image->data;
-    auto dbuf = surface->buffer;
+    auto sbuf = image->buf32;
+    auto dbuf = surface->buf32;
     int32_t sw = static_cast<int32_t>(image->stride);
     int32_t sh = image->h;
     int32_t dw = surface->stride;
@@ -94,7 +94,7 @@
         x = x1;
 
 #ifdef TEXMAP_MASKING
-        cmp = &surface->compositor->image.data[y * surface->compositor->image.stride + x1];
+        cmp = &surface->compositor->image.buf32[y * surface->compositor->image.stride + x1];
 #endif
         //Draw horizontal line
         while (x++ < x2) {

--- a/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmapInternal.h
@@ -130,9 +130,9 @@
                 px = INTERPOLATE(ab, px, px2);
             }
 #if defined(TEXMAP_MASKING) && defined(TEXMAP_TRANSLUCENT)
-            auto src = ALPHA_BLEND(px, _multiplyAlpha(opacity, blendMethod(*cmp)));
+            auto src = ALPHA_BLEND(px, _multiplyAlpha(opacity, blender(*cmp)));
 #elif defined(TEXMAP_MASKING)
-            auto src = ALPHA_BLEND(px, blendMethod(*cmp));
+            auto src = ALPHA_BLEND(px, blender(*cmp));
 #elif defined(TEXMAP_TRANSLUCENT)
             auto src = ALPHA_BLEND(px, opacity);
 #else

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -664,6 +664,13 @@ bool SwRenderer::endComposite(Compositor* cmp)
 }
 
 
+ColorSpace SwRenderer::colorSpace()
+{
+    if (surface) return surface->cs;
+    else return ColorSpace::Unsupported;
+}
+
+
 bool SwRenderer::dispose(RenderData data)
 {
     auto task = static_cast<SwTask*>(data);

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -449,8 +449,9 @@ bool SwRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
 
 bool SwRenderer::preRender()
 {
-    return rasterClear(surface);
+    return rasterClear(surface, 0, 0, surface->w, surface->h);
 }
+
 
 void SwRenderer::clearCompositors()
 {
@@ -631,17 +632,11 @@ Compositor* SwRenderer::target(const RenderRegion& region, ColorSpace cs)
     cmp->compositor->image.h = surface->h;
     cmp->compositor->image.direct = true;
 
-    //We know partial clear region
-    cmp->buffer = cmp->compositor->image.data + (cmp->stride * y + x);
-    cmp->w = w;
-    cmp->h = h;
-
-    rasterClear(cmp);
-
-    //Recover context
     cmp->buffer = cmp->compositor->image.data;
     cmp->w = cmp->compositor->image.w;
     cmp->h = cmp->compositor->image.h;
+
+    rasterClear(cmp, x, y, w, h);
 
     //Switch render target
     surface = cmp;

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -285,7 +285,7 @@ struct SwImageTask : SwTask
             if (!source->premultiplied) rasterPremultiply(source);
         }
 
-        image.data = source->buffer;
+        image.data = source->data;
         image.w = source->w;
         image.h = source->h;
         image.stride = source->stride;
@@ -424,13 +424,13 @@ bool SwRenderer::viewport(const RenderRegion& vp)
 }
 
 
-bool SwRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs)
+bool SwRenderer::target(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs)
 {
-    if (!buffer || stride == 0 || w == 0 || h == 0 || w > stride) return false;
+    if (!data || stride == 0 || w == 0 || h == 0 || w > stride) return false;
 
     if (!surface) surface = new SwSurface;
 
-    surface->buffer = buffer;
+    surface->data = data;
     surface->stride = stride;
     surface->w = w;
     surface->h = h;
@@ -608,7 +608,7 @@ Compositor* SwRenderer::target(const RenderRegion& region, ColorSpace cs)
         cmp->compositor = new SwCompositor;
 
         //TODO: We can optimize compositor surface size from (surface->stride x surface->h) to Parameter(w x h)
-        cmp->compositor->image.data = (uint32_t*) malloc(reqChannelSize * surface->stride * surface->h);
+        cmp->compositor->image.data = (pixel_t*)malloc(reqChannelSize * surface->stride * surface->h);
         cmp->channelSize = cmp->compositor->image.channelSize = reqChannelSize;
 
         compositors.push(cmp);
@@ -632,7 +632,7 @@ Compositor* SwRenderer::target(const RenderRegion& region, ColorSpace cs)
     cmp->compositor->image.h = surface->h;
     cmp->compositor->image.direct = true;
 
-    cmp->buffer = cmp->compositor->image.data;
+    cmp->data = cmp->compositor->image.data;
     cmp->w = cmp->compositor->image.w;
     cmp->h = cmp->compositor->image.h;
 

--- a/src/lib/sw_engine/tvgSwRenderer.cpp
+++ b/src/lib/sw_engine/tvgSwRenderer.cpp
@@ -581,7 +581,7 @@ Compositor* SwRenderer::target(const RenderRegion& region)
     auto sh = static_cast<int32_t>(surface->h);
 
     //Out of boundary
-    if (x > sw || y > sh) return nullptr;
+    if (x >= sw || y >= sh || x + w < 0 || y + h < 0) return nullptr;
 
     SwSurface* cmp = nullptr;
 
@@ -596,17 +596,14 @@ Compositor* SwRenderer::target(const RenderRegion& region)
     //New Composition
     if (!cmp) {
         cmp = new SwSurface;
-        if (!cmp) goto err;
 
         //Inherits attributes from main surface
         *cmp = *surface;
 
         cmp->compositor = new SwCompositor;
-        if (!cmp->compositor) goto err;
 
         //SwImage, Optimize Me: Surface size from MainSurface(WxH) to Parameter W x H
         cmp->compositor->image.data = (uint32_t*) malloc(sizeof(uint32_t) * surface->stride * surface->h);
-        if (!cmp->compositor->image.data) goto err;
         compositors.push(cmp);
     }
 
@@ -644,14 +641,6 @@ Compositor* SwRenderer::target(const RenderRegion& region)
     surface = cmp;
 
     return cmp->compositor;
-
-err:
-    if (cmp) {
-        if (cmp->compositor) delete(cmp->compositor);
-        delete(cmp);
-    }
-
-    return nullptr;
 }
 
 

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -54,7 +54,7 @@ public:
     bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs);
     bool mempool(bool shared);
 
-    Compositor* target(const RenderRegion& region) override;
+    Compositor* target(const RenderRegion& region, ColorSpace cs) override;
     bool beginComposite(Compositor* cmp, CompositeMethod method, uint32_t opacity) override;
     bool endComposite(Compositor* cmp) override;
     void clearCompositors();

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -51,7 +51,7 @@ public:
 
     bool clear() override;
     bool sync() override;
-    bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs);
+    bool target(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs);
     bool mempool(bool shared);
 
     Compositor* target(const RenderRegion& region, ColorSpace cs) override;

--- a/src/lib/sw_engine/tvgSwRenderer.h
+++ b/src/lib/sw_engine/tvgSwRenderer.h
@@ -47,6 +47,7 @@ public:
     RenderRegion region(RenderData data) override;
     RenderRegion viewport() override;
     bool viewport(const RenderRegion& vp) override;
+    ColorSpace colorSpace() override;
 
     bool clear() override;
     bool sync() override;

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -168,8 +168,9 @@ bool Paint::Impl::render(RenderMethod& renderer)
         auto region = smethod->bounds(renderer);
         if (region.w == 0 || region.h == 0) return true;
         cmp = renderer.target(region);
-        renderer.beginComposite(cmp, CompositeMethod::None, 255);
-        compData->target->pImpl->render(renderer);
+        if (renderer.beginComposite(cmp, CompositeMethod::None, 255)) {
+            compData->target->pImpl->render(renderer);
+        }
     }
 
     if (cmp) renderer.beginComposite(cmp, compData->method, compData->target->pImpl->opacity);

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -167,7 +167,8 @@ bool Paint::Impl::render(RenderMethod& renderer)
     if (compData && compData->method != CompositeMethod::ClipPath && !(compData->target->pImpl->ctxFlag & ContextFlag::FastTrack)) {
         auto region = smethod->bounds(renderer);
         if (region.w == 0 || region.h == 0) return true;
-        cmp = renderer.target(region);
+        //cmp = renderer.target(region, COMPOSITE_TO_COLORSPACE(renderer, compData->method));
+        cmp = renderer.target(region, renderer.colorSpace());
         if (renderer.beginComposite(cmp, CompositeMethod::None, 255)) {
             compData->target->pImpl->render(renderer);
         }

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -167,8 +167,7 @@ bool Paint::Impl::render(RenderMethod& renderer)
     if (compData && compData->method != CompositeMethod::ClipPath && !(compData->target->pImpl->ctxFlag & ContextFlag::FastTrack)) {
         auto region = smethod->bounds(renderer);
         if (region.w == 0 || region.h == 0) return true;
-        //cmp = renderer.target(region, COMPOSITE_TO_COLORSPACE(renderer, compData->method));
-        cmp = renderer.target(region, renderer.colorSpace());
+        cmp = renderer.target(region, COMPOSITE_TO_COLORSPACE(renderer, compData->method));
         if (renderer.beginComposite(cmp, CompositeMethod::None, 255)) {
             compData->target->pImpl->render(renderer);
         }

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -116,7 +116,7 @@ const uint32_t* Picture::data(uint32_t* w, uint32_t* h) const noexcept
         if (w) *w = 0;
         if (h) *h = 0;
     }
-    if (pImpl->surface) return pImpl->surface->buffer;
+    if (pImpl->surface) return pImpl->surface->buf32;
     else return nullptr;
 }
 

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -41,6 +41,7 @@ enum ColorSpace
     ARGB8888,          //The channels are joined in the order: alpha, red, green, blue. Colors are alpha-premultiplied.
     ABGR8888S,         //The channels are joined in the order: alpha, blue, green, red. Colors are un-alpha-premultiplied.
     ARGB8888S,         //The channels are joined in the order: alpha, red, green, blue. Colors are un-alpha-premultiplied.
+    Grayscale8,        //One single channel data.
     Unsupported        //TODO: Change to the default, At the moment, we put it in the last to align with SwCanvas::Colorspace.
 };
 

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -30,6 +30,7 @@ namespace tvg
 {
 
 using RenderData = void*;
+using pixel_t = uint32_t;
 
 enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, All = 255};
 
@@ -47,7 +48,11 @@ enum ColorSpace
 
 struct Surface
 {
-    uint32_t* buffer;
+    union {
+        pixel_t* data;       //system based data pointer
+        uint32_t* buf32;     //for explicit 32bits channels
+        uint8_t*  buf8;      //for explicit 8bits grayscale
+    };
     uint32_t stride;
     uint32_t w, h;
     ColorSpace  cs;

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -221,6 +221,7 @@ public:
     virtual RenderRegion region(RenderData data) = 0;
     virtual RenderRegion viewport() = 0;
     virtual bool viewport(const RenderRegion& vp) = 0;
+    virtual ColorSpace colorSpace() = 0;
 
     virtual bool clear() = 0;
     virtual bool sync() = 0;

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -135,7 +135,7 @@ struct Scene::Impl
         Compositor* cmp = nullptr;
 
         if (needComposition(opacity)) {
-            cmp = renderer.target(bounds(renderer));
+            cmp = renderer.target(bounds(renderer), renderer.colorSpace());
             renderer.beginComposite(cmp, CompositeMethod::None, opacity);
         }
 

--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -160,7 +160,7 @@ unique_ptr<Surface> JpgLoader::bitmap()
 
     //TODO: It's better to keep this surface instance in the loader side
     auto surface = new Surface;
-    surface->buffer = (uint32_t*)(image);
+    surface->buf8 = image;
     surface->stride = w;
     surface->w = w;
     surface->h = h;

--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -165,6 +165,7 @@ unique_ptr<Surface> JpgLoader::bitmap()
     surface->w = w;
     surface->h = h;
     surface->cs = cs;
+    surface->channelSize = sizeof(uint32_t);
     surface->premultiplied = true;
     surface->owner = true;
 

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -111,6 +111,7 @@ unique_ptr<Surface> PngLoader::bitmap()
     surface->w = w;
     surface->h = h;
     surface->cs = cs;
+    surface->channelSize = sizeof(uint32_t);
     surface->owner = true;
     surface->premultiplied = false;
 

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -106,7 +106,7 @@ unique_ptr<Surface> PngLoader::bitmap()
 
     //TODO: It's better to keep this surface instance in the loader side
     auto surface = new Surface;
-    surface->buffer = content;
+    surface->buf32 = content;
     surface->stride = w;
     surface->w = w;
     surface->h = h;

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -120,7 +120,7 @@ unique_ptr<Surface> JpgLoader::bitmap()
 
     //TODO: It's better to keep this surface instance in the loader side
     auto surface = new Surface;
-    surface->buffer = reinterpret_cast<uint32_t*>(image);
+    surface->buf8 = image;
     surface->stride = static_cast<uint32_t>(w);
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -125,6 +125,7 @@ unique_ptr<Surface> JpgLoader::bitmap()
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);
     surface->cs = cs;
+    surface->channelSize = sizeof(uint32_t);
     surface->premultiplied = true;
     surface->owner = true;
 

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -161,6 +161,7 @@ unique_ptr<Surface> PngLoader::bitmap()
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);
     surface->cs = cs;
+    surface->channelSize = sizeof(uint32_t);
     surface->premultiplied = false;
     surface->owner = true;
 

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -156,7 +156,7 @@ unique_ptr<Surface> PngLoader::bitmap()
 
     //TODO: It's better to keep this surface instance in the loader side
     auto surface = new Surface;
-    surface->buffer = reinterpret_cast<uint32_t*>(image);
+    surface->buf8 = image;
     surface->stride = static_cast<uint32_t>(w);
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -82,7 +82,7 @@ unique_ptr<Surface> RawLoader::bitmap()
 
     //TODO: It's better to keep this surface instance in the loader side
     auto surface = new Surface;
-    surface->buffer = content;
+    surface->buf32 = content;
     surface->stride = static_cast<uint32_t>(w);
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -87,6 +87,7 @@ unique_ptr<Surface> RawLoader::bitmap()
     surface->w = static_cast<uint32_t>(w);
     surface->h = static_cast<uint32_t>(h);
     surface->cs = cs;
+    surface->channelSize = sizeof(uint32_t);
     surface->premultiplied = true;
     surface->owner = true;
 


### PR DESCRIPTION
https://github.com/thorvg/thorvg/issues/976

Currently, TVG uses a 4-channel (RGBA) masking buffer. However, it could be optimized by replacing it with a one-byte buffer.
Theoretical, alpha masking memory usage can be reduced by 3x.

Test case: examples/Performance, (single picture, resolution: 800x800)
Memory Usage: 41,012kb -> 39,336kb (-1,676kb)
Rendering Time (on my local machine): 0.0145 -> 0.0143 (-0.0002s)

