### PR TITLE
gl_engine: refactor matrix calculation

### DIFF
--- a/src/lib/gl_engine/tvgGlGeometry.cpp
+++ b/src/lib/gl_engine/tvgGlGeometry.cpp
@@ -254,17 +254,9 @@ void GlGeometry::updateBuffer(uint32_t location, const VertexDataArray& vertexAr
 }
 
 
-GlPoint GlGeometry::normalizePoint(const GlPoint& pt, float viewWd, float viewHt)
-{
-    GlPoint p;
-    p.x = (pt.x * 2.0f / viewWd) - 1.0f;
-    p.y = -1.0f * ((pt.y * 2.0f / viewHt) - 1.0f);
-    return p;
-}
-
 void GlGeometry::addGeometryPoint(VertexDataArray& geometry, const GlPoint &pt, float viewWd, float viewHt, float opacity)
 {
-    VertexData tv = { normalizePoint(pt, viewWd, viewHt), opacity};
+    VertexData tv = {pt, opacity};
     geometry.vertices.push_back(tv);
 }
 
@@ -349,19 +341,22 @@ void GlGeometry::decomposeCubicCurve(GlPrimitive& primitve, const GlPoint& pt1, 
 
 void GlGeometry::updateTransform(const RenderTransform* transform, float w, float h)
 {
+    float modelMatrix[16];
     if (transform) {
-        mTransform.x = transform->x;
-        mTransform.y = transform->y;
-        mTransform.angle = transform->degree;
-        mTransform.scale = transform->scale;
+        GET_MATRIX44(transform->m, modelMatrix);
+    } else {
+        memset(modelMatrix, 0, 16 * sizeof(float));
+        modelMatrix[0] = 1.f;
+        modelMatrix[5] = 1.f;
+        modelMatrix[10] = 1.f;
+        modelMatrix[15] = 1.f;
     }
 
-    mTransform.w = w;
-    mTransform.h = h;
-    GET_TRANSFORMATION(NORMALIZED_LEFT_3D, NORMALIZED_TOP_3D, mTransform.matrix);
+    MVP_MATRIX();
+    MULTIPLY_MATRIX(mvp, modelMatrix, mTransform)
 }
 
 float* GlGeometry::getTransforMatrix()
 {
-    return mTransform.matrix;
+    return mTransform;
 }

--- a/src/lib/gl_engine/tvgGlGeometry.h
+++ b/src/lib/gl_engine/tvgGlGeometry.h
@@ -31,21 +31,10 @@
 
 #define MVP_MATRIX() \
     float mvp[4*4] = { \
-        mTransform.scale, 0.0, 0.0f, 0.0f, \
-        0.0, mTransform.scale, 0.0f, 0.0f, \
-        0.0f, 0.0f, mTransform.scale, 0.0f, \
-        (mTransform.x * 2.0f) * (mTransform.scale / mTransform.w), -(mTransform.y * 2.0f) * (mTransform.scale / mTransform.h), 0.0f, 1.0f \
-    };
-
-#define ROTATION_MATRIX(xPivot, yPivot) \
-    auto radian = mTransform.angle / 180.0f * PI; \
-    auto cosVal = cosf(radian);  \
-    auto sinVal = sinf(radian); \
-    float rotate[4*4] = { \
-        cosVal, -sinVal, 0.0f, 0.0f, \
-        sinVal, cosVal, 0.0f, 0.0f, \
-        0.0f, 0.0f, 1.0f, 0.0f, \
-        (xPivot * (1.0f - cosVal)) - (yPivot * sinVal), (yPivot *(1.0f - cosVal)) + (xPivot * sinVal), 0.0f, 1.0f \
+        2.f / w, 0.0, 0.0f, 0.0f, \
+        0.0, -2.f / h, 0.0f, 0.0f, \
+        0.0f, 0.0f, -1.f, 0.0f, \
+        -1.f, 1.f, 0.0f, 1.0f \
     };
 
 #define MULTIPLY_MATRIX(A, B, transform) \
@@ -90,11 +79,6 @@
         mat4[14] = 0;               \
         mat4[15] = mat3.e33;        \
     } while (false)
