### PR TITLE
sw_engine: fix an invalid memory access.

### DIFF
--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -773,10 +773,8 @@ RenderData SwRenderer::prepare(Surface* surface, const RenderMesh* mesh, RenderD
     //prepare task
     auto task = static_cast<SwImageTask*>(data);
     if (!task) task = new SwImageTask;
-    if (flags & RenderUpdateFlag::Image) {
-        task->source = surface;
-        task->mesh = mesh;
-    }
+    task->source = surface;
+    task->mesh = mesh;
     return prepareCommon(task, transform, clips, opacity, flags);
 }
 

--- a/wasm_cross.txt
+++ b/wasm_cross.txt
@@ -13,6 +13,7 @@ exe_suffix = 'js'
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
 cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sFORCE_FILESYSTEM=1']
+#cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sFORCE_FILESYSTEM=1', '-g']   //enable g flag for wasm debugging
 
 [host_machine]
 system = 'emscripten'


### PR DESCRIPTION
the surface and mesh data can be missed by an invalid condition. this fixes an invalid memory access problem.

Issue: https://github.com/thorvg/thorvg/issues/1671