### PR TITLE
common: changed a returned value from load function

### DIFF
--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -245,7 +245,7 @@ struct Picture::Impl
         if (paint || surface) return Result::InsufficientCondition;
         if (loader) loader->close();
         loader = LoaderMgr::loader(data, w, h, copy);
-        if (!loader) return Result::NonSupport;
+        if (!loader) return Result::FailedAllocation;
         this->w = loader->w;
         this->h = loader->h;
         return Result::Success;


### PR DESCRIPTION
In the event that malloc returns a nullptr while copying loaded raw data, a Result::NonSupport value is returned. However, it appears that Result::FailedAllocation would be more accurate.