### PR TITLE
sw_engine: Correct the color conversion condition.

### DIFF
--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -2024,11 +2024,11 @@ bool rasterConvertCS(Surface* surface, ColorSpace to)
     //TOOD: Support SIMD accelerations
     auto from = surface->cs;
 
-    if ((from == ColorSpace::ABGR8888 && to == ColorSpace::ARGB8888) || (from == ColorSpace::ABGR8888S && to == ColorSpace::ARGB8888S)) {
+    if (((from == ColorSpace::ABGR8888) || (from == ColorSpace::ABGR8888S)) && ((to == ColorSpace::ARGB8888) || (to == ColorSpace::ARGB8888S))) {
         surface->cs = to;
         return cRasterABGRtoARGB(surface);
     }
-    if ((from == ColorSpace::ARGB8888 && to == ColorSpace::ABGR8888) || (from == ColorSpace::ARGB8888S && to == ColorSpace::ABGR8888S)) {
+    if (((from == ColorSpace::ARGB8888) || (from == ColorSpace::ARGB8888S)) && ((to == ColorSpace::ABGR8888) || (to == ColorSpace::ABGR8888S))) {
         surface->cs = to;
         return cRasterARGBtoABGR(surface);
     }


### PR DESCRIPTION
The color conversion is supposed to take into account the differences between straight alpha premultiplied color and pre-multiplied alpha color.

The previous logic does not perfectly cover these conditions.

The problem was occured in the thorvg viewer with a jpeg bgra format.