### PR TITLE
sw_engine/shape: fix a dash-line infite-loop bug.

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -129,8 +129,7 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix* trans
             Line left, right;
             if (dash.curLen > 0) {
                 len -= dash.curLen;
-                _lineSplitAt(cur, dash.curLen, left, right);;
-                dash.curIdx = (dash.curIdx + 1) % dash.cnt;
+                _lineSplitAt(cur, dash.curLen, left, right);
                 if (!dash.curOpGap) {
                     _outlineMoveTo(*dash.outline, &left.pt1, transform);
                     _outlineLineTo(*dash.outline, &left.pt2, transform);
@@ -138,6 +137,7 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix* trans
             } else {
                 right = cur;
             }
+            dash.curIdx = (dash.curIdx + 1) % dash.cnt;
             dash.curLen = dash.pattern[dash.curIdx];
             dash.curOpGap = !dash.curOpGap;
             cur = right;


### PR DESCRIPTION
a regresion bug was introduced by d683d2e70d2dca1eb574a8874f101f6a79e64934