### PR TITLE
gl_engine: fix compilation erros due to redundant header inclusion

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.h
+++ b/src/renderer/gl_engine/tvgGlGeometry.h
@@ -24,9 +24,8 @@
 #define _TVG_GL_GEOMETRY_H_
 
 #include <vector>
-#include "tvgMath.h"
-#include "tvgArray.h"
 #include "tvgGlCommon.h"
+#include "tvgMath.h"
 
 
 #define MVP_MATRIX() \

--- a/src/renderer/gl_engine/tvgGlGpuBuffer.h
+++ b/src/renderer/gl_engine/tvgGlGpuBuffer.h
@@ -25,7 +25,6 @@
 
 #include <memory>
 
-#include "tvgArray.h"
 #include "tvgGlCommon.h"
 
 class GlGpuBuffer

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -25,10 +25,8 @@
 
 #include <cstdint>
 
-#include "tvgCommon.h"
-#include "tvgArray.h"
-#include "tvgBezier.h"
 #include "tvgGlGeometry.h"
+#include "tvgBezier.h"
 
 namespace tvg
 {


### PR DESCRIPTION
Fix the following error during gl_engine compile
```
In file included from ../src/renderer/gl_engine/tvgGlGpuBuffer.h:28,
                 from ../src/renderer/gl_engine/tvgGlGeometry.cpp:24:
../src/common/tvgArray.h: In instantiation of ‘tvg::Array<T>::~Array() [with T = tvg::PathCommand]’:
../src/renderer/tvgRender.h:161:5:   required from here
../src/common/tvgArray.h:154:13: error: ‘free’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
  154 |         free(data);
      |         ~~~~^~~~~~
```