### PR TITLE
sw_engine: support for radial grad focal attribs

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -765,7 +765,7 @@ public:
      *
      * @return Result::Success when succeed, Result::InvalidArguments in case the @p r value is zero or less.
      */
-    Result radial(float cx, float cy, float r) noexcept;
+    TVG_DEPRECATED Result radial(float cx, float cy, float r) noexcept;
 
     /**
      * @brief Sets the radial gradient attributes.
@@ -784,6 +784,9 @@ public:
      *
      * @return Result::Success when succeed, Result::InvalidArguments in case the @p r or @p fr value is zero or less.
      *
+     * @note Should you choose not to specify the focal point, ensure that the values for @p fx and @p fy match
+     * those of @p cx and @p cy, and set @p fr to 0.
+     *
      * @BETA_API
      */
     Result radial(float cx, float cy, float r, float fx, float fy, float fr) noexcept;
@@ -799,7 +802,7 @@ public:
     *
     * @return Result::Success when succeed.
     */
-    Result radial(float* cx, float* cy, float* r) const noexcept;
+    TVG_DEPRECATED Result radial(float* cx, float* cy, float* r) const noexcept;
 
     /**
      * @brief Gets the radial gradient attributes.

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -757,28 +757,67 @@ public:
     /**
      * @brief Sets the radial gradient bounds.
      *
-     * The radial gradient bounds are defined as a circle centered in a given point (@p cx, @p cy) of a given radius.
+     * The radial gradient bounds are defined as a circle centered in a given point (@p cx, @p cy) of a given radius @p r.
      *
      * @param[in] cx The horizontal coordinate of the center of the bounding circle.
      * @param[in] cy The vertical coordinate of the center of the bounding circle.
-     * @param[in] radius The radius of the bounding circle.
+     * @param[in] r The radius of the bounding circle.
      *
-     * @return Result::Success when succeed, Result::InvalidArguments in case the @p radius value is zero or less.
+     * @return Result::Success when succeed, Result::InvalidArguments in case the @p r value is zero or less.
      */
-    Result radial(float cx, float cy, float radius) noexcept;
+    Result radial(float cx, float cy, float r) noexcept;
 
     /**
-     * @brief Gets the radial gradient bounds.
+     * @brief Sets the radial gradient attributes.
      *
-     * The radial gradient bounds are defined as a circle centered in a given point (@p cx, @p cy) of a given radius.
+     * The radial gradient is defined by the end circle with a center (@p cx, @p cy) and a radius @p r and
+     * the start circle with a center - focal point (@p fx, @p fy) and a radius @p fr.
+     * The gradient will be rendered in a way that aligns the 100% gradient stop with the edge of the end circle
+     * and 0% gradient stop with the edge of the start circle.
      *
-     * @param[out] cx The horizontal coordinate of the center of the bounding circle.
-     * @param[out] cy The vertical coordinate of the center of the bounding circle.
-     * @param[out] radius The radius of the bounding circle.
+     * @param[in] cx The horizontal coordinate of the center of the end circle.
+     * @param[in] cy The vertical coordinate of the center of the end circle.
+     * @param[in] r The radius of the end circle.
+     * @param[in] fx The horizontal coordinate of the center of the start circle.
+     * @param[in] fy The vertical coordinate of the center of the start circle.
+     * @param[in] fr The radius of the start circle.
+     *
+     * @return Result::Success when succeed, Result::InvalidArguments in case the @p r or @p fr value is zero or less.
+     *
+     * @BETA_API
+     */
+    Result radial(float cx, float cy, float r, float fx, float fy, float fr) noexcept;
+
+    /**
+    * @brief Gets the radial gradient bounds.
+    *
+    * The radial gradient bounds are defined as a circle centered in a given point (@p cx, @p cy) of a given radius.
+    *
+    * @param[out] cx The horizontal coordinate of the center of the bounding circle.
+    * @param[out] cy The vertical coordinate of the center of the bounding circle.
+    * @param[out] r The radius of the bounding circle.
+    *
+    * @return Result::Success when succeed.
+    */
+    Result radial(float* cx, float* cy, float* r) const noexcept;
+
+    /**
+     * @brief Gets the radial gradient attributes.
+     *
+     * @param[out] cx The horizontal coordinate of the center of the end circle.
+     * @param[out] cy The vertical coordinate of the center of the end circle.
+     * @param[out] r The radius of the end circle.
+     * @param[out] fx The horizontal coordinate of the center of the start circle.
+     * @param[out] fy The vertical coordinate of the center of the start circle.
+     * @param[out] fr The radius of the start circle.
      *
      * @return Result::Success when succeed.
+     *
+     * @see Result radial(float cx, float cy, float r, float fx, float fy, float fr) noexcept
+     *
+     * @BETA_API
      */
