### PR TITLE
infa: Install svg2png and svg2tvg.

### DIFF
--- a/src/bin/svg2png/meson.build
+++ b/src/bin/svg2png/meson.build
@@ -4,4 +4,5 @@ executable('svg2png',
            svg2png_src,
            include_directories : headers,
            cpp_args : compiler_flags,
+           install : true,
            link_with : thorvg_lib)

--- a/src/bin/svg2tvg/meson.build
+++ b/src/bin/svg2tvg/meson.build
@@ -4,4 +4,5 @@ executable('svg2tvg',
            svg2tvg_src,
            include_directories : headers,
            cpp_args : compiler_flags,
+           install : true,
            link_with : thorvg_lib)


### PR DESCRIPTION
Meson can install stripped versions to
the standards-compliant (or --prefix) location.

I made some ci's to get the static and dynamic svg2xxx binaries:
https://github.com/capnm/thorvg_exp/actions
It seems to work.
```
[47/48] Linking target src/bin/svg2tvg/svg2tvg.exe
[48/48] Linking target src/bin/svg2png/svg2png.exe
Installing src\libthorvg.a to D:\a\thorvg_exp\thorvg_exp/thorvg\lib
Installing src\bin\svg2png\svg2png.exe to D:\a\thorvg_exp\thorvg_exp/thorvg\bin
Stripping target 'src\\bin\\svg2png\\svg2png.exe'.
Installing src\bin\svg2tvg\svg2tvg.exe to D:\a\thorvg_exp\thorvg_exp/thorvg\bin
Stripping target 'src\\bin\\svg2tvg\\svg2tvg.exe'.
```