### PR TITLE
THORVG_LOG: --compiler -Werror=empty-body

### DIFF
--- a/src/renderer/tvgCommon.h
+++ b/src/renderer/tvgCommon.h
@@ -76,8 +76,8 @@ using Size = Point;
     #define TVGERR(tag, fmt, ...) fprintf(stderr, "%s[E]%s %s" tag "%s (%s %d): %s" fmt "\n", ErrorBgColor, ResetColors, ErrorColor, GreyColor, __FILE__, __LINE__, ResetColors, ##__VA_ARGS__)
     #define TVGLOG(tag, fmt, ...) fprintf(stdout, "%s[L]%s %s" tag "%s (%s %d): %s" fmt "\n", LogBgColor, ResetColors, LogColor, GreyColor, __FILE__, __LINE__, ResetColors, ##__VA_ARGS__)
 #else
-    #define TVGERR(...)
-    #define TVGLOG(...)
+    #define TVGERR(...) do {} while(0)
+    #define TVGLOG(...) do {} while(0)
 #endif
 
 uint16_t THORVG_VERSION_NUMBER();


### PR DESCRIPTION
Godot CI:
Error: (thirdparty/thorvg/)src/renderer/tvgPaint.h:85:80: error: suggest braces around empty body in an 'if' statement [-Werror=empty-body]
   85 |             if (refCnt == 255) TVGERR("RENDERER", "Corrupted reference count!");
...

Hi @hermet I quickly tested the current ThorVG main + Godot. This broke the Godot CI, but the change  breaks here
the Lottie parser, so I think it would be better to insert the braces around the LOG macros everywhere...

https://github.com/capnm/godot4/commits/update_thorvg_main

++ I get now
`WARNING: ThreadSanitizer: data race`. Could you take a look if it's a ThorVG issue?
-> https://github.com/capnm/godot4/actions/runs/6004479786/job/16285182152
```
#0 std::vector<std::thread, std::allocator<std::thread> >::size() const
/usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../../include/c++/10/bits/stl_vector.h:919:40
(godot.linuxbsd.editor.dev.x86_64.llvm.san+0x56b15a9)

#1 tvg::TaskSchedulerImpl::run(unsigned int)
 /home/runner/work/godot4/godot4/thirdparty/thorvg/src/renderer/tvgTaskScheduler.cpp:134:46
(godot.linuxbsd.editor.dev.x86_64.llvm.san+0x6f0ce8d)
...
```
Thanks.