### PR TITLE
infra: Add debugging tool in action(win build)

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -30,6 +30,10 @@ jobs:
         name: result
         path: build/src/thorvg*
 
+    - if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
+
   static_loaders:
     runs-on: windows-latest
     steps:
@@ -71,3 +75,4 @@ jobs:
       with:
         name: UnitTestReport
         path: build/meson-logs/testlog.txt
+


### PR DESCRIPTION
tmate is a tool that helps debugging github actions.
If CI fails, opens an ssh connection for debugging.
It is difficult to predict the msvc dev environment of the window-latest image.
This can be useful when problems occurs.

https://github.com/marketplace/actions/debugging-with-tmate