### PR TITLE
infra: Avoid meson warning.

### DIFF
--- a/src/examples/meson.build
+++ b/src/examples/meson.build
@@ -80,4 +80,4 @@ endif
 
 execute_all_src = join_paths(meson.source_root(), 'src/examples/all.sh')
 execute_all_dst = join_paths(meson.build_root(), 'src/examples/all.sh')
-run_command('cp', execute_all_src, execute_all_dst)
+run_command('cp', execute_all_src, execute_all_dst, check: true)


### PR DESCRIPTION
WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300

Breaks my CI ...

Regression Testing / test (pull_request) Failing after 9s – that seems to be github issue:
https://github.com/thorvg/thorvg/actions/runs/5037647542/jobs/9034626080?pr=1467#step:3:88