### PR TITLE
common: optimize paint data size.

### DIFF
--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -637,7 +637,7 @@ TVG_API Tvg_Result tvg_gradient_get_transform(const Tvg_Gradient* grad, Tvg_Matr
 TVG_API Tvg_Result tvg_gradient_get_identifier(const Tvg_Gradient* grad, Tvg_Identifier* identifier)
 {
     if (!grad || !identifier) return TVG_RESULT_INVALID_ARGUMENT;
-    *identifier = static_cast<Tvg_Identifier>(reinterpret_cast<const Paint*>(grad)->identifier());
+    *identifier = static_cast<Tvg_Identifier>(reinterpret_cast<const Fill*>(grad)->identifier());
     return TVG_RESULT_SUCCESS;
 }
 

--- a/src/lib/tvgFill.h
+++ b/src/lib/tvgFill.h
@@ -55,7 +55,7 @@ struct Fill::Impl
     uint32_t cnt = 0;
     FillSpread spread;
     DuplicateMethod<Fill>* dup = nullptr;
-    uint32_t id;
+    uint8_t id;
 
     ~Impl()
     {

--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -184,7 +184,7 @@ bool Paint::Impl::render(RenderMethod& renderer)
 }
 
 
-RenderData Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, uint32_t pFlag, bool clipper)
+RenderData Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag pFlag, bool clipper)
 {
     if (renderFlag & RenderUpdateFlag::Transform) {
         if (!rTransform) return nullptr;

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -28,7 +28,7 @@
 
 namespace tvg
 {
-    enum ContextFlag {Invalid = 0, FastTrack = 1};
+    enum ContextFlag : uint8_t {Invalid = 0, FastTrack = 1};
 
     struct Iterator
     {
@@ -63,9 +63,9 @@ namespace tvg
         StrategyMethod* smethod = nullptr;
         RenderTransform* rTransform = nullptr;
         Composite* compData = nullptr;
-        uint32_t renderFlag = RenderUpdateFlag::None;
-        uint32_t ctxFlag = ContextFlag::Invalid;
-        uint32_t id;
+        uint8_t renderFlag = RenderUpdateFlag::None;
+        uint8_t ctxFlag = ContextFlag::Invalid;
+        uint8_t id;
         uint8_t opacity = 255;
 
         ~Impl()
@@ -147,7 +147,7 @@ namespace tvg
         bool scale(float factor);
         bool translate(float x, float y);
         bool bounds(float* x, float* y, float* w, float* h, bool transformed);
-        RenderData update(RenderMethod& renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, uint32_t pFlag, bool clipper = false);
+        RenderData update(RenderMethod& renderer, const RenderTransform* pTransform, uint32_t opacity, Array<RenderData>& clips, RenderUpdateFlag pFlag, bool clipper = false);
         bool render(RenderMethod& renderer);
         Paint* duplicate();
     };

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -91,7 +91,7 @@ struct Picture::Impl
         return ret;
     }
 
-    uint32_t load()
+    RenderUpdateFlag load()
     {
         if (loader) {
             if (!paint) {

--- a/src/lib/tvgRender.h
+++ b/src/lib/tvgRender.h
@@ -32,7 +32,7 @@ namespace tvg
 using RenderData = void*;
 using pixel_t = uint32_t;
 
-enum RenderUpdateFlag {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, All = 255};
+enum RenderUpdateFlag : uint8_t {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, All = 255};
 
 struct Surface;
 

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -34,8 +34,8 @@ struct Shape::Impl
 {
     RenderShape rs;                     //shape data
     RenderData rd = nullptr;            //engine data
-    uint32_t flag = RenderUpdateFlag::None;
     Shape* shape;
+    uint8_t flag = RenderUpdateFlag::None;
     uint8_t opacity;                    //for composition
     bool needComp;                      //composite or not
 


### PR DESCRIPTION
packing the data fields with the appropriate size.

96 -> 24 (-9 bytes per one paint)