### PR TITLE
common: shape's composition fixed

### DIFF
--- a/src/lib/tvgShapeImpl.h
+++ b/src/lib/tvgShapeImpl.h
@@ -70,7 +70,7 @@ struct Shape::Impl
         if (opacity == 0) return false;
 
         //Shape composition is only necessary when stroking & fill are valid.
-        if (!rs.stroke || rs.stroke->width < FLT_EPSILON || rs.stroke->color[3] == 0) return false;
+        if (!rs.stroke || rs.stroke->width < FLT_EPSILON || (!rs.stroke->fill && rs.stroke->color[3] == 0)) return false;
         if (!rs.fill && rs.color[3] == 0) return false;
 
         //translucent fill & stroke


### PR DESCRIPTION
In the case of a gradient stroke and a valid
fill, the composition wasn't applied correctly,
resulting in an unexpected overlap between
the fill and stroke.

@Issue: https://github.com/thorvg/thorvg/issues/445

sample:
```
    tvg::Fill::ColorStop colorStops2[2];
    colorStops2[0] = {0, 255, 0, 0, 255};
    colorStops2[1] = {1, 0, 0, 255, 255};

    auto fillStroke = tvg::RadialGradient::gen();
    fillStroke->radial(250, 250, 400);
    fillStroke->colorStops(colorStops2, 2);

    auto scene = tvg::Scene::gen();
    auto shape1 = tvg::Shape::gen();
    shape1->appendRect(100, 100, 400, 400);
    shape1->fill(0, 255, 0, 255);
    shape1->stroke(150);
    shape1->stroke(std::move(fillStroke));
    shape1->opacity(155);

    canvas->push(std::move(shape1));
```

before:
<img width="353" alt="Zrzut ekranu 2023-08-20 o 09 14 29" src="https://github.com/thorvg/thorvg/assets/67589014/69eb6c84-09be-427d-ba46-dc518927f82d">

after:
<img width="353" alt="Zrzut ekranu 2023-08-20 o 09 16 16" src="https://github.com/thorvg/thorvg/assets/67589014/8667a8ac-a80c-45fb-aec6-4c48367b598e">