-    Result radial(float* cx, float* cy, float* radius) const noexcept;
+    Result radial(float* cx, float* cy, float* r, float* fx, float* fy, float* fr) const noexcept;
 
     /**
      * @brief Creates a new RadialGradient object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1703,35 +1703,47 @@ TVG_API Tvg_Result tvg_linear_gradient_get(Tvg_Gradient* grad, float* x1, float*
 
 
 /*!
-* \brief Sets the radial gradient bounds.
+* \brief Sets the radial gradient attributes.
 *
-* The radial gradient bounds are defined as a circle centered in a given point (@p cx, @p cy) of a given radius.
+* The radial gradient is defined by the end circle with a center (@p cx, @p cy) and a radius @p r and
+* the start circle with a center - focal point (@p fx, @p fy) and a radius @p fr.
+* The gradient will be rendered in a way that aligns the 100% gradient stop with the edge of the end circle
+* and 0% gradient stop with the edge of the start circle.
 *
-* \param[in] grad The Tvg_Gradient object of which bounds are to be set.
-* \param[in] cx The horizontal coordinate of the center of the bounding circle.
-* \param[in] cy The vertical coordinate of the center of the bounding circle.
-* \param[in] radius The radius of the bounding circle.
+* \param[in] grad The Tvg_Gradient object of which attributes are to be set.
+* \param[in] cx The horizontal coordinate of the center of the end circle.
+* \param[in] cy The vertical coordinate of the center of the end circle.
+* \param[in] r The radius of the end circle.
+* \param[in] fx The horizontal coordinate of the center of the start circle.
+* \param[in] fy The vertical coordinate of the center of the start circle.
+* \param[in] fr The radius of the start circle.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Gradient pointer or the @p radius value less than zero.
+*
+* \note Should you choose not to specify the focal point, ensure that the values for @p fx and @p fy match
+* those of @p cx and @p cy, and set @p fr to 0.
 */
-TVG_API Tvg_Result tvg_radial_gradient_set(Tvg_Gradient* grad, float cx, float cy, float radius);
+TVG_API Tvg_Result tvg_radial_gradient_set(Tvg_Gradient* grad, float cx, float cy, float r, float fx, float fy, float fr);
 
 
 /*!
-* \brief The function gets radial gradient center point ant radius
+* \brief The function gets radial gradient attributes.
 *
-* \param[in] grad The Tvg_Gradient object of which bounds are to be set.
-* \param[out] cx The horizontal coordinate of the center of the bounding circle.
-* \param[out] cy The vertical coordinate of the center of the bounding circle.
-* \param[out] radius The radius of the bounding circle.
+* \param[in] grad The Tvg_Gradient object of which attributes are to be set.
+* \param[out] cx The horizontal coordinate of the center of the end circle.
+* \param[out] cy The vertical coordinate of the center of the end circle.
+* \param[out] r The radius of the end circle.
+* \param[out] fx The horizontal coordinate of the center of the start circle.
+* \param[out] fy The vertical coordinate of the center of the start circle.
+* \param[out] fr The radius of the start circle.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Gradient pointer.
 */
-TVG_API Tvg_Result tvg_radial_gradient_get(Tvg_Gradient* grad, float* cx, float* cy, float* radius);
+TVG_API Tvg_Result tvg_radial_gradient_get(Tvg_Gradient* grad, float* cx, float* cy, float* r, float* fx, float* fy, float* fr);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -575,17 +575,17 @@ TVG_API Tvg_Result tvg_linear_gradient_get(Tvg_Gradient* grad, float* x1, float*
 }
 
 
-TVG_API Tvg_Result tvg_radial_gradient_set(Tvg_Gradient* grad, float cx, float cy, float radius)
+TVG_API Tvg_Result tvg_radial_gradient_set(Tvg_Gradient* grad, float cx, float cy, float r, float fx, float fy, float fr)
 {
     if (!grad) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<RadialGradient*>(grad)->radial(cx, cy, radius);
+    return (Tvg_Result) reinterpret_cast<RadialGradient*>(grad)->radial(cx, cy, r, fx, fy, fr);
 }
 
 
-TVG_API Tvg_Result tvg_radial_gradient_get(Tvg_Gradient* grad, float* cx, float* cy, float* radius)
+TVG_API Tvg_Result tvg_radial_gradient_get(Tvg_Gradient* grad, float* cx, float* cy, float* r, float* fx, float* fy, float* fr)
 {
     if (!grad) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<RadialGradient*>(grad)->radial(cx, cy, radius);
+    return (Tvg_Result) reinterpret_cast<RadialGradient*>(grad)->radial(cx, cy, r, fx, fy, fr);
 }
 
 

--- a/src/examples/Blending.cpp
+++ b/src/examples/Blending.cpp
@@ -93,7 +93,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //RadialGradient
     auto fill2 = tvg::RadialGradient::gen();
-    fill2->radial(300, 800, 150);
+    fill2->radial(300, 800, 150, 300, 800, 0);
     fill2->colorStops(colorStops, 2);
 
     shape6->fill(std::move(fill2));

--- a/src/examples/Capi.cpp
+++ b/src/examples/Capi.cpp
@@ -107,7 +107,7 @@ void testCapi()
 
     //Prepare a radial gradient for the fill
     Tvg_Gradient* grad2 = tvg_radial_gradient_new();
