### PR TITLE
tvgJpgd.cpp: compiler warnings

### DIFF
--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -1336,11 +1336,10 @@ void jpeg_decoder::read_sos_marker()
 // Finds the next marker.
 int jpeg_decoder::next_marker()
 {
-    uint32_t c, bytes = 0;
+    uint32_t c;
 
     do {
         do {
-            bytes++;
             c = get_bits(8);
         } while (c != 0xFF);
 
@@ -1349,7 +1348,6 @@ int jpeg_decoder::next_marker()
         } while (c == 0xFF);
     } while (c == 0);
 
-    // If bytes > 0 here, there where extra bytes before the marker (not good).
     return c;
 }
 
@@ -1770,7 +1768,7 @@ void jpeg_decoder::load_next_row()
     int i;
     jpgd_block_t *p;
     jpgd_quant_t *q;
-    int mcu_row, mcu_block, row_block = 0;
+    int mcu_row, mcu_block;
     int component_num, component_id;
     int block_x_mcu[JPGD_MAX_COMPONENTS];
 
@@ -1800,8 +1798,6 @@ void jpeg_decoder::load_next_row()
                     p[g_ZAG[i]] = static_cast<jpgd_block_t>(p[g_ZAG[i]] * q[i]);
                 }
             }
-
-            row_block++;
 
             if (m_comps_in_scan == 1) block_x_mcu[component_id]++;
             else {
@@ -1873,8 +1869,6 @@ static inline int dequantize_ac(int c, int q)
 // Decodes and dequantizes the next row of coefficients.
 void jpeg_decoder::decode_next_row()
 {
-    int row_block = 0;
-
     for (int mcu_row = 0; mcu_row < m_mcus_per_row; mcu_row++) {
         if ((m_restart_interval) && (m_restarts_left == 0)) process_restart();
 
@@ -1937,7 +1931,6 @@ void jpeg_decoder::decode_next_row()
             }
 
             m_mcu_block_max_zag[mcu_block] = k;
-            row_block++;
         }
         if (m_freq_domain_chroma_upsample) transform_mcu_expand(mcu_row);
         else transform_mcu(mcu_row);


### PR DESCRIPTION
[41/145] Compiling C++ object src/libthorvg.a.p/loaders_jpg_tvgJpgd.cpp.o ../src/loaders/jpg/tvgJpgd.cpp:1339:17: warning: variable 'bytes' set but not used [-Wunused-but-set-variable]
    uint32_t c, bytes = 0;
                ^
../src/loaders/jpg/tvgJpgd.cpp:1773:29: warning: variable 'row_block' set but not used [-Wunused-but-set-variable]
    int mcu_row, mcu_block, row_block = 0;
                            ^
../src/loaders/jpg/tvgJpgd.cpp:1876:9: warning: variable 'row_block' set but not used [-Wunused-but-set-variable]
    int row_block = 0;
        ^
3 warnings generated.