### PR TITLE
examples webp: --compiler warning.

### DIFF
--- a/src/examples/PictureWebp.cpp
+++ b/src/examples/PictureWebp.cpp
@@ -35,7 +35,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto bg = tvg::Shape::gen();
     bg->appendRect(0, 0, WIDTH, HEIGHT);    //x, y, w, h
     bg->fill(255, 255, 255);                //r, g, b
-    canvas->push(move(bg));
+    canvas->push(std::move(bg));
 
     //Load webp file from path
     auto opacity = 31;
@@ -50,7 +50,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
         picture->rotate(30 * i);
         picture->size(200, 200);
         picture->opacity(opacity + opacity * i);
-        if (canvas->push(move(picture)) != tvg::Result::Success) return;
+        if (canvas->push(std::move(picture)) != tvg::Result::Success) return;
     }
 
     //Open file manually
@@ -74,7 +74,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     free(data);
     picture->translate(400, 0);
     picture->scale(0.8);
-    canvas->push(move(picture));
+    canvas->push(std::move(picture));
 
 }
 


### PR DESCRIPTION
1 warning generated.
[122/183] Compiling C++ object src/examples/PictureWebp.p/PictureWebp.cpp.o ../thorvg-git/src/examples/PictureWebp.cpp:38:18: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
    canvas->push(move(bg));
                 ^
                 std::
../thorvg-git/src/examples/PictureWebp.cpp:53:26: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
        if (canvas->push(move(picture)) != tvg::Result::Success) return;
                         ^
                         std::
../thorvg-git/src/examples/PictureWebp.cpp:77:18: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
    canvas->push(move(picture));
                 ^
                 std::