### PR TITLE
common: deleted paints only when they are no longer valid.

### DIFF
--- a/src/lib/tvgCanvasImpl.h
+++ b/src/lib/tvgCanvasImpl.h
@@ -66,8 +66,9 @@ struct Canvas::Impl
         //Free paints
         if (free) {
             for (auto paint : paints) {
-                paint->pImpl->dispose(*renderer);
-                delete(paint);
+                if (paint->pImpl->dispose(*renderer)) {
+                    delete(paint);
+                }
             }
             paints.clear();
         }

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -42,7 +42,7 @@ namespace tvg
     {
         virtual ~StrategyMethod() {}
 
-        virtual bool dispose(RenderMethod& renderer) = 0;
+        virtual bool dispose(RenderMethod& renderer) = 0;     //return true if the deletion is allowed.
         virtual void* update(RenderMethod& renderer, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper) = 0;   //Return engine data if it has.
         virtual bool render(RenderMethod& renderer) = 0;
         virtual bool bounds(float* x, float* y, float* w, float* h) = 0;

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -84,12 +84,10 @@ struct Picture::Impl
 
     bool dispose(RenderMethod& renderer)
     {
-        bool ret = true;
-        if (paint) ret = paint->pImpl->dispose(renderer);
-        else if (surface) ret =  renderer.dispose(rd);
+        if (paint) paint->pImpl->dispose(renderer);
+        else if (surface) renderer.dispose(rd);
         rd = nullptr;
-
-        return ret;
+        return !animated;
     }
 
     RenderUpdateFlag load()

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -85,11 +85,11 @@ struct Scene::Impl
             paint->pImpl->dispose(renderer);
         }
 
-        auto ret = renderer.dispose(rd);
+        renderer.dispose(rd);
         this->renderer = nullptr;
         this->rd = nullptr;
 
-        return ret;
+        return true;
     }
 
     bool needComposition(uint8_t opacity)
@@ -231,7 +231,7 @@ struct Scene::Impl
         auto dispose = renderer ? true : false;
 
         for (auto paint : paints) {
-            if (dispose) paint->pImpl->dispose(*renderer);
+            if (dispose) free &= paint->pImpl->dispose(*renderer);
             if (free) delete(paint);
         }
         paints.clear();

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -46,9 +46,9 @@ struct Shape::Impl
 
     bool dispose(RenderMethod& renderer)
     {
-        auto ret = renderer.dispose(rd);
+        renderer.dispose(rd);
         rd = nullptr;
-        return ret;
+        return true;
     }
 
     bool render(RenderMethod& renderer)


### PR DESCRIPTION
Pictures can be shared with Animation instances.
The condition can now be distinguished by checking the `dispose()` return value.