### PR TITLE
svg_loader: update style in defs

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3503,6 +3503,7 @@ void SvgLoader::run(unsigned tid)
         if (defs) _updateComposite(loaderData.doc, defs);
 
         _updateStyle(loaderData.doc, nullptr);
+        if (defs) _updateStyle(defs, nullptr);
 
         if (loaderData.gradients.count > 0) _updateGradient(&loaderData, loaderData.doc, &loaderData.gradients);
         if (defs) _updateGradient(&loaderData, loaderData.doc, &defs->node.defs.gradients);


### PR DESCRIPTION
In the defs node the style was not updated, hence
the inheritance wasn't applied causing wrong results.

sample:
```
  <svg id="svg1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
    <defs>
      <mask id="myMaskUS" fill="red" maskContentUnits="userSpaceOnUse" >
        <circle cx="50" cy="50" r="30" />
        <circle cx="90" cy="30" r="10" />
      </mask>
    </defs>

    <rect x="0" y="-4" width="110" height="50"  fill="red" 
        mask="url(#myMaskUS)"/>
  </svg>
```

before:
<img width="111" alt="Zrzut ekranu 2023-07-28 o 02 10 08" src="https://github.com/thorvg/thorvg/assets/67589014/3e94d6ce-b978-49da-b304-e97c458dbc96">

after:
<img width="111" alt="Zrzut ekranu 2023-07-28 o 02 10 01" src="https://github.com/thorvg/thorvg/assets/67589014/46761bfd-318f-4e77-9f37-bed149efd8e5">
