### PR TITLE
gl_engine: pack all data into one gpu buffer

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.h
+++ b/src/renderer/gl_engine/tvgGlGeometry.h
@@ -181,7 +181,7 @@ public:
     }
 };
 
-class GlGpuBuffer;
+class GlStageBuffer;
 
 class GlGeometry
 {
@@ -189,26 +189,19 @@ public:
 
     ~GlGeometry();
 
-    bool tesselate(const RenderShape& rshape, RenderUpdateFlag flag);
+    bool tesselate(const RenderShape& rshape, RenderUpdateFlag flag, GlStageBuffer* gpuBuffer);
     void disableVertex(uint32_t location);
     void draw(const uint32_t location, RenderUpdateFlag flag);
     void updateTransform(const RenderTransform* transform, float w, float h);
     float* getTransforMatrix();
 
 private:
-    void updateBuffer(const uint32_t location);
-
-    Array<float> mStaveVertex;
-    Array<uint32_t> mStageIndex;
     uint32_t mFillVertexOffset;
     uint32_t mFillIndexOffset;
     uint32_t mFillCount;
     uint32_t mStrokeVertexOffset;
     uint32_t mStrokeIndexOffset;
     uint32_t mStrokeCount;
-    GLuint mVao = 0;
-    std::unique_ptr<GlGpuBuffer> mVertexBuffer;
-    std::unique_ptr<GlGpuBuffer> mIndexBuffer;
     float mTransform[16];
 };
 

--- a/src/renderer/gl_engine/tvgGlGpuBuffer.h
+++ b/src/renderer/gl_engine/tvgGlGpuBuffer.h
@@ -23,6 +23,9 @@
 #ifndef _TVG_GL_GPU_BUFFER_H_
 #define _TVG_GL_GPU_BUFFER_H_
 
+#include <memory>
+
+#include "tvgArray.h"
 #include "tvgGlCommon.h"
 
 class GlGpuBuffer
@@ -37,10 +40,30 @@ public:
     GlGpuBuffer();
     ~GlGpuBuffer();
     void updateBufferData(Target target, uint32_t size, const void* data);
+    void bind(Target target);
     void unbind(Target target);
 private:
     uint32_t    mGlBufferId = 0;
 
+};
+
+class GlStageBuffer {
+public:
+    GlStageBuffer() = default;
+    ~GlStageBuffer();
+
+    uint32_t push(void* data, uint32_t size);
+
+    void flushToGPU();
+
+    void bind();
+
+    void unbind();
+
+private:
+    GLuint mVao = 0;
+    unique_ptr<GlGpuBuffer> mGpuBuffer = {};
+    Array<uint8_t> mStageBuffer = {};
 };
 
 #endif /* _TVG_GL_GPU_BUFFER_H_ */

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -87,16 +87,21 @@ bool GlRenderer::preRender()
     }
     GlRenderTask::unload();
 
+    mGpuBuffer->flushToGPU();
+
     // Blend function for straight alpha
     GL_CHECK(glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
     GL_CHECK(glEnable(GL_BLEND));
+
+    mGpuBuffer->bind();
+
     return true;
 }
 
 
 bool GlRenderer::postRender()
 {
-    //TODO: called just after render()
+    mGpuBuffer->unbind();
 
     return true;
 }
@@ -238,7 +243,7 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
     if (sdata->updateFlag & (RenderUpdateFlag::Color | RenderUpdateFlag::Stroke | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform) )
     {
-        if (!sdata->geometry->tesselate(rshape, sdata->updateFlag)) return sdata;
+        if (!sdata->geometry->tesselate(rshape, sdata->updateFlag, mGpuBuffer.get())) return sdata;
     }
     return sdata;
 }

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -24,6 +24,7 @@
 #define _TVG_GL_RENDERER_H_
 
 #include "tvgGlRenderTask.h"
+#include "tvgGlGpuBuffer.h"
 
 class GlRenderer : public RenderMethod
 {
@@ -58,7 +59,7 @@ public:
     static int term();
 
 private:
-    GlRenderer(){};
+    GlRenderer(): mGpuBuffer(new GlStageBuffer) {};
     ~GlRenderer();
 
     void initShaders();
@@ -66,6 +67,7 @@ private:
     void drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFlag flag);
 
     vector<shared_ptr<GlRenderTask>>  mRenderTasks;
+    std::unique_ptr<GlStageBuffer> mGpuBuffer;
 };
 
 #endif /* _TVG_GL_RENDERER_H_ */


### PR DESCRIPTION
This PR changed GPU buffer management and pack all data into one gpu buffer to avoid memory fragmentation in GPU.

Some reference:
[Best Practices for Video Memory Management](https://docs.nvidia.com/drive/drive_os_5.1.6.1L/nvvib_docs/index.html#page/DRIVE_OS_Linux_SDK_Development_Guide/Graphics/graphics_opengl.html#wwpID0EXHA)