### PR TITLE
sw_engine c: fix compile warnings on windows.

### DIFF
--- a/src/lib/sw_engine/tvgSwRasterC.h
+++ b/src/lib/sw_engine/tvgSwRasterC.h
@@ -26,7 +26,7 @@ static void inline cRasterPixels(PIXEL_T* dst, PIXEL_T val, uint32_t offset, int
     dst += offset;
 
     //fix the misaligned memory
-    auto alignOffset = (long) dst % 8;
+    auto alignOffset = (long long) dst % 8;
     if (alignOffset > 0) {
         if (sizeof(PIXEL_T) == 4) alignOffset /= 4;
         else if (sizeof(PIXEL_T) == 1) alignOffset = 8 - alignOffset;


### PR DESCRIPTION
[31/75] Compiling C++ object src/thorvg-0.dll.p/lib_sw_engine_tvgSwRaster.cpp.obj D:\Projects\thorvg\src\lib\sw_engine\tvgSwRasterC.h(29): warning C4311: 'type cast': pointer truncation from 'PIXEL_T *' to 'long'
        with
        [
            PIXEL_T=uint8_t
        ]
../src/lib/sw_engine/tvgSwRaster.cpp(1900): note: see reference to function template instantiation 'void cRasterPixels<uint8_t>(PIXEL_T *,PIXEL_T,uint32_t,int32_t)' being compiled
        with
        [
            PIXEL_T=uint8_t
        ]
D:\Projects\thorvg\src\lib\sw_engine\tvgSwRasterC.h(29): warning C4302: 'type cast': truncation from 'PIXEL_T *' to 'long'
        with
        [
            PIXEL_T=uint8_t
        ]
D:\Projects\thorvg\src\lib\sw_engine\tvgSwRasterC.h(29): warning C4311: 'type cast': pointer truncation from 'PIXEL_T *' to 'long'
        with
        [
            PIXEL_T=uint32_t
        ]
../src/lib/sw_engine/tvgSwRaster.cpp(1911): note: see reference to function template instantiation 'void cRasterPixels<uint32_t>(PIXEL_T *,PIXEL_T,uint32_t,int32_t)' being compiled
        with
        [
            PIXEL_T=uint32_t
        ]
D:\Projects\thorvg\src\lib\sw_engine\tvgSwRasterC.h(29): warning C4302: 'type cast': truncation from 'PIXEL_T *' to 'long'
        with
        [
            PIXEL_T=uint32_t
        ]