### PR TITLE
svg2png: changing image size

### DIFF
--- a/src/bin/svg2png/svg2png.cpp
+++ b/src/bin/svg2png/svg2png.cpp
@@ -109,7 +109,8 @@ public:
                     w = static_cast<uint32_t>(h * scale);
                 }
                 cout << "Warning: The SVG width and/or height values exceed the 8k resolution. "
-                        "To avoid the heap overflow, the conversion to the PNG file made in " << WIDTH_8K << " x " << HEIGHT_8K << " resolution." << endl;
+                        "To avoid the heap overflow, the conversion to the PNG file made in " << w << " x " << h << " resolution." << endl;
+                picture->size(static_cast<float>(w), static_cast<float>(h));
             }
         } else {
             picture->size(static_cast<float>(w), static_cast<float>(h));


### PR DESCRIPTION
For resolution > 8k image's width and height are changed, but the change was not applied to the image itself. Now fixed.