### PR TITLE
Clarify build/export definition.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -26,7 +26,7 @@
 
 #ifndef TVG_STATIC
     #ifdef _WIN32
-        #if TVG_BUILD
+        #if TVG_EXPORT
             #define TVG_API __declspec(dllexport)
         #else
             #define TVG_API __declspec(dllimport)

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -27,7 +27,7 @@
 
 #ifndef TVG_STATIC
     #ifdef _WIN32
-        #if TVG_BUILD
+        #if TVG_EXPORT
             #define TVG_API __declspec(dllexport)
         #else
             #define TVG_API __declspec(dllimport)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,10 +1,10 @@
-compiler_flags = []
+compiler_flags = ['-DTVG_BUILD']
 override_options = []
 
 lib_type = get_option('default_library')
 
 if (lib_type == 'shared')
-    compiler_flags += ['-DTVG_EXPORT', '-DTVG_BUILD']
+    compiler_flags += ['-DTVG_EXPORT']
 else
     compiler_flags += ['-DTVG_STATIC']
 endif


### PR DESCRIPTION
The meaning of these two flags is somewhat confusing.

* The TVG_EXPORT flag is used to build external APIs.
* The TVG_BUILD flag is used to build the internal thorvg codebase.

See: https://github.com/thorvg/thorvg/pull/1527