### PR TITLE
webp_loader: libwebp set to be a required depend

### DIFF
--- a/src/loaders/external_webp/meson.build
+++ b/src/loaders/external_webp/meson.build
@@ -3,12 +3,10 @@ source_file = [
    'tvgWebpLoader.cpp',
 ]
 
-webp_dep = dependency('libwebp', required: false)
+webp_dep = dependency('libwebp', required: true)
 
-if webp_dep.found()
-    subloader_dep += [declare_dependency(
-        include_directories : include_directories('.'),
-        dependencies : webp_dep,
-        sources : source_file
+subloader_dep += [declare_dependency(
+    include_directories : include_directories('.'),
+    dependencies : webp_dep,
+    sources : source_file
     )]
-endif


### PR DESCRIPTION
While building on windows (MinGW) no 'libwebp' was found, which resulted in build errors. The building process should have been stopped earlier for clarity.