### PR TITLE
api: remove deprecated apis

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -322,21 +322,6 @@ public:
     Result composite(std::unique_ptr<Paint> target, CompositeMethod method) noexcept;
 
     /**
-     * @brief Gets the bounding box of the paint object before any transformation.
-     *
-     * @param[out] x The x coordinate of the upper left corner of the object.
-     * @param[out] y The y coordinate of the upper left corner of the object.
-     * @param[out] w The width of the object.
-     * @param[out] h The height of the object.
-     *
-     * @return Result::Success when succeed, Result::InsufficientCondition otherwise.
-     *
-     * @note The bounding box doesn't indicate the final rendered region. It's the smallest rectangle that encloses the object.
-     * @see Paint::bounds(float* x, float* y, float* w, float* h, bool transformed);
-     */
-    TVG_DEPRECATED Result bounds(float* x, float* y, float* w, float* h) const noexcept;
-
-    /**
      * @brief Gets the axis-aligned bounding box of the paint object.
      *
      * In case @p transform is @c true, all object's transformations are applied first, and then the bounding box is established. Otherwise, the bounding box is determined before any transformations.
@@ -1144,24 +1129,6 @@ public:
      * @see Initializer::init()
      */
     Result load(const std::string& path) noexcept;
-
-    /**
-     * @brief Loads a picture data from a memory block of a given size.
-     *
-     * @param[in] data A pointer to a memory location where the content of the picture file is stored.
-     * @param[in] size The size in bytes of the memory occupied by the @p data.
-     * @param[in] copy Decides whether the data should be copied into the engine local buffer.
-     *
-     * @retval Result::Success When succeed.
-     * @retval Result::InvalidArguments In case no data are provided or the @p size is zero or less.
-     * @retval Result::NonSupport When trying to load a file with an unknown extension.
-     * @retval Result::Unknown If an error occurs at a later stage.
-     *
-     * @warning: you have responsibility to release the @p data memory if the @p copy is true
-     * @deprecated Use load(const char* data, uint32_t size, const std::string& mimeType, bool copy) instead.
-     * @see Result load(const char* data, uint32_t size, const std::string& mimeType, bool copy = false) noexcept
-     */
-    TVG_DEPRECATED Result load(const char* data, uint32_t size, bool copy = false) noexcept;
 
     /**
      * @brief Loads a picture data from a memory block of a given size.

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -348,12 +348,6 @@ Matrix Paint::transform() noexcept
 }
 
 
-TVG_DEPRECATED Result Paint::bounds(float* x, float* y, float* w, float* h) const noexcept
-{
-    return this->bounds(x, y, w, h, false);
-}
-
-
 Result Paint::bounds(float* x, float* y, float* w, float* h, bool transform) const noexcept
 {
     if (pImpl->bounds(x, y, w, h, transform)) return Result::Success;

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -67,12 +67,6 @@ Result Picture::load(const char* data, uint32_t size, const string& mimeType, bo
 }
 
 
-TVG_DEPRECATED Result Picture::load(const char* data, uint32_t size, bool copy) noexcept
-{
-    return load(data, size, "", copy);
-}
-
-
 Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept
 {
     if (!data || w <= 0 || h <= 0) return Result::InvalidArguments;


### PR DESCRIPTION
- Result Paint::bounds(float* x, float* y, float* w, float* h) const noexcept;
- Result Picture::load(const char* data, uint32_t size, bool copy = false) noexcept;

@Issue: https://github.com/thorvg/thorvg/issues/1372