### PR TITLE
gl_engine: upgrade min gl version

### DIFF
--- a/src/examples/Common.h
+++ b/src/examples/Common.h
@@ -88,7 +88,7 @@ static Eo* createGlView(uint32_t w = 800, uint32_t h = 800)
     Eo* win = elm_win_util_standard_add(NULL, "ThorVG Test");
     evas_object_smart_callback_add(win, "delete,request", win_del, 0);
 
-    Eo* view = elm_glview_add(win);
+    Eo* view = elm_glview_version_add(win, EVAS_GL_GLES_3_X);
     evas_object_size_hint_weight_set(view, EVAS_HINT_EXPAND, EVAS_HINT_EXPAND);
     elm_glview_mode_set(view, ELM_GLVIEW_ALPHA);
     elm_glview_resize_policy_set(view, ELM_GLVIEW_RESIZE_POLICY_RECREATE);

--- a/src/lib/gl_engine/meson.build
+++ b/src/lib/gl_engine/meson.build
@@ -19,9 +19,9 @@ source_file = [
    'tvgGlShaderSrc.cpp',
 ]
 
-egl_dep = meson.get_compiler('cpp').find_library('EGL')
 gles_dep = meson.get_compiler('cpp').find_library('GLESv2')
-external_dep = [egl_dep, gles_dep]
+
+external_dep = [gles_dep]
 
 engine_dep += [declare_dependency(
     dependencies        : external_dep,

--- a/src/lib/gl_engine/tvgGlCommon.h
+++ b/src/lib/gl_engine/tvgGlCommon.h
@@ -24,7 +24,7 @@
 #define _TVG_GL_COMMON_H_
 
 #include <assert.h>
-#include <GLES2/gl2.h>
+#include <GLES3/gl3.h>
 #include "tvgCommon.h"
 #include "tvgRender.h"
 


### PR DESCRIPTION
This PR changes the min gl version used inside GL Engine

Since most device supported morden gl (GLES 3.0 for mobile GPU, GL 3.3 for desktop GPU)
 
And I plan to use some advance and convenient API like [VAO](https://www.khronos.org/opengl/wiki/Vertex_Specification#Vertex_Array_Object) and [UBO](https://www.khronos.org/opengl/wiki/Uniform_Buffer_Object)

So I changed the example code to create a GLES3.x context with EFL. And the header file included inside GL Engine.
And the rest code in #1531 rely on this.
