### PR TITLE
example stack: updated sample.

### DIFF
--- a/src/examples/Stacking.cpp
+++ b/src/examples/Stacking.cpp
@@ -26,37 +26,30 @@
 /* Drawing Commands                                                     */
 /************************************************************************/
 
-static tvg::Paint* paints[4];
-static int order = 0;
-
 void tvgDrawCmds(tvg::Canvas* canvas)
 {
     if (!canvas) return;
 
     //Prepare Round Rectangle
     auto shape1 = tvg::Shape::gen();
-    paints[0] = shape1.get();
     shape1->appendRect(0, 0, 400, 400, 50, 50);  //x, y, w, h, rx, ry
     shape1->fill(0, 255, 0);                     //r, g, b
     if (canvas->push(std::move(shape1)) != tvg::Result::Success) return;
 
     //Prepare Round Rectangle2
     auto shape2 = tvg::Shape::gen();
-    paints[1] = shape2.get();
     shape2->appendRect(100, 100, 400, 400, 50, 50);  //x, y, w, h, rx, ry
     shape2->fill(255, 255, 0);                       //r, g, b
     if (canvas->push(std::move(shape2)) != tvg::Result::Success) return;
 
     //Prepare Round Rectangle3
     auto shape3 = tvg::Shape::gen();
-    paints[2] = shape3.get();
     shape3->appendRect(200, 200, 400, 400, 50, 50);  //x, y, w, h, rx, ry
     shape3->fill(0, 255, 255);                       //r, g, b
     if (canvas->push(std::move(shape3)) != tvg::Result::Success) return;
 
     //Prepare Scene
     auto scene = tvg::Scene::gen();
-    paints[3] = scene.get();
 
     auto shape4 = tvg::Shape::gen();
     shape4->appendCircle(400, 400, 100, 100);
@@ -80,39 +73,11 @@ void tvgUpdateCmds(tvg::Canvas* canvas)
 {
     if (!canvas) return;
 
-    //Explicitly clear all retained paint nodes from canvas but not free them.
-    if (canvas->clear(false) != tvg::Result::Success) return;
-
-    switch (order) {
-        case 0:
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[0]));
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[1]));
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[2]));
-            canvas->push(unique_ptr<tvg::Scene>((tvg::Scene*)paints[3]));
-            break;
-        case 1:
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[1]));
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[2]));
-            canvas->push(unique_ptr<tvg::Scene>((tvg::Scene*)paints[3]));
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[0]));
-            break;
-        case 2:
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[2]));
-            canvas->push(unique_ptr<tvg::Scene>((tvg::Scene*)paints[3]));
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[0]));
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[1]));
-            break;
-        case 3:
-            canvas->push(unique_ptr<tvg::Scene>((tvg::Scene*)paints[3]));
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[0]));
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[1]));
-            canvas->push(unique_ptr<tvg::Shape>((tvg::Shape*)paints[2]));
-            break;
-    }
-
-    ++order;
-
-    if (order > 3) order = 0;
+    //Circular list
+    auto& list = canvas->paints();
+    auto paint = *list.begin();
+    list.pop_front();
+    list.push_back(paint);
 }
 
 


### PR DESCRIPTION
use paints() method instead of grabbing a manual list.

@Issue: https://github.com/thorvg/thorvg/issues/1501