### PR TITLE
sw_engine: fix clang compiler warnings.

### DIFF
--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -176,7 +176,7 @@ struct SwStroke
     SwPoint ptStartSubPath;
     SwFixed subPathLineLength;
     SwFixed width;
-    float miterlimit;
+    SwFixed miterlimit;
 
     StrokeCap cap;
     StrokeJoin join;

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -256,8 +256,8 @@ static uint32_t _interpUpScaler(const uint32_t *img, TVG_UNUSED uint32_t stride,
 //OPTIMIZE_ME: Skip the function pointer access
 static uint32_t _interpDownScaler(const uint32_t *img, uint32_t stride, uint32_t w, uint32_t h, float sx, float sy, uint32_t n, uint32_t n2)
 {
-    uint32_t rx = sx;
-    uint32_t ry = sy;
+    uint32_t rx = lround(sx);
+    uint32_t ry = lround(sy);
     uint32_t c[4] = {0, 0, 0, 0};
     auto src = img + rx - n + (ry - n) * stride;
 

--- a/src/lib/sw_engine/tvgSwStroke.cpp
+++ b/src/lib/sw_engine/tvgSwStroke.cpp
@@ -838,7 +838,7 @@ void strokeReset(SwStroke* stroke, const RenderShape* rshape, const Matrix* tran
 
     stroke->width = HALF_STROKE(rshape->strokeWidth());
     stroke->cap = rshape->strokeCap();
-    stroke->miterlimit = rshape->strokeMiterlimit() * (1 << 16);
+    stroke->miterlimit = static_cast<SwFixed>(rshape->strokeMiterlimit()) << 16;
 
     //Save line join: it can be temporarily changed when stroking curves...
     stroke->joinSaved = stroke->join = rshape->strokeJoin();


### PR DESCRIPTION
[29/73] Compiling C++ object src/libthorvg.a.p/lib_sw_engine_tvgSwStroke.cpp.obj ../src/lib/sw_engine/tvgSwStroke.cpp(258): warning C4244: 'argument': conversion from 'float' to 'int64_t', possible loss of data [32/73] Compiling C++ object src/libthorvg.a.p/lib_sw_engine_tvgSwRaster.cpp.obj ../src/lib/sw_engine/tvgSwRaster.cpp(259): warning C4244: 'initializing': conversion from 'float' to 'uint32_t', possible loss of data ../src/lib/sw_engine/tvgSwRaster.cpp(260): warning C4244: 'initializing': conversion from 'float' to 'uint32_t', possible loss of data