### PR TITLE
lottie_loader: fixing error with math consts

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -20,7 +20,6 @@
  * SOFTWARE.
  */
 
-#include <math.h>
 #include "tvgLoader.h"
 #include "tvgLottieLoader.h"
 #include "tvgLottieModel.h"

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -48,13 +48,9 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-
-#define _USE_MATH_DEFINES       //Math Constants are not defined in Standard C/C++.
-
 #include <cstring>
 #include <fstream>
 #include <float.h>
-#include <math.h>
 #include "tvgLoader.h"
 #include "tvgXmlParser.h"
 #include "tvgSvgLoader.h"


### PR DESCRIPTION
The math.h was included before the _USE_MATH_DEFINES was defined causing an error while MinGw was used.