### PR TITLE
loader: avoid attempting forceful loading when the given MIME type is…

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1270,7 +1270,7 @@ public:
      *
      * @param[in] data A pointer to a memory location where the content of the picture file is stored.
      * @param[in] size The size in bytes of the memory occupied by the @p data.
-     * @param[in] mimeType Mimetype or extension of data such as "jpg", "jpeg", "svg", "svg+xml", "png", etc. In case an empty string or an unknown type is provided, the loaders will be tried one by one.
+     * @param[in] mimeType Mimetype or extension of data such as "jpg", "jpeg", "lottie", "svg", "svg+xml", "png", etc. In case an empty string or an unknown type is provided, the loaders will be tried one by one.
      * @param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
      *
      * @retval Result::Success When succeed.
@@ -1280,6 +1280,7 @@ public:
      *
      * @warning: It's the user responsibility to release the @p data memory if the @p copy is @c true.
      *
+     * @note If you are unsure about the MIME type, you can provide an empty value like @c "", and thorvg will attempt to figure it out.
      * @since 0.5
      */
     Result load(const char* data, uint32_t size, const std::string& mimeType, bool copy = false) noexcept;


### PR DESCRIPTION
… unknown.

Loading images when the MIME type is unknown is unnecessary and often results in failure, adding unnecessary processing overhead.

Pictures should have a clear MIME type assigned by users.