### PR TITLE
Fix clang compiler warnings in unit tests.

### DIFF
--- a/test/testAccessor.cpp
+++ b/test/testAccessor.cpp
@@ -55,7 +55,7 @@ TEST_CASE("Set", "[tvgAccessor]")
     REQUIRE(accessor);
 
     //Case 1
-    picture = accessor->set(move(picture), nullptr);
+    picture = accessor->set(std::move(picture), nullptr);
     REQUIRE(picture);
 
     //Case 2
@@ -71,7 +71,7 @@ TEST_CASE("Set", "[tvgAccessor]")
         return true;
     };
 
-    picture = accessor->set(move(picture), f);
+    picture = accessor->set(std::move(picture), f);
     REQUIRE(picture);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);

--- a/test/testFill.cpp
+++ b/test/testFill.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Common Filling", "[tvgFill]")
     REQUIRE(shape);
 
     auto pFill = fill.get();
-    REQUIRE(shape->fill(move(fill)) == Result::Success);
+    REQUIRE(shape->fill(std::move(fill)) == Result::Success);
     REQUIRE(shape->fill() == pFill);
 }
 

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -156,7 +156,7 @@ TEST_CASE("Duplication", "[tvgPaint]")
 
     auto comp = Shape::gen();
     REQUIRE(comp);
-    REQUIRE(shape->composite(move(comp), CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(shape->composite(std::move(comp), CompositeMethod::ClipPath) == Result::Success);
 
     //Duplication
     auto dup = tvg::cast<Shape>(shape->duplicate());
@@ -189,12 +189,12 @@ TEST_CASE("Composition", "[tvgPaint]")
 
     auto comp = Shape::gen();
     REQUIRE(shape->composite(nullptr, CompositeMethod::ClipPath) == Result::InvalidArguments);
-    REQUIRE(shape->composite(move(comp), CompositeMethod::None) == Result::InvalidArguments);
+    REQUIRE(shape->composite(std::move(comp), CompositeMethod::None) == Result::InvalidArguments);
 
     //ClipPath
     comp = Shape::gen();
     auto pComp = comp.get();
-    REQUIRE(shape->composite(move(comp), CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(shape->composite(std::move(comp), CompositeMethod::ClipPath) == Result::Success);
 
     const Paint* pComp2 = nullptr;
     REQUIRE(shape->composite(&pComp2) == CompositeMethod::ClipPath);
@@ -203,7 +203,7 @@ TEST_CASE("Composition", "[tvgPaint]")
     //AlphaMask
     comp = Shape::gen();
     pComp = comp.get();
-    REQUIRE(shape->composite(move(comp), CompositeMethod::AlphaMask) == Result::Success);
+    REQUIRE(shape->composite(std::move(comp), CompositeMethod::AlphaMask) == Result::Success);
 
     REQUIRE(shape->composite(&pComp2) == CompositeMethod::AlphaMask);
     REQUIRE(pComp == pComp2);
@@ -211,7 +211,7 @@ TEST_CASE("Composition", "[tvgPaint]")
     //InvAlphaMask
     comp = Shape::gen();
     pComp = comp.get();
-    REQUIRE(shape->composite(move(comp), CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(shape->composite(std::move(comp), CompositeMethod::InvAlphaMask) == Result::Success);
 
     REQUIRE(shape->composite(&pComp2) == CompositeMethod::InvAlphaMask);
     REQUIRE(pComp == pComp2);
@@ -219,7 +219,7 @@ TEST_CASE("Composition", "[tvgPaint]")
     //LumaMask
     comp = Shape::gen();
     pComp = comp.get();
-    REQUIRE(shape->composite(move(comp), CompositeMethod::LumaMask) == Result::Success);
+    REQUIRE(shape->composite(std::move(comp), CompositeMethod::LumaMask) == Result::Success);
 
     REQUIRE(shape->composite(&pComp2) == CompositeMethod::LumaMask);
     REQUIRE(pComp == pComp2);
@@ -227,7 +227,7 @@ TEST_CASE("Composition", "[tvgPaint]")
     //InvLumaMask
     comp = Shape::gen();
     pComp = comp.get();
-    REQUIRE(shape->composite(move(comp), CompositeMethod::InvLumaMask) == Result::Success);
+    REQUIRE(shape->composite(std::move(comp), CompositeMethod::InvLumaMask) == Result::Success);
 
     REQUIRE(shape->composite(&pComp2) == CompositeMethod::InvLumaMask);
     REQUIRE(pComp == pComp2);

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -93,7 +93,7 @@ TEST_CASE("Load RAW file and render", "[tvgPicture]")
     REQUIRE(picture->load(data, 200, 300, false) == Result::Success);
     REQUIRE(picture->size(100, 150) == Result::Success);
 
-    REQUIRE(canvas->push(move(picture)) == Result::Success);
+    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
 
@@ -282,7 +282,7 @@ TEST_CASE("Load SVG file and render", "[tvgPicture]")
     REQUIRE(picture->load(TEST_DIR"/tag.svg") == Result::Success);
     REQUIRE(picture->size(100, 100) == Result::Success);
 
-    REQUIRE(canvas->push(move(picture)) == Result::Success);
+    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
@@ -353,7 +353,7 @@ TEST_CASE("Load PNG file and render", "[tvgPicture]")
     REQUIRE(picture->opacity(192) == Result::Success);
     REQUIRE(picture->scale(5.0) == Result::Success);
 
-    REQUIRE(canvas->push(move(picture)) == Result::Success);
+    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
 }
@@ -421,7 +421,7 @@ TEST_CASE("Load JPG file and render", "[tvgPicture]")
 
     REQUIRE(picture->load(TEST_DIR"/test.jpg") == Result::Success);
 
-    REQUIRE(canvas->push(move(picture)) == Result::Success);
+    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
 }
@@ -489,12 +489,12 @@ TEST_CASE("Load TVG file and render", "[tvgPicture]")
     auto pictureTag = Picture::gen();
     REQUIRE(pictureTag);
     REQUIRE(pictureTag->load(TEST_DIR"/tag.tvg") == Result::Success);
-    REQUIRE(canvas->push(move(pictureTag)) == Result::Success);
+    REQUIRE(canvas->push(std::move(pictureTag)) == Result::Success);
 
     auto pictureTest = Picture::gen();
     REQUIRE(pictureTest);
     REQUIRE(pictureTest->load(TEST_DIR"/test.tvg") == Result::Success);
-    REQUIRE(canvas->push(move(pictureTest)) == Result::Success);
+    REQUIRE(canvas->push(std::move(pictureTest)) == Result::Success);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
 

--- a/test/testSavers.cpp
+++ b/test/testSavers.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Save empty shape", "[tvgSavers]")
     auto saver = Saver::gen();
     REQUIRE(saver);
 
-    REQUIRE(saver->save(move(shape), TEST_DIR"/test.tvg") == Result::Unknown);
+    REQUIRE(saver->save(std::move(shape), TEST_DIR"/test.tvg") == Result::Unknown);
 }
 
 TEST_CASE("Save svg into tvg", "[tvgSavers]")
@@ -58,7 +58,7 @@ TEST_CASE("Save svg into tvg", "[tvgSavers]")
     auto saver = Saver::gen();
     REQUIRE(saver);
 
-    REQUIRE(saver->save(move(picture), TEST_DIR"/tag.tvg") == Result::Success);
+    REQUIRE(saver->save(std::move(picture), TEST_DIR"/tag.tvg") == Result::Success);
     REQUIRE(saver->sync() == Result::Success);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
@@ -85,11 +85,11 @@ TEST_CASE("Save scene into tvg", "[tvgSavers]")
     REQUIRE(mask);
     REQUIRE(mask->appendCircle(400, 400, 15, 15) == Result::Success);
     REQUIRE(mask->fill(0, 0, 0, 255) == Result::Success);
-    REQUIRE(picture->composite(move(mask), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(picture->composite(std::move(mask), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
 
     auto saver = Saver::gen();
     REQUIRE(saver);
-    REQUIRE(saver->save(move(picture), TEST_DIR"/test.tvg") == Result::Success);
+    REQUIRE(saver->save(std::move(picture), TEST_DIR"/test.tvg") == Result::Success);
     REQUIRE(saver->sync() == Result::Success);
 
     REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);

--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Pushing Paints Into Scene", "[tvgScene]")
 
     //Pushing Invalid Paint
     std::unique_ptr<Shape> shape = nullptr;
-    REQUIRE(scene->push(move(shape)) == Result::MemoryCorruption);
+    REQUIRE(scene->push(std::move(shape)) == Result::MemoryCorruption);
 }
 
 TEST_CASE("Scene Memory Reservation", "[tvgScene]")
@@ -90,8 +90,8 @@ TEST_CASE("Scene Clear And Reuse Shape", "[tvgScene]")
     REQUIRE(shape);
     Shape* pShape = shape.get();
 
-    REQUIRE(scene->push(move(shape)) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape)) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
     REQUIRE(canvas->update() == Result::Success);
 
     //No deallocate shape.

--- a/test/testSwCanvasBase.cpp
+++ b/test/testSwCanvasBase.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Pushing Paints", "[tvgSwCanvasBase]")
 
     //Negative case 2
     std::unique_ptr<Shape> shape6 = nullptr;
-    REQUIRE(canvas->push(move(shape6)) == Result::MemoryCorruption);
+    REQUIRE(canvas->push(std::move(shape6)) == Result::MemoryCorruption);
 
     //Negative case 3
     REQUIRE(canvas->push(Shape::gen()) == Result::Success);
@@ -111,7 +111,7 @@ TEST_CASE("Clear", "[tvgSwCanvasBase]")
         REQUIRE(shape2);
         ptrs[i] = shape2.get();
 
-        REQUIRE(canvas2->push(move(shape2)) == Result::Success);
+        REQUIRE(canvas2->push(std::move(shape2)) == Result::Success);
     }
 
     REQUIRE(canvas->clear() == Result::Success);
@@ -130,7 +130,7 @@ TEST_CASE("Clear", "[tvgSwCanvasBase]")
         REQUIRE(shape2);
         ptrs[i] = shape2.get();
 
-        REQUIRE(canvas2->push(move(shape2)) == Result::Success);
+        REQUIRE(canvas2->push(std::move(shape2)) == Result::Success);
     }
 
     REQUIRE(canvas->update() == Result::Success);
@@ -166,7 +166,7 @@ TEST_CASE("Update", "[tvgSwCanvasBase]")
 
     //Normal case
     auto ptr = shape.get();
-    REQUIRE(canvas->push(move(shape)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape)) == Result::Success);
     REQUIRE(canvas->update(ptr) == Result::Success);
     REQUIRE(canvas->update() == Result::Success);
     REQUIRE(canvas->draw() == Result::Success);
@@ -199,7 +199,7 @@ TEST_CASE("Synchronized Drawing", "[tvgSwCanvasBase]")
     //Invalid Shape
     auto shape = Shape::gen();
     REQUIRE(shape);
-    REQUIRE(canvas->push(move(shape)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape)) == Result::Success);
 
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
@@ -210,7 +210,7 @@ TEST_CASE("Synchronized Drawing", "[tvgSwCanvasBase]")
     REQUIRE(shape2->appendRect(0, 0, 100, 100, 0, 0) == Result::Success);
     REQUIRE(shape2->fill(255, 255, 255, 255) == Result::Success);
 
-    REQUIRE(canvas->push(move(shape2)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape2)) == Result::Success);
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
@@ -234,7 +234,7 @@ TEST_CASE("Asynchronized Drawing", "[tvgSwCanvasBase]")
         REQUIRE(shape->appendRect(0, 0, 100, 100, 0, 0) == Result::Success);
         REQUIRE(shape->fill(255, 255, 255, 255) == Result::Success);
 
-        REQUIRE(canvas->push(move(shape)) == Result::Success);
+        REQUIRE(canvas->push(std::move(shape)) == Result::Success);
     }
 
     REQUIRE(canvas->draw() == Result::Success);

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -47,7 +47,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
     REQUIRE(shape1->appendArc(150, 150, 80, 10, 180, false) == Result::Success);
     REQUIRE(shape1->stroke(255, 255, 255, 255) == Result::Success);
     REQUIRE(shape1->stroke(2) == Result::Success);
-    REQUIRE(canvas->push(move(shape1)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape1)) == Result::Success);
 
     //Cubic
     auto shape2 = tvg::Shape::gen();
@@ -57,7 +57,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
     REQUIRE(shape2->cubicTo(62, 25, 75, 38, 75, 50) == Result::Success);
     REQUIRE(shape2->close() == Result::Success);
     REQUIRE(shape2->stroke(1) == Result::Success);
-    REQUIRE(canvas->push(move(shape2)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape2)) == Result::Success);
 
     //Line
     auto shape3 = tvg::Shape::gen();
@@ -69,7 +69,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
     REQUIRE(shape3->lineTo(0, 20) == Result::Success);
     REQUIRE(shape3->close() == Result::Success);
     REQUIRE(shape3->fill(255, 255, 255, 255) == Result::Success);
-    REQUIRE(canvas->push(move(shape3)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
 
     //Dashed shape
     auto shape4 = tvg::Shape::gen();
@@ -84,7 +84,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
     REQUIRE(shape4->stroke(2) == Result::Success);
     REQUIRE(shape4->stroke(dashPattern, 2) == Result::Success);
     REQUIRE(shape4->stroke(StrokeCap::Round) == Result::Success);
-    REQUIRE(canvas->push(move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -153,28 +153,28 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(rleMask7);
 
     // Rect
-    REQUIRE(basicPicture->composite(move(rectMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture)) == Result::Success);
+    REQUIRE(basicPicture->composite(std::move(rectMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture)) == Result::Success);
 
-    REQUIRE(basicPicture2->composite(move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture2)) == Result::Success);
+    REQUIRE(basicPicture2->composite(std::move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
 
-    REQUIRE(basicPicture3->composite(move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture3)) == Result::Success);
+    REQUIRE(basicPicture3->composite(std::move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
 
-    REQUIRE(basicPicture4->composite(move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture4)) == Result::Success);
+    REQUIRE(basicPicture4->composite(std::move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture4)) == Result::Success);
 
     REQUIRE(basicPicture5->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture5)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->composite(move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture6)) == Result::Success);
+    REQUIRE(basicPicture6->composite(std::move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
 
-    REQUIRE(basicPicture7->composite(move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture7->composite(std::move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture7)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
 
 
     // Transformed images
@@ -219,28 +219,28 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(rleMask7);
 
     // Rect
-    REQUIRE(basicPicture->composite(move(rectMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture)) == Result::Success);
+    REQUIRE(basicPicture->composite(std::move(rectMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture)) == Result::Success);
 
-    REQUIRE(basicPicture2->composite(move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture2)) == Result::Success);
+    REQUIRE(basicPicture2->composite(std::move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
 
-    REQUIRE(basicPicture3->composite(move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture3)) == Result::Success);
+    REQUIRE(basicPicture3->composite(std::move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
 
-    REQUIRE(basicPicture4->composite(move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture4)) == Result::Success);
+    REQUIRE(basicPicture4->composite(std::move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture4)) == Result::Success);
 
     REQUIRE(basicPicture5->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture5)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->composite(move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture6)) == Result::Success);
+    REQUIRE(basicPicture6->composite(std::move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
 
-    REQUIRE(basicPicture7->composite(move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture7->composite(std::move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture7)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
 
 
     // Upscaled images
@@ -284,28 +284,28 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(rleMask7);
 
     // Rect
-    REQUIRE(basicPicture->composite(move(rectMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture)) == Result::Success);
+    REQUIRE(basicPicture->composite(std::move(rectMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture)) == Result::Success);
 
-    REQUIRE(basicPicture2->composite(move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture2)) == Result::Success);
+    REQUIRE(basicPicture2->composite(std::move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
 
-    REQUIRE(basicPicture3->composite(move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture3)) == Result::Success);
+    REQUIRE(basicPicture3->composite(std::move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
 
-    REQUIRE(basicPicture4->composite(move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture4)) == Result::Success);
+    REQUIRE(basicPicture4->composite(std::move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture4)) == Result::Success);
 
     REQUIRE(basicPicture5->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture5)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->composite(move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture6)) == Result::Success);
+    REQUIRE(basicPicture6->composite(std::move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
 
-    REQUIRE(basicPicture7->composite(move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture7->composite(std::move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture7)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
 
 
     // Downscaled images
@@ -349,28 +349,28 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(rleMask7);
 
     // Rect
-    REQUIRE(basicPicture->composite(move(rectMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture)) == Result::Success);
+    REQUIRE(basicPicture->composite(std::move(rectMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture)) == Result::Success);
 
-    REQUIRE(basicPicture2->composite(move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture2)) == Result::Success);
+    REQUIRE(basicPicture2->composite(std::move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
 
-    REQUIRE(basicPicture3->composite(move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture3)) == Result::Success);
+    REQUIRE(basicPicture3->composite(std::move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
 
-    REQUIRE(basicPicture4->composite(move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture4)) == Result::Success);
+    REQUIRE(basicPicture4->composite(std::move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture4)) == Result::Success);
 
     REQUIRE(basicPicture5->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture5)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->composite(move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture6)) == Result::Success);
+    REQUIRE(basicPicture6->composite(std::move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
 
-    REQUIRE(basicPicture7->composite(move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture7->composite(std::move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(move(basicPicture7)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -419,19 +419,19 @@ TEST_CASE("Rect Draw", "[tvgSwEngine]")
     auto basicShape5 = tvg::cast<Shape>(basicShape->duplicate());
     REQUIRE(basicShape5);
 
-    REQUIRE(basicShape->composite(move(basicMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicShape)) == Result::Success);
+    REQUIRE(basicShape->composite(std::move(basicMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape)) == Result::Success);
 
-    REQUIRE(basicShape2->composite(move(basicMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicShape2)) == Result::Success);
+    REQUIRE(basicShape2->composite(std::move(basicMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape2)) == Result::Success);
 
-    REQUIRE(basicShape3->composite(move(basicMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicShape3)) == Result::Success);
+    REQUIRE(basicShape3->composite(std::move(basicMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape3)) == Result::Success);
 
-    REQUIRE(basicShape4->composite(move(basicMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicShape4)) == Result::Success);
+    REQUIRE(basicShape4->composite(std::move(basicMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape4)) == Result::Success);
 
-    REQUIRE(canvas->push(move(basicShape5)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape5)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -478,19 +478,19 @@ TEST_CASE("RLE Draw", "[tvgSwEngine]")
     auto basicShape5 = tvg::cast<Shape>(basicShape->duplicate());
     REQUIRE(basicShape5);
 
-    REQUIRE(basicShape->composite(move(basicMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicShape)) == Result::Success);
+    REQUIRE(basicShape->composite(std::move(basicMask), tvg::CompositeMethod::AlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape)) == Result::Success);
 
-    REQUIRE(basicShape2->composite(move(basicMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicShape2)) == Result::Success);
+    REQUIRE(basicShape2->composite(std::move(basicMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape2)) == Result::Success);
 
-    REQUIRE(basicShape3->composite(move(basicMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(basicShape3)) == Result::Success);
+    REQUIRE(basicShape3->composite(std::move(basicMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape3)) == Result::Success);
 
-    REQUIRE(basicShape4->composite(move(basicMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
-    REQUIRE(canvas->push(move(basicShape4)) == Result::Success);
+    REQUIRE(basicShape4->composite(std::move(basicMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape4)) == Result::Success);
 
-    REQUIRE(canvas->push(move(basicShape5)) == Result::Success);
+    REQUIRE(canvas->push(std::move(basicShape5)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -536,11 +536,11 @@ TEST_CASE("Filling Draw", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
-    REQUIRE(canvas->push(move(shape3)) == Result::Success);
-    REQUIRE(canvas->push(move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -586,11 +586,11 @@ TEST_CASE("Filling Opaque Draw", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
-    REQUIRE(canvas->push(move(shape3)) == Result::Success);
-    REQUIRE(canvas->push(move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -641,16 +641,16 @@ TEST_CASE("Filling AlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(move(shape3)) == Result::Success);
-    REQUIRE(scene->push(move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(move(mask), tvg::CompositeMethod::AlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
+    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::AlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -701,16 +701,16 @@ TEST_CASE("Filling InvAlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(move(shape3)) == Result::Success);
-    REQUIRE(scene->push(move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(move(mask), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
+    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -761,16 +761,16 @@ TEST_CASE("Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(move(shape3)) == Result::Success);
-    REQUIRE(scene->push(move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(move(mask), tvg::CompositeMethod::LumaMask) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
+    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::LumaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -821,16 +821,16 @@ TEST_CASE("Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(move(shape3)) == Result::Success);
-    REQUIRE(scene->push(move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(move(mask), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
+    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -876,11 +876,11 @@ TEST_CASE("RLE Filling Draw", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
-    REQUIRE(canvas->push(move(shape3)) == Result::Success);
-    REQUIRE(canvas->push(move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -926,11 +926,11 @@ TEST_CASE("RLE Filling Opaque Draw", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
-    REQUIRE(canvas->push(move(shape3)) == Result::Success);
-    REQUIRE(canvas->push(move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
+    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -981,16 +981,16 @@ TEST_CASE("RLE Filling AlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(move(shape3)) == Result::Success);
-    REQUIRE(scene->push(move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(move(mask), tvg::CompositeMethod::AlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
+    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::AlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1041,16 +1041,16 @@ TEST_CASE("RLE Filling InvAlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(move(shape3)) == Result::Success);
-    REQUIRE(scene->push(move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(move(mask), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
+    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1101,16 +1101,16 @@ TEST_CASE("RLE Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(move(shape3)) == Result::Success);
-    REQUIRE(scene->push(move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(move(mask), tvg::CompositeMethod::LumaMask) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
+    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::LumaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1161,16 +1161,16 @@ TEST_CASE("RLE Filling InvLumaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(move(shape3)) == Result::Success);
-    REQUIRE(scene->push(move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(move(mask), tvg::CompositeMethod::InvLumaMask) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
+    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::InvLumaMask) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1221,16 +1221,16 @@ TEST_CASE("RLE Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(move(shape3)) == Result::Success);
-    REQUIRE(scene->push(move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(move(mask), tvg::CompositeMethod::ClipPath) == Result::Success);
-    REQUIRE(canvas->push(move(scene)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
+    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
+    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);


### PR DESCRIPTION
[clang] Warn on unqualified calls to std::move and std::forward See: https://reviews.llvm.org/D119670
```
[141/166] Compiling C++ object test/tvgUnitTests.p/testAccessor.cpp.o ../thorvg-git/test/testAccessor.cpp:58:29: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
    picture = accessor->set(move(picture), nullptr);
                            ^
                            std::
...
```
fgrep -rlZ '(move(' test/ |  xargs -0 sed -i 's/(move(/(std::move(/g' :)

@jsuya perhaps remove the optional alpha values (except two for test) here as well.
