### PR TITLE
svg_loader: fixing finding defs node

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1903,6 +1903,7 @@ static SvgNode* _getDefsNode(SvgNode* node)
     }
 
     if (node->type == SvgNodeType::Doc) return node->node.doc.defs;
+    if (node->type == SvgNodeType::Defs) return node;
 
     return nullptr;
 }


### PR DESCRIPTION
In the case when a 'use' node was used
in a 'defs' block  and the element it
referenced was also defined within the same
'defs' block, the reference node could not
be cloned. This was because the 'defs' node
could not be located.

@Issue: https://github.com/thorvg/thorvg/issues/1451

sample: https://github.com/thorvg/thorvg/issues/1451#issuecomment-1548089583