### PR TITLE
portability: fix usage of TVG_API

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -23,28 +23,36 @@
     #undef TVG_API
 #endif
 
-#if defined(_WIN32) && !defined(__clang__)
-    #if TVG_BUILD
-        #if TVG_EXPORT
+#ifndef TVG_STATIC
+    #ifdef _WIN32
+        #if TVG_BUILD
             #define TVG_API __declspec(dllexport)
         #else
-            #define TVG_API
+            #define TVG_API __declspec(dllimport)
         #endif
+    #elif (defined(__SUNPRO_C)  || defined(__SUNPRO_CC))
+        #define TVG_API __global
     #else
-        #define TVG_API __declspec(dllimport)
-    #endif
-    #define TVG_DEPRECATED __declspec(deprecated)
-#else
-    #if TVG_BUILD
-        #if TVG_EXPORT
-            #define TVG_API __attribute__ ((visibility ("default")))
+        #if (defined(__GNUC__) && __GNUC__ >= 4) || defined(__INTEL_COMPILER)
+            #define TVG_API __attribute__ ((visibility("default")))
         #else
             #define TVG_API
         #endif
-    #else
-        #define TVG_API
     #endif
+#else
+    #define TVG_API
+#endif
+
+#ifdef TVG_DEPRECATED
+    #undef TVG_DEPRECATED
+#endif
+
+#ifdef _WIN32
+    #define TVG_DEPRECATED __declspec(deprecated)
+#elif __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)
     #define TVG_DEPRECATED __attribute__ ((__deprecated__))
+#else
+    #define TVG_DEPRECATED
 #endif
 
 #ifdef __cplusplus

--- a/src/bin/meson.build
+++ b/src/bin/meson.build
@@ -1,4 +1,6 @@
-compiler_flags = ['-DTVG_BUILD']
+if (lib_type == 'static')
+    compiler_flags += ['-DTVG_STATIC']
+endif
 
 if all_tools or get_option('tools').contains('svg2png') == true
    subdir('svg2png')

--- a/src/bin/svg2png/meson.build
+++ b/src/bin/svg2png/meson.build
@@ -3,5 +3,5 @@ svg2png_src  = files('svg2png.cpp', 'lodepng.cpp')
 executable('svg2png',
            svg2png_src,
            include_directories : headers,
-           cpp_args: compiler_flags,
+           cpp_args : compiler_flags,
            link_with : thorvg_lib)

--- a/src/bin/svg2tvg/meson.build
+++ b/src/bin/svg2tvg/meson.build
@@ -3,5 +3,5 @@ svg2tvg_src  = files('svg2tvg.cpp')
 executable('svg2tvg',
            svg2tvg_src,
            include_directories : headers,
-           cpp_args: compiler_flags,
+           cpp_args : compiler_flags,
            link_with : thorvg_lib)

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -25,28 +25,36 @@
     #undef TVG_API
 #endif
 
-#if defined(_WIN32) && !defined(__clang__)
-    #if TVG_BUILD
-        #if TVG_EXPORT
+#ifndef TVG_STATIC
+    #ifdef _WIN32
+        #if TVG_BUILD
             #define TVG_API __declspec(dllexport)
         #else
-            #define TVG_API
+            #define TVG_API __declspec(dllimport)
         #endif
+    #elif (defined(__SUNPRO_C)  || defined(__SUNPRO_CC))
+        #define TVG_API __global
     #else
-        #define TVG_API __declspec(dllimport)
-    #endif
-    #define TVG_DEPRECATED __declspec(deprecated)
-#else
-    #if TVG_BUILD
-        #if TVG_EXPORT
-            #define TVG_API __attribute__ ((visibility ("default")))
+        #if (defined(__GNUC__) && __GNUC__ >= 4) || defined(__INTEL_COMPILER)
+            #define TVG_API __attribute__ ((visibility("default")))
         #else
             #define TVG_API
         #endif
-    #else
-        #define TVG_API
     #endif
+#else
+    #define TVG_API
+#endif
+
+#ifdef TVG_DEPRECATED
+    #undef TVG_DEPRECATED
+#endif
+
+#ifdef _WIN32
+    #define TVG_DEPRECATED __declspec(deprecated)
+#elif __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)
     #define TVG_DEPRECATED __attribute__ ((__deprecated__))
+#else
+    #define TVG_DEPRECATED
 #endif
 
 #ifdef __cplusplus

--- a/src/examples/meson.build
+++ b/src/examples/meson.build
@@ -1,4 +1,6 @@
-compiler_flags = ['-DTVG_BUILD']
+if (lib_type == 'static')
+    compiler_flags += ['-DTVG_STATIC']
+endif
 
 examples_dep = dependency('elementary', required : true)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,10 +1,12 @@
-compiler_flags = ['-DTVG_BUILD']
+compiler_flags = []
 override_options = []
 
 lib_type = get_option('default_library')
 
 if (lib_type == 'shared')
-    compiler_flags += ['-DTVG_EXPORT']
+    compiler_flags += ['-DTVG_EXPORT', '-DTVG_BUILD']
+else
+    compiler_flags += ['-DTVG_STATIC']
 endif
 
 cc = meson.get_compiler('cpp')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,4 +1,6 @@
-compiler_flags = ['-DTVG_BUILD']
+if (lib_type == 'static')
+    compiler_flags += ['-DTVG_STATIC']
+endif
 
 test_file = [
     'testAccessor.cpp',


### PR DESCRIPTION
Rule of thumb on Windows:
  * for a DLL: * if the library is built, set TVG_API to __declspec(dllexport) * if the library is used, set TVG_API to __declspec(dllimport)
  * for a static library, set TVG_API to nothing

To set TVG_API for a static library, TVG_STATIC is defined when the stataic library is built. Otherwise, TVG_API is correctly set for a DLL.
Also sun and intel compilers are handled

@issue: https://github.com/thorvg/thorvg/issues/1446