### PR TITLE
jpg_loader: Add file existence check

### DIFF
--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -55,6 +55,10 @@ bool JpgLoader::open(const string& path)
 {
     clear();
 
+    auto jpegFile = fopen(path.c_str(), "rb");
+    if (!jpegFile) return false;
+    fclose(jpegFile);
+
     int width, height;
     decoder = jpgdHeader(path.c_str(), &width, &height);
     if (!decoder) return false;


### PR DESCRIPTION
Prevent memory leaks.
```
==2277==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f71c4ff2587 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cc:104
    #1 0x7f71c4a8d56a in jpgdHeader(char const*, int*, int*) ../src/loaders/jpg/tvgJpgd.cpp:2930
    #2 0x7f71c4ad4f85 in JpgLoader::open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ../src/loaders/jpg/tvgJpgLoader.cpp:59
    #3 0x7f71c497d663 in LoaderMgr::loader(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool*) ../src/lib/tvgLoader.cpp:174
    #4 0x7f71c4992d81 in tvg::Picture::Impl::load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ../src/lib/tvgPictureImpl.h:220
    #5 0x7f71c498aa86 in tvg::Picture::load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ../src/lib/tvgPicture.cpp:58
    #6 0x55df238cb293 in C_A_T_C_H_T_E_S_T_24 ../test/testPicture.cpp:371
    #7 0x55df2366d499 in Catch::RunContext::invokeActiveTestCase() ../test/catch.hpp:13025
    #8 0x55df236dee1b in Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) ../test/catch.hpp:12998
    #9 0x55df23710586 in Catch::RunContext::runTest(Catch::TestCase const&) ../test/catch.hpp:12759
    #10 0x55df237252d4 in execute ../test/catch.hpp:13352
    #11 0x55df237252d4 in Catch::Session::runInternal() ../test/catch.hpp:13562
    #12 0x55df23726b86 in Catch::Session::run() ../test/catch.hpp:13518
    #13 0x55df235f7179 in int Catch::Session::run<char>(int, char const* const*) ../test/catch.hpp:13236
    #14 0x55df235f7179 in main ../test/catch.hpp:17543
    #15 0x7f71c3791082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: 24 byte(s) leaked in 1 allocation(s).
```