-    tvg_radial_gradient_set(grad2, 600.0f, 180.0f, 50.0f);
+    tvg_radial_gradient_set(grad2, 600.0f, 180.0f, 50.0f, 600.0f, 180.0f, 0.0f);
     Tvg_Color_Stop color_stops2[3] =
     {
         {0.0f, 255,   0, 255, 255},
@@ -126,10 +126,10 @@ void testCapi()
     tvg_gradient_get_color_stops(grad2, &color_stops2_get, &cnt);
 
     float cx, cy, radius;
-    tvg_radial_gradient_get(grad2, &cx, &cy, &radius);
+    tvg_radial_gradient_get(grad2, &cx, &cy, &radius, nullptr, nullptr, nullptr);
 
     Tvg_Gradient* grad2_stroke = tvg_radial_gradient_new();
-    tvg_radial_gradient_set(grad2_stroke, cx, cy, radius);
+    tvg_radial_gradient_set(grad2_stroke, cx, cy, radius, cx, cy, 0.0f);
     tvg_gradient_set_color_stops(grad2_stroke, color_stops2_get, cnt);
     tvg_gradient_set_spread(grad2_stroke, TVG_STROKE_FILL_REPEAT);
 

--- a/src/examples/GradientStroke.cpp
+++ b/src/examples/GradientStroke.cpp
@@ -83,7 +83,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     shape2->stroke(80);
 
     auto fillStroke2 = tvg::RadialGradient::gen();
-    fillStroke2->radial(600, 175, 100);
+    fillStroke2->radial(600, 175, 100, 600, 175, 0);
     fillStroke2->colorStops(colorStops2, 2);
     shape2->stroke(std::move(fillStroke2));
 

--- a/src/examples/GradientTransform.cpp
+++ b/src/examples/GradientTransform.cpp
@@ -89,7 +89,7 @@ void tvgUpdateCmds(tvg::Canvas* canvas, float progress)
 
     //RadialGradient
     auto fill3 = tvg::RadialGradient::gen();
-    fill3->radial(175, 150, 75);
+    fill3->radial(175, 150, 75, 175, 150, 0);
 
     //Gradient Color Stops
     tvg::Fill::ColorStop colorStops3[4];

--- a/src/examples/RadialGradient.cpp
+++ b/src/examples/RadialGradient.cpp
@@ -36,7 +36,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //RadialGradient
     auto fill = tvg::RadialGradient::gen();
-    fill->radial(200, 200, 200);
+    fill->radial(200, 200, 200, 200, 200, 0);
 
     //Gradient Color Stops
     tvg::Fill::ColorStop colorStops[2];
@@ -54,7 +54,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //RadialGradient
     auto fill2 = tvg::RadialGradient::gen();
-    fill2->radial(400, 400, 200);
+    fill2->radial(400, 400, 200, 450, 450, 50);
 
     //Gradient Color Stops
     tvg::Fill::ColorStop colorStops2[3];
@@ -74,7 +74,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //RadialGradient
     auto fill3 = tvg::RadialGradient::gen();
-    fill3->radial(600, 600, 150);
+    fill3->radial(600, 600, 150, 600, 600, 0);
 
     //Gradient Color Stops
     tvg::Fill::ColorStop colorStops3[4];

--- a/src/examples/TvgSaver.cpp
+++ b/src/examples/TvgSaver.cpp
@@ -130,7 +130,7 @@ unique_ptr<tvg::Paint> tvgNestedPaints(tvg::Fill::ColorStop* colorStops, int col
     auto shape2 = tvg::Shape::gen();
     shape2->appendRect(0, 0, 50, 100, 10, 40);
     auto fillShape = tvg::RadialGradient::gen();
-    fillShape->radial(25, 50, 25);
+    fillShape->radial(25, 50, 25, 25, 50, 0);
     fillShape->colorStops(colorStops, colorStopsCnt);
     shape2->fill(std::move(fillShape));
     shape2->scale(2);
@@ -178,7 +178,7 @@ unique_ptr<tvg::Paint> tvgCircle2(tvg::Fill::ColorStop* colorStops, int colorSto
     auto circ = tvg::Shape::gen();
     circ->appendCircle(400, 425, 50, 50);
     auto fill = tvg::RadialGradient::gen();
-    fill->radial(400, 425, 50);
+    fill->radial(400, 425, 50, 400, 425, 0);
     fill->colorStops(colorStops, colorStopsCnt);
     circ->fill(std::move(fill));
 

--- a/src/lib/sw_engine/tvgSwCommon.h
+++ b/src/lib/sw_engine/tvgSwCommon.h
@@ -139,10 +139,12 @@ struct SwFill
     };
 
     struct SwRadial {
-        float a11, a12, shiftX;
-        float a21, a22, shiftY;
-        float detSecDeriv;
-        float a;
+        float a11, a12, a13;
+        float a21, a22, a23;
+
+        float fx, fy, fr;
+        float dx, dy, dr;
+        float invA, a;
     };
 
     union {
@@ -558,6 +560,9 @@ void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
 void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlender op, uint8_t a);                                         //blending ver.
 void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlender op, SwBlender op2, uint8_t a);                          //blending + BlendingMethod(op2) ver.
 void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, uint8_t* cmp, SwAlpha alpha, uint8_t csize, uint8_t opacity);     //masking ver.
+void fillRadialEdgeCase(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlender op, uint8_t a);                                         //blending ver.
+void fillRadialEdgeCase(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlender op, SwBlender op2, uint8_t a);                          //blending + BlendingMethod(op2) ver.
+void fillRadialEdgeCase(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, uint8_t* cmp, SwAlpha alpha, uint8_t csize, uint8_t opacity);     //masking ver.
 
 SwRleData* rleRender(SwRleData* rle, const SwOutline* outline, const SwBBox& renderRegion, bool antiAlias);
 SwRleData* rleRender(const SwBBox* bbox);

--- a/src/lib/sw_engine/tvgSwRaster.cpp
+++ b/src/lib/sw_engine/tvgSwRaster.cpp
@@ -74,24 +74,6 @@ struct FillRadial
     }
 };
 
-struct FillRadialEdgeCase
-{
-    void operator()(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlender op, uint8_t a)
-    {
-        fillRadialEdgeCase(fill, dst, y, x, len, op, a);
-    }
-
-    void operator()(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, uint8_t* cmp, SwAlpha alpha, uint8_t csize, uint8_t opacity)
-    {
-        fillRadialEdgeCase(fill, dst, y, x, len, cmp, alpha, csize, opacity);
-    }
-
-    void operator()(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlender op, SwBlender op2, uint8_t a)
-    {
-        fillRadialEdgeCase(fill, dst, y, x, len, op, op2, a);
-    }
-};
-
 
 static bool _rasterDirectImage(SwSurface* surface, const SwImage* image, const SwBBox& region,  uint8_t opacity = 255);
 
@@ -1737,30 +1719,17 @@ static bool _rasterLinearGradientRect(SwSurface* surface, const SwBBox& region, 
 
 static bool _rasterRadialGradientRect(SwSurface* surface, const SwBBox& region, const SwFill* fill)
 {
-    if (fill->radial.a < FLT_EPSILON) {
-        if (_compositing(surface)) {
-            if (_matting(surface)) return _rasterGradientMattedRect<FillRadialEdgeCase>(surface, region, fill);
-            else return _rasterGradientMaskedRect<FillRadialEdgeCase>(surface, region, fill);
-        } else if (_blending(surface)) {
-            return _rasterBlendingGradientRect<FillRadialEdgeCase>(surface, region, fill);
-        } else {
-            if (fill->translucent) return _rasterTranslucentGradientRect<FillRadialEdgeCase>(surface, region, fill);
-            else _rasterSolidGradientRect<FillRadialEdgeCase>(surface, region, fill);
-        }
+    if (_compositing(surface)) {
+        if (_matting(surface)) return _rasterGradientMattedRect<FillRadial>(surface, region, fill);
+        else return _rasterGradientMaskedRect<FillRadial>(surface, region, fill);
+    } else if (_blending(surface)) {
+        return _rasterBlendingGradientRect<FillRadial>(surface, region, fill);
     } else {
-        if (_compositing(surface)) {
-            if (_matting(surface)) return _rasterGradientMattedRect<FillRadial>(surface, region, fill);
-            else return _rasterGradientMaskedRect<FillRadial>(surface, region, fill);
-        } else if (_blending(surface)) {
-            return _rasterBlendingGradientRect<FillRadial>(surface, region, fill);
-        } else {
-            if (fill->translucent) return _rasterTranslucentGradientRect<FillRadial>(surface, region, fill);
-            else _rasterSolidGradientRect<FillRadial>(surface, region, fill);
-        }
+        if (fill->translucent) return _rasterTranslucentGradientRect<FillRadial>(surface, region, fill);
+        else _rasterSolidGradientRect<FillRadial>(surface, region, fill);
     }
     return false;
 }
-
 
 
 /************************************************************************/
@@ -1904,26 +1873,14 @@ static bool _rasterRadialGradientRle(SwSurface* surface, const SwRleData* rle, c
 {
     if (!rle) return false;
 
-    if (fill->radial.a < FLT_EPSILON) {
-        if (_compositing(surface)) {
-            if (_matting(surface)) return _rasterGradientMattedRle<FillRadialEdgeCase>(surface, rle, fill);
-            else return _rasterGradientMaskedRle<FillRadialEdgeCase>(surface, rle, fill);
-        } else if (_blending(surface)) {
-            _rasterBlendingGradientRle<FillRadialEdgeCase>(surface, rle, fill);
-        } else {
-            if (fill->translucent) _rasterTranslucentGradientRle<FillRadialEdgeCase>(surface, rle, fill);
-            else return _rasterSolidGradientRle<FillRadialEdgeCase>(surface, rle, fill);
-        }
+    if (_compositing(surface)) {
+        if (_matting(surface)) return _rasterGradientMattedRle<FillRadial>(surface, rle, fill);
+        else return _rasterGradientMaskedRle<FillRadial>(surface, rle, fill);
+    } else if (_blending(surface)) {
+        _rasterBlendingGradientRle<FillRadial>(surface, rle, fill);
     } else {
-        if (_compositing(surface)) {
-            if (_matting(surface)) return _rasterGradientMattedRle<FillRadial>(surface, rle, fill);
-            else return _rasterGradientMaskedRle<FillRadial>(surface, rle, fill);
-        } else if (_blending(surface)) {
-            _rasterBlendingGradientRle<FillRadial>(surface, rle, fill);
-        } else {
-            if (fill->translucent) _rasterTranslucentGradientRle<FillRadial>(surface, rle, fill);
-            else return _rasterSolidGradientRle<FillRadial>(surface, rle, fill);
-        }
+        if (fill->translucent) _rasterTranslucentGradientRle<FillRadial>(surface, rle, fill);
+        else return _rasterSolidGradientRle<FillRadial>(surface, rle, fill);
     }
     return false;
 }

--- a/src/lib/tvgRadialGradient.cpp
+++ b/src/lib/tvgRadialGradient.cpp
@@ -29,9 +29,9 @@
 
 struct RadialGradient::Impl
 {
-    float cx {}, cy {};
-    float fx {}, fy {};
-    float r {}, fr {};
+    float cx = 0.0f, cy = 0.0f;
+    float fx = 0.0f, fy = 0.0f;
+    float r = 0.0f, fr = 0.0f;
 
     Fill* duplicate()
     {

--- a/src/lib/tvgRadialGradient.cpp
+++ b/src/lib/tvgRadialGradient.cpp
@@ -29,9 +29,9 @@
 
 struct RadialGradient::Impl
 {
-    float cx = 0;
-    float cy = 0;
-    float radius = 0;
+    float cx {}, cy {};
+    float fx {}, fy {};
+    float r {}, fr {};
 
     Fill* duplicate()
     {
@@ -40,7 +40,11 @@ struct RadialGradient::Impl
 
         ret->pImpl->cx = cx;
         ret->pImpl->cy = cy;
-        ret->pImpl->radius = radius;
+        ret->pImpl->r = r;
+
+        ret->pImpl->fx = fx;
+        ret->pImpl->fy = fy;
+        ret->pImpl->fr = fr;
 
         return ret.release();
     }
@@ -64,23 +68,52 @@ RadialGradient::~RadialGradient()
 }
 
 
-Result RadialGradient::radial(float cx, float cy, float radius) noexcept
+Result RadialGradient::radial(float cx, float cy, float r) noexcept
 {
-    if (radius < 0) return Result::InvalidArguments;
+    if (r < 0) return Result::InvalidArguments;
 
-    pImpl->cx = cx;
-    pImpl->cy = cy;
-    pImpl->radius = radius;
+    pImpl->cx = pImpl->fx = cx;
+    pImpl->cy = pImpl->fy = cy;
+    pImpl->r = r;
+    pImpl->fr = 0.0f;
 
     return Result::Success;
 }
 
 
-Result RadialGradient::radial(float* cx, float* cy, float* radius) const noexcept
+Result RadialGradient::radial(float cx, float cy, float r, float fx, float fy, float fr) noexcept
+{
+    if (r < 0 || fr < 0) return Result::InvalidArguments;
+
+    pImpl->cx = cx;
+    pImpl->cy = cy;
+    pImpl->r = r;
+    pImpl->fx = fx;
+    pImpl->fy = fy;
+    pImpl->fr = fr;
+
+    return Result::Success;
+}
+
+
+Result RadialGradient::radial(float* cx, float* cy, float* r) const noexcept
 {
     if (cx) *cx = pImpl->cx;
     if (cy) *cy = pImpl->cy;
-    if (radius) *radius = pImpl->radius;
+    if (r) *r = pImpl->r;
+
+    return Result::Success;
+}
+
+
+Result RadialGradient::radial(float* cx, float* cy, float* r, float* fx, float* fy, float* fr) const noexcept
+{
+    if (cx) *cx = pImpl->cx;
+    if (cy) *cy = pImpl->cy;
+    if (r) *r = pImpl->r;
+    if (fx) *fx = pImpl->fx;
+    if (fy) *fy = pImpl->fy;
+    if (fr) *fr = pImpl->fr;
 
     return Result::Success;
 }

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -50,7 +50,7 @@ Fill* LottieGradient::fill(int32_t frameNo)
         auto w = fabsf(end(frameNo).x - sx);
         auto h = fabsf(end(frameNo).y - sy);
         auto radius = (w > h) ? (w + 0.375f * h) : (h + 0.375f * w);
-        static_cast<RadialGradient*>(fill)->radial(sx, sy, radius);
+        static_cast<RadialGradient*>(fill)->radial(sx, sy, radius, sx, sy, 0.0f);
 
         //TODO: focal support?
     }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2093,6 +2093,12 @@ static void _handleRadialFyAttr(SvgLoaderData* loader, SvgRadialGradient* radial
 }
 
 
+static void _handleRadialFrAttr(SvgLoaderData* loader, SvgRadialGradient* radial, const char* value)
+{
+    radial->fr = _gradientToFloat(loader->svgParse, value, radial->isFrPercentage);
+}
+
+
 static void _handleRadialRAttr(SvgLoaderData* loader, SvgRadialGradient* radial, const char* value)
 {
     radial->r = _gradientToFloat(loader->svgParse, value, radial->isRPercentage);
@@ -2120,6 +2126,13 @@ static void _recalcRadialFxAttr(SvgLoaderData* loader, SvgRadialGradient* radial
 static void _recalcRadialFyAttr(SvgLoaderData* loader, SvgRadialGradient* radial, bool userSpace)
 {
     if (userSpace && !radial->isFyPercentage) radial->fy = radial->fy / loader->svgParse->global.h;
+}
+
+
+static void _recalcRadialFrAttr(SvgLoaderData* loader, SvgRadialGradient* radial, bool userSpace)
+{
+    // scaling factor based on the Units paragraph from : https://www.w3.org/TR/2015/WD-SVG2-20150915/coords.html
+    if (userSpace && !radial->isFrPercentage) radial->fr = radial->fr / (sqrtf(powf(loader->svgParse->global.h, 2) + powf(loader->svgParse->global.w, 2)) / sqrtf(2.0));
 }
 
 
@@ -2166,6 +2179,15 @@ static void _recalcInheritedRadialFyAttr(SvgLoaderData* loader, SvgRadialGradien
 }
 
 
+static void _recalcInheritedRadialFrAttr(SvgLoaderData* loader, SvgRadialGradient* radial, bool userSpace)
+{
+    if (!radial->isFrPercentage) {
+        if (userSpace) radial->fr /= sqrtf(powf(loader->svgParse->global.h, 2) + powf(loader->svgParse->global.w, 2)) / sqrtf(2.0);
+        else radial->fr *= sqrtf(powf(loader->svgParse->global.h, 2) + powf(loader->svgParse->global.w, 2)) / sqrtf(2.0);
+    }
+}
+
+
 static void _recalcInheritedRadialRAttr(SvgLoaderData* loader, SvgRadialGradient* radial, bool userSpace)
 {
     if (!radial->isRPercentage) {
@@ -2207,6 +2229,14 @@ static void _inheritRadialFyAttr(SvgStyleGradient* to, SvgStyleGradient* from)
 }
 
 
+static void _inheritRadialFrAttr(SvgStyleGradient* to, SvgStyleGradient* from)
+{
+    to->radial->fr = from->radial->fr;
+    to->radial->isFrPercentage = from->radial->isFrPercentage;
+    to->flags = (to->flags | SvgGradientFlags::Fr);
+}
+
+
 static void _inheritRadialRAttr(SvgStyleGradient* to, SvgStyleGradient* from)
 {
     to->radial->r = from->radial->r;
@@ -2240,7 +2270,8 @@ static constexpr struct
     RADIAL_DEF(cy, Cy, SvgGradientFlags::Cy),
     RADIAL_DEF(fx, Fx, SvgGradientFlags::Fx),
     RADIAL_DEF(fy, Fy, SvgGradientFlags::Fy),
-    RADIAL_DEF(r, R, SvgGradientFlags::R)
+    RADIAL_DEF(r, R, SvgGradientFlags::R),
+    RADIAL_DEF(fr, Fr, SvgGradientFlags::Fr)
 };
 
 
@@ -2308,6 +2339,7 @@ static SvgStyleGradient* _createRadialGradient(SvgLoaderData* loader, const char
     grad->radial->isFxPercentage = true;
     grad->radial->isFyPercentage = true;
     grad->radial->isRPercentage = true;
+    grad->radial->isFrPercentage = true;
 
     loader->svgParse->gradient.parsedFx = false;
     loader->svgParse->gradient.parsedFy = false;

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -182,7 +182,8 @@ enum class SvgGradientFlags
     Cy = 0x80,
     R = 0x100,
     Fx = 0x200,
-    Fy = 0x400
+    Fy = 0x400,
+    Fr = 0x800
 };
 
 constexpr bool operator &(SvgGradientFlags a, SvgGradientFlags b)
@@ -390,11 +391,13 @@ struct SvgRadialGradient
     float fx;
     float fy;
     float r;
+    float fr;
     bool isCxPercentage;
     bool isCyPercentage;
     bool isFxPercentage;
     bool isFyPercentage;
     bool isRPercentage;
+    bool isFrPercentage;
 };
 
 struct SvgComposite

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -150,6 +150,7 @@ static unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient*
         g->radial->r = g->radial->r * sqrtf(powf(vBox.w, 2.0f) + powf(vBox.h, 2.0f)) / sqrtf(2.0f);
         g->radial->fx = g->radial->fx * vBox.w;
         g->radial->fy = g->radial->fy * vBox.h;
+        g->radial->fr = g->radial->fr * sqrtf(powf(vBox.w, 2.0f) + powf(vBox.h, 2.0f)) / sqrtf(2.0f);
     } else {
         Matrix m = {vBox.w, 0, vBox.x, 0, vBox.h, vBox.y, 0, 0, 1};
         if (isTransform) _transformMultiply(&m, &finalTransform);
@@ -161,11 +162,7 @@ static unique_ptr<RadialGradient> _applyRadialGradientProperty(SvgStyleGradient*
 
     if (isTransform) fillGrad->transform(finalTransform);
 
-    //TODO: Tvg is not support to focal
-    //if (g->radial->fx != 0 && g->radial->fy != 0) {
-    //    fillGrad->radial(g->radial->fx, g->radial->fy, g->radial->r);
-    //}
-    fillGrad->radial(g->radial->cx, g->radial->cy, g->radial->r);
+    fillGrad->radial(g->radial->cx, g->radial->cy, g->radial->r, g->radial->fx, g->radial->fy, g->radial->fr);
     fillGrad->spread(g->spread);
 
     //Update the stops

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -184,7 +184,7 @@ static unique_ptr<Fill> _parseShapeFill(const char *ptr, const char *end)
                 READ_FLOAT(&radius, ptr);
 
                 auto fillGradRadial = RadialGradient::gen();
-                fillGradRadial->radial(x, y, radius);
+                fillGradRadial->radial(x, y, radius, x, y, 0.0f);
                 fillGrad = std::move(fillGradRadial);
                 break;
             }

--- a/src/savers/tvg/tvgTvgSaver.cpp
+++ b/src/savers/tvg/tvgTvgSaver.cpp
@@ -412,7 +412,7 @@ TvgBinCounter TvgSaver::serializeFill(const Fill* fill, TvgBinTag tag, const Mat
     //radial fill
     if (fill->identifier() == TVG_CLASS_ID_RADIAL) {
         float args[3];
-        static_cast<const RadialGradient*>(fill)->radial(args, args + 1, args + 2);
+        static_cast<const RadialGradient*>(fill)->radial(args, args + 1, args + 2, nullptr, nullptr, nullptr);
         cnt += writeTagProperty(TVG_TAG_FILL_RADIAL_GRADIENT, SIZE(args), args);
     //linear fill
     } else {

--- a/test/capi/capiRadialGradient.cpp
+++ b/test/capi/capiRadialGradient.cpp
@@ -41,13 +41,16 @@ TEST_CASE("Set gradient center point and radius", "[capiRadialGradient]")
 {
     Tvg_Gradient *gradient = tvg_radial_gradient_new();
     REQUIRE(gradient);
-    REQUIRE(tvg_radial_gradient_set(gradient, 10.0, 15.0, 30.0) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_radial_gradient_set(gradient, 10.0, 15.0, 30.0, 11.0, 16.0, 2.0) == TVG_RESULT_SUCCESS);
 
-    float cx, cy, radius;
-    REQUIRE(tvg_radial_gradient_get(gradient, &cx, &cy, &radius) == TVG_RESULT_SUCCESS);
+    float cx, cy, r, fx, fy, fr;
+    REQUIRE(tvg_radial_gradient_get(gradient, &cx, &cy, &r, &fx, &fy, &fr) == TVG_RESULT_SUCCESS);
     REQUIRE(cx == Approx(10.0).margin(0.000001));
     REQUIRE(cy == Approx(15.0).margin(0.000001));
-    REQUIRE(radius == Approx(30.0).margin(0.000001));
+    REQUIRE(r == Approx(30.0).margin(0.000001));
+    REQUIRE(fx == Approx(11.0).margin(0.000001));
+    REQUIRE(fy == Approx(16.0).margin(0.000001));
+    REQUIRE(fr == Approx(2.0).margin(0.000001));
 
     REQUIRE(tvg_gradient_del(gradient) == TVG_RESULT_SUCCESS);
 }
@@ -194,7 +197,7 @@ TEST_CASE("Stroke Radial Gradient", "[capiRadialGradient]")
     Tvg_Gradient *gradient = tvg_radial_gradient_new();
     REQUIRE(gradient);
 
-    REQUIRE(tvg_radial_gradient_set(gradient, 10.0, 15.0, 30.0) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_radial_gradient_set(gradient, 10.0, 15.0, 30.0, 10.0, 15.0, 0.0) == TVG_RESULT_SUCCESS);
 
     Tvg_Color_Stop color_stops[2] = {
         {0.0, 0, 0,   0, 255},
@@ -218,11 +221,14 @@ TEST_CASE("Stroke Radial Gradient", "[capiRadialGradient]")
     REQUIRE(color_stops_ret);
     REQUIRE(color_stops_count_ret == 2);
 
-    float cx, cy, radius;
-    REQUIRE(tvg_radial_gradient_get(gradient_ret, &cx, &cy, &radius) == TVG_RESULT_SUCCESS);
+    float cx, cy, r, fx, fy, fr;
+    REQUIRE(tvg_radial_gradient_get(gradient_ret, &cx, &cy, &r, &fx, &fy, &fr) == TVG_RESULT_SUCCESS);
     REQUIRE(cx == Approx(10.0).margin(0.000001));
     REQUIRE(cy == Approx(15.0).margin(0.000001));
-    REQUIRE(radius == Approx(30.0).margin(0.000001));
+    REQUIRE(r == Approx(30.0).margin(0.000001));
+    REQUIRE(fx == Approx(10.0).margin(0.000001));
+    REQUIRE(fy == Approx(15.0).margin(0.000001));
+    REQUIRE(fr == Approx(0.0).margin(0.000001));
 
     REQUIRE(tvg_paint_del(shape) == TVG_RESULT_SUCCESS);
 }

--- a/test/testFill.cpp
+++ b/test/testFill.cpp
@@ -153,24 +153,31 @@ TEST_CASE("Radial Filling", "[tvgFill]")
     auto fill = RadialGradient::gen();
     REQUIRE(fill);
 
-    float cx, cy, radius;
+    float cx, cy, r, fx, fy, fr;
 
-    REQUIRE(fill->radial(0, 0, -1) == Result::InvalidArguments);
-    REQUIRE(fill->radial(nullptr, nullptr, nullptr) == Result::Success);
-    REQUIRE(fill->radial(100, 120, 50) == Result::Success);
+    REQUIRE(fill->radial(0, 0, -1, 0, 0, 0) == Result::InvalidArguments);
+    REQUIRE(fill->radial(0, 0, 0, 0, 0, -1) == Result::InvalidArguments);
+    REQUIRE(fill->radial(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr) == Result::Success);
+    REQUIRE(fill->radial(100, 120, 50, 110, 130, 0) == Result::Success);
 
-    REQUIRE(fill->radial(&cx, nullptr, &radius) == Result::Success);
+    REQUIRE(fill->radial(&cx, nullptr, &r, nullptr, nullptr, &fr) == Result::Success);
     REQUIRE(cx == 100.0f);
-    REQUIRE(radius == 50.0f);
+    REQUIRE(r == 50.0f);
+    REQUIRE(fr == 0.0f);
 
-    REQUIRE(fill->radial(nullptr, &cy, nullptr) == Result::Success);
-    REQUIRE(cy == 120);
+    REQUIRE(fill->radial(nullptr, &cy, nullptr, &fx, &fy, nullptr) == Result::Success);
+    REQUIRE(cy == 120.0f);
+    REQUIRE(fx == 110.0f);
+    REQUIRE(fy == 130.0f);
 
-    REQUIRE(fill->radial(0, 0, 0) == Result::Success);
-    REQUIRE(fill->radial(&cx, &cy, &radius) == Result::Success);
+    REQUIRE(fill->radial(0, 0, 0, 0, 0, 0) == Result::Success);
+    REQUIRE(fill->radial(&cx, &cy, &r, &fx, &fy, &fr) == Result::Success);
     REQUIRE(cx == 0.0f);
     REQUIRE(cy == 0.0f);
-    REQUIRE(radius == 0.0f);
+    REQUIRE(r == 0.0f);
+    REQUIRE(fx == 0.0f);
+    REQUIRE(fy == 0.0f);
+    REQUIRE(fr == 0.0f);
 }
 
 TEST_CASE("Linear Filling Dupliction", "[tvgFill]")
@@ -243,7 +250,7 @@ TEST_CASE("Radial Filling Dupliction", "[tvgFill]")
 
     REQUIRE(fill->colorStops(cs, 4) == Result::Success);
     REQUIRE(fill->spread(FillSpread::Reflect) == Result::Success);
-    REQUIRE(fill->radial(100.0f, 120.0f, 50.0f) == Result::Success);
+    REQUIRE(fill->radial(100.0f, 120.0f, 50.0f, 105.0f, 125.0f, 5.0f) == Result::Success);
 
     auto m = Matrix{1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, -7.7f, -8.8f, -9.9f};
     REQUIRE(fill->transform(m) == Result::Success);
@@ -254,11 +261,14 @@ TEST_CASE("Radial Filling Dupliction", "[tvgFill]")
 
     REQUIRE(dup->spread() == FillSpread::Reflect);
 
-    float cx, cy, radius;
-    REQUIRE(dup->radial(&cx, &cy, &radius) == Result::Success);
+    float cx, cy, r, fx, fy, fr;
+    REQUIRE(dup->radial(&cx, &cy, &r, &fx, &fy, &fr) == Result::Success);
     REQUIRE(cx == 100.0f);
     REQUIRE(cy == 120.0f);
-    REQUIRE(radius == 50.0f);
+    REQUIRE(r == 50.0f);
+    REQUIRE(fx == 105.0f);
+    REQUIRE(fy == 125.0f);
+    REQUIRE(fr == 5.0f);
 
     const Fill::ColorStop* cs2 = nullptr;
     REQUIRE(fill->colorStops(&cs2) == 4);

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -526,7 +526,7 @@ TEST_CASE("Filling Draw", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Filled Shapes
     auto shape3 = tvg::Shape::gen();
@@ -576,7 +576,7 @@ TEST_CASE("Filling Opaque Draw", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Filled Shapes
     auto shape3 = tvg::Shape::gen();
@@ -626,7 +626,7 @@ TEST_CASE("Filling AlphaMask", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Mask
     auto mask = tvg::Shape::gen();
@@ -686,7 +686,7 @@ TEST_CASE("Filling InvAlphaMask", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Mask
     auto mask = tvg::Shape::gen();
@@ -746,7 +746,7 @@ TEST_CASE("Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Mask
     auto mask = tvg::Shape::gen();
@@ -806,7 +806,7 @@ TEST_CASE("Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Mask
     auto mask = tvg::Shape::gen();
@@ -866,7 +866,7 @@ TEST_CASE("RLE Filling Draw", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Filled Shapes
     auto shape3 = tvg::Shape::gen();
@@ -916,7 +916,7 @@ TEST_CASE("RLE Filling Opaque Draw", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Filled Shapes
     auto shape3 = tvg::Shape::gen();
@@ -966,7 +966,7 @@ TEST_CASE("RLE Filling AlphaMask", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Mask
     auto mask = tvg::Shape::gen();
@@ -1026,7 +1026,7 @@ TEST_CASE("RLE Filling InvAlphaMask", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Mask
     auto mask = tvg::Shape::gen();
@@ -1086,7 +1086,7 @@ TEST_CASE("RLE Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Mask
     auto mask = tvg::Shape::gen();
@@ -1146,7 +1146,7 @@ TEST_CASE("RLE Filling InvLumaMask", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Mask
     auto mask = tvg::Shape::gen();
@@ -1206,7 +1206,7 @@ TEST_CASE("RLE Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(linearFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(radialFill->colorStops(cs, 4) == Result::Success);
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
-    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
+    REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f, 50.0f, 50.0f, 0.0f) == Result::Success);
 
     //Mask
     auto mask = tvg::Shape::gen();


### PR DESCRIPTION
Till now only the end circle values of the radial grad were supported. Now also the start circle values are. These are the focal point and the radius of the start circle.
In the svg_loader support for the 'fr' attrib of the radial grad is added.

@Issue: https://github.com/thorvg/thorvg/issues/1558

sample:
```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
  <defs>
    <radialGradient id="grad" r="50" cx="100" cy="100" 
      fr="21" fx="80" fy="80"
      gradientUnits="userSpaceOnUse">
      <stop style="stop-color:#ff00ff;stop-opacity:1;" offset="0"/>
      <stop style="stop-color:#0000ff;stop-opacity:1;" offset="0.5"/>
      <stop style="stop-color:#00ff00;stop-opacity:1;" offset="1"/>
    </radialGradient>
  </defs>

  <circle cx="100" cy="100" r="50" fill="url(#grad)"/>
</svg>
```

result:
<img width="398" alt="Zrzut ekranu 2023-08-7 o 23 09 06" src="https://github.com/thorvg/thorvg/assets/67589014/f4e3d58a-5de2-45be-98cb-d14a3f8b8e1f">
