### PR TITLE
svg2png: rounding up svg width and height

### DIFF
--- a/src/bin/svg2png/svg2png.cpp
+++ b/src/bin/svg2png/svg2png.cpp
@@ -98,6 +98,8 @@ public:
             picture->size(&fw, &fh);
             w = static_cast<uint32_t>(fw);
             h = static_cast<uint32_t>(fh);
+            if (fw > w) w++;
+            if (fh > h) h++;
 
             if (w * h > SIZE_8K) {
                 float scale = fw / fh;


### PR DESCRIPTION
The svg width/height values were cast to int,
which could result in cutting off a small part
of the image. Now, in the case of a non-integer
size, it will be rounded up.

@Issue: https://github.com/thorvg/thorvg/issues/1414