### PR TITLE
tvg_saver: fixing unwanted merging

### DIFF
--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -75,7 +75,10 @@ static bool _merge(Shape* from, Shape* to)
     from->fillColor(&r, &g, &b, &a);
     to->fillColor(&r2, &g2, &b2, &a2);
 
-    if (r != r2 || g != g2 || b != b2 || a != a2) return false;
+    if (r != r2 || g != g2 || b != b2 || a != a2 || a < 255) return false;
+
+    auto fromRule = from->fillRule();
+    if (fromRule == FillRule::EvenOdd || fromRule != to->fillRule()) return false;
 
     //composition
     if (from->composite(nullptr) != CompositeMethod::None) return false;


### PR DESCRIPTION
Similar shapes are merged to improve
performance. This should not be the case
with a semi-transparent fill.

@Issue: https://github.com/thorvg/thorvg/issues/1440

sample:
```
<svg width="100%" height="100%" viewBox="0 0 144 144" version="1.1" >
<path d="M18.341,82.683c0,0 0.264,-3.777 -4.742,-7.114c-5.006,-3.337 -4.303,-11.153 3.249,-13.172c7.553,-2.02 3.513,-10.363 0.615,-11.329c7.026,1.054 8.694,2.898 9.397,6.147c0.702,3.25 0.091,8.386 -7.289,10.714c-5.622,1.773 4.303,5.533 -1.23,14.754Z" style="fill:#c3c3bd;fill-opacity:0.7;"/>
<path d="M20.586,72.784c0,0 -0.626,-2.941 2.942,-6.121c3.567,-3.181 2.148,-9.251 -4.017,-10.002c-6.165,-0.751 -3.913,-7.762 -1.74,-8.843c-5.41,1.608 -6.518,3.244 -6.71,5.878c-0.192,2.633 0.859,6.606 6.922,7.619c4.619,0.771 -2.771,4.829 2.603,11.469Z" style="fill:#c3c3bd;fill-opacity:0.7;"/>
</svg>
```