### PR TITLE
taskschduler: fix a regression deadlock issue

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -25,6 +25,7 @@
 #include "tvgShape.h"
 #include "tvgLottieModel.h"
 #include "tvgLottieBuilder.h"
+#include "tvgTaskScheduler.h"
 
 
 /************************************************************************/
@@ -577,11 +578,17 @@ static void _updateImage(LottieGroup* parent, LottieImage* image, int32_t frameN
 
     if (!picture) {
         picture = Picture::gen().release();
+
+        //force to load a picture on the same thread
+        TaskScheduler::async(false);
+
         if (image->size > 0) {
             if (picture->load((const char*)image->b64Data, image->size, image->mimeType, false) != Result::Success) return;
         } else {
             if (picture->load(image->path) != Result::Success) return;
         }
+
+        TaskScheduler::async(true);
     }
 
     if (ctx.propagator) {

--- a/src/renderer/tvgTaskScheduler.h
+++ b/src/renderer/tvgTaskScheduler.h
@@ -38,6 +38,7 @@ struct TaskScheduler
     static void init(unsigned threads);
     static void term();
     static void request(Task* task);
+    static void async(bool on);
 };
 
 struct Task


### PR DESCRIPTION
This fix introduces a workaround to enforce synchronous tasking on worker threads. Sometimes, out of threads get stuck in a deadlock condition.

@Issue: https://github.com/thorvg/thorvg/issues/1636