### PR TITLE
Fix invalid conversion error in Avx raster.

### DIFF
--- a/src/lib/sw_engine/tvgSwRasterAvx.h
+++ b/src/lib/sw_engine/tvgSwRasterAvx.h
@@ -94,7 +94,7 @@ static bool avxRasterTranslucentRect(SwSurface* surface, const SwBBox& region, u
     auto h = static_cast<uint32_t>(region.max.y - region.min.y);
     auto w = static_cast<uint32_t>(region.max.x - region.min.x);
 
-    auto ialpha = 255 - static_cast<uint8_t>(_alpha(color));
+    uint32_t ialpha = 255 - a;
 
     auto avxColor = _mm_set1_epi32(color);
     auto avxIalpha = _mm_set1_epi8(ialpha);
@@ -148,7 +148,7 @@ static bool avxRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, ui
         if (span->coverage < 255) src = ALPHA_BLEND(color, span->coverage);
         else src = color;
 
-        auto ialpha = 255 - static_cast<uint8_t>(_alpha(src));
+	auto ialpha = _ialpha(src);
 
         //1. fill the not aligned memory (for 128-bit registers a 16-bytes alignment is required)
         auto notAligned = ((uintptr_t)dst & 0xf) / 4;


### PR DESCRIPTION
Hi,
Thorvg does not compile on x64, due to an invalid conversion in tvgSwRasterAvx.h.
The compiler says:
```
./src/lib/sw_engine/tvgSwRasterAvx.h: In function ‘bool avxRasterTranslucentRect(SwSurface*, const SwBBox&, uint8_t, uint8_t, uint8_t, uint8_t)’:
../src/lib/sw_engine/tvgSwRasterAvx.h:97:53: error: invalid conversion from ‘unsigned int’ to ‘uint8_t*’ {aka ‘unsigned char*’} [-fpermissive]
   97 |     auto ialpha = 255 - static_cast<uint8_t>(_alpha(color));
      |                                                     ^~~~~
      |                                                     |
      |                                                     unsigned int
../src/lib/sw_engine/tvgSwRaster.cpp:53:39: note:   initializing argument 1 of ‘uint8_t _alpha(uint8_t*)’
   53 | static inline uint8_t _alpha(uint8_t* a)
      |                              ~~~~~~~~~^
../src/lib/sw_engine/tvgSwRasterAvx.h: In function ‘bool avxRasterTranslucentRle(SwSurface*, const SwRleData*, uint8_t, uint8_t, uint8_t, uint8_t)’:
../src/lib/sw_engine/tvgSwRasterAvx.h:151:57: error: invalid conversion from ‘uint32_t’ {aka ‘unsigned int’} to ‘uint8_t*’ {aka ‘unsigned char*’} [-fpermissive]
  151 |         auto ialpha = 255 - static_cast<uint8_t>(_alpha(src));
      |                                                         ^~~
      |                                                         |
      |                                                         uint32_t {aka unsigned int}
../src/lib/sw_engine/tvgSwRaster.cpp:53:39: note:   initializing argument 1 of ‘uint8_t _alpha(uint8_t*)’
   53 | static inline uint8_t _alpha(uint8_t* a)
      |   
```
patch attached. 
Thank you.

Vincenzo
