### PR TITLE
Fix clang compiler warnings.

### DIFF
--- a/src/bin/svg2png/svg2png.cpp
+++ b/src/bin/svg2png/svg2png.cpp
@@ -140,11 +140,11 @@ public:
             shape->appendRect(0, 0, static_cast<float>(w), static_cast<float>(h), 0, 0);
             shape->fill(r, g, b, 255);
 
-            if (canvas->push(move(shape)) != tvg::Result::Success) return 1;
+            if (canvas->push(std::move(shape)) != tvg::Result::Success) return 1;
         }
 
         //Drawing
-        canvas->push(move(picture));
+        canvas->push(std::move(picture));
         canvas->draw();
         canvas->sync();
 

--- a/src/bin/svg2tvg/svg2tvg.cpp
+++ b/src/bin/svg2tvg/svg2tvg.cpp
@@ -68,7 +68,7 @@ private:
       if (picture->load(in) != Result::Success) return false;
 
       auto saver = Saver::gen();
-      if (saver->save(move(picture), out) != Result::Success) return false;
+      if (saver->save(std::move(picture), out) != Result::Success) return false;
       if (saver->sync() != Result::Success) return false;
 
       if (Initializer::term(CanvasEngine::Sw) != Result::Success) return false;

--- a/src/wasm/thorvgwasm.cpp
+++ b/src/wasm/thorvgwasm.cpp
@@ -149,7 +149,7 @@ public:
             mErrorMsg = "Saving initialization failed";
             return false;
         }
-        if (saver->save(move(duplicate), "file.tvg", compress) != tvg::Result::Success) {
+        if (saver->save(std::move(duplicate), "file.tvg", compress) != tvg::Result::Success) {
             mErrorMsg = "Tvg saving failed";
             return false;
         }


### PR DESCRIPTION
[clang] Warn on unqualified calls to std::move and std::forward. See: https://reviews.llvm.org/D119670

I have found some others.