### PR TITLE
svg_loader: copy the use node properties

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2934,6 +2934,16 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             }
             break;
         }
+        case SvgNodeType::Use: {
+            to->node.use.x = from->node.use.x;
+            to->node.use.y = from->node.use.y;
+            to->node.use.w = from->node.use.w;
+            to->node.use.h = from->node.use.h;
+            to->node.use.isWidthSet = from->node.use.isWidthSet;
+            to->node.use.isHeightSet = from->node.use.isHeightSet;
+            to->node.use.symbol = from->node.use.symbol;
+            break;
+        }
         default: {
             break;
         }


### PR DESCRIPTION
A bug was observed when a 'use' node was
referenced in another 'use' node.

@Issue: https://github.com/thorvg/thorvg/issues/1451

sample:
```
<svg viewBox="0 0 80 20" xmlns="http://www.w3.org/2000/svg">

  <use id="a" href="#myDot" x="5" y="5" style="fill:red" />  
  <use href="#a" x="20" y="5" style="fill:blue; opacity:0.4" />

  <symbol id="myDot" width="10" height="10" viewBox="0 0 2 2">
    <circle cx="1" cy="1" r="1" />
  </symbol>
</svg>
```

before:
<img width="265" alt="Zrzut ekranu 2023-05-16 o 01 01 39" src="https://github.com/thorvg/thorvg/assets/67589014/e8ceaf59-a14f-459d-8f2d-9f05567437e3">

after:
<img width="265" alt="Zrzut ekranu 2023-05-16 o 01 01 59" src="https://github.com/thorvg/thorvg/assets/67589014/1f2ae783-9d4c-4ca6-a03f-584b63db58bc">
