### PR TITLE
gl_engine: Fix mistake in glbuffer id check

### DIFF
--- a/src/lib/gl_engine/tvgGlGpuBuffer.cpp
+++ b/src/lib/gl_engine/tvgGlGpuBuffer.cpp
@@ -29,7 +29,7 @@
 GlGpuBuffer::GlGpuBuffer()
 {
     GL_CHECK(glGenBuffers(1, &mGlBufferId));
-    assert(mGlBufferId != GL_INVALID_VALUE);
+    assert(mGlBufferId != 0);
 }
 
 


### PR DESCRIPTION
`GL_INVALID_VALUE` is generate during `glGenBuffers` and is checked by calling `glGetError()` inside `GL_CHECK` macro.

While the buffer id is valid if the value is not zero.