### PR TITLE
api: enhance API usability

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -866,7 +866,7 @@ public:
      *
      * @note For @p rx and @p ry greater than or equal to the half of @p w and the half of @p h, respectively, the shape become an ellipse.
      */
-    Result appendRect(float x, float y, float w, float h, float rx, float ry) noexcept;
+    Result appendRect(float x, float y, float w, float h, float rx = 0, float ry = 0) noexcept;
 
     /**
      * @brief Appends an ellipse to the path.

--- a/src/examples/AnimateMasking.cpp
+++ b/src/examples/AnimateMasking.cpp
@@ -36,7 +36,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     // background
     auto bg = tvg::Shape::gen();
-    bg->appendRect(0,0,WIDTH, HEIGHT,0, 0);
+    bg->appendRect(0, 0, WIDTH, HEIGHT);
     bg->fill(255, 255, 255);
     canvas->push(std::move(bg));
 

--- a/src/examples/Async.cpp
+++ b/src/examples/Async.cpp
@@ -53,7 +53,7 @@ bool tvgUpdateCmds(tvg::Canvas* canvas)
         float w = 1 + rand() % (int)(WIDTH * 1.3 / 2);
         float h = 1 + rand() %  (int)(HEIGHT * 1.3 / 2);
 
-        shape->appendRect(x, y, w, h, 0, 0);
+        shape->appendRect(x, y, w, h);
 
         //LinearGradient
         auto fill = tvg::LinearGradient::gen();

--- a/src/examples/ClipPath.cpp
+++ b/src/examples/ClipPath.cpp
@@ -46,7 +46,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     if (!canvas) return;
     //Background
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);
+    shape->appendRect(0, 0, WIDTH, HEIGHT);
     shape->fill(255, 255, 255);
     if (canvas->push(std::move(shape)) != tvg::Result::Success) return;
 
@@ -111,7 +111,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     // color/alpha/opacity are ignored for a clip object - no need to set them
     auto clipRect = tvg::Shape::gen();
-    clipRect->appendRect(500, 120, 200, 200, 0, 0);          //x, y, w, h, rx, ry
+    clipRect->appendRect(500, 120, 200, 200);          //x, y, w, h
     clipRect->translate(20, 20);
 
     //Clipping scene to rect(shape)
@@ -144,7 +144,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     // color/alpha/opacity are ignored for a clip object - no need to set them
     auto clipShape = tvg::Shape::gen();
-    clipShape->appendRect(600, 420, 100, 100, 0, 0);
+    clipShape->appendRect(600, 420, 100, 100);
 
     //Clipping shape1 to clipShape
     shape1->composite(std::move(clipShape), tvg::CompositeMethod::ClipPath);

--- a/src/examples/DirectUpdate.cpp
+++ b/src/examples/DirectUpdate.cpp
@@ -33,7 +33,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Shape (for BG)
     auto bg = tvg::Shape::gen();
-    bg->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);
+    bg->appendRect(0, 0, WIDTH, HEIGHT);
 
     //fill property will be retained
     bg->fill(255, 255, 255);
@@ -47,7 +47,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
        instead, you should consider not to interrupt this pointer life-cycle. */
     pShape = shape.get();
 
-    shape->appendRect(-100, -100, 200, 200, 0, 0);
+    shape->appendRect(-100, -100, 200, 200);
 
     //fill property will be retained
     shape->fill(127, 255, 255);

--- a/src/examples/Duplicate.cpp
+++ b/src/examples/Duplicate.cpp
@@ -35,8 +35,8 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     {
         //Original Shape
         auto shape1 = tvg::Shape::gen();
-        shape1->appendRect(10, 10, 200, 200, 0, 0);
-        shape1->appendRect(220, 10, 100, 100, 0, 0);
+        shape1->appendRect(10, 10, 200, 200);
+        shape1->appendRect(220, 10, 100, 100);
 
         shape1->stroke(3);
         shape1->stroke(0, 255, 0);

--- a/src/examples/GradientMasking.cpp
+++ b/src/examples/GradientMasking.cpp
@@ -33,7 +33,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Solid Rectangle
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, 400, 400, 0, 0);
+    shape->appendRect(0, 0, 400, 400);
 
     //Mask
     auto mask = tvg::Shape::gen();
@@ -87,7 +87,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Solid Rectangle
     auto shape2 = tvg::Shape::gen();
-    shape2->appendRect(0, 400, 400, 400, 0, 0);
+    shape2->appendRect(0, 400, 400, 400);
 
     //Mask
     auto mask2 = tvg::Shape::gen();

--- a/src/examples/GradientTransform.cpp
+++ b/src/examples/GradientTransform.cpp
@@ -34,7 +34,7 @@ void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
 
     //Shape1
     auto shape = tvg::Shape::gen();
-    shape->appendRect(-285, -300, 200, 200, 0, 0);
+    shape->appendRect(-285, -300, 200, 200);
     shape->appendRect(-185, -200, 300, 300, 100, 100);
     shape->appendCircle(115, 100, 100, 100);
     shape->appendCircle(115, 200, 170, 100);
@@ -61,7 +61,7 @@ void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
 
     //Shape2
     auto shape2 = tvg::Shape::gen();
-    shape2->appendRect(-50, -50, 100, 100, 0, 0);
+    shape2->appendRect(-50, -50, 100, 100);
     shape2->translate(400, 400);
 
     //LinearGradient

--- a/src/examples/InvLumaMasking.cpp
+++ b/src/examples/InvLumaMasking.cpp
@@ -33,7 +33,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Solid Rectangle
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, 400, 400, 0, 0);
+    shape->appendRect(0, 0, 400, 400);
     shape->fill(255, 0, 0);
 
     //Mask
@@ -103,7 +103,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Mask4
     auto mask4 = tvg::Scene::gen();
     auto mask4_rect = tvg::Shape::gen();
-    mask4_rect->appendRect(500, 400, 200, 300, 0, 0);
+    mask4_rect->appendRect(500, 400, 200, 300);
     mask4_rect->fill(255, 255, 255);
     auto mask4_circle = tvg::Shape::gen();
     mask4_circle->appendCircle(600, 550, 125, 125);

--- a/src/examples/InvMasking.cpp
+++ b/src/examples/InvMasking.cpp
@@ -33,7 +33,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Solid Rectangle
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, 400, 400, 0, 0);
+    shape->appendRect(0, 0, 400, 400);
     shape->fill(0, 0, 255);
 
     //Mask

--- a/src/examples/LinearGradient.cpp
+++ b/src/examples/LinearGradient.cpp
@@ -32,7 +32,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Prepare Round Rectangle
     auto shape1 = tvg::Shape::gen();
-    shape1->appendRect(0, 0, 400, 400, 0, 0);    //x, y, w, h, rx, ry
+    shape1->appendRect(0, 0, 400, 400);    //x, y, w, h
 
     //LinearGradient
     auto fill = tvg::LinearGradient::gen();

--- a/src/examples/LumaMasking.cpp
+++ b/src/examples/LumaMasking.cpp
@@ -33,7 +33,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Solid Rectangle
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, 400, 400, 0, 0);
+    shape->appendRect(0, 0, 400, 400);
     shape->fill(255, 0, 0);
 
     //Mask
@@ -103,7 +103,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Mask4
     auto mask4 = tvg::Scene::gen();
     auto mask4_rect = tvg::Shape::gen();
-    mask4_rect->appendRect(500, 400, 200, 300, 0, 0);
+    mask4_rect->appendRect(500, 400, 200, 300);
     mask4_rect->fill(255, 255, 255);
     auto mask4_circle = tvg::Shape::gen();
     mask4_circle->appendCircle(600, 550, 125, 125);

--- a/src/examples/Masking.cpp
+++ b/src/examples/Masking.cpp
@@ -33,7 +33,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Solid Rectangle
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, 400, 400, 0, 0);
+    shape->appendRect(0, 0, 400, 400);
     shape->fill(0, 0, 255);
 
     //Mask

--- a/src/examples/MaskingMethods.cpp
+++ b/src/examples/MaskingMethods.cpp
@@ -145,11 +145,11 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     {
         //Rect + Rect Mask Add
         auto shape = tvg::Shape::gen();
-        shape->appendRect(75, 500, 100, 100, 0, 0);
+        shape->appendRect(75, 500, 100, 100);
         shape->fill(255, 255, 255);
 
         auto mask = tvg::Shape::gen();
-        mask->appendRect(125, 450, 100, 100, 0, 0);
+        mask->appendRect(125, 450, 100, 100);
         mask->fill(255, 255, 255);
         shape->composite(std::move(mask), tvg::CompositeMethod::AddMask);
 
@@ -157,11 +157,11 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
         //Rect + Rect Mask Subtract
         auto shape2 = tvg::Shape::gen();
-        shape2->appendRect(325, 500, 100, 100, 0, 0);
+        shape2->appendRect(325, 500, 100, 100);
         shape2->fill(255, 255, 255);
 
         auto mask2 = tvg::Shape::gen();
-        mask2->appendRect(375, 450, 100, 100, 0, 0);
+        mask2->appendRect(375, 450, 100, 100);
         mask2->fill(255, 255, 255);
         shape2->composite(std::move(mask2), tvg::CompositeMethod::SubtractMask);
 
@@ -169,11 +169,11 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
         //Rect + Rect Mask Intersect
         auto shape3 = tvg::Shape::gen();
-        shape3->appendRect(575, 500, 100, 100, 0, 0);
+        shape3->appendRect(575, 500, 100, 100);
         shape3->fill(255, 255, 255);
 
         auto mask3 = tvg::Shape::gen();
-        mask3->appendRect(625, 450, 100, 100, 0, 0);
+        mask3->appendRect(625, 450, 100, 100);
         mask3->fill(255, 255, 255);
         shape3->composite(std::move(mask3), tvg::CompositeMethod::IntersectMask);
 
@@ -181,11 +181,11 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
         //Rect + Rect Mask Difference
         auto shape4 = tvg::Shape::gen();
-        shape4->appendRect(825, 500, 100, 100, 0, 0);
+        shape4->appendRect(825, 500, 100, 100);
         shape4->fill(255, 255, 255);
 
         auto mask4 = tvg::Shape::gen();
-        mask4->appendRect(875, 450, 100, 100, 0, 0);
+        mask4->appendRect(875, 450, 100, 100);
         mask4->fill(255, 255, 255);
         shape4->composite(std::move(mask4), tvg::CompositeMethod::DifferenceMask);
 

--- a/src/examples/PicturePng.cpp
+++ b/src/examples/PicturePng.cpp
@@ -33,8 +33,8 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Background
     auto bg = tvg::Shape::gen();
-    bg->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
-    bg->fill(255, 255, 255);                      //r, g, b
+    bg->appendRect(0, 0, WIDTH, HEIGHT);    //x, y, w, h
+    bg->fill(255, 255, 255);                //r, g, b
     canvas->push(std::move(bg));
 
     //Load png file from path

--- a/src/examples/PictureRaw.cpp
+++ b/src/examples/PictureRaw.cpp
@@ -33,7 +33,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Background
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);
+    shape->appendRect(0, 0, WIDTH, HEIGHT);
     shape->fill(255, 255, 255);
 
     if (canvas->push(std::move(shape)) != tvg::Result::Success) return;
@@ -60,7 +60,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     picture2->opacity(128);
 
     auto circle = tvg::Shape::gen();
-    circle->appendCircle(350, 350, 200,200);
+    circle->appendCircle(350, 350, 200, 200);
 
     picture2->composite(std::move(circle), tvg::CompositeMethod::ClipPath);
 

--- a/src/examples/PictureWebp.cpp
+++ b/src/examples/PictureWebp.cpp
@@ -33,8 +33,8 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Background
     auto bg = tvg::Shape::gen();
-    bg->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
-    bg->fill(255, 255, 255);                      //r, g, b
+    bg->appendRect(0, 0, WIDTH, HEIGHT);    //x, y, w, h
+    bg->fill(255, 255, 255);                //r, g, b
     canvas->push(move(bg));
 
     //Load webp file from path

--- a/src/examples/RadialGradient.cpp
+++ b/src/examples/RadialGradient.cpp
@@ -32,7 +32,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Prepare Round Rectangle
     auto shape1 = tvg::Shape::gen();
-    shape1->appendRect(0, 0, 400, 400, 0, 0);    //x, y, w, h, rx, ry
+    shape1->appendRect(0, 0, 400, 400);    //x, y, w, h
 
     //RadialGradient
     auto fill = tvg::RadialGradient::gen();

--- a/src/examples/Shape.cpp
+++ b/src/examples/Shape.cpp
@@ -32,7 +32,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Prepare a Shape (Rectangle + Rectangle + Circle + Circle)
     auto shape1 = tvg::Shape::gen();
-    shape1->appendRect(0, 0, 200, 200, 0, 0);          //x, y, w, h, rx, ry
+    shape1->appendRect(0, 0, 200, 200);                //x, y, w, h
     shape1->appendRect(100, 100, 300, 300, 100, 100);  //x, y, w, h, rx, ry
     shape1->appendCircle(400, 400, 100, 100);          //cx, cy, radiusW, radiusH
     shape1->appendCircle(400, 500, 170, 100);          //cx, cy, radiusW, radiusH

--- a/src/examples/Stress.cpp
+++ b/src/examples/Stress.cpp
@@ -90,7 +90,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Background
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
+    shape->appendRect(0, 0, WIDTH, HEIGHT);          //x, y, w, h
     shape->fill(255, 255, 255);                      //r, g, b
 
     if (canvas->push(std::move(shape)) != tvg::Result::Success) return;

--- a/src/examples/Stroke.cpp
+++ b/src/examples/Stroke.cpp
@@ -32,7 +32,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Shape 1
     auto shape1 = tvg::Shape::gen();
-    shape1->appendRect(50, 50, 200, 200, 0, 0);
+    shape1->appendRect(50, 50, 200, 200);
     shape1->fill(50, 50, 50);
     shape1->stroke(255, 255, 255);            //color: r, g, b
     shape1->stroke(tvg::StrokeJoin::Bevel);   //default is Bevel
@@ -42,7 +42,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Shape 2
     auto shape2 = tvg::Shape::gen();
-    shape2->appendRect(300, 50, 200, 200, 0, 0);
+    shape2->appendRect(300, 50, 200, 200);
     shape2->fill(50, 50, 50);
     shape2->stroke(255, 255, 255);
     shape2->stroke(tvg::StrokeJoin::Round);
@@ -52,7 +52,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Shape 3
     auto shape3 = tvg::Shape::gen();
-    shape3->appendRect(550, 50, 200, 200, 0, 0);
+    shape3->appendRect(550, 50, 200, 200);
     shape3->fill(50, 50, 50);
     shape3->stroke(255, 255, 255);
     shape3->stroke(tvg::StrokeJoin::Miter);

--- a/src/examples/StrokeLine.cpp
+++ b/src/examples/StrokeLine.cpp
@@ -142,7 +142,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto shape10 = tvg::Shape::gen();
     shape10->appendArc(70, 600, 160, 10, 30, true);
     shape10->appendCircle(70, 700, 20, 60);
-    shape10->appendRect(130, 710, 100, 40, 0, 0);
+    shape10->appendRect(130, 710, 100, 40);
     shape10->stroke(255, 0, 0);
     shape10->stroke(5);
     shape10->stroke(tvg::StrokeJoin::Round);
@@ -153,7 +153,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto shape11 = tvg::Shape::gen();
     shape11->appendArc(320, 600, 160, 10, 30, false);
     shape11->appendCircle(320, 700, 20, 60);
-    shape11->appendRect(380, 710, 100, 40, 0, 0);
+    shape11->appendRect(380, 710, 100, 40);
     shape11->stroke(255, 255, 0);
     shape11->stroke(5);
     shape11->stroke(tvg::StrokeJoin::Bevel);
@@ -164,7 +164,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto shape12 = tvg::Shape::gen();
     shape12->appendArc(570, 600, 160, 10, 30, true);
     shape12->appendCircle(570, 700, 20, 60);
-    shape12->appendRect(630, 710, 100, 40, 0, 0);
+    shape12->appendRect(630, 710, 100, 40);
     shape12->stroke(0, 255, 0);
     shape12->stroke(5);
     shape12->stroke(tvg::StrokeJoin::Miter);

--- a/src/examples/Svg.cpp
+++ b/src/examples/Svg.cpp
@@ -78,7 +78,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Background
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
+    shape->appendRect(0, 0, WIDTH, HEIGHT);          //x, y, w, h
     shape->fill(255, 255, 255);                      //r, g, b
 
     if (canvas->push(std::move(shape)) != tvg::Result::Success) return;

--- a/src/examples/Svg2.cpp
+++ b/src/examples/Svg2.cpp
@@ -35,7 +35,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Background
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
+    shape->appendRect(0, 0, WIDTH, HEIGHT);          //x, y, w, h
     shape->fill(255, 255, 255);                      //r, g, b
 
     if (canvas->push(std::move(shape)) != tvg::Result::Success) return;

--- a/src/examples/Texmap.cpp
+++ b/src/examples/Texmap.cpp
@@ -33,7 +33,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Background
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);
+    shape->appendRect(0, 0, WIDTH, HEIGHT);
     shape->fill(255, 255, 255);
 
     if (canvas->push(std::move(shape)) != tvg::Result::Success) return;

--- a/src/examples/Transform.cpp
+++ b/src/examples/Transform.cpp
@@ -34,7 +34,7 @@ void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
 
     //Shape1
     auto shape = tvg::Shape::gen();
-    shape->appendRect(-285, -300, 200, 200, 0, 0);
+    shape->appendRect(-285, -300, 200, 200);
     shape->appendRect(-185, -200, 300, 300, 100, 100);
     shape->appendCircle(115, 100, 100, 100);
     shape->appendCircle(115, 200, 170, 100);
@@ -47,7 +47,7 @@ void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
 
     //Shape2
     auto shape2 = tvg::Shape::gen();
-    shape2->appendRect(-50, -50, 100, 100, 0, 0);
+    shape2->appendRect(-50, -50, 100, 100);
     shape2->fill(0, 255, 255);
     shape2->translate(400, 400);
     shape2->rotate(360 * progress);

--- a/src/examples/Tvg.cpp
+++ b/src/examples/Tvg.cpp
@@ -64,7 +64,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Background
     auto shape = tvg::Shape::gen();
-    shape->appendRect(0, 0, WIDTH, HEIGHT, 0, 0);    //x, y, w, h, rx, ry
+    shape->appendRect(0, 0, WIDTH, HEIGHT);          //x, y, w, h
     shape->fill(255, 255, 255);                      //r, g, b
 
     if (canvas->push(std::move(shape)) != tvg::Result::Success) return;

--- a/src/examples/Update.cpp
+++ b/src/examples/Update.cpp
@@ -32,7 +32,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Shape
     auto shape = tvg::Shape::gen();
-    shape->appendRect(-100, -100, 200, 200, 0, 0);
+    shape->appendRect(-100, -100, 200, 200);
     shape->fill(255, 255, 255);
     canvas->push(std::move(shape));
 }

--- a/test/testSwCanvasBase.cpp
+++ b/test/testSwCanvasBase.cpp
@@ -191,7 +191,7 @@ TEST_CASE("Synchronized Drawing", "[tvgSwCanvasBase]")
 
     auto shape2 = Shape::gen();
     REQUIRE(shape2);
-    REQUIRE(shape2->appendRect(0, 0, 100, 100, 0, 0) == Result::Success);
+    REQUIRE(shape2->appendRect(0, 0, 100, 100) == Result::Success);
     REQUIRE(shape2->fill(255, 255, 255, 255) == Result::Success);
 
     REQUIRE(canvas->push(std::move(shape2)) == Result::Success);
@@ -215,7 +215,7 @@ TEST_CASE("Asynchronized Drawing", "[tvgSwCanvasBase]")
     for (int i = 0; i < 3; ++i) {
         auto shape = Shape::gen();
         REQUIRE(shape);
-        REQUIRE(shape->appendRect(0, 0, 100, 100, 0, 0) == Result::Success);
+        REQUIRE(shape->appendRect(0, 0, 100, 100) == Result::Success);
         REQUIRE(shape->fill(255, 255, 255, 255) == Result::Success);
 
         REQUIRE(canvas->push(std::move(shape)) == Result::Success);

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -117,7 +117,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(basicPicture->load(data, 200, 300, false) == Result::Success);
     auto rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
-    REQUIRE(rectMask->appendRect(10, 10, 30, 30, 0, 0) == Result::Success);
+    REQUIRE(rectMask->appendRect(10, 10, 30, 30) == Result::Success);
     REQUIRE(rectMask->fill(100, 100, 100, 255) == Result::Success);
     auto rleMask = tvg::Shape::gen();
     REQUIRE(rleMask);
@@ -185,7 +185,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(basicPicture->rotate(45) == Result::Success);
     rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
-    REQUIRE(rectMask->appendRect(10, 10, 30, 30, 0, 0) == Result::Success);
+    REQUIRE(rectMask->appendRect(10, 10, 30, 30) == Result::Success);
     rleMask = tvg::Shape::gen();
     REQUIRE(rleMask);
     REQUIRE(rleMask->appendRect(0, 10, 20, 30, 5, 5) == Result::Success);
@@ -250,7 +250,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(basicPicture->scale(2) == Result::Success);
     rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
-    REQUIRE(rectMask->appendRect(10, 10, 30, 30, 0, 0) == Result::Success);
+    REQUIRE(rectMask->appendRect(10, 10, 30, 30) == Result::Success);
     rleMask = tvg::Shape::gen();
     REQUIRE(rleMask);
     REQUIRE(rleMask->appendRect(0, 10, 20, 30, 5, 5) == Result::Success);
@@ -315,7 +315,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(basicPicture->scale(0.2f) == Result::Success);
     rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
-    REQUIRE(rectMask->appendRect(10, 10, 30, 30, 0, 0) == Result::Success);
+    REQUIRE(rectMask->appendRect(10, 10, 30, 30) == Result::Success);
     rleMask = tvg::Shape::gen();
     REQUIRE(rleMask);
     REQUIRE(rleMask->appendRect(0, 10, 20, 30, 5, 5) == Result::Success);
@@ -397,8 +397,8 @@ TEST_CASE("Rect Draw", "[tvgSwEngine]")
     REQUIRE(basicShape);
     auto basicMask = tvg::Shape::gen();
     REQUIRE(basicMask);
-    REQUIRE(basicShape->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
-    REQUIRE(basicMask->appendRect(10, 10, 30, 30, 0, 0) == Result::Success);
+    REQUIRE(basicShape->appendRect(0, 0, 50, 50) == Result::Success);
+    REQUIRE(basicMask->appendRect(10, 10, 30, 30) == Result::Success);
     REQUIRE(basicShape->fill(255, 255, 255, 155) == Result::Success);
 
     auto basicShape2 = tvg::cast<Shape>(basicShape->duplicate());
@@ -457,7 +457,7 @@ TEST_CASE("RLE Draw", "[tvgSwEngine]")
     auto basicMask = tvg::Shape::gen();
     REQUIRE(basicMask);
     REQUIRE(basicShape->appendRect(0, 0, 50, 50, 50, 50) == Result::Success);
-    REQUIRE(basicMask->appendRect(10, 10, 30, 30, 0, 0) == Result::Success);
+    REQUIRE(basicMask->appendRect(10, 10, 30, 30) == Result::Success);
     REQUIRE(basicShape->fill(255, 255, 255, 100) == Result::Success);
 
     auto basicShape2 = tvg::cast<Shape>(basicShape->duplicate());
@@ -533,8 +533,8 @@ TEST_CASE("Filling Draw", "[tvgSwEngine]")
     REQUIRE(shape3);
     auto shape4 = tvg::Shape::gen();
     REQUIRE(shape4);
-    REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
-    REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
+    REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
+    REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
     REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
     REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
@@ -583,8 +583,8 @@ TEST_CASE("Filling Opaque Draw", "[tvgSwEngine]")
     REQUIRE(shape3);
     auto shape4 = tvg::Shape::gen();
     REQUIRE(shape4);
-    REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
-    REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
+    REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
+    REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
     REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
     REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
@@ -638,8 +638,8 @@ TEST_CASE("Filling AlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3);
     auto shape4 = tvg::Shape::gen();
     REQUIRE(shape4);
-    REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
-    REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
+    REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
+    REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
     REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
     REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
@@ -698,8 +698,8 @@ TEST_CASE("Filling InvAlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3);
     auto shape4 = tvg::Shape::gen();
     REQUIRE(shape4);
-    REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
-    REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
+    REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
+    REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
     REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
     REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
@@ -758,8 +758,8 @@ TEST_CASE("Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(shape3);
     auto shape4 = tvg::Shape::gen();
     REQUIRE(shape4);
-    REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
-    REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
+    REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
+    REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
     REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
     REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
@@ -818,8 +818,8 @@ TEST_CASE("Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(shape3);
     auto shape4 = tvg::Shape::gen();
     REQUIRE(shape4);
-    REQUIRE(shape3->appendRect(0, 0, 50, 50, 0, 0) == Result::Success);
-    REQUIRE(shape4->appendRect(50, 0, 50, 50, 0, 0) == Result::Success);
+    REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
+    REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
     REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
     REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);


### PR DESCRIPTION
Set the default values of rx = 0 and ry = 0 for the shape. 
Only the round rectangle shape requires the usage of these values.