### PR TITLE
svg_loader: custom strndup moved into utils

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -392,15 +392,8 @@ static char* _idFromUrl(const char* url)
 
     int i = 0;
     while (url[i] > ' ' && url[i] != ')' && url[i] != '\'') ++i;
-
-    //custom strndup() for portability
-    int len = strlen(url);
-    if (i < len) len = i;
-
-    auto ret = (char*) malloc(len + 1);
-    if (!ret) return 0;
-    ret[len] = '\0';
-    return (char*) memcpy(ret, url, len);
+    
+    return svgUtilStrndup(url, i);
 }
 
 

--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -275,3 +275,16 @@ string svgUtilBase64Decode(const char *src)
     }
     return decoded;
 }
+
+
+char* svgUtilStrndup(const char* str, size_t n)
+{
+    int len = strlen(str);
+    if (len < n) n = len;
+
+    auto ret = (char*)malloc(n + 1);
+    if (!ret) return nullptr;
+    ret[n] = '\0';
+
+    return (char*)memcpy(ret, str, n);
+}

--- a/src/loaders/svg/tvgSvgUtil.h
+++ b/src/loaders/svg/tvgSvgUtil.h
@@ -30,4 +30,6 @@ float svgUtilStrtof(const char *nPtr, char **endPtr);
 string svgUtilURLDecode(const char *src);
 string svgUtilBase64Decode(const char *src);
 
+char* svgUtilStrndup(const char* str, size_t n);
+
 #endif //_TVG_SVG_UTIL_H_

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -33,6 +33,7 @@
 #endif
 
 #include "tvgXmlParser.h"
+#include "tvgSvgUtil.h"
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -237,14 +238,6 @@ static SimpleXMLType _getXMLType(const char* itr, const char* itrEnd, size_t &to
     return SimpleXMLType::Open;
 }
 
-
-static char* _strndup(const char* src, unsigned len)
-{
-    auto ret = (char*)malloc(len + 1);
-    if (!ret) return nullptr;
-    ret[len] = '\0';
-    return (char*)memcpy(ret, src, len);
-}
 
 /************************************************************************/
 /* External Class Implementation                                        */
@@ -564,10 +557,10 @@ const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char
     }
 
     if (p == itr) *tag = strdup("all");
-    else *tag = _strndup(itr, p - itr);
+    else *tag = svgUtilStrndup(itr, p - itr);
 
     if (p == itrEnd) *name = nullptr;
-    else *name = _strndup(p + 1, itrEnd - p - 1);
+    else *name = svgUtilStrndup(p + 1, itrEnd - p - 1);
 
     return (nextElement ? nextElement + 1 : nullptr);
 }


### PR DESCRIPTION
The custom _strndup was used only in one file
as an internal function and wasn't accessible
in other parts of the code. Now function
is available as svgUtilStrndup.