### PR TITLE
loader tvg: add missing strokeFirst property.

### DIFF
--- a/src/lib/tvgBinaryDesc.h
+++ b/src/lib/tvgBinaryDesc.h
@@ -81,6 +81,7 @@ using TvgBinFlag = TvgBinByte;
 #define TVG_TAG_SHAPE_STROKE_FILL                   (TvgBinTag)0x54
 #define TVG_TAG_SHAPE_STROKE_DASHPTRN               (TvgBinTag)0x55
 #define TVG_TAG_SHAPE_STROKE_MITERLIMIT             (TvgBinTag)0x56
+#define TVG_TAG_SHAPE_STROKE_ORDER                  (TvgBinTag)0x57
 
 
 //Fill

--- a/src/lib/tvgMath.h
+++ b/src/lib/tvgMath.h
@@ -45,6 +45,15 @@ static inline bool mathEqual(float a, float b)
     return (fabsf(a - b) < FLT_EPSILON);
 }
 
+static inline bool mathEqual(const Matrix& a, const Matrix& b)
+{
+    if (!mathEqual(a.e11, b.e11) || !mathEqual(a.e12, b.e12) || !mathEqual(a.e13, b.e13) ||
+        !mathEqual(a.e21, b.e21) || !mathEqual(a.e22, b.e22) || !mathEqual(a.e23, b.e23) ||
+        !mathEqual(a.e31, b.e31) || !mathEqual(a.e32, b.e32) || !mathEqual(a.e33, b.e33)) {
+       return false;
+    }
+    return true;
+}
 
 static inline bool mathRightAngle(const Matrix* m)
 {

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -24,6 +24,7 @@
 #define _TVG_SHAPE_IMPL_H_
 
 #include <memory.h>
+#include "tvgMath.h"
 #include "tvgPaint.h"
 
 /************************************************************************/
@@ -292,6 +293,12 @@ struct Shape::Impl
         flag |= RenderUpdateFlag::Stroke;
 
         return true;
+    }
+
+    bool strokeFirst()
+    {
+        if (!rs.stroke) return true;
+        return rs.stroke->strokeFirst;
     }
 
     bool strokeFirst(bool strokeFirst)

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -31,7 +31,10 @@
 #endif
 
 #include "tvgTvgCommon.h"
+#include "tvgShapeImpl.h"
 
+
+#define P(A) A->pImpl
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -285,6 +288,11 @@ static bool _parseShapeStroke(const char *ptr, const char *end, Shape *shape)
             case TVG_TAG_SHAPE_STROKE_JOIN: {
                 if (block.length != SIZE(TvgBinFlag)) return false;
                 shape->stroke((StrokeJoin) *block.data);
+                break;
+            }
+            case TVG_TAG_SHAPE_STROKE_ORDER: {
+                if (block.length != SIZE(TvgBinFlag)) return false;
+                P(shape)->strokeFirst((bool) *block.data);
                 break;
             }
             case TVG_TAG_SHAPE_STROKE_WIDTH: {

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -20,12 +20,12 @@
  * SOFTWARE.
  */
 
-#include "tvgMath.h"
+#include <cstring>
+
 #include "tvgSaveModule.h"
 #include "tvgTvgSaver.h"
 #include "tvgLzw.h"
-
-#include <cstring>
+#include "tvgShapeImpl.h"
 
 #ifdef _WIN32
     #include <malloc.h>
@@ -50,6 +50,8 @@ static FILE* _fopen(const char* filename, const char* mode)
 }
 
 #define SIZE(A) sizeof(A)
+
+#define P(A) A->pImpl
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -98,6 +100,8 @@ static bool _merge(Shape* from, Shape* to)
     }
 
     //stroke
+    if (P(from)->strokeFirst() != P(to)->strokeFirst()) return false;
+
     r = g = b = a = r2 = g2 = b2 = a2 = 0;
 
     from->strokeColor(&r, &g, &b, &a);
@@ -454,6 +458,10 @@ TvgBinCounter TvgSaver::serializeStroke(const Shape* shape, const Matrix* pTrans
     //join
     if (auto flag = static_cast<TvgBinFlag>(shape->strokeJoin()))
         cnt += writeTagProperty(TVG_TAG_SHAPE_STROKE_JOIN, SIZE(TvgBinFlag), &flag);
+
+    //order
+    if (auto flag = static_cast<TvgBinFlag>(P(shape)->strokeFirst()))
+        writeTagProperty(TVG_TAG_SHAPE_STROKE_ORDER, SIZE(TvgBinFlag), &flag);
 
     //fill
     if (auto fill = shape->strokeFill()) {

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -93,11 +93,7 @@ static bool _merge(Shape* from, Shape* to)
     auto t1 = from->transform();
     auto t2 = to->transform();
 
-    if (!mathEqual(t1.e11, t2.e11) || !mathEqual(t1.e12, t2.e12) || !mathEqual(t1.e13, t2.e13) ||
-        !mathEqual(t1.e21, t2.e21) || !mathEqual(t1.e22, t2.e22) || !mathEqual(t1.e23, t2.e23) ||
-        !mathEqual(t1.e31, t2.e31) || !mathEqual(t1.e32, t2.e32) || !mathEqual(t1.e33, t2.e33)) {
-       return false;
-    }
+    if (!mathEqual(t1, t2)) return false;
 
     //stroke
     if (P(from)->strokeFirst() != P(to)->strokeFirst()) return false;


### PR DESCRIPTION
tvg binary missed the stroke order,
this patch implements the missing condition.

@Issue: https://github.com/thorvg/thorvg/issues/1499