-
-#define GET_TRANSFORMATION(xPivot, yPivot, transform) \
-    MVP_MATRIX(); \
-    ROTATION_MATRIX(xPivot, yPivot); \
-    MULTIPLY_MATRIX(mvp, rotate, transform);
 
 class GlPoint
 {
@@ -249,17 +233,6 @@ struct GlPrimitive
     bool mIsClosed = false;
 };
 
-struct GlTransform
-{
-    float x = 0.0f;
-    float y = 0.0f;
-    float angle = 0.0f;
-    float scale = 1.0f;
-    float w;
-    float h;
-    float matrix[16];
-};
-
 class GlGpuBuffer;
 
 class GlGeometry
@@ -279,7 +252,6 @@ public:
     float* getTransforMatrix();
 
 private:
-    GlPoint normalizePoint(const GlPoint &pt, float viewWd, float viewHt);
     void addGeometryPoint(VertexDataArray &geometry, const GlPoint &pt, float viewWd, float viewHt, float opacity);
     GlPoint getNormal(const GlPoint &p1, const GlPoint &p2);
     float dotProduct(const GlPoint &p1, const GlPoint &p2);
@@ -296,7 +268,7 @@ private:
     std::unique_ptr<GlGpuBuffer> mVertexBuffer;
     std::unique_ptr<GlGpuBuffer> mIndexBuffer;
     vector<GlPrimitive>     mPrimitives;
-    GlTransform             mTransform;
+    float                   mTransform[16];
 };
 
 #endif /* _TVG_GL_GEOMETRY_H_ */

--- a/src/lib/gl_engine/tvgGlRenderTask.cpp
+++ b/src/lib/gl_engine/tvgGlRenderTask.cpp
@@ -174,30 +174,10 @@ GlGradientRenderTask::GlGradientRenderTask(GlRenderTask::RenderTypes renderType,
     :GlRenderTask(renderType, shader)
 {
     VertexProperty* prop = nullptr;
-    ADD_UNIFORM_PROPERTY(prop, this, getProgram(), "uSize", FORMAT_SIZE_VEC_2, mLocPrimitiveSize);
-    ADD_UNIFORM_PROPERTY(prop, this, getProgram(), "uCanvasSize", FORMAT_SIZE_VEC_2, mLocCanvasSize);
     ADD_UNIFORM_PROPERTY(prop, this, getProgram(), "noise_level", FORMAT_SIZE_FLOAT, mLocNoise);
     ADD_UNIFORM_PROPERTY(prop, this, getProgram(), "nStops", FORMAT_SIZE_FLOAT, mLocStopCnt);
     ADD_UNIFORM_PROPERTY(prop, this, getProgram(), "stopPoints", FORMAT_SIZE_FLOAT, mLocStops);
     ADD_UNIFORM_PROPERTY(prop, this, getProgram(), "stopColors", FORMAT_SIZE_VEC_4, mLocStopColors);
-}
-
-
-void GlGradientRenderTask::setPrimitveSize(float width, float height)
-{
-    if (mLocPrimitiveSize != -1)
-    {
-        PropertyInterface::setProperty(this, mLocPrimitiveSize, width, height);
-    }
-}
-
-
-void GlGradientRenderTask::setCanvasSize(float width, float height)
-{
-    if (mLocCanvasSize != -1)
-    {
-        PropertyInterface::setProperty(this, mLocCanvasSize, width, height);
-    }
 }
 
 

--- a/src/lib/gl_engine/tvgGlRenderTask.h
+++ b/src/lib/gl_engine/tvgGlRenderTask.h
@@ -85,8 +85,6 @@ public:
     void setStopColor(int index, float stopVal, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
     int32_t getTransformLocationPropertyId() const;
 private:
-    int32_t mLocPrimitiveSize = -1;
-    int32_t mLocCanvasSize = -1;
     int32_t mLocNoise = -1;
     int32_t mLocStopCnt = -1;
     int32_t mLocStops = -1;

--- a/src/lib/gl_engine/tvgGlRenderer.cpp
+++ b/src/lib/gl_engine/tvgGlRenderer.cpp
@@ -345,7 +345,6 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, uint32_t primit
     if (stopCnt < 2) return;
 
     GlGradientRenderTask* rTask = nullptr;
-    auto size = sdata.geometry->getPrimitiveSize(primitiveIndex);
     auto matrix = sdata.geometry->getTransforMatrix();
 
     switch (fill->identifier()) {
@@ -378,8 +377,6 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, uint32_t primit
     }
     if (rTask) {
         auto vertexLoc = rTask->getLocationPropertyId();
-        rTask->setPrimitveSize(size.x, size.y);
-        rTask->setCanvasSize(sdata.viewWd, sdata.viewHt);
         rTask->setNoise(NOISE_LEVEL);
         rTask->setStopCount((int)stopCnt);
         rTask->setTransform(FORMAT_SIZE_MAT_4x4, matrix);

--- a/src/lib/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/lib/gl_engine/tvgGlShaderSrc.cpp
@@ -54,14 +54,12 @@ void main()                                                                     
 {                                                                               \n
     gl_Position = uTransform * vec4(aLocation.xy, 0.0, 1.0);                    \n
     vOpacity = aLocation.z;                                                     \n
-    vPos = vec2((aLocation.x + 1.0) / 2.0, ((-1.0 * aLocation.y) +1.0) / 2.0);  \n
+    vPos =  aLocation.xy;                                                       \n
 });
 
 
 std::string STR_GRADIENT_FRAG_COMMON_VARIABLES = TVG_COMPOSE_SHADER(                                                                               \n
 const int MAX_STOP_COUNT = 4;                                                                           \n
-uniform vec2 uSize;                                                                                     \n
-uniform vec2 uCanvasSize;                                                                               \n
 uniform float nStops;                                                                                   \n
 uniform float noise_level;                                                                              \n
 uniform float stopPoints[MAX_STOP_COUNT];                                                               \n
@@ -123,14 +121,13 @@ std::string STR_LINEAR_GRADIENT_MAIN = TVG_COMPOSE_SHADER(
 out vec4 FragColor;                                                                                     \n
 void main()                                                                                             \n
 {                                                                                                       \n
-    vec2 pos = vec2(vPos.x * uCanvasSize.x, vPos.y * uCanvasSize.y);                                    \n
-    vec2 spos = vec2(pos.x / uSize.x, pos.y / uSize.y);                                                 \n
-    vec2 st = gradStartPos / (uSize.xy);                                                                \n
-    vec2 ed = gradEndPos / (uSize.xy);                                                                  \n
+    vec2 pos = vPos;                                                                                    \n
+    vec2 st = gradStartPos;                                                                             \n
+    vec2 ed = gradEndPos;                                                                               \n
                                                                                                         \n
     vec2 ba = ed - st;                                                                                  \n
                                                                                                         \n
-    float t = dot(spos - st, ba) / dot(ba, ba);                                                         \n
+    float t = dot(pos - st, ba) / dot(ba, ba);                                                          \n
                                                                                                         \n
     //t = smoothstep(0.0, 1.0, clamp(t, 0.0, 1.0));                                                     \n
     t = clamp(t, 0.0, 1.0);                                                                             \n
@@ -151,8 +148,7 @@ std::string STR_RADIAL_GRADIENT_MAIN = TVG_COMPOSE_SHADER(
 out vec4 FragColor;                                                                                     \n
 void main()                                                                                             \n
 {                                                                                                       \n
-    vec2 pos = vec2(vPos.x * uCanvasSize.x, vPos.y * uCanvasSize.y);                                    \n
-    vec2 spos = vec2(pos.x / uSize.x, pos.y / uSize.y);                                                 \n
+    vec2 pos = vPos;                                                                                    \n
                                                                                                         \n
     float ba = stRadius;                                                                                \n
     float d = distance(gradStartPos, pos);                                                              \n


### PR DESCRIPTION
This PR doing the following things:

1. convert mat4 directly from exist mat3, and remove unused calculation code.

2. since normalized position is only meaningful in vertex shader stage. Change to use logical position in fragment shader stage for all gradient pipeline.