### PR TITLE
loader/png: revert force colorspace conversion.

### DIFF
--- a/src/loaders/png/tvgLodePng.cpp
+++ b/src/loaders/png/tvgLodePng.cpp
@@ -1762,11 +1762,7 @@ static void getPixelColorsRGBA8(unsigned char* LODEPNG_RESTRICT buffer, size_t n
     } else if (mode->colortype == LCT_RGB) {
         if (mode->bitdepth == 8) {
             for (i = 0; i != numpixels; ++i, buffer += num_channels) {
-                //lodepng_memcpy(buffer, &in[i * 3], 3);
-                //Convert colortype to LCT_BGR?
-                buffer[0] = in[i * 3 + 2];
-                buffer[1] = in[i * 3 + 1];
-                buffer[2] = in[i * 3 + 0];
+                lodepng_memcpy(buffer, &in[i * 3], 3);
                 buffer[3] = 255;
             }
             if (mode->key_defined) {
@@ -2089,44 +2085,30 @@ static unsigned unfilterScanline(unsigned char* recon, const unsigned char* scan
 
     size_t i;
     switch (filterType) {
-        case 0: {
-            if (bytewidth == 4) {
-                for (i = 0; i < length; i += 4) {
-                    //RGBA -> BGRA
-                    recon[i + 0] = scanline[i + 2];
-                    recon[i + 1] = scanline[i + 1];
-                    recon[i + 2] = scanline[i + 0];
-                    recon[i + 3] = scanline[i + 3];
-                }
-            } else {
-                for (i = 0; i != length; ++i) recon[i] = scanline[i];
-            }
+        case 0:
+            for (i = 0; i != length; ++i) recon[i] = scanline[i];
             break;
-        }
-        case 1: {
+        case 1:
             for (i = 0; i != bytewidth; ++i) recon[i] = scanline[i];
             for (i = bytewidth; i < length; ++i) recon[i] = scanline[i] + recon[i - bytewidth];
             break;
-        }
-        case 2: {
+        case 2:
             if (precon) {
-                for (i = 0; i != length; ++i) recon[i] = scanline[i] + precon[i];
+                for(i = 0; i != length; ++i) recon[i] = scanline[i] + precon[i];
             } else {
-                for (i = 0; i != length; ++i) recon[i] = scanline[i];
+                for(i = 0; i != length; ++i) recon[i] = scanline[i];
             }
             break;
-        }
-        case 3: {
-            if (precon) {
-                for (i = 0; i != bytewidth; ++i) recon[i] = scanline[i] + (precon[i] >> 1u);
-                for (i = bytewidth; i < length; ++i) recon[i] = scanline[i] + ((recon[i - bytewidth] + precon[i]) >> 1u);
-            } else {
-                for (i = 0; i != bytewidth; ++i) recon[i] = scanline[i];
-                for (i = bytewidth; i < length; ++i) recon[i] = scanline[i] + (recon[i - bytewidth] >> 1u);
-            }
-            break;
-        }
-        case 4: {
+        case 3:
+          if (precon) {
+              for (i = 0; i != bytewidth; ++i) recon[i] = scanline[i] + (precon[i] >> 1u);
+              for (i = bytewidth; i < length; ++i) recon[i] = scanline[i] + ((recon[i - bytewidth] + precon[i]) >> 1u);
+          } else {
+              for (i = 0; i != bytewidth; ++i) recon[i] = scanline[i];
+              for (i = bytewidth; i < length; ++i) recon[i] = scanline[i] + (recon[i - bytewidth] >> 1u);
+          }
+          break;
+        case 4:
             if (precon) {
                 for (i = 0; i != bytewidth; ++i) {
                     recon[i] = (scanline[i] + precon[i]); /*paethPredictor(0, precon[i], 0) is always precon[i]*/
@@ -2182,7 +2164,6 @@ static unsigned unfilterScanline(unsigned char* recon, const unsigned char* scan
                 }
             }
             break;
-        }
         default: return 36; /* error: invalid filter type given */
     }
     return 0;

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -125,8 +125,7 @@ bool PngLoader::open(const char* data, uint32_t size, bool copy)
     h = static_cast<float>(height);
     this->size = size;
 
-    if (state.info_png.color.colortype == LCT_RGBA) cs = ColorSpace::ABGR8888;
-    else cs = ColorSpace::ARGB8888;
+    cs = ColorSpace::ABGR8888;
 
     return true;
 }
@@ -154,6 +153,8 @@ unique_ptr<Surface> PngLoader::bitmap()
 {
     this->done();
 
+    if (!image) return nullptr;
+
     //TODO: It's better to keep this surface instance in the loader side
     auto surface = new Surface;
     surface->buf8 = image;
@@ -178,5 +179,7 @@ void PngLoader::run(unsigned tid)
     auto width = static_cast<unsigned>(w);
     auto height = static_cast<unsigned>(h);
 
-    lodepng_decode(&image, &width, &height, &state, data, size);
+    if (lodepng_decode(&image, &width, &height, &state, data, size)) {
+        TVGERR("PNG", "Failed to decode image");
+    }
 }


### PR DESCRIPTION
We have a base color space conversion in the renderer, so there's no need to forcefully align with BGRA.