### PR TITLE
renderer/paint: added an option for stroking when acquiring bounding …

### DIFF
--- a/src/lib/tvgPaint.cpp
+++ b/src/lib/tvgPaint.cpp
@@ -263,12 +263,12 @@ RenderData Paint::Impl::update(RenderMethod& renderer, const RenderTransform* pT
 }
 
 
-bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transformed)
+bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transformed, bool stroking)
 {
     Matrix* m = nullptr;
 
     //Case: No transformed, quick return!
-    if (!transformed || !(m = this->transform())) return smethod->bounds(x, y, w, h);
+    if (!transformed || !(m = this->transform())) return smethod->bounds(x, y, w, h, stroking);
 
     //Case: Transformed
     auto tx = 0.0f;
@@ -276,7 +276,7 @@ bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transforme
     auto tw = 0.0f;
     auto th = 0.0f;
 
-    auto ret = smethod->bounds(&tx, &ty, &tw, &th);
+    auto ret = smethod->bounds(&tx, &ty, &tw, &th, stroking);
 
     //Get vertices
     Point pt[4] = {{tx, ty}, {tx + tw, ty}, {tx + tw, ty + th}, {tx, ty + th}};
@@ -365,7 +365,7 @@ TVG_DEPRECATED Result Paint::bounds(float* x, float* y, float* w, float* h) cons
 
 Result Paint::bounds(float* x, float* y, float* w, float* h, bool transform) const noexcept
 {
-    if (pImpl->bounds(x, y, w, h, transform)) return Result::Success;
+    if (pImpl->bounds(x, y, w, h, transform, true)) return Result::Success;
     return Result::InsufficientCondition;
 }
 

--- a/src/lib/tvgPaint.h
+++ b/src/lib/tvgPaint.h
@@ -45,7 +45,7 @@ namespace tvg
         virtual bool dispose(RenderMethod& renderer) = 0;     //return true if the deletion is allowed.
         virtual void* update(RenderMethod& renderer, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper) = 0;   //Return engine data if it has.
         virtual bool render(RenderMethod& renderer) = 0;
-        virtual bool bounds(float* x, float* y, float* w, float* h) = 0;
+        virtual bool bounds(float* x, float* y, float* w, float* h, bool stroking) = 0;
         virtual RenderRegion bounds(RenderMethod& renderer) const = 0;
         virtual Paint* duplicate() = 0;
         virtual Iterator* iterator() = 0;
@@ -161,7 +161,7 @@ namespace tvg
         bool rotate(float degree);
         bool scale(float factor);
         bool translate(float x, float y);
-        bool bounds(float* x, float* y, float* w, float* h, bool transformed);
+        bool bounds(float* x, float* y, float* w, float* h, bool transformed, bool stroking);
         RenderData update(RenderMethod& renderer, const RenderTransform* pTransform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper = false);
         bool render(RenderMethod& renderer);
         Paint* duplicate();
@@ -176,9 +176,9 @@ namespace tvg
         PaintMethod(T* _inst) : inst(_inst) {}
         ~PaintMethod() {}
 
-        bool bounds(float* x, float* y, float* w, float* h) override
+        bool bounds(float* x, float* y, float* w, float* h, bool stroking) override
         {
-            return inst->bounds(x, y, w, h);
+            return inst->bounds(x, y, w, h, stroking);
         }
 
         RenderRegion bounds(RenderMethod& renderer) const override

--- a/src/lib/tvgPictureImpl.h
+++ b/src/lib/tvgPictureImpl.h
@@ -159,7 +159,7 @@ struct Picture::Impl
         return true;
     }
 
-    bool bounds(float* x, float* y, float* w, float* h)
+    bool bounds(float* x, float* y, float* w, float* h, bool stroking)
     {
         if (rm.triangleCnt > 0) {
             auto triangles = rm.triangles;

--- a/src/lib/tvgSceneImpl.h
+++ b/src/lib/tvgSceneImpl.h
@@ -181,7 +181,7 @@ struct Scene::Impl
         return {x1, y1, (x2 - x1), (y2 - y1)};
     }
 
-    bool bounds(float* px, float* py, float* pw, float* ph)
+    bool bounds(float* px, float* py, float* pw, float* ph, bool stroking)
     {
         if (paints.empty()) return false;
 
@@ -196,7 +196,7 @@ struct Scene::Impl
             auto w = 0.0f;
             auto h = 0.0f;
 
-            if (paint->bounds(&x, &y, &w, &h, true) != tvg::Result::Success) continue;
+            if (!P(paint)->bounds(&x, &y, &w, &h, true, stroking)) continue;
 
             //Merge regions
             if (x < x1) x1 = x;

--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -104,7 +104,7 @@ struct Shape::Impl
         return renderer.region(rd);
     }
 
-    bool bounds(float* x, float* y, float* w, float* h)
+    bool bounds(float* x, float* y, float* w, float* h, bool stroking)
     {
         //Path bounding size
         if (rs.path.pts.count > 0 ) {
@@ -126,7 +126,7 @@ struct Shape::Impl
         }
 
         //Stroke feathering
-        if (rs.stroke) {
+        if (stroking && rs.stroke) {
             if (x) *x -= rs.stroke->width * 0.5f;
             if (y) *y -= rs.stroke->width * 0.5f;
             if (w) *w += rs.stroke->width;


### PR DESCRIPTION
…box size.

The 'Paint' function now includes an internal stroking option, allowing the bounding box to be calculated with or without the stroke size taken into account.

This feature is particularly useful for SVG loaders, and we might consider making the interface available for user demands in the future.