### PR TITLE
API clean up

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -990,7 +990,8 @@ public:
      * @param[in] strokeFirst If @c true the stroke is rendered before the fill, otherwise the stroke is rendered as the second one (the default option).
      *
      * @return Result::Success when succeed, Result::FailedAllocation otherwise.
-     * @BETA_API
+     *
+     * @since 0.10
      */
     Result order(bool strokeFirst) noexcept;
 
@@ -1602,7 +1603,7 @@ public:
  *
  * @warning We strongly warn you not to change the paints of a scene unless you really know the design-structure.
  *
- * @BETA_API
+ * @since 0.10
  */
 class TVG_API Accessor final
 {
@@ -1618,8 +1619,6 @@ public:
      * @return Return the given @p picture instance.
      *
      * @note The bitmap based picture might not have the scene-tree.
-     *
-     * @BETA_API
      */
     std::unique_ptr<Picture> set(std::unique_ptr<Picture> picture, std::function<bool(const Paint* paint)> func) noexcept;
 
@@ -1627,8 +1626,6 @@ public:
      * @brief Creates a new Accessor object.
      *
      * @return A new Accessor object.
-     *
-     * @BETA_API
      */
     static std::unique_ptr<Accessor> gen() noexcept;
 

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1361,8 +1361,8 @@ public:
     {
         ABGR8888 = 0,      ///< The channels are joined in the order: alpha, blue, green, red. Colors are alpha-premultiplied.
         ARGB8888,          ///< The channels are joined in the order: alpha, red, green, blue. Colors are alpha-premultiplied.
-        ABGR8888_STRAIGHT, ///< @BETA_API The channels are joined in the order: alpha, blue, green, red. Colors are un-alpha-premultiplied.
-        ARGB8888_STRAIGHT, ///< @BETA_API The channels are joined in the order: alpha, red, green, blue. Colors are un-alpha-premultiplied.
+        ABGR8888S,         ///< @BETA_API The channels are joined in the order: alpha, blue, green, red. Colors are un-alpha-premultiplied.
+        ARGB8888S,         ///< @BETA_API The channels are joined in the order: alpha, red, green, blue. Colors are un-alpha-premultiplied.
     };
 
     /**

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1239,15 +1239,6 @@ public:
     uint32_t mesh(const Polygon** triangles) const noexcept;
 
     /**
-     * @brief Gets the position and the size of the loaded SVG picture.
-     *
-     * @warning Please do not use it, this API is not official one. It could be modified in the next version.
-     *
-     * @BETA_API
-     */
-    Result viewbox(float* x, float* y, float* w, float* h) const noexcept;
-
-    /**
      * @brief Creates a new Picture object.
      *
      * @return A new Picture object.

--- a/src/bin/svg2png/svg2png.cpp
+++ b/src/bin/svg2png/svg2png.cpp
@@ -125,7 +125,7 @@ public:
             return 1;
         }
 
-        if (canvas->target(buffer, w, w, h, tvg::SwCanvas::ARGB8888_STRAIGHT) != tvg::Result::Success) {
+        if (canvas->target(buffer, w, w, h, tvg::SwCanvas::ARGB8888S) != tvg::Result::Success) {
             cout << "Error: Canvas target failure" << endl;
             return 1;
         }

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1920,14 +1920,6 @@ TVG_API Tvg_Result tvg_picture_set_size(Tvg_Paint* paint, float w, float h);
 TVG_API Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, float* h);
 
 
-/*!
-* \brief Gets the position and the size of the loaded picture. (BETA_API)
-*
-* \warning Please do not use it, this API is not official one. It can be modified in the next version.
-*/
-TVG_API Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
-
-
 /** \} */   // end defgroup ThorVGCapi_Picture
 
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -508,13 +508,6 @@ TVG_API Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, float*
 }
 
 
-TVG_API Tvg_Result tvg_picture_get_viewbox(const Tvg_Paint* paint, float* x, float* y, float* w, float* h)
-{
-    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<const Picture*>(paint)->viewbox(x, y, w, h);
-}
-
-
 /************************************************************************/
 /* Gradient API                                                         */
 /************************************************************************/

--- a/src/lib/tvgLoadModule.h
+++ b/src/lib/tvgLoadModule.h
@@ -31,11 +31,6 @@ namespace tvg
 class LoadModule
 {
 public:
-    //default view box, if any.
-    float vx = 0;
-    float vy = 0;
-    float vw = 0;
-    float vh = 0;
     float w = 0, h = 0;                             //default image size
     ColorSpace cs = ColorSpace::Unsupported;        //must be clarified at open()
 

--- a/src/lib/tvgPicture.cpp
+++ b/src/lib/tvgPicture.cpp
@@ -75,13 +75,6 @@ Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept
 }
 
 
-Result Picture::viewbox(float* x, float* y, float* w, float* h) const noexcept
-{
-    if (pImpl->viewbox(x, y, w, h)) return Result::Success;
-    return Result::InsufficientCondition;
-}
-
-
 Result Picture::size(float w, float h) noexcept
 {
     if (pImpl->size(w, h)) return Result::Success;

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -181,16 +181,6 @@ struct Picture::Impl
         return ret;
     }
 
-    bool viewbox(float* x, float* y, float* w, float* h)
-    {
-        if (!loader) return false;
-        if (x) *x = loader->vx;
-        if (y) *y = loader->vy;
-        if (w) *w = loader->vw;
-        if (h) *h = loader->vh;
-        return true;
-    }
-
     bool size(float w, float h)
     {
         this->w = w;

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -54,6 +54,10 @@ private:
     SvgViewFlag viewFlag = SvgViewFlag::None;
     AspectRatioAlign align = AspectRatioAlign::XMidYMid;
     AspectRatioMeetOrSlice meetOrSlice = AspectRatioMeetOrSlice::Meet;
+    float vx = 0;
+    float vy = 0;
+    float vw = 0;
+    float vh = 0;
 
     bool header();
     void clear();

--- a/test/capi/capiPicture.cpp
+++ b/test/capi/capiPicture.cpp
@@ -123,15 +123,6 @@ TEST_CASE("Load Svg Data in Picture", "[capiPicture]")
     REQUIRE(w == Approx(wNew).epsilon(0.0000001));
     REQUIRE(h == Approx(hNew).epsilon(0.0000001));
 
-
-    //Verify Position
-    float x, y;
-    REQUIRE(tvg_picture_get_viewbox(picture, &x, &y, &w, &h) == TVG_RESULT_SUCCESS);
-    REQUIRE(x == Approx(0).epsilon(0.0000001));
-    REQUIRE(y == Approx(0).epsilon(0.0000001));
-    REQUIRE(w == Approx(600).epsilon(0.0000001));
-    REQUIRE(h == Approx(600).epsilon(0.0000001));
-
     REQUIRE(tvg_paint_del(picture) == TVG_RESULT_SUCCESS);
 }
 

--- a/test/testShape.cpp
+++ b/test/testShape.cpp
@@ -141,6 +141,10 @@ TEST_CASE("Stroking", "[tvgShape]")
     auto shape = Shape::gen();
     REQUIRE(shape);
 
+    //Stroke Order Before Stroke Setting
+    REQUIRE(shape->order(true) == Result::Success);
+    REQUIRE(shape->order(false) == Result::Success);
+
     //Stroke Width
     REQUIRE(shape->stroke(0) == Result::Success);
     REQUIRE(shape->strokeWidth() == 0);
@@ -186,6 +190,10 @@ TEST_CASE("Stroking", "[tvgShape]")
     REQUIRE(shape->stroke(StrokeJoin::Miter) == Result::Success);
     REQUIRE(shape->stroke(StrokeJoin::Round) == Result::Success);
     REQUIRE(shape->strokeJoin() == StrokeJoin::Round);
+
+    //Stroke Order After Stroke Setting
+    REQUIRE(shape->order(true) == Result::Success);
+    REQUIRE(shape->order(false) == Result::Success);
 }
 
 TEST_CASE("Shape Filling", "[tvgShape]")

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
-    REQUIRE(canvas->target(buffer, 100, 100, 100, SwCanvas::Colorspace::ABGR8888_STRAIGHT) == Result::Success);
+    REQUIRE(canvas->target(buffer, 100, 100, 100, SwCanvas::Colorspace::ABGR8888S) == Result::Success);
 
     //Arc Line
     auto shape1 = tvg::Shape::gen();


### PR DESCRIPTION
BETA -> Official 0.10
- unique_ptr<Picture> Accessor::set(std::unique_ptr<Picture> picture, std::function<bool(const Paint* paint)> func);
- static Accessor::std::unique_ptr<Accessor> gen();
- Result Shape::order(bool strokeFirst);

Modify:
- SwCanvas::Colorspace::ABGR8888_STRAIGHT -> SwCanvas::Colorspace::ABGR8888S
- SwCanvas::Colorspace::ARGB8888_STRAIGHT -> SwCanvas::Colorspace::ARGB8888S

Removal:
- Result Picture::viewbox(float* x, float* y, float* w, float* h) const;

@Issue: https://github.com/thorvg/thorvg/issues/1372