### PR TITLE
gl_engine: use vertex array and index buffer when render primitive

### DIFF
--- a/src/lib/gl_engine/tvgGlGeometry.h
+++ b/src/lib/gl_engine/tvgGlGeometry.h
@@ -266,6 +266,8 @@ class GlGeometry
 {
 public:
 
+    ~GlGeometry();
+
     uint32_t getPrimitiveCount();
     const GlSize getPrimitiveSize(const uint32_t primitiveIndex) const;
     bool decomposeOutline(const RenderShape& rshape);
@@ -290,7 +292,9 @@ private:
     void decomposeCubicCurve(GlPrimitive& primitve, const GlPoint &pt1, const GlPoint &cpt1, const GlPoint &cpt2, const GlPoint &pt2, GlPoint &min, GlPoint &max);
     void updateBuffer(const uint32_t location, const VertexDataArray& vertexArray);
 
-    unique_ptr<GlGpuBuffer> mGpuBuffer;
+    GLuint mVao = 0;
+    std::unique_ptr<GlGpuBuffer> mVertexBuffer;
+    std::unique_ptr<GlGpuBuffer> mIndexBuffer;
     vector<GlPrimitive>     mPrimitives;
     GlTransform             mTransform;
 };

--- a/src/lib/gl_engine/tvgGlGpuBuffer.h
+++ b/src/lib/gl_engine/tvgGlGpuBuffer.h
@@ -31,7 +31,7 @@ public:
     enum class Target
     {
         ARRAY_BUFFER = GL_ARRAY_BUFFER,
-        ELEMENT_ARRAY_BUFFER = GL_ARRAY_BUFFER
+        ELEMENT_ARRAY_BUFFER = GL_ELEMENT_ARRAY_BUFFER,
     };
 
     GlGpuBuffer();


### PR DESCRIPTION
This PR use [Vertex Array Object](https://www.khronos.org/opengl/wiki/Vertex_Specification#Vertex_Array_Object) and `Element Array Buffer`  in GlGeometry 

VAO is new object in modern GL API, which can split and manage vertex buffer and attribute state. This is optional in GLES and is mandatory in GL.

Also index buffer is faster then pass cpu data in GL draw call, and must be used with a valid `Vertex Array Object`