### PR TITLE
capi order

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1476,6 +1476,22 @@ TVG_API Tvg_Result tvg_shape_get_fill_rule(const Tvg_Paint* paint, Tvg_Fill_Rule
 
 
 /*!
+* \brief Sets the rendering order of the stroke and the fill.
+*
+* \param[in] paint A Tvg_Paint pointer to the shape object.
+* \param[in] strokeFirst If @c true the stroke is rendered before the fill, otherwise the stroke is rendered as the second one (the default option).
+*
+* \return Tvg_Result enumeration.
+* \retval TVG_RESULT_SUCCESS Succeed.
+* \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
+* \retval TVG_RESULT_FAILED_ALLOCATION An internal error with a memory allocation.
+*
+* \since 0.10
+*/
+TVG_API Tvg_Result tvg_shape_set_paint_order(Tvg_Paint* paint, bool strokeFirst);
+
+
+/*!
 * \brief Sets the linear gradient fill for all of the figures from the path.
 *
 * The parts of the shape defined as inner are filled.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -442,6 +442,13 @@ TVG_API Tvg_Result tvg_shape_get_fill_rule(const Tvg_Paint* paint, Tvg_Fill_Rule
 }
 
 
+TVG_API Tvg_Result tvg_shape_set_paint_order(Tvg_Paint* paint, bool strokeFirst)
+{
+    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->order(strokeFirst);
+}
+
+
 TVG_API Tvg_Result tvg_shape_set_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;

--- a/test/capi/capiShape.cpp
+++ b/test/capi/capiShape.cpp
@@ -272,3 +272,16 @@ TEST_CASE("Fill rule", "[capiFillRule]")
 
     REQUIRE(tvg_paint_del(paint) == TVG_RESULT_SUCCESS);
 }
+
+TEST_CASE("Paint order", "[capiPaintOrder]")
+{
+    Tvg_Paint* paint = tvg_shape_new();
+    REQUIRE(paint);
+
+    REQUIRE(tvg_shape_set_paint_order(nullptr, true) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_paint_order(paint, true) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_shape_set_paint_order(paint, false) == TVG_RESULT_SUCCESS);
+
+    REQUIRE(tvg_paint_del(paint) == TVG_RESULT_SUCCESS);
+}
+


### PR DESCRIPTION
[capi: tvg_shape_set_paint_order introduced](https://github.com/thorvg/thorvg/commit/da7c2498a44becee610cfc4aaf293c08796a6ac6) 

[tests: capi test for tvg_shape_set_paint_order](https://github.com/thorvg/thorvg/commit/ac21accf97844fa57a13fad8cc75f870fb05d2c7)