### PR TITLE
sw_engine: optimize code.

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -591,7 +591,7 @@ bool rasterImage(SwSurface* surface, SwImage* image, const RenderMesh* mesh, con
 bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id);
 bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
-void rasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len);
+void rasterPixel32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len);
 void rasterGrayscale8(uint8_t *dst, uint8_t val, uint32_t offset, int32_t len);
 void rasterUnpremultiply(Surface* surface);
 void rasterPremultiply(Surface* surface);

--- a/src/lib/sw_engine/tvgSwRasterAvx.h
+++ b/src/lib/sw_engine/tvgSwRasterAvx.h
@@ -62,7 +62,7 @@ static inline __m128i ALPHA_BLEND(__m128i c, __m128i a)
 }
 
 
-static void avxRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
+static void avxRasterPixel32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 {
     //1. calculate how many iterations we need to cover the length
     uint32_t iterations = len / N_32BITS_IN_256REG;

--- a/src/lib/sw_engine/tvgSwRasterNeon.h
+++ b/src/lib/sw_engine/tvgSwRasterNeon.h
@@ -31,7 +31,7 @@ static inline uint8x8_t ALPHA_BLEND(uint8x8_t c, uint8x8_t a)
 }
 
 
-static void neonRasterRGBA32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
+static void neonRasterPixel32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 {
     uint32_t iterations = len / 4;
     uint32_t neonFilled = iterations * 4;

--- a/src/lib/sw_engine/tvgSwRasterTexmap.h
+++ b/src/lib/sw_engine/tvgSwRasterTexmap.h
@@ -91,12 +91,12 @@ static void _rasterMaskedPolygonImageSegmentInt(SwSurface* surface, const SwImag
     auto size = surface->compositor->bbox.max.x - surface->compositor->bbox.min.x;
     if (dirFlag == 1) {     //left top case.
         for(int y = surface->compositor->bbox.min.y; y < yStart; ++y) {
-            rasterRGBA32(surface->compositor->image.buf32 + y * surface->compositor->image.stride, 0, surface->compositor->bbox.min.x, size);
+            rasterPixel32(surface->compositor->image.buf32 + y * surface->compositor->image.stride, 0, surface->compositor->bbox.min.x, size);
         }
     }
     if (dirFlag == 4) {     //right bottom case.
         for(int y = yEnd; y < surface->compositor->bbox.max.y; ++y) {
-            rasterRGBA32(surface->compositor->image.buf32 + y * surface->compositor->image.stride, 0, surface->compositor->bbox.min.x, size);
+            rasterPixel32(surface->compositor->image.buf32 + y * surface->compositor->image.stride, 0, surface->compositor->bbox.min.x, size);
         }
     }
 


### PR DESCRIPTION
Considering the fundamental scenario,
the masking feature would likely be used less frequently.

We sacrifice a small amount of performance
by substituting the multiple implementations with blender calls.

However, this trade-off can result in a reduction in binary size.

Bin size: 212089 -> 205907 (-6kb)