### PR TITLE
renderer/wg_engine: introduce webgpu canvas

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -213,7 +213,8 @@ enum class BlendMethod : uint8_t
 enum class CanvasEngine
 {
     Sw = (1 << 1), ///< CPU rasterizer.
-    Gl = (1 << 2)  ///< OpenGL rasterizer.
+    Gl = (1 << 2), ///< OpenGL rasterizer.
+    Wg = (1 << 3), ///< WebGPU rasterizer.
 };
 
 
@@ -1590,6 +1591,43 @@ public:
     static std::unique_ptr<GlCanvas> gen() noexcept;
 
     _TVG_DECLARE_PRIVATE(GlCanvas);
+};
+
+
+/**
+ * @class WgCanvas
+ *
+ * @brief A class for the rendering graphic elements with a WebGPU raster engine.
+ *
+ * @warning Please do not use it. This class is not fully supported yet.
+ *
+ * @BETA_API
+ */
+class TVG_API WgCanvas final : public Canvas
+{
+public:
+    ~WgCanvas();
+
+    /**
+     * @brief Sets the target buffer for the rasterization.
+     *
+     * @warning Please do not use it, this API is not official one. It could be modified in the next version.
+     *
+     * @BETA_API
+     */
+    Result target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h) noexcept;
+    Result target(void* window, uint32_t w, uint32_t h) noexcept;
+
+    /**
+     * @brief Creates a new WgCanvas object.
+     *
+     * @return A new WgCanvas object.
+     *
+     * @BETA_API
+     */
+    static std::unique_ptr<WgCanvas> gen() noexcept;
+
+    _TVG_DECLARE_PRIVATE(WgCanvas);
 };
 
 

--- a/src/renderer/tvgInitializer.cpp
+++ b/src/renderer/tvgInitializer.cpp
@@ -36,6 +36,10 @@
     #include "tvgGlRenderer.h"
 #endif
 
+#ifdef THORVG_WG_RASTER_SUPPORT
+    #include "tvgWgRenderer.h"
+#endif
+
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -102,6 +106,11 @@ Result Initializer::init(CanvasEngine engine, uint32_t threads) noexcept
             if (!GlRenderer::init(threads)) return Result::FailedAllocation;
             nonSupport = false;
         #endif
+    } else if (engine & CanvasEngine::Wg) {
+        #ifdef THORVG_WG_RASTER_SUPPORT
+            if (!WgRenderer::init(threads)) return Result::FailedAllocation;
+            nonSupport = false;
+        #endif
     } else {
         return Result::InvalidArguments;
     }
@@ -134,6 +143,11 @@ Result Initializer::term(CanvasEngine engine) noexcept
     } else if (engine & CanvasEngine::Gl) {
         #ifdef THORVG_GL_RASTER_SUPPORT
             if (!GlRenderer::term()) return Result::InsufficientCondition;
+            nonSupport = false;
+        #endif
+    } else if (engine & CanvasEngine::Wg) {
+        #ifdef THORVG_WG_RASTER_SUPPORT
+            if (!WgRenderer::term()) return Result::InsufficientCondition;
             nonSupport = false;
         #endif
     } else {

--- a/src/renderer/tvgWgCanvas.cpp
+++ b/src/renderer/tvgWgCanvas.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgCanvas.h"
+
+#ifdef THORVG_WG_RASTER_SUPPORT
+    #include "tvgWgRenderer.h"
+#else
+    class WgRenderer : public RenderMethod
+    {
+        //Non Supported. Dummy Class */
+    };
+#endif
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
+
+struct WgCanvas::Impl
+{
+};
+
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
+
+// webgpy canvas constructor
+#ifdef THORVG_WG_RASTER_SUPPORT
+WgCanvas::WgCanvas() : Canvas(WgRenderer::gen()), pImpl(new Impl)
+#else
+WgCanvas::WgCanvas() : Canvas(nullptr), pImpl(new Impl)
+#endif
+{
+}
+
+// webgpy canvas destructor
+WgCanvas::~WgCanvas()
+{
+    delete pImpl;
+}
+
+// set target buffer
+Result WgCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h) noexcept
+{
+#ifdef THORVG_WG_RASTER_SUPPORT
+    //We know renderer type, avoid dynamic_cast for performance.
+    auto renderer = static_cast<WgRenderer*>(Canvas::pImpl->renderer);
+    if (!renderer) return Result::MemoryCorruption;
+
+    if (!renderer->target(buffer, stride, w, h)) return Result::Unknown;
+
+    //Paints must be updated again with this new target.
+    Canvas::pImpl->needRefresh();
+
+    return Result::Success;
+#endif
+    return Result::NonSupport;
+}
+
+// set target window
+Result WgCanvas::target(void* window, uint32_t w, uint32_t h) noexcept
+{
+#ifdef THORVG_WG_RASTER_SUPPORT
+    //We know renderer type, avoid dynamic_cast for performance.
+    auto renderer = static_cast<WgRenderer*>(Canvas::pImpl->renderer);
+    if (!renderer) return Result::MemoryCorruption;
+
+    if (!renderer->target(window, w, h)) return Result::Unknown;
+
+    //Paints must be updated again with this new target.
+    Canvas::pImpl->needRefresh();
+
+    return Result::Success;
+#endif
+    return Result::NonSupport;
+}
+
+// generate canvas instance
+unique_ptr<WgCanvas> WgCanvas::gen() noexcept
+{
+#ifdef THORVG_WG_RASTER_SUPPORT
+    return unique_ptr<WgCanvas>(new WgCanvas);
+#endif
+    return nullptr;
+}

--- a/src/renderer/wg_engine/tvgWgBrush.cpp
+++ b/src/renderer/wg_engine/tvgWgBrush.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgBrush.h"
+
+/************************************************************************/
+// WgBrushData
+/************************************************************************/
+
+// update matrix
+void WgBrushData::updateMatrix(const float* viewMatrix, const RenderTransform* transform) {
+    // create model matrix 4*4
+    float modelMatrix[16]{};
+    if (transform) {
+        modelMatrix[0]  = transform->m.e11;
+        modelMatrix[1]  = transform->m.e21;
+        modelMatrix[3]  = transform->m.e31;
+        modelMatrix[4]  = transform->m.e12;
+        modelMatrix[5]  = transform->m.e22;
+        modelMatrix[7]  = transform->m.e32;
+        modelMatrix[10] = 1.0f;
+        modelMatrix[12] = transform->m.e13;
+        modelMatrix[13] = transform->m.e23;
+        modelMatrix[15] = transform->m.e33;
+    } else {
+        modelMatrix[0] = 1.0f;
+        modelMatrix[5] = 1.0f;
+        modelMatrix[10] = 1.0f;
+        modelMatrix[15] = 1.0f;
+    }
+    // matrix multiply
+    for(auto i = 0; i < 4; ++i) {
+        for(auto j = 0; j < 4; ++j) {
+            float sum = 0.0;
+            for (auto k = 0; k < 4; ++k)
+                sum += viewMatrix[k*4+i] * modelMatrix[j*4+k];
+            uMatrix.transform[j*4+i] = sum;
+        }
+    }
+}
+
+/************************************************************************/
+// WgBrushBindGroup
+/************************************************************************/
+
+// brush data group bind
+void WgBrushBindGroup::bind(WGPURenderPassEncoder renderPassEncoder, uint32_t groupIndex) {
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, groupIndex, mBindGroup, 0, nullptr);
+}
+
+/************************************************************************/
+// WgBrushPipeline
+/************************************************************************/
+
+// set as current pipeline
+void WgBrushPipeline::set(WGPURenderPassEncoder renderPassEncoder) {
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, mRenderPipeline);
+}

--- a/src/renderer/wg_engine/tvgWgBrush.h
+++ b/src/renderer/wg_engine/tvgWgBrush.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_BRUSH_H_
+#define _TVG_WG_BRUSH_H_
+
+#include "tvgWgCommon.h"
+
+// brush matrix
+struct WgBrushMatrix {
+    float transform[4*4]{};
+};
+
+// brush data
+struct WgBrushData {
+    // uMatrix
+    WgBrushMatrix uMatrix{};
+    // update matrix
+    void updateMatrix(const float* viewMatrix, const RenderTransform* transform);
+};
+
+// brush bind group
+class WgBrushBindGroup {
+public:
+    // data handles
+    WGPUBuffer uBufferMatrix{};
+    // handles
+    WGPUBindGroup mBindGroup{};
+    // bind
+    void bind(WGPURenderPassEncoder renderPassEncoder, uint32_t groupIndex);
+};
+
+// brush pipeline
+class WgBrushPipeline {
+public:
+    // handles
+    WGPUBindGroupLayout mBindGroupLayout{}; // @group(0)
+    WGPUPipelineLayout  mPipelineLayout{};
+    WGPUShaderModule    mShaderModule{};
+    WGPURenderPipeline  mRenderPipeline{};
+public:
+    // initialize and release
+    virtual void initialize(WGPUDevice device) = 0;
+    virtual void release() = 0;
+
+    // utils
+    void set(WGPURenderPassEncoder renderPassEncoder);
+};
+
+#endif // _TVG_WG_BRUSH_H_

--- a/src/renderer/wg_engine/tvgWgBrushEmpty.cpp
+++ b/src/renderer/wg_engine/tvgWgBrushEmpty.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgBrushEmpty.h"
+#include "tvgWgShaderSrc.h"
+
+//************************************************************************
+// WgBrushBindGroupEmpty
+//************************************************************************
+
+// initialize
+void WgBrushBindGroupEmpty::initialize(WGPUDevice device, WgBrushPipelineEmpty& brushPipelineEmpty) {
+    // buffer uniform uMatrix
+    WGPUBufferDescriptor bufferUniformDesc_uMatrix{};
+    bufferUniformDesc_uMatrix.nextInChain = nullptr;
+    bufferUniformDesc_uMatrix.label = "Buffer uniform brush empty uMatrix";
+    bufferUniformDesc_uMatrix.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform;
+    bufferUniformDesc_uMatrix.size = sizeof(WgBrushMatrix);
+    bufferUniformDesc_uMatrix.mappedAtCreation = false;
+    uBufferMatrix = wgpuDeviceCreateBuffer(device, &bufferUniformDesc_uMatrix);
+    assert(uBufferMatrix);
+
+    // bind group entry @binding(0) uMatrix
+    WGPUBindGroupEntry bindGroupEntry_uMatrix{};
+    bindGroupEntry_uMatrix.nextInChain = nullptr;
+    bindGroupEntry_uMatrix.binding = 0;
+    bindGroupEntry_uMatrix.buffer = uBufferMatrix;
+    bindGroupEntry_uMatrix.offset = 0;
+    bindGroupEntry_uMatrix.size = sizeof(WgBrushMatrix);
+    bindGroupEntry_uMatrix.sampler = nullptr;
+    bindGroupEntry_uMatrix.textureView = nullptr;
+    // bind group entries
+    WGPUBindGroupEntry bindGroupEntries[] {
+        bindGroupEntry_uMatrix // @binding(0) uMatrix
+    };
+    // bind group descriptor
+    WGPUBindGroupDescriptor bindGroupDescBrush{};
+    bindGroupDescBrush.nextInChain = nullptr;
+    bindGroupDescBrush.label = "The binding group brush empty";
+    bindGroupDescBrush.layout = brushPipelineEmpty.mBindGroupLayout;
+    bindGroupDescBrush.entryCount = 1;
+    bindGroupDescBrush.entries = bindGroupEntries;
+    mBindGroup = wgpuDeviceCreateBindGroup(device, &bindGroupDescBrush);
+    assert(mBindGroup);
+}
+
+// release
+void WgBrushBindGroupEmpty::release() {
+    // destroy uniform buffer natrix
+    if (uBufferMatrix) wgpuBufferDestroy(uBufferMatrix);
+    if (uBufferMatrix) wgpuBufferRelease(uBufferMatrix);
+    uBufferMatrix = nullptr;
+    // release bind group
+    if (mBindGroup) wgpuBindGroupRelease(mBindGroup);
+    mBindGroup = nullptr;
+}
+
+// update buffers
+void WgBrushBindGroupEmpty::update(WGPUQueue queue, WgBrushDataEmpty& brushDataEmpty) {
+    // write uMatrux buffer
+    wgpuQueueWriteBuffer(queue, uBufferMatrix, 0, &brushDataEmpty.uMatrix, sizeof(brushDataEmpty.uMatrix));
+}
+
+//************************************************************************
+// WgBrushPipelineEmpty
+//************************************************************************
+
+// create
+void WgBrushPipelineEmpty::initialize(WGPUDevice device) {
+    // bind group layout group 0
+    // bind group layout descriptor @group(0) @binding(0) uMatrix
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntry_uMatrix{};
+    bindGroupLayoutEntry_uMatrix.nextInChain = nullptr;
+    bindGroupLayoutEntry_uMatrix.binding = 0;
+    bindGroupLayoutEntry_uMatrix.visibility = WGPUShaderStage_Vertex | WGPUShaderStage_Fragment;
+    bindGroupLayoutEntry_uMatrix.buffer.nextInChain = nullptr;
+    bindGroupLayoutEntry_uMatrix.buffer.type = WGPUBufferBindingType_Uniform;
+    bindGroupLayoutEntry_uMatrix.buffer.hasDynamicOffset = false;
+    bindGroupLayoutEntry_uMatrix.buffer.minBindingSize = 0;
+    // bind group layout entries @group(0)
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntries[] {
+        bindGroupLayoutEntry_uMatrix
+    };
+    // bind group layout descriptor scene @group(0)
+    WGPUBindGroupLayoutDescriptor bindGroupLayoutDesc{};
+    bindGroupLayoutDesc.nextInChain = nullptr;
+    bindGroupLayoutDesc.label = "Bind group layout brush empty";
+    bindGroupLayoutDesc.entryCount = 1;
+    bindGroupLayoutDesc.entries = bindGroupLayoutEntries; // @binding
+    mBindGroupLayout = wgpuDeviceCreateBindGroupLayout(device, &bindGroupLayoutDesc);
+    assert(mBindGroupLayout);
+
+    // pipeline layout
+
+    // bind group layout descriptors
+    WGPUBindGroupLayout mBindGroupLayouts[] {
+        mBindGroupLayout
+    };
+    // pipeline layout descriptor
+    WGPUPipelineLayoutDescriptor pipelineLayoutDesc{};
+    pipelineLayoutDesc.nextInChain = nullptr;
+    pipelineLayoutDesc.label = "Brush pipeline layout empty";
+    pipelineLayoutDesc.bindGroupLayoutCount = 1;
+    pipelineLayoutDesc.bindGroupLayouts = mBindGroupLayouts;
+    mPipelineLayout = wgpuDeviceCreatePipelineLayout(device, &pipelineLayoutDesc);
+    assert(mPipelineLayout);
+
+    // depth stencil state
+    WGPUDepthStencilState depthStencilState{};
+    depthStencilState.nextInChain = nullptr;
+    depthStencilState.format = WGPUTextureFormat_Stencil8;
+    depthStencilState.depthWriteEnabled = false;
+    depthStencilState.depthCompare = WGPUCompareFunction_Always;
+    // depthStencilState.stencilFront
+    depthStencilState.stencilFront.compare = WGPUCompareFunction_Always;
+    depthStencilState.stencilFront.failOp = WGPUStencilOperation_Invert;
+    depthStencilState.stencilFront.depthFailOp = WGPUStencilOperation_Invert;
+    depthStencilState.stencilFront.passOp = WGPUStencilOperation_Invert;
+    // depthStencilState.stencilBack
+    depthStencilState.stencilBack.compare = WGPUCompareFunction_Always;
+    depthStencilState.stencilBack.failOp = WGPUStencilOperation_Invert;
+    depthStencilState.stencilBack.depthFailOp = WGPUStencilOperation_Invert;
+    depthStencilState.stencilBack.passOp = WGPUStencilOperation_Invert;
+    // stencil mask
+    depthStencilState.stencilReadMask = 0xFFFFFFFF;
+    depthStencilState.stencilWriteMask = 0xFFFFFFFF;
+    // depth bias
+    depthStencilState.depthBias = 0;
+    depthStencilState.depthBiasSlopeScale = 0.0f;
+    depthStencilState.depthBiasClamp = 0.0f;
+
+    // shader module wgsl descriptor
+    WGPUShaderModuleWGSLDescriptor shaderModuleWGSLDesc{};
+	shaderModuleWGSLDesc.chain.next = nullptr;
+	shaderModuleWGSLDesc.chain.sType = WGPUSType_ShaderModuleWGSLDescriptor;
+    shaderModuleWGSLDesc.code = cShaderSource_BrushEmpty;
+    // shader module descriptor
+    WGPUShaderModuleDescriptor shaderModuleDesc{};
+    shaderModuleDesc.nextInChain = &shaderModuleWGSLDesc.chain;
+    shaderModuleDesc.label = "The shader module brush empty";
+    shaderModuleDesc.hintCount = 0;
+    shaderModuleDesc.hints = nullptr;
+    mShaderModule = wgpuDeviceCreateShaderModule(device, &shaderModuleDesc);
+    assert(mShaderModule);
+
+    // vertex attributes
+    WGPUVertexAttribute vertexAttributes[] = {
+        { WGPUVertexFormat_Float32x3, sizeof(float) * 0, 0 }, // position
+    };
+    // vertex buffer layout
+    WGPUVertexBufferLayout vertexBufferLayout{};
+    vertexBufferLayout.arrayStride = sizeof(float) * 3; // position
+    vertexBufferLayout.stepMode = WGPUVertexStepMode_Vertex;
+    vertexBufferLayout.attributeCount = 1; // position
+    vertexBufferLayout.attributes = vertexAttributes;
+    
+    // blend state
+    WGPUBlendState blendState{};
+    // blendState.color
+    blendState.color.operation = WGPUBlendOperation_Add;
+    blendState.color.srcFactor = WGPUBlendFactor_SrcAlpha;
+    blendState.color.dstFactor = WGPUBlendFactor_OneMinusSrcAlpha;
+    // blendState.alpha
+    blendState.alpha.operation = WGPUBlendOperation_Add;
+    blendState.alpha.srcFactor = WGPUBlendFactor_Zero;
+    blendState.alpha.dstFactor = WGPUBlendFactor_One;
+
+    // color target state (WGPUTextureFormat_BGRA8UnormSrgb)
+    WGPUColorTargetState colorTargetState0{};
+    colorTargetState0.nextInChain = nullptr;
+    colorTargetState0.format = WGPUTextureFormat_BGRA8Unorm;
+    //colorTargetState0.format = WGPUTextureFormat_BGRA8UnormSrgb;
+    colorTargetState0.blend = &blendState;
+    colorTargetState0.writeMask = WGPUColorWriteMask_All;
+    // color target states
+    WGPUColorTargetState colorTargetStates[] = {
+        colorTargetState0
+    };
+    // fragmanet state
+    WGPUFragmentState fragmentState{};
+    fragmentState.nextInChain = nullptr;
+    fragmentState.module = mShaderModule;
+    fragmentState.entryPoint = "fs_main";
+    fragmentState.constantCount = 0;
+    fragmentState.constants = nullptr;
+    fragmentState.targetCount = 1;
+    fragmentState.targets = colorTargetStates; // render target index
+
+    // render pipeline descriptor
+    WGPURenderPipelineDescriptor renderPipelineDesc{};
+    renderPipelineDesc.nextInChain = nullptr;
+    renderPipelineDesc.label = "Render pipeline brush empty";
+    // renderPipelineDesc.layout
+    renderPipelineDesc.layout = mPipelineLayout;
+    // renderPipelineDesc.vertex
+    renderPipelineDesc.vertex.nextInChain = nullptr;
+    renderPipelineDesc.vertex.module = mShaderModule;
+    renderPipelineDesc.vertex.entryPoint = "vs_main";
+    renderPipelineDesc.vertex.constantCount = 0;
+    renderPipelineDesc.vertex.constants = nullptr;
+    renderPipelineDesc.vertex.bufferCount = 1;
+    renderPipelineDesc.vertex.buffers = &vertexBufferLayout; // buffer index
+    // renderPipelineDesc.primitive
+    renderPipelineDesc.primitive.nextInChain = nullptr;
+    renderPipelineDesc.primitive.topology = WGPUPrimitiveTopology_TriangleList;
+    renderPipelineDesc.primitive.stripIndexFormat = WGPUIndexFormat_Undefined;
+    renderPipelineDesc.primitive.frontFace = WGPUFrontFace_CCW;
+    renderPipelineDesc.primitive.cullMode = WGPUCullMode_None;
+    // renderPipelineDesc.depthStencil
+    renderPipelineDesc.depthStencil = &depthStencilState;
+    // renderPipelineDesc.multisample
+    renderPipelineDesc.multisample.nextInChain = nullptr;
+    renderPipelineDesc.multisample.count = 1;
+    renderPipelineDesc.multisample.mask = 0xFFFFFFFF;
+    renderPipelineDesc.multisample.alphaToCoverageEnabled = false;
+    // renderPipelineDesc.fragment
+    renderPipelineDesc.fragment = &fragmentState;
+    mRenderPipeline = wgpuDeviceCreateRenderPipeline(device, &renderPipelineDesc);
+    assert(mRenderPipeline);
+}
+
+// release
+void WgBrushPipelineEmpty::release() {
+    // render pipeline release
+    wgpuRenderPipelineRelease(mRenderPipeline);
+    // shader module release
+    wgpuShaderModuleRelease(mShaderModule);
+    // pipeline layout release
+    wgpuPipelineLayoutRelease(mPipelineLayout);
+    // bind group layouts release
+    wgpuBindGroupLayoutRelease(mBindGroupLayout);
+}

--- a/src/renderer/wg_engine/tvgWgBrushEmpty.h
+++ b/src/renderer/wg_engine/tvgWgBrushEmpty.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_BRUSH_EMPTY_H_
+#define _TVG_WG_BRUSH_EMPTY_H_
+
+#include "tvgWgBrush.h"
+
+// brush empty
+class WgBrushPipelineEmpty;
+
+// uniforms data brush empty
+struct WgBrushDataEmpty: WgBrushData {};
+
+// wgpu brush color uniforms data
+class WgBrushBindGroupEmpty: public WgBrushBindGroup {
+public:
+    // initialize and release
+    void initialize(WGPUDevice device, WgBrushPipelineEmpty& brushPipelineEmpty);
+    void release();
+
+    // update
+    void update(WGPUQueue mQueue, WgBrushDataEmpty& brushDataSolid);
+};
+
+// brush color
+class WgBrushPipelineEmpty: public WgBrushPipeline {
+public:
+    // initialize and release
+    void initialize(WGPUDevice device) override;
+    void release() override;
+};
+
+#endif // _TVG_WG_BRUSH_EMPTY_H_

--- a/src/renderer/wg_engine/tvgWgBrushLinear.cpp
+++ b/src/renderer/wg_engine/tvgWgBrushLinear.cpp
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgBrushLinear.h"
+#include "tvgWgShaderSrc.h"
+
+//************************************************************************
+// WgBrushBindGroupLinear
+//************************************************************************
+
+// update gradient linear
+void WgBrushDataLinear::updateGradient(LinearGradient* linearGradient) {
+    // check handle
+    assert(linearGradient);
+    // get stops
+    const Fill::ColorStop* stops = nullptr;
+    auto stopCnt = linearGradient->colorStops(&stops);
+    // set stops count
+    uGradientInfo.nStops[0] = stopCnt * 1.0f;
+    uGradientInfo.nStops[1] = 0.5f;
+    // set stops
+    for (uint32_t i = 0; i < stopCnt; ++i) {
+        uGradientInfo.stopPoints[i] = stops[i].offset;
+        uGradientInfo.stopColors[i * 4 + 0] = stops[i].r / 255.f;
+        uGradientInfo.stopColors[i * 4 + 1] = stops[i].g / 255.f;
+        uGradientInfo.stopColors[i * 4 + 2] = stops[i].b / 255.f;
+        uGradientInfo.stopColors[i * 4 + 3] = stops[i].a / 255.f;
+    }
+    // get line info
+    linearGradient->linear(
+        &uGradientInfo.startPos[0],
+        &uGradientInfo.startPos[1],
+        &uGradientInfo.endPos[0],
+        &uGradientInfo.endPos[1]);
+}
+
+//************************************************************************
+// WgBrushBindGroupLinear
+//************************************************************************
+
+// initialize
+void WgBrushBindGroupLinear::initialize(WGPUDevice device, WgBrushPipelineLinear& brushPipelineLinear) {
+        // buffer uniform uMatrix
+    WGPUBufferDescriptor bufferUniformDesc_uMatrix{};
+    bufferUniformDesc_uMatrix.nextInChain = nullptr;
+    bufferUniformDesc_uMatrix.label = "Buffer uniform brush linear uMatrix";
+    bufferUniformDesc_uMatrix.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform;
+    bufferUniformDesc_uMatrix.size = sizeof(WgBrushMatrix);
+    bufferUniformDesc_uMatrix.mappedAtCreation = false;
+    uBufferMatrix = wgpuDeviceCreateBuffer(device, &bufferUniformDesc_uMatrix);
+    assert(uBufferMatrix);
+    // buffer uniform uColorInfo
+    WGPUBufferDescriptor bufferUniformDesc_uGradientInfo{};
+    bufferUniformDesc_uGradientInfo.nextInChain = nullptr;
+    bufferUniformDesc_uGradientInfo.label = "Buffer uniform brush linear uGradientInfo";
+    bufferUniformDesc_uGradientInfo.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform;
+    bufferUniformDesc_uGradientInfo.size = sizeof(WgBrushLinearGradientInfo);
+    bufferUniformDesc_uGradientInfo.mappedAtCreation = false;
+    uBufferGradientInfo = wgpuDeviceCreateBuffer(device, &bufferUniformDesc_uGradientInfo);
+    assert(uBufferGradientInfo);
+
+    // bind group entry @binding(0) uMatrix
+    WGPUBindGroupEntry bindGroupEntry_uMatrix{};
+    bindGroupEntry_uMatrix.nextInChain = nullptr;
+    bindGroupEntry_uMatrix.binding = 0;
+    bindGroupEntry_uMatrix.buffer = uBufferMatrix;
+    bindGroupEntry_uMatrix.offset = 0;
+    bindGroupEntry_uMatrix.size = sizeof(WgBrushMatrix);
+    bindGroupEntry_uMatrix.sampler = nullptr;
+    bindGroupEntry_uMatrix.textureView = nullptr;
+    // bind group entry @binding(1) uGradientInfo
+    WGPUBindGroupEntry bindGroupEntry_uGradientInfo{};
+    bindGroupEntry_uGradientInfo.nextInChain = nullptr;
+    bindGroupEntry_uGradientInfo.binding = 1;
+    bindGroupEntry_uGradientInfo.buffer = uBufferGradientInfo;
+    bindGroupEntry_uGradientInfo.offset = 0;
+    bindGroupEntry_uGradientInfo.size = sizeof(WgBrushLinearGradientInfo);
+    bindGroupEntry_uGradientInfo.sampler = nullptr;
+    bindGroupEntry_uGradientInfo.textureView = nullptr;
+    // bind group entries
+    WGPUBindGroupEntry bindGroupEntries[] {
+        bindGroupEntry_uMatrix,      // @binding(0) uMatrix
+        bindGroupEntry_uGradientInfo // @binding(1) uGradientInfo
+    };
+    // bind group descriptor
+    WGPUBindGroupDescriptor bindGroupDescBrush{};
+    bindGroupDescBrush.nextInChain = nullptr;
+    bindGroupDescBrush.label = "The binding group brush linear";
+    bindGroupDescBrush.layout = brushPipelineLinear.mBindGroupLayout;
+    bindGroupDescBrush.entryCount = 2;
+    bindGroupDescBrush.entries = bindGroupEntries;
+    mBindGroup = wgpuDeviceCreateBindGroup(device, &bindGroupDescBrush);
+    assert(mBindGroup);
+}
+
+// release
+void WgBrushBindGroupLinear::release() {
+    // destroy uniform buffer color info
+    if (uBufferGradientInfo) wgpuBufferDestroy(uBufferGradientInfo);
+    if (uBufferGradientInfo) wgpuBufferRelease(uBufferGradientInfo);
+    uBufferGradientInfo = nullptr;
+    // destroy uniform buffer natrix
+    if (uBufferMatrix) wgpuBufferDestroy(uBufferMatrix);
+    if (uBufferMatrix) wgpuBufferRelease(uBufferMatrix);
+    uBufferMatrix = nullptr;
+    // release bind group
+    if (mBindGroup) wgpuBindGroupRelease(mBindGroup);
+    mBindGroup = nullptr;
+}
+
+// update buffers
+void WgBrushBindGroupLinear::update(WGPUQueue queue, WgBrushDataLinear& brushDataLinear) {
+    // write uMatrux buffer
+    wgpuQueueWriteBuffer(queue, uBufferMatrix, 0, &brushDataLinear.uMatrix, sizeof(brushDataLinear.uMatrix));
+    // write uColorInfo buffer
+    wgpuQueueWriteBuffer(queue, uBufferGradientInfo, 0, &brushDataLinear.uGradientInfo, sizeof(brushDataLinear.uGradientInfo));
+}
+
+//************************************************************************
+// WgBrushPipelineLinear
+//************************************************************************
+
+// create
+void WgBrushPipelineLinear::initialize(WGPUDevice device) {
+    // bind group layout group 0
+    // bind group layout descriptor @group(0) @binding(0) uMatrix
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntry_uMatrix{};
+    bindGroupLayoutEntry_uMatrix.nextInChain = nullptr;
+    bindGroupLayoutEntry_uMatrix.binding = 0;
+    bindGroupLayoutEntry_uMatrix.visibility = WGPUShaderStage_Vertex | WGPUShaderStage_Fragment;
+    bindGroupLayoutEntry_uMatrix.buffer.nextInChain = nullptr;
+    bindGroupLayoutEntry_uMatrix.buffer.type = WGPUBufferBindingType_Uniform;
+    bindGroupLayoutEntry_uMatrix.buffer.hasDynamicOffset = false;
+    bindGroupLayoutEntry_uMatrix.buffer.minBindingSize = 0;
+    // bind group layout descriptor @group(0) @binding(1) uColorInfo
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntry_uColorInfo{};
+    bindGroupLayoutEntry_uColorInfo.nextInChain = nullptr;
+    bindGroupLayoutEntry_uColorInfo.binding = 1;
+    bindGroupLayoutEntry_uColorInfo.visibility = WGPUShaderStage_Vertex | WGPUShaderStage_Fragment;
+    bindGroupLayoutEntry_uColorInfo.buffer.nextInChain = nullptr;
+    bindGroupLayoutEntry_uColorInfo.buffer.type = WGPUBufferBindingType_Uniform;
+    bindGroupLayoutEntry_uColorInfo.buffer.hasDynamicOffset = false;
+    bindGroupLayoutEntry_uColorInfo.buffer.minBindingSize = 0;
+    // bind group layout entries @group(0)
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntries[] {
+        bindGroupLayoutEntry_uMatrix,
+        bindGroupLayoutEntry_uColorInfo
+    };
+    // bind group layout descriptor scene @group(0)
+    WGPUBindGroupLayoutDescriptor bindGroupLayoutDesc{};
+    bindGroupLayoutDesc.nextInChain = nullptr;
+    bindGroupLayoutDesc.label = "Bind group layout brush linear";
+    bindGroupLayoutDesc.entryCount = 2;
+    bindGroupLayoutDesc.entries = bindGroupLayoutEntries; // @binding
+    mBindGroupLayout = wgpuDeviceCreateBindGroupLayout(device, &bindGroupLayoutDesc);
+    assert(mBindGroupLayout);
+
+    // pipeline layout
+
+    // bind group layout descriptors
+    WGPUBindGroupLayout mBindGroupLayouts[] {
+        mBindGroupLayout
+    };
+    // pipeline layout descriptor
+    WGPUPipelineLayoutDescriptor pipelineLayoutDesc{};
+    pipelineLayoutDesc.nextInChain = nullptr;
+    pipelineLayoutDesc.label = "Brush pipeline layout linear";
+    pipelineLayoutDesc.bindGroupLayoutCount = 1;
+    pipelineLayoutDesc.bindGroupLayouts = mBindGroupLayouts;
+    mPipelineLayout = wgpuDeviceCreatePipelineLayout(device, &pipelineLayoutDesc);
+    assert(mPipelineLayout);
+
+    // depth stencil state
+    WGPUDepthStencilState depthStencilState{};
+    depthStencilState.nextInChain = nullptr;
+    depthStencilState.format = WGPUTextureFormat_Stencil8;
+    depthStencilState.depthWriteEnabled = false;
+    depthStencilState.depthCompare = WGPUCompareFunction_Always;
+    // depthStencilState.stencilFront
+    depthStencilState.stencilFront.compare = WGPUCompareFunction_NotEqual;
+    depthStencilState.stencilFront.failOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilFront.depthFailOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilFront.passOp = WGPUStencilOperation_Zero;
+    // depthStencilState.stencilBack
+    depthStencilState.stencilBack.compare = WGPUCompareFunction_NotEqual;
+    depthStencilState.stencilBack.failOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilBack.depthFailOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilBack.passOp = WGPUStencilOperation_Zero;
+    // stencil mask
+    depthStencilState.stencilReadMask = 0xFFFFFFFF;
+    depthStencilState.stencilWriteMask = 0xFFFFFFFF;
+    // depth bias
+    depthStencilState.depthBias = 0;
+    depthStencilState.depthBiasSlopeScale = 0.0f;
+    depthStencilState.depthBiasClamp = 0.0f;
+
+    // shader module wgsl descriptor
+    WGPUShaderModuleWGSLDescriptor shaderModuleWGSLDesc{};
+	shaderModuleWGSLDesc.chain.next = nullptr;
+	shaderModuleWGSLDesc.chain.sType = WGPUSType_ShaderModuleWGSLDescriptor;
+    shaderModuleWGSLDesc.code = cShaderSource_BrushLinear;
+    // shader module descriptor
+    WGPUShaderModuleDescriptor shaderModuleDesc{};
+    shaderModuleDesc.nextInChain = &shaderModuleWGSLDesc.chain;
+    shaderModuleDesc.label = "The shader module brush linear";
+    shaderModuleDesc.hintCount = 0;
+    shaderModuleDesc.hints = nullptr;
+    mShaderModule = wgpuDeviceCreateShaderModule(device, &shaderModuleDesc);
+    assert(mShaderModule);
+
+    // vertex attributes
+    WGPUVertexAttribute vertexAttributes[] = {
+        { WGPUVertexFormat_Float32x3, sizeof(float) * 0, 0 }, // position
+    };
+    // vertex buffer layout
+    WGPUVertexBufferLayout vertexBufferLayout{};
+    vertexBufferLayout.arrayStride = sizeof(float) * 3; // position
+    vertexBufferLayout.stepMode = WGPUVertexStepMode_Vertex;
+    vertexBufferLayout.attributeCount = 1; // position
+    vertexBufferLayout.attributes = vertexAttributes;
+    
+    // blend state
+    WGPUBlendState blendState{};
+    // blendState.color
+    blendState.color.operation = WGPUBlendOperation_Add;
+    blendState.color.srcFactor = WGPUBlendFactor_SrcAlpha;
+    blendState.color.dstFactor = WGPUBlendFactor_OneMinusSrcAlpha;
+    // blendState.alpha
+    blendState.alpha.operation = WGPUBlendOperation_Add;
+    blendState.alpha.srcFactor = WGPUBlendFactor_Zero;
+    blendState.alpha.dstFactor = WGPUBlendFactor_One;
+
+    // color target state (WGPUTextureFormat_BGRA8UnormSrgb)
+    WGPUColorTargetState colorTargetState0{};
+    colorTargetState0.nextInChain = nullptr;
+    colorTargetState0.format = WGPUTextureFormat_BGRA8Unorm;
+    //colorTargetState0.format = WGPUTextureFormat_BGRA8UnormSrgb;
+    colorTargetState0.blend = &blendState;
+    colorTargetState0.writeMask = WGPUColorWriteMask_All;
+    // color target states
+    WGPUColorTargetState colorTargetStates[] = {
+        colorTargetState0
+    };
+    // fragmanet state
+    WGPUFragmentState fragmentState{};
+    fragmentState.nextInChain = nullptr;
+    fragmentState.module = mShaderModule;
+    fragmentState.entryPoint = "fs_main";
+    fragmentState.constantCount = 0;
+    fragmentState.constants = nullptr;
+    fragmentState.targetCount = 1;
+    fragmentState.targets = colorTargetStates; // render target index
+
+    // render pipeline descriptor
+    WGPURenderPipelineDescriptor renderPipelineDesc{};
+    renderPipelineDesc.nextInChain = nullptr;
+    renderPipelineDesc.label = "Render pipeline brush linear";
+    // renderPipelineDesc.layout
+    renderPipelineDesc.layout = mPipelineLayout;
+    // renderPipelineDesc.vertex
+    renderPipelineDesc.vertex.nextInChain = nullptr;
+    renderPipelineDesc.vertex.module = mShaderModule;
+    renderPipelineDesc.vertex.entryPoint = "vs_main";
+    renderPipelineDesc.vertex.constantCount = 0;
+    renderPipelineDesc.vertex.constants = nullptr;
+    renderPipelineDesc.vertex.bufferCount = 1;
+    renderPipelineDesc.vertex.buffers = &vertexBufferLayout; // buffer index
+    // renderPipelineDesc.primitive
+    renderPipelineDesc.primitive.nextInChain = nullptr;
+    renderPipelineDesc.primitive.topology = WGPUPrimitiveTopology_TriangleList;
+    renderPipelineDesc.primitive.stripIndexFormat = WGPUIndexFormat_Undefined;
+    renderPipelineDesc.primitive.frontFace = WGPUFrontFace_CCW;
+    renderPipelineDesc.primitive.cullMode = WGPUCullMode_None;
+    // renderPipelineDesc.depthStencil
+    renderPipelineDesc.depthStencil = &depthStencilState;
+    // renderPipelineDesc.multisample
+    renderPipelineDesc.multisample.nextInChain = nullptr;
+    renderPipelineDesc.multisample.count = 1;
+    renderPipelineDesc.multisample.mask = 0xFFFFFFFF;
+    renderPipelineDesc.multisample.alphaToCoverageEnabled = false;
+    // renderPipelineDesc.fragment
+    renderPipelineDesc.fragment = &fragmentState;
+    mRenderPipeline = wgpuDeviceCreateRenderPipeline(device, &renderPipelineDesc);
+    assert(mRenderPipeline);
+}
+
+// release
+void WgBrushPipelineLinear::release() {
+    // render pipeline release
+    wgpuRenderPipelineRelease(mRenderPipeline);
+    // shader module release
+    wgpuShaderModuleRelease(mShaderModule);
+    // pipeline layout release
+    wgpuPipelineLayoutRelease(mPipelineLayout);
+    // bind group layouts release
+    wgpuBindGroupLayoutRelease(mBindGroupLayout);
+}

--- a/src/renderer/wg_engine/tvgWgBrushLinear.h
+++ b/src/renderer/wg_engine/tvgWgBrushLinear.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_BRUSH_LINEAR_H_
+#define _TVG_WG_BRUSH_LINEAR_H_
+
+#include "tvgWgBrush.h"
+
+// brush linear
+class WgBrushPipelineLinear;
+
+// struct uGradientInfo
+#define MAX_LINEAR_GRADIENT_STOPS 4
+struct WgBrushLinearGradientInfo {
+    alignas(16) float nStops[4]{};
+    alignas(16) float startPos[2]{};
+    alignas(8)  float endPos[2]{};
+    alignas(8)  float stopPoints[MAX_LINEAR_GRADIENT_STOPS]{};
+    alignas(16) float stopColors[4 * MAX_LINEAR_GRADIENT_STOPS]{};
+};
+
+// uniforms data brush color
+struct WgBrushDataLinear: WgBrushData {
+    // uColorInfo
+    WgBrushLinearGradientInfo uGradientInfo{}; // @binding(1)
+    void updateGradient(LinearGradient* linearGradient);
+};
+
+// wgpu brush linear uniforms data
+class WgBrushBindGroupLinear: public WgBrushBindGroup {
+private:
+    // data handles
+    WGPUBuffer uBufferGradientInfo{}; // @binding(1)
+public:
+    // initialize and release
+    void initialize(WGPUDevice device, WgBrushPipelineLinear& brushPipelineLinear);
+    void release();
+
+    // update
+    void update(WGPUQueue mQueue, WgBrushDataLinear& brushDataLinear);
+};
+
+// brush color
+class WgBrushPipelineLinear: public WgBrushPipeline {
+public:
+    // initialize and release
+    void initialize(WGPUDevice device) override;
+    void release() override;
+};
+
+#endif //_TVG_WG_BRUSH_LINEAR_H_

--- a/src/renderer/wg_engine/tvgWgBrushRadial.cpp
+++ b/src/renderer/wg_engine/tvgWgBrushRadial.cpp
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgBrushRadial.h"
+#include "tvgWgShaderSrc.h"
+
+//************************************************************************
+// WgBrushBindGroupRadial
+//************************************************************************
+
+// update gradient radial
+void WgBrushDataRadial::updateGradient(RadialGradient* radialGradient) {
+    // check handle
+    assert(radialGradient);
+    // get stops
+    const Fill::ColorStop* stops = nullptr;
+    auto stopCnt = radialGradient->colorStops(&stops);
+    // set stops count
+    uGradientInfo.nStops[0] = stopCnt * 1.0f;
+    uGradientInfo.nStops[1] = 0.5f;
+    // set stops
+    for (uint32_t i = 0; i < stopCnt; ++i) {
+        uGradientInfo.stopPoints[i] = stops[i].offset;
+        uGradientInfo.stopColors[i * 4 + 0] = stops[i].r / 255.f;
+        uGradientInfo.stopColors[i * 4 + 1] = stops[i].g / 255.f;
+        uGradientInfo.stopColors[i * 4 + 2] = stops[i].b / 255.f;
+        uGradientInfo.stopColors[i * 4 + 3] = stops[i].a / 255.f;
+    }
+    // get circle info
+    radialGradient->radial(
+        &uGradientInfo.centerPos[0],
+        &uGradientInfo.centerPos[1],
+        &uGradientInfo.radius[0]);
+}
+
+//************************************************************************
+// WgBrushBindGroupRadial
+//************************************************************************
+
+// initialize
+void WgBrushBindGroupRadial::initialize(WGPUDevice device, WgBrushPipelineRadial& brushPipelineRadial) {
+        // buffer uniform uMatrix
+    WGPUBufferDescriptor bufferUniformDesc_uMatrix{};
+    bufferUniformDesc_uMatrix.nextInChain = nullptr;
+    bufferUniformDesc_uMatrix.label = "Buffer uniform brush radial uMatrix";
+    bufferUniformDesc_uMatrix.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform;
+    bufferUniformDesc_uMatrix.size = sizeof(WgBrushMatrix);
+    bufferUniformDesc_uMatrix.mappedAtCreation = false;
+    uBufferMatrix = wgpuDeviceCreateBuffer(device, &bufferUniformDesc_uMatrix);
+    assert(uBufferMatrix);
+    // buffer uniform uColorInfo
+    WGPUBufferDescriptor bufferUniformDesc_uGradientInfo{};
+    bufferUniformDesc_uGradientInfo.nextInChain = nullptr;
+    bufferUniformDesc_uGradientInfo.label = "Buffer uniform brush radial uGradientInfo";
+    bufferUniformDesc_uGradientInfo.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform;
+    bufferUniformDesc_uGradientInfo.size = sizeof(WgBrushRadialGradientInfo);
+    bufferUniformDesc_uGradientInfo.mappedAtCreation = false;
+    uBufferGradientInfo = wgpuDeviceCreateBuffer(device, &bufferUniformDesc_uGradientInfo);
+    assert(uBufferGradientInfo);
+
+    // bind group entry @binding(0) uMatrix
+    WGPUBindGroupEntry bindGroupEntry_uMatrix{};
+    bindGroupEntry_uMatrix.nextInChain = nullptr;
+    bindGroupEntry_uMatrix.binding = 0;
+    bindGroupEntry_uMatrix.buffer = uBufferMatrix;
+    bindGroupEntry_uMatrix.offset = 0;
+    bindGroupEntry_uMatrix.size = sizeof(WgBrushMatrix);
+    bindGroupEntry_uMatrix.sampler = nullptr;
+    bindGroupEntry_uMatrix.textureView = nullptr;
+    // bind group entry @binding(1) uGradientInfo
+    WGPUBindGroupEntry bindGroupEntry_uGradientInfo{};
+    bindGroupEntry_uGradientInfo.nextInChain = nullptr;
+    bindGroupEntry_uGradientInfo.binding = 1;
+    bindGroupEntry_uGradientInfo.buffer = uBufferGradientInfo;
+    bindGroupEntry_uGradientInfo.offset = 0;
+    bindGroupEntry_uGradientInfo.size = sizeof(WgBrushRadialGradientInfo);
+    bindGroupEntry_uGradientInfo.sampler = nullptr;
+    bindGroupEntry_uGradientInfo.textureView = nullptr;
+    // bind group entries
+    WGPUBindGroupEntry bindGroupEntries[] {
+        bindGroupEntry_uMatrix,      // @binding(0) uMatrix
+        bindGroupEntry_uGradientInfo // @binding(1) uGradientInfo
+    };
+    // bind group descriptor
+    WGPUBindGroupDescriptor bindGroupDescBrush{};
+    bindGroupDescBrush.nextInChain = nullptr;
+    bindGroupDescBrush.label = "The binding group brush radial";
+    bindGroupDescBrush.layout = brushPipelineRadial.mBindGroupLayout;
+    bindGroupDescBrush.entryCount = 2;
+    bindGroupDescBrush.entries = bindGroupEntries;
+    mBindGroup = wgpuDeviceCreateBindGroup(device, &bindGroupDescBrush);
+    assert(mBindGroup);
+}
+
+// release
+void WgBrushBindGroupRadial::release() {
+    // destroy uniform buffer color info
+    if (uBufferGradientInfo) wgpuBufferDestroy(uBufferGradientInfo);
+    if (uBufferGradientInfo) wgpuBufferRelease(uBufferGradientInfo);
+    uBufferGradientInfo = nullptr;
+    // destroy uniform buffer natrix
+    if (uBufferMatrix) wgpuBufferDestroy(uBufferMatrix);
+    if (uBufferMatrix) wgpuBufferRelease(uBufferMatrix);
+    uBufferMatrix = nullptr;
+    // release bind group
+    if (mBindGroup) wgpuBindGroupRelease(mBindGroup);
+    mBindGroup = nullptr;
+}
+
+// update buffers
+void WgBrushBindGroupRadial::update(WGPUQueue queue, WgBrushDataRadial& brushDataRadial) {
+    // write uMatrux buffer
+    wgpuQueueWriteBuffer(queue, uBufferMatrix, 0, &brushDataRadial.uMatrix, sizeof(brushDataRadial.uMatrix));
+    // write uColorInfo buffer
+    wgpuQueueWriteBuffer(queue, uBufferGradientInfo, 0, &brushDataRadial.uGradientInfo, sizeof(brushDataRadial.uGradientInfo));
+}
+
+//************************************************************************
+// WgBrushPipelineRadial
+//************************************************************************
+
+// create
+void WgBrushPipelineRadial::initialize(WGPUDevice device) {
+    // bind group layout group 0
+    // bind group layout descriptor @group(0) @binding(0) uMatrix
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntry_uMatrix{};
+    bindGroupLayoutEntry_uMatrix.nextInChain = nullptr;
+    bindGroupLayoutEntry_uMatrix.binding = 0;
+    bindGroupLayoutEntry_uMatrix.visibility = WGPUShaderStage_Vertex | WGPUShaderStage_Fragment;
+    bindGroupLayoutEntry_uMatrix.buffer.nextInChain = nullptr;
+    bindGroupLayoutEntry_uMatrix.buffer.type = WGPUBufferBindingType_Uniform;
+    bindGroupLayoutEntry_uMatrix.buffer.hasDynamicOffset = false;
+    bindGroupLayoutEntry_uMatrix.buffer.minBindingSize = 0;
+    // bind group layout descriptor @group(0) @binding(1) uColorInfo
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntry_uColorInfo{};
+    bindGroupLayoutEntry_uColorInfo.nextInChain = nullptr;
+    bindGroupLayoutEntry_uColorInfo.binding = 1;
+    bindGroupLayoutEntry_uColorInfo.visibility = WGPUShaderStage_Vertex | WGPUShaderStage_Fragment;
+    bindGroupLayoutEntry_uColorInfo.buffer.nextInChain = nullptr;
+    bindGroupLayoutEntry_uColorInfo.buffer.type = WGPUBufferBindingType_Uniform;
+    bindGroupLayoutEntry_uColorInfo.buffer.hasDynamicOffset = false;
+    bindGroupLayoutEntry_uColorInfo.buffer.minBindingSize = 0;
+    // bind group layout entries @group(0)
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntries[] {
+        bindGroupLayoutEntry_uMatrix,
+        bindGroupLayoutEntry_uColorInfo
+    };
+    // bind group layout descriptor scene @group(0)
+    WGPUBindGroupLayoutDescriptor bindGroupLayoutDesc{};
+    bindGroupLayoutDesc.nextInChain = nullptr;
+    bindGroupLayoutDesc.label = "Bind group layout brush radial";
+    bindGroupLayoutDesc.entryCount = 2;
+    bindGroupLayoutDesc.entries = bindGroupLayoutEntries; // @binding
+    mBindGroupLayout = wgpuDeviceCreateBindGroupLayout(device, &bindGroupLayoutDesc);
+    assert(mBindGroupLayout);
+
+    // pipeline layout
+
+    // bind group layout descriptors
+    WGPUBindGroupLayout mBindGroupLayouts[] {
+        mBindGroupLayout
+    };
+    // pipeline layout descriptor
+    WGPUPipelineLayoutDescriptor pipelineLayoutDesc{};
+    pipelineLayoutDesc.nextInChain = nullptr;
+    pipelineLayoutDesc.label = "Brush pipeline layout radial";
+    pipelineLayoutDesc.bindGroupLayoutCount = 1;
+    pipelineLayoutDesc.bindGroupLayouts = mBindGroupLayouts;
+    mPipelineLayout = wgpuDeviceCreatePipelineLayout(device, &pipelineLayoutDesc);
+    assert(mPipelineLayout);
+
+    // depth stencil state
+    WGPUDepthStencilState depthStencilState{};
+    depthStencilState.nextInChain = nullptr;
+    depthStencilState.format = WGPUTextureFormat_Stencil8;
+    depthStencilState.depthWriteEnabled = false;
+    depthStencilState.depthCompare = WGPUCompareFunction_Always;
+    // depthStencilState.stencilFront
+    depthStencilState.stencilFront.compare = WGPUCompareFunction_NotEqual;
+    depthStencilState.stencilFront.failOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilFront.depthFailOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilFront.passOp = WGPUStencilOperation_Zero;
+    // depthStencilState.stencilBack
+    depthStencilState.stencilBack.compare = WGPUCompareFunction_NotEqual;
+    depthStencilState.stencilBack.failOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilBack.depthFailOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilBack.passOp = WGPUStencilOperation_Zero;
+    // stencil mask
+    depthStencilState.stencilReadMask = 0xFFFFFFFF;
+    depthStencilState.stencilWriteMask = 0xFFFFFFFF;
+    // depth bias
+    depthStencilState.depthBias = 0;
+    depthStencilState.depthBiasSlopeScale = 0.0f;
+    depthStencilState.depthBiasClamp = 0.0f;
+
+    // shader module wgsl descriptor
+    WGPUShaderModuleWGSLDescriptor shaderModuleWGSLDesc{};
+	shaderModuleWGSLDesc.chain.next = nullptr;
+	shaderModuleWGSLDesc.chain.sType = WGPUSType_ShaderModuleWGSLDescriptor;
+    shaderModuleWGSLDesc.code = cShaderSource_BrushRadial;
+    // shader module descriptor
+    WGPUShaderModuleDescriptor shaderModuleDesc{};
+    shaderModuleDesc.nextInChain = &shaderModuleWGSLDesc.chain;
+    shaderModuleDesc.label = "The shader module brush radial";
+    shaderModuleDesc.hintCount = 0;
+    shaderModuleDesc.hints = nullptr;
+    mShaderModule = wgpuDeviceCreateShaderModule(device, &shaderModuleDesc);
+    assert(mShaderModule);
+
+    // vertex attributes
+    WGPUVertexAttribute vertexAttributes[] = {
+        { WGPUVertexFormat_Float32x3, sizeof(float) * 0, 0 }, // position
+    };
+    // vertex buffer layout
+    WGPUVertexBufferLayout vertexBufferLayout{};
+    vertexBufferLayout.arrayStride = sizeof(float) * 3; // position
+    vertexBufferLayout.stepMode = WGPUVertexStepMode_Vertex;
+    vertexBufferLayout.attributeCount = 1; // position
+    vertexBufferLayout.attributes = vertexAttributes;
+    
+    // blend state
+    WGPUBlendState blendState{};
+    // blendState.color
+    blendState.color.operation = WGPUBlendOperation_Add;
+    blendState.color.srcFactor = WGPUBlendFactor_SrcAlpha;
+    blendState.color.dstFactor = WGPUBlendFactor_OneMinusSrcAlpha;
+    // blendState.alpha
+    blendState.alpha.operation = WGPUBlendOperation_Add;
+    blendState.alpha.srcFactor = WGPUBlendFactor_Zero;
+    blendState.alpha.dstFactor = WGPUBlendFactor_One;
+
+    // color target state (WGPUTextureFormat_BGRA8UnormSrgb)
+    WGPUColorTargetState colorTargetState0{};
+    colorTargetState0.nextInChain = nullptr;
+    colorTargetState0.format = WGPUTextureFormat_BGRA8Unorm;
+    //colorTargetState0.format = WGPUTextureFormat_BGRA8UnormSrgb;
+    colorTargetState0.blend = &blendState;
+    colorTargetState0.writeMask = WGPUColorWriteMask_All;
+    // color target states
+    WGPUColorTargetState colorTargetStates[] = {
+        colorTargetState0
+    };
+    // fragmanet state
+    WGPUFragmentState fragmentState{};
+    fragmentState.nextInChain = nullptr;
+    fragmentState.module = mShaderModule;
+    fragmentState.entryPoint = "fs_main";
+    fragmentState.constantCount = 0;
+    fragmentState.constants = nullptr;
+    fragmentState.targetCount = 1;
+    fragmentState.targets = colorTargetStates; // render target index
+
+    // render pipeline descriptor
+    WGPURenderPipelineDescriptor renderPipelineDesc{};
+    renderPipelineDesc.nextInChain = nullptr;
+    renderPipelineDesc.label = "Render pipeline brush radial";
+    // renderPipelineDesc.layout
+    renderPipelineDesc.layout = mPipelineLayout;
+    // renderPipelineDesc.vertex
+    renderPipelineDesc.vertex.nextInChain = nullptr;
+    renderPipelineDesc.vertex.module = mShaderModule;
+    renderPipelineDesc.vertex.entryPoint = "vs_main";
+    renderPipelineDesc.vertex.constantCount = 0;
+    renderPipelineDesc.vertex.constants = nullptr;
+    renderPipelineDesc.vertex.bufferCount = 1;
+    renderPipelineDesc.vertex.buffers = &vertexBufferLayout; // buffer index
+    // renderPipelineDesc.primitive
+    renderPipelineDesc.primitive.nextInChain = nullptr;
+    renderPipelineDesc.primitive.topology = WGPUPrimitiveTopology_TriangleList;
+    renderPipelineDesc.primitive.stripIndexFormat = WGPUIndexFormat_Undefined;
+    renderPipelineDesc.primitive.frontFace = WGPUFrontFace_CCW;
+    renderPipelineDesc.primitive.cullMode = WGPUCullMode_None;
+    // renderPipelineDesc.depthStencil
+    renderPipelineDesc.depthStencil = &depthStencilState;
+    // renderPipelineDesc.multisample
+    renderPipelineDesc.multisample.nextInChain = nullptr;
+    renderPipelineDesc.multisample.count = 1;
+    renderPipelineDesc.multisample.mask = 0xFFFFFFFF;
+    renderPipelineDesc.multisample.alphaToCoverageEnabled = false;
+    // renderPipelineDesc.fragment
+    renderPipelineDesc.fragment = &fragmentState;
+    mRenderPipeline = wgpuDeviceCreateRenderPipeline(device, &renderPipelineDesc);
+    assert(mRenderPipeline);
+}
+
+// release
+void WgBrushPipelineRadial::release() {
+    // render pipeline release
+    wgpuRenderPipelineRelease(mRenderPipeline);
+    // shader module release
+    wgpuShaderModuleRelease(mShaderModule);
+    // pipeline layout release
+    wgpuPipelineLayoutRelease(mPipelineLayout);
+    // bind group layouts release
+    wgpuBindGroupLayoutRelease(mBindGroupLayout);
+}

--- a/src/renderer/wg_engine/tvgWgBrushRadial.h
+++ b/src/renderer/wg_engine/tvgWgBrushRadial.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_BRUSH_RADIAL_H_
+#define _TVG_WG_BRUSH_RADIAL_H_
+
+#include "tvgWgBrush.h"
+
+// brush radial
+class WgBrushPipelineRadial;
+
+// struct uGradientInfo
+#define MAX_RADIAL_GRADIENT_STOPS 4
+struct WgBrushRadialGradientInfo {
+    alignas(16) float nStops[4]{};
+    alignas(16) float centerPos[2]{};
+    alignas(8)  float radius[2]{};
+    alignas(8)  float stopPoints[MAX_RADIAL_GRADIENT_STOPS]{};
+    alignas(16) float stopColors[4 * MAX_RADIAL_GRADIENT_STOPS]{};
+};
+
+// uniforms data brush color
+struct WgBrushDataRadial: WgBrushData {
+    // uColorInfo
+    WgBrushRadialGradientInfo uGradientInfo{}; // @binding(1)
+    void updateGradient(RadialGradient* radialGradient);
+};
+
+// wgpu brush linear uniforms data
+class WgBrushBindGroupRadial: public WgBrushBindGroup {
+private:
+    // data handles
+    WGPUBuffer uBufferGradientInfo{}; // @binding(1)
+public:
+    // initialize and release
+    void initialize(WGPUDevice device, WgBrushPipelineRadial& brushPipelineRadial);
+    void release();
+
+    // update
+    void update(WGPUQueue mQueue, WgBrushDataRadial& brushDataRadial);
+};
+
+// brush color
+class WgBrushPipelineRadial: public WgBrushPipeline {
+public:
+    // initialize and release
+    void initialize(WGPUDevice device) override;
+    void release() override;
+};
+
+#endif //_TVG_WG_BRUSH_RADIAL_H_

--- a/src/renderer/wg_engine/tvgWgBrushSolid.cpp
+++ b/src/renderer/wg_engine/tvgWgBrushSolid.cpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgBrushSolid.h"
+#include "tvgWgShaderSrc.h"
+
+//************************************************************************
+// WgBrushDataSolid
+//************************************************************************
+
+void WgBrushDataSolid::updateColor(const RenderShape& renderShape) {
+    // get solid fill color
+    uint8_t r = 0, g = 0, b = 0, a = 0;
+    renderShape.fillColor(&r, &g, &b, &a);
+    // update color
+    uColorInfo.color[0] = r / 255.0f;
+    uColorInfo.color[1] = g / 255.0f;
+    uColorInfo.color[2] = b / 255.0f;
+    uColorInfo.color[3] = a / 255.0f;
+}
+
+//************************************************************************
+// WgBrushBindGroupSolid
+//************************************************************************
+
+// initialize
+void WgBrushBindGroupSolid::initialize(WGPUDevice device, WgBrushPipelineSolid& brushPipelineSolid) {
+        // buffer uniform uMatrix
+    WGPUBufferDescriptor bufferUniformDesc_uMatrix{};
+    bufferUniformDesc_uMatrix.nextInChain = nullptr;
+    bufferUniformDesc_uMatrix.label = "Buffer uniform brush solid uMatrix";
+    bufferUniformDesc_uMatrix.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform;
+    bufferUniformDesc_uMatrix.size = sizeof(WgBrushMatrix);
+    bufferUniformDesc_uMatrix.mappedAtCreation = false;
+    uBufferMatrix = wgpuDeviceCreateBuffer(device, &bufferUniformDesc_uMatrix);
+    assert(uBufferMatrix);
+    // buffer uniform uColorInfo
+    WGPUBufferDescriptor bufferUniformDesc_uColorInfo{};
+    bufferUniformDesc_uColorInfo.nextInChain = nullptr;
+    bufferUniformDesc_uColorInfo.label = "Buffer uniform brush solid uColorInfo";
+    bufferUniformDesc_uColorInfo.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform;
+    bufferUniformDesc_uColorInfo.size = sizeof(WgBrushSolidColorInfo);
+    bufferUniformDesc_uColorInfo.mappedAtCreation = false;
+    uBufferColorInfo = wgpuDeviceCreateBuffer(device, &bufferUniformDesc_uColorInfo);
+    assert(uBufferColorInfo);
+
+    // bind group entry @binding(0) uMatrix
+    WGPUBindGroupEntry bindGroupEntry_uMatrix{};
+    bindGroupEntry_uMatrix.nextInChain = nullptr;
+    bindGroupEntry_uMatrix.binding = 0;
+    bindGroupEntry_uMatrix.buffer = uBufferMatrix;
+    bindGroupEntry_uMatrix.offset = 0;
+    bindGroupEntry_uMatrix.size = sizeof(WgBrushMatrix);
+    bindGroupEntry_uMatrix.sampler = nullptr;
+    bindGroupEntry_uMatrix.textureView = nullptr;
+    // bind group entry @binding(1) uColorInfo
+    WGPUBindGroupEntry bindGroupEntry_uColorInfo{};
+    bindGroupEntry_uColorInfo.nextInChain = nullptr;
+    bindGroupEntry_uColorInfo.binding = 1;
+    bindGroupEntry_uColorInfo.buffer = uBufferColorInfo;
+    bindGroupEntry_uColorInfo.offset = 0;
+    bindGroupEntry_uColorInfo.size = sizeof(WgBrushSolidColorInfo);
+    bindGroupEntry_uColorInfo.sampler = nullptr;
+    bindGroupEntry_uColorInfo.textureView = nullptr;
+    // bind group entries
+    WGPUBindGroupEntry bindGroupEntries[] {
+        bindGroupEntry_uMatrix,   // @binding(0) uMatrix
+        bindGroupEntry_uColorInfo // @binding(1) uColorInfo
+    };
+    // bind group descriptor
+    WGPUBindGroupDescriptor bindGroupDescBrush{};
+    bindGroupDescBrush.nextInChain = nullptr;
+    bindGroupDescBrush.label = "The binding group brush solid";
+    bindGroupDescBrush.layout = brushPipelineSolid.mBindGroupLayout;
+    bindGroupDescBrush.entryCount = 2;
+    bindGroupDescBrush.entries = bindGroupEntries;
+    mBindGroup = wgpuDeviceCreateBindGroup(device, &bindGroupDescBrush);
+    assert(mBindGroup);
+}
+
+// release
+void WgBrushBindGroupSolid::release() {
+    // destroy uniform buffer color info
+    if (uBufferColorInfo) wgpuBufferDestroy(uBufferColorInfo);
+    if (uBufferColorInfo) wgpuBufferRelease(uBufferColorInfo);
+    uBufferColorInfo = nullptr;
+    // destroy uniform buffer natrix
+    if (uBufferMatrix) wgpuBufferDestroy(uBufferMatrix);
+    if (uBufferMatrix) wgpuBufferRelease(uBufferMatrix);
+    uBufferMatrix = nullptr;
+    // release bind group
+    if (mBindGroup) wgpuBindGroupRelease(mBindGroup);
+    mBindGroup = nullptr;
+}
+
+// update buffers
+void WgBrushBindGroupSolid::update(WGPUQueue queue, WgBrushDataSolid& brushDataSolid) {
+    // write uMatrux buffer
+    wgpuQueueWriteBuffer(queue, uBufferMatrix, 0, &brushDataSolid.uMatrix, sizeof(brushDataSolid.uMatrix));
+    // write uColorInfo buffer
+    wgpuQueueWriteBuffer(queue, uBufferColorInfo, 0, &brushDataSolid.uColorInfo, sizeof(brushDataSolid.uColorInfo));
+}
+
+//************************************************************************
+// WgBrushPipelineSolid
+//************************************************************************
+
+// create
+void WgBrushPipelineSolid::initialize(WGPUDevice device) {
+    // bind group layout group 0
+    // bind group layout descriptor @group(0) @binding(0) uMatrix
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntry_uMatrix{};
+    bindGroupLayoutEntry_uMatrix.nextInChain = nullptr;
+    bindGroupLayoutEntry_uMatrix.binding = 0;
+    bindGroupLayoutEntry_uMatrix.visibility = WGPUShaderStage_Vertex | WGPUShaderStage_Fragment;
+    bindGroupLayoutEntry_uMatrix.buffer.nextInChain = nullptr;
+    bindGroupLayoutEntry_uMatrix.buffer.type = WGPUBufferBindingType_Uniform;
+    bindGroupLayoutEntry_uMatrix.buffer.hasDynamicOffset = false;
+    bindGroupLayoutEntry_uMatrix.buffer.minBindingSize = 0;
+    // bind group layout descriptor @group(0) @binding(1) uColorInfo
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntry_uColorInfo{};
+    bindGroupLayoutEntry_uColorInfo.nextInChain = nullptr;
+    bindGroupLayoutEntry_uColorInfo.binding = 1;
+    bindGroupLayoutEntry_uColorInfo.visibility = WGPUShaderStage_Vertex | WGPUShaderStage_Fragment;
+    bindGroupLayoutEntry_uColorInfo.buffer.nextInChain = nullptr;
+    bindGroupLayoutEntry_uColorInfo.buffer.type = WGPUBufferBindingType_Uniform;
+    bindGroupLayoutEntry_uColorInfo.buffer.hasDynamicOffset = false;
+    bindGroupLayoutEntry_uColorInfo.buffer.minBindingSize = 0;
+    // bind group layout entries @group(0)
+    WGPUBindGroupLayoutEntry bindGroupLayoutEntries[] {
+        bindGroupLayoutEntry_uMatrix,
+        bindGroupLayoutEntry_uColorInfo
+    };
+    // bind group layout descriptor scene @group(0)
+    WGPUBindGroupLayoutDescriptor bindGroupLayoutDesc{};
+    bindGroupLayoutDesc.nextInChain = nullptr;
+    bindGroupLayoutDesc.label = "Bind group layout brush solid";
+    bindGroupLayoutDesc.entryCount = 2;
+    bindGroupLayoutDesc.entries = bindGroupLayoutEntries; // @binding
+    mBindGroupLayout = wgpuDeviceCreateBindGroupLayout(device, &bindGroupLayoutDesc);
+    assert(mBindGroupLayout);
+
+    // pipeline layout
+
+    // bind group layout descriptors
+    WGPUBindGroupLayout mBindGroupLayouts[] {
+        mBindGroupLayout
+    };
+    // pipeline layout descriptor
+    WGPUPipelineLayoutDescriptor pipelineLayoutDesc{};
+    pipelineLayoutDesc.nextInChain = nullptr;
+    pipelineLayoutDesc.label = "Brush pipeline layout solid";
+    pipelineLayoutDesc.bindGroupLayoutCount = 1;
+    pipelineLayoutDesc.bindGroupLayouts = mBindGroupLayouts;
+    mPipelineLayout = wgpuDeviceCreatePipelineLayout(device, &pipelineLayoutDesc);
+    assert(mPipelineLayout);
+
+    // depth stencil state
+    WGPUDepthStencilState depthStencilState{};
+    depthStencilState.nextInChain = nullptr;
+    depthStencilState.format = WGPUTextureFormat_Stencil8;
+    depthStencilState.depthWriteEnabled = false;
+    depthStencilState.depthCompare = WGPUCompareFunction_Always;
+    // depthStencilState.stencilFront
+    depthStencilState.stencilFront.compare = WGPUCompareFunction_NotEqual;
+    depthStencilState.stencilFront.failOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilFront.depthFailOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilFront.passOp = WGPUStencilOperation_Zero;
+    // depthStencilState.stencilBack
+    depthStencilState.stencilBack.compare = WGPUCompareFunction_NotEqual;
+    depthStencilState.stencilBack.failOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilBack.depthFailOp = WGPUStencilOperation_Zero;
+    depthStencilState.stencilBack.passOp = WGPUStencilOperation_Zero;
+    // stencil mask
+    depthStencilState.stencilReadMask = 0xFFFFFFFF;
+    depthStencilState.stencilWriteMask = 0xFFFFFFFF;
+    // depth bias
+    depthStencilState.depthBias = 0;
+    depthStencilState.depthBiasSlopeScale = 0.0f;
+    depthStencilState.depthBiasClamp = 0.0f;
+
+    // shader module wgsl descriptor
+    WGPUShaderModuleWGSLDescriptor shaderModuleWGSLDesc{};
+	shaderModuleWGSLDesc.chain.next = nullptr;
+	shaderModuleWGSLDesc.chain.sType = WGPUSType_ShaderModuleWGSLDescriptor;
+    shaderModuleWGSLDesc.code = cShaderSource_BrushSolid;
+    // shader module descriptor
+    WGPUShaderModuleDescriptor shaderModuleDesc{};
+    shaderModuleDesc.nextInChain = &shaderModuleWGSLDesc.chain;
+    shaderModuleDesc.label = "The shader module brush solid";
+    shaderModuleDesc.hintCount = 0;
+    shaderModuleDesc.hints = nullptr;
+    mShaderModule = wgpuDeviceCreateShaderModule(device, &shaderModuleDesc);
+    assert(mShaderModule);
+
+    // vertex attributes
+    WGPUVertexAttribute vertexAttributes[] = {
+        { WGPUVertexFormat_Float32x3, sizeof(float) * 0, 0 }, // position
+    };
+    // vertex buffer layout
+    WGPUVertexBufferLayout vertexBufferLayout{};
+    vertexBufferLayout.arrayStride = sizeof(float) * 3; // position
+    vertexBufferLayout.stepMode = WGPUVertexStepMode_Vertex;
+    vertexBufferLayout.attributeCount = 1; // position
+    vertexBufferLayout.attributes = vertexAttributes;
+    
+    // blend state
+    WGPUBlendState blendState{};
+    // blendState.color
+    blendState.color.operation = WGPUBlendOperation_Add;
+    blendState.color.srcFactor = WGPUBlendFactor_SrcAlpha;
+    blendState.color.dstFactor = WGPUBlendFactor_OneMinusSrcAlpha;
+    // blendState.alpha
+    blendState.alpha.operation = WGPUBlendOperation_Add;
+    blendState.alpha.srcFactor = WGPUBlendFactor_Zero;
+    blendState.alpha.dstFactor = WGPUBlendFactor_One;
+
+    // color target state (WGPUTextureFormat_BGRA8UnormSrgb)
+    WGPUColorTargetState colorTargetState0{};
+    colorTargetState0.nextInChain = nullptr;
+    colorTargetState0.format = WGPUTextureFormat_BGRA8Unorm;
+    //colorTargetState0.format = WGPUTextureFormat_BGRA8UnormSrgb;
+    colorTargetState0.blend = &blendState;
+    colorTargetState0.writeMask = WGPUColorWriteMask_All;
+    // color target states
+    WGPUColorTargetState colorTargetStates[] = {
+        colorTargetState0
+    };
+    // fragmanet state
+    WGPUFragmentState fragmentState{};
+    fragmentState.nextInChain = nullptr;
+    fragmentState.module = mShaderModule;
+    fragmentState.entryPoint = "fs_main";
+    fragmentState.constantCount = 0;
+    fragmentState.constants = nullptr;
+    fragmentState.targetCount = 1;
+    fragmentState.targets = colorTargetStates; // render target index
+
+    // render pipeline descriptor
+    WGPURenderPipelineDescriptor renderPipelineDesc{};
+    renderPipelineDesc.nextInChain = nullptr;
+    renderPipelineDesc.label = "Render pipeline brush solid";
+    // renderPipelineDesc.layout
+    renderPipelineDesc.layout = mPipelineLayout;
+    // renderPipelineDesc.vertex
+    renderPipelineDesc.vertex.nextInChain = nullptr;
+    renderPipelineDesc.vertex.module = mShaderModule;
+    renderPipelineDesc.vertex.entryPoint = "vs_main";
+    renderPipelineDesc.vertex.constantCount = 0;
+    renderPipelineDesc.vertex.constants = nullptr;
+    renderPipelineDesc.vertex.bufferCount = 1;
+    renderPipelineDesc.vertex.buffers = &vertexBufferLayout; // buffer index
+    // renderPipelineDesc.primitive
+    renderPipelineDesc.primitive.nextInChain = nullptr;
+    renderPipelineDesc.primitive.topology = WGPUPrimitiveTopology_TriangleList;
+    renderPipelineDesc.primitive.stripIndexFormat = WGPUIndexFormat_Undefined;
+    renderPipelineDesc.primitive.frontFace = WGPUFrontFace_CCW;
+    renderPipelineDesc.primitive.cullMode = WGPUCullMode_None;
+    // renderPipelineDesc.depthStencil
+    renderPipelineDesc.depthStencil = &depthStencilState;
+    // renderPipelineDesc.multisample
+    renderPipelineDesc.multisample.nextInChain = nullptr;
+    renderPipelineDesc.multisample.count = 1;
+    renderPipelineDesc.multisample.mask = 0xFFFFFFFF;
+    renderPipelineDesc.multisample.alphaToCoverageEnabled = false;
+    // renderPipelineDesc.fragment
+    renderPipelineDesc.fragment = &fragmentState;
+    mRenderPipeline = wgpuDeviceCreateRenderPipeline(device, &renderPipelineDesc);
+    assert(mRenderPipeline);
+}
+
+// release
+void WgBrushPipelineSolid::release() {
+    // render pipeline release
+    wgpuRenderPipelineRelease(mRenderPipeline);
+    // shader module release
+    wgpuShaderModuleRelease(mShaderModule);
+    // pipeline layout release
+    wgpuPipelineLayoutRelease(mPipelineLayout);
+    // bind group layouts release
+    wgpuBindGroupLayoutRelease(mBindGroupLayout);
+}

--- a/src/renderer/wg_engine/tvgWgBrushSolid.h
+++ b/src/renderer/wg_engine/tvgWgBrushSolid.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_BRUSH_SOLID_H_
+#define _TVG_WG_BRUSH_SOLID_H_
+
+#include "tvgWgBrush.h"
+
+// brush color
+class WgBrushPipelineSolid;
+
+// struct uColorInfo
+struct WgBrushSolidColorInfo {
+    float color[4]{};
+};
+
+// uniforms data brush color
+struct WgBrushDataSolid: WgBrushData {
+    // uColorInfo
+    WgBrushSolidColorInfo uColorInfo{}; // @binding(1)
+    void updateColor(const RenderShape& renderShape);
+};
+
+// wgpu brush color uniforms data
+class WgBrushBindGroupSolid: public WgBrushBindGroup {
+private:
+    // data handles
+    WGPUBuffer uBufferColorInfo{}; // @binding(1)
+public:
+    // initialize and release
+    void initialize(WGPUDevice device, WgBrushPipelineSolid& brushPipelineSolid);
+    void release();
+
+    // update
+    void update(WGPUQueue mQueue, WgBrushDataSolid& brushDataSolid);
+};
+
+// brush color
+class WgBrushPipelineSolid: public WgBrushPipeline {
+public:
+    // initialize and release
+    void initialize(WGPUDevice device) override;
+    void release() override;
+};
+
+#endif //_TVG_WG_BRUSH_SOLID_H_

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_COMMON_H_
+#define _TVG_WG_COMMON_H_
+
+#include <cassert>
+#include <webgpu/webgpu.h>
+#include "tvgCommon.h"
+#include "tvgRender.h"
+
+#endif // _TVG_WG_COMMON_H_

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgRenderData.h"
+
+//***********************************************************************
+// WgGeometryData
+//***********************************************************************
+
+// synk
+void WgGeometryData::draw(WGPURenderPassEncoder renderPassEncoder) {
+    wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 0, mBufferVertex, 0, mVertexCount * sizeof(float) * 3);
+    wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, mBufferIndex, WGPUIndexFormat_Uint32, 0, mIndexCount * sizeof(uint32_t));
+    wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, mIndexCount, 1, 0, 0, 0);
+}
+
+// update
+void WgGeometryData::update(WGPUDevice device, WGPUQueue queue, float* vertexData, size_t vertexCount, uint32_t* indexData, size_t indexCount) {
+    // release first (Sergii: I don`t like this solution, but I can`t come up how to do it better)
+    release();
+
+    // buffer vertex data create and write
+    WGPUBufferDescriptor bufferVertexDesc{};
+    bufferVertexDesc.nextInChain = nullptr;
+    bufferVertexDesc.label = "Buffer vertex geometry data";
+    bufferVertexDesc.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Vertex;
+    bufferVertexDesc.size = sizeof(float) * vertexCount * 3; // x, y, z
+    bufferVertexDesc.mappedAtCreation = false;
+    mBufferVertex = wgpuDeviceCreateBuffer(device, &bufferVertexDesc);
+    assert(mBufferVertex);
+    wgpuQueueWriteBuffer(queue, mBufferVertex, 0, vertexData, sizeof(float) * vertexCount * 3);
+    mVertexCount = vertexCount;
+    // buffer index data create and write
+    WGPUBufferDescriptor bufferIndexDesc{};
+    bufferIndexDesc.nextInChain = nullptr;
+    bufferIndexDesc.label = "Buffer index geometry data";
+    bufferIndexDesc.usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Index;
+    bufferIndexDesc.size = sizeof(uint32_t) * indexCount;
+    bufferIndexDesc.mappedAtCreation = false;
+    mBufferIndex = wgpuDeviceCreateBuffer(device, &bufferIndexDesc);
+    assert(mBufferIndex);
+    wgpuQueueWriteBuffer(queue, mBufferIndex, 0, indexData, sizeof(uint32_t) * indexCount);
+    mIndexCount = indexCount;
+}
+
+// release
+void WgGeometryData::release() {
+    // buffer index destroy
+    if (mBufferIndex) wgpuBufferDestroy(mBufferIndex);
+    if (mBufferIndex) wgpuBufferRelease(mBufferIndex);
+    mBufferIndex = nullptr;
+    // buffer vertex destroy
+    if (mBufferVertex) wgpuBufferDestroy(mBufferVertex);
+    if (mBufferVertex) wgpuBufferRelease(mBufferVertex);
+    mBufferVertex = nullptr;
+    // null counts
+    mVertexCount = 0;
+    mIndexCount = 0;
+}
+
+//***********************************************************************
+// WgRenderDataShape
+//***********************************************************************
+
+// initialize
+void WgRenderDataShape::initialize(WGPUDevice device) {
+}
+
+// release
+void WgRenderDataShape::release() {
+    // release render data
+    releaseRenderData();
+    // release bind group
+    mBrushBindGroupSolid.release();
+    //mBrushBindGroupLinear.release();
+    //mBrushBindGroupRadial.release();
+}
+
+// release render data
+void WgRenderDataShape::releaseRenderData() {
+    // release and delete geometry render data fill
+    for (uint32_t i = 0; i < mGeometryDataFill.count; i++) {
+        mGeometryDataFill[i]->release();
+        delete mGeometryDataFill[i];
+    }
+    // clear render data fill
+    mGeometryDataFill.clear();
+}
+
+// tesselate
+void WgRenderDataShape::tesselate(WGPUDevice device, WGPUQueue queue, const RenderShape& rshape) {
+    // release render data
+    releaseRenderData();
+    // outlines
+    Array<Array<float>*> outlines;
+    // iterate commands
+    size_t pntIndex = 0;
+    for (uint32_t cmdIndex = 0; cmdIndex < rshape.path.cmds.count; cmdIndex++) {
+        // get current command
+        PathCommand cmd = rshape.path.cmds[cmdIndex];
+        // MoveTo command
+        if (cmd == PathCommand::MoveTo) {
+            // create new outline
+            outlines.push(new Array<float>);
+            // get last outline
+            auto outline = outlines.last();
+            // get point coordinates
+            float x = rshape.path.pts[pntIndex].x;
+            float y = rshape.path.pts[pntIndex].y;
+            // push new vertex
+            outline->push(x);
+            outline->push(y);
+            outline->push(0.0f);
+            // move to next point
+            pntIndex++;
+        } else // LineTo command
+        if (cmd == PathCommand::LineTo) {
+            // get last outline
+            auto outline = outlines.last();
+            // get point coordinates
+            float x = rshape.path.pts[pntIndex].x;
+            float y = rshape.path.pts[pntIndex].y;
+            // push new vertex
+            outline->push(x);
+            outline->push(y);
+            outline->push(0.0f);
+            // move to next point
+            pntIndex++;
+        } else // Close command
+        if (cmd == PathCommand::Close) {
+            // get last outline
+            auto outline = outlines.last();
+            // close path
+            if ((outline) && (outline->count > 1)) {
+                // get point coordinates
+                float x = outline->data[0]; // x
+                float y = outline->data[1]; // y
+                // push new vertex
+                outline->push(x);
+                outline->push(y);
+                outline->push(0.0f);
+            }
+        } else
+        if (cmd == PathCommand::CubicTo) {
+            // get last outline
+            auto outline = outlines.last();
+            // get cubic base points
+            Point p0{};
+            p0.x = outline->data[outline->count - 3];
+            p0.y = outline->data[outline->count - 2];
+            Point p1{};
+            p1.x = rshape.path.pts[pntIndex + 0].x;
+            p1.y = rshape.path.pts[pntIndex + 0].y;
+            Point p2{};
+            p2.x = rshape.path.pts[pntIndex + 1].x;
+            p2.y = rshape.path.pts[pntIndex + 1].y;
+            Point p3{};
+            p3.x = rshape.path.pts[pntIndex + 2].x;
+            p3.y = rshape.path.pts[pntIndex + 2].y;
+            // calculate cubic spline
+            const size_t segs = 16;
+            for (size_t i = 1; i <= segs; i++) {
+                float t = i / (float)segs;
+                // get coefficients
+                float t0 = 1 * (1.0f - t) * (1.0f - t) * (1.0f - t);
+                float t1 = 3 * (1.0f - t) * (1.0f - t) * t;
+                float t2 = 3 * (1.0f - t) * t * t;
+                float t3 = 1 * t * t * t;
+                // compute coordinates
+                float x = p0.x * t0 + p1.x * t1 + p2.x * t2 + p3.x * t3;
+                float y = p0.y * t0 + p1.y * t1 + p2.y * t2 + p3.y * t3;
+                // push new vertex
+                outline->push(x);
+                outline->push(y);
+                outline->push(0.0f);
+            }
+            // move to next point
+            pntIndex += 3;
+        } 
+    }
+    // create render index buffers
+    Array<uint32_t> indexBuffer;
+    for (size_t i = 0; i < outlines.count; i++) {
+        // get current outline
+        auto outline = outlines[i];
+        // get vertex count
+        size_t vertexCount = outline->count / 3;
+        assert(vertexCount > 2);
+        // index buffer (for triangle fan)
+        indexBuffer.clear();
+        indexBuffer.reserve((vertexCount - 2) * 3);
+        for (size_t j = 0; j < vertexCount - 2; j++) {
+            indexBuffer.push(0);
+            indexBuffer.push(j + 1);
+            indexBuffer.push(j + 2);
+        }
+        // create new geometry data
+        WgGeometryData* geometryData = new WgGeometryData();
+        geometryData->initialize(device);
+        geometryData->update(device, queue, outline->data, vertexCount, indexBuffer.data, indexBuffer.count);
+        // push geometry data
+        mGeometryDataFill.push(geometryData);
+    }
+    // delete outlines
+    for (size_t i = 0; i < outlines.count; i++)
+        delete outlines[i];
+}

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgBrushSolid.h"
+#include "tvgWgBrushLinear.h"
+#include "tvgWgBrushRadial.h"
+
+#ifndef _TVG_WG_RENDER_DATA_H_
+#define _TVG_WG_RENDER_DATA_H_
+
+// geometry data
+class WgGeometryData {
+public:
+    WGPUBuffer mBufferVertex{};
+    WGPUBuffer mBufferIndex{};
+    size_t     mVertexCount{};
+    size_t     mIndexCount{};
+public:
+    // constructor and destructor
+    WgGeometryData() {}
+    virtual ~WgGeometryData() { release(); }
+
+    // initialize
+    void initialize(WGPUDevice device) {};
+    // draw
+    void draw(WGPURenderPassEncoder renderPassEncoder);
+    // update
+    void update(WGPUDevice device, WGPUQueue queue, float* vertexData, size_t vertexCount, uint32_t* indexData, size_t indexCount);
+    // release
+    void release();
+};
+
+// render data
+class WgRenderData {
+public:
+    // initialize and release
+    virtual void initialize(WGPUDevice device) = 0;
+    virtual void release() = 0;
+};
+
+// render data shape
+class WgRenderDataShape: public WgRenderData {
+public:
+    // geometry data for fill and stroke
+    Array<WgGeometryData*> mGeometryDataFill;
+    Array<WgGeometryData*> mGeometryDataStroke;
+    // brushes data
+    WgBrushBindGroupSolid mBrushBindGroupSolid{};
+    WgBrushBindGroupLinear mBrushBindGroupLinear{};
+    WgBrushBindGroupRadial mBrushBindGroupRadial{};
+    // current brush handles
+    WgBrushPipeline* mBrushPipeline{}; // external
+    WgBrushBindGroup* mBrushBindGroup{}; // external
+public:
+    // constructor
+    WgRenderDataShape() {}
+
+    // initialize and release
+    void initialize(WGPUDevice device) override;
+    void release() override;
+    void releaseRenderData();
+
+    void tesselate(WGPUDevice device, WGPUQueue queue, const RenderShape& rshape);
+};
+
+#endif //_TVG_WG_RENDER_DATA_H_

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgRenderer.h"
+
+#include <iostream>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#include "tvgWgRenderData.h"
+#include "tvgWgShaderSrc.h"
+
+// constructor
+WgRenderer::WgRenderer() {
+    initialize();
+}
+
+// destructor
+WgRenderer::~WgRenderer() {
+    release();
+}
+
+// initialize renderer
+void WgRenderer::initialize() {
+        // create instance
+    WGPUInstanceDescriptor instanceDesc{};
+    instanceDesc.nextInChain = nullptr;
+    mInstance = wgpuCreateInstance(&instanceDesc);
+    assert(mInstance);
+
+    // request adapter options
+    WGPURequestAdapterOptions requestAdapterOptions{};
+    requestAdapterOptions.nextInChain = nullptr;
+    requestAdapterOptions.compatibleSurface = nullptr;
+    requestAdapterOptions.powerPreference = WGPUPowerPreference_HighPerformance;
+    requestAdapterOptions.forceFallbackAdapter = false;
+    // on adapter request ended function
+    auto onAdapterRequestEnded = [](WGPURequestAdapterStatus status, WGPUAdapter adapter, char const * message, void * pUserData) {
+        #ifdef _DEBUG
+        assert(!status);
+        if (status != WGPURequestAdapterStatus_Success)
+            std::cout << "Adapter request: " << message << std::endl;
+        #endif
+        *((WGPUAdapter *)pUserData) = adapter;
+    };
+    // request adapter
+    wgpuInstanceRequestAdapter(mInstance, &requestAdapterOptions, onAdapterRequestEnded, &mAdapter);
+    assert(mAdapter);
+
+    // adapter enumarate fueatures
+    WGPUFeatureName featureNames[32]{};
+    size_t featuresCount = wgpuAdapterEnumerateFeatures(mAdapter, featureNames);
+    // get adapter properties
+    WGPUAdapterProperties adapterProperties{};
+    wgpuAdapterGetProperties(mAdapter, &adapterProperties);
+    // get supported limits
+    WGPUSupportedLimits supportedLimits{};
+    wgpuAdapterGetLimits(mAdapter, &supportedLimits);
+
+    // reguest device
+    WGPUDeviceDescriptor deviceDesc{};
+    deviceDesc.nextInChain = nullptr;
+    deviceDesc.label = "The device";
+    deviceDesc.requiredFeaturesCount = featuresCount;
+    deviceDesc.requiredFeatures = featureNames;
+    deviceDesc.requiredLimits = nullptr;
+    deviceDesc.defaultQueue.nextInChain = nullptr;
+    deviceDesc.defaultQueue.label = "The default queue";
+    deviceDesc.deviceLostCallback = nullptr;
+    deviceDesc.deviceLostUserdata = nullptr;
+    // on device request ended function
+    auto onDeviceRequestEnded = [](WGPURequestDeviceStatus status, WGPUDevice device, char const * message, void * pUserData) {
+        #ifdef _DEBUG
+        assert(!status);
+        if (status != WGPURequestDeviceStatus_Success)
+            std::cout << "Device request: " << message << std::endl;
+        #endif
+        *((WGPUDevice *)pUserData) = device;
+    };
+    // request device
+    wgpuAdapterRequestDevice(mAdapter, &deviceDesc, onDeviceRequestEnded, &mDevice);
+    assert(mDevice);
+
+    #ifdef _DEBUG
+    // on device error function
+    auto onDeviceError = [](WGPUErrorType type, char const* message, void* pUserData) {
+        std::cout << "Uncaptured device error: " << message << std::endl;
+    };
+    // set device error handling
+    wgpuDeviceSetUncapturedErrorCallback(mDevice, onDeviceError, nullptr);
+    #endif
+
+    // get queue
+    mQueue = wgpuDeviceGetQueue(mDevice);
+    assert(mQueue);
+
+    #ifdef _DEBUG
+    // queue work done function
+    auto onQueueWorkDone = [](WGPUQueueWorkDoneStatus status, void* pUserData) {
+        std::cout << "Queued work finished with status: " << status << std::endl;
+    };
+    // submittet queue work done function
+    wgpuQueueOnSubmittedWorkDone(mQueue, onQueueWorkDone, nullptr);
+    #endif
+    
+    // create brushes
+    mBrushPipelineEmpty.initialize(mDevice);
+    mBrushPipelineSolid.initialize(mDevice);
+    mBrushPipelineLinear.initialize(mDevice);
+    mBrushPipelineRadial.initialize(mDevice);
+    mBrushBindGroupEmpty.initialize(mDevice, mBrushPipelineEmpty);
+    mGeometryDataBrush.initialize(mDevice);
+}
+
+// release renderer
+void WgRenderer::release() {
+    // remove stencil hendles
+    if (mStencilTex) wgpuTextureDestroy(mStencilTex);
+    if (mStencilTex) wgpuTextureRelease(mStencilTex);
+    if (mStencilTexView) wgpuTextureViewRelease(mStencilTexView);
+    // swapchaine release
+    if (mSwapChain) wgpuSwapChainRelease(mSwapChain);
+    // serface release
+    if (mSurface) wgpuSurfaceRelease(mSurface);
+    // create brushes
+    mGeometryDataBrush.release();
+    mBrushBindGroupEmpty.release();
+    mBrushPipelineRadial.release();
+    mBrushPipelineLinear.release();
+    mBrushPipelineSolid.release();
+    mBrushPipelineEmpty.release();
+    // device release
+    if (mDevice) wgpuDeviceDestroy(mDevice);
+    if (mDevice) wgpuDeviceRelease(mDevice);
+    // adapter release
+    if (mAdapter) wgpuAdapterRelease(mAdapter);
+    // instance release
+    if (mInstance) wgpuInstanceRelease(mInstance);
+}
+
+// prepare render shape
+RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags, bool clipper) {
+    // get or create render data shape
+    auto renderDataShape = (WgRenderDataShape *)data;
+    if (!renderDataShape) {
+        renderDataShape = new WgRenderDataShape();
+        renderDataShape->initialize(mDevice);
+        renderDataShape->mBrushBindGroupSolid.initialize(mDevice, mBrushPipelineSolid);
+        renderDataShape->mBrushBindGroupLinear.initialize(mDevice, mBrushPipelineLinear);
+        renderDataShape->mBrushBindGroupRadial.initialize(mDevice, mBrushPipelineRadial);
+    }
+    
+    // tesselate path
+    if (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Stroke | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform))
+        renderDataShape->tesselate(mDevice, mQueue, rshape);
+
+    // gradient fill
+    if ((flags & (RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform)) && (rshape.fill)) {
+        // linear brush
+        if (rshape.fill->identifier() == TVG_CLASS_ID_LINEAR) {
+            // brush radial data
+            WgBrushDataLinear brushDataLinear{};
+            brushDataLinear.updateMatrix(mViewMatrix, transform);
+            brushDataLinear.updateGradient((LinearGradient *)rshape.fill);
+            // update bind group
+            renderDataShape->mBrushBindGroupLinear.update(mQueue, brushDataLinear);
+            // set current brush handles
+            renderDataShape->mBrushBindGroup = &renderDataShape->mBrushBindGroupLinear;
+            renderDataShape->mBrushPipeline = &mBrushPipelineLinear;
+        }
+
+        // radial brush
+        if (rshape.fill->identifier() == TVG_CLASS_ID_RADIAL) {
+            // brush radial data
+            WgBrushDataRadial brushDataRadial{};
+            brushDataRadial.updateMatrix(mViewMatrix, transform);
+            brushDataRadial.updateGradient((RadialGradient *)rshape.fill);
+            // update bind group
+            renderDataShape->mBrushBindGroupRadial.update(mQueue, brushDataRadial);
+            // set current brush handles
+            renderDataShape->mBrushBindGroup = &renderDataShape->mBrushBindGroupRadial;
+            renderDataShape->mBrushPipeline = &mBrushPipelineRadial;
+        }
+    }
+
+    // solid fill
+    if ((flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Transform)) && (!rshape.fill)) {
+        // update brush data solid
+        WgBrushDataSolid brushDataSolid{};
+        brushDataSolid.updateMatrix(mViewMatrix, transform);
+        brushDataSolid.updateColor(rshape);
+        // update bind group
+        renderDataShape->mBrushBindGroupSolid.update(mQueue, brushDataSolid);
+        // set current brush handles
+        renderDataShape->mBrushBindGroup = &renderDataShape->mBrushBindGroupSolid;
+        renderDataShape->mBrushPipeline = &mBrushPipelineSolid;
+    }
+
+    // return render data shape
+    return renderDataShape;
+}
+
+// prepare scene
+RenderData WgRenderer::prepare(const Array<RenderData>& scene, RenderData data, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags) {
+    // nothing
+    return nullptr;
+}
+
+// prepare surface
+RenderData WgRenderer::prepare(Surface* surface, const RenderMesh* mesh, RenderData data, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags) {
+    // nothing
+    return nullptr;
+}
+
+// pre render
+bool WgRenderer::preRender() {
+    // nothing
+    return true;
+}
+
+// render shape
+bool WgRenderer::renderShape(RenderData data) {
+    mRenderDatas.push(data);
+    return true;
+}
+
+// render image
+bool WgRenderer::renderImage(RenderData data) {
+    // nothing
+    return true;
+}
+
+// post render
+bool WgRenderer::postRender() {
+    // nothing
+    return true;
+}
+
+// dispose render data
+bool WgRenderer::dispose(RenderData data) {
+    // release render data
+    auto renderData = (WgRenderData *)data;
+    if (renderData)
+        renderData->release();
+    // nothing
+    return true;
+}
+
+// get region of render data
+RenderRegion WgRenderer::region(RenderData data) {
+    // nothing
+    return { 0, 0, INT32_MAX, INT32_MAX };
+}
+
+// get current viewport
+RenderRegion WgRenderer::viewport() {
+    // nothing
+    return { 0, 0, INT32_MAX, INT32_MAX };
+}
+
+// set current viewport
+bool WgRenderer::viewport(const RenderRegion& vp) {
+    // nothing
+    return true;
+}
+
+// blend
+bool WgRenderer::blend(BlendMethod method) {
+    return false;
+}
+
+// color space
+ColorSpace WgRenderer::colorSpace() {
+    return ColorSpace::Unsupported;
+}
+
+// clear
+bool WgRenderer::clear() {
+    return true;
+}
+
+// sync
+bool WgRenderer::sync() {
+    // get buffer
+    WGPUTextureView backBufferView = wgpuSwapChainGetCurrentTextureView(mSwapChain);
+    
+    // command buffer descriptor
+    WGPUCommandBufferDescriptor commandBufferDesc{};
+    commandBufferDesc.nextInChain = nullptr;
+    commandBufferDesc.label = "The command buffer";
+    WGPUCommandBuffer commandsBuffer = nullptr; {
+        // command encoder descriptor
+        WGPUCommandEncoderDescriptor commandEncoderDesc{};
+        commandEncoderDesc.nextInChain = nullptr;
+        commandEncoderDesc.label = "The command encoder";
+        // begin render pass
+        WGPUCommandEncoder commandEncoder = wgpuDeviceCreateCommandEncoder(mDevice, &commandEncoderDesc); {
+            // render pass depth stencil attachment
+            WGPURenderPassDepthStencilAttachment depthStencilAttachment{};
+            depthStencilAttachment.view = mStencilTexView;
+            depthStencilAttachment.depthLoadOp = WGPULoadOp_Clear;
+            depthStencilAttachment.depthStoreOp = WGPUStoreOp_Store;
+            depthStencilAttachment.depthClearValue = 1.0f;
+            depthStencilAttachment.depthReadOnly = false;
+            depthStencilAttachment.stencilLoadOp = WGPULoadOp_Clear;
+            depthStencilAttachment.stencilStoreOp = WGPUStoreOp_Store;
+            depthStencilAttachment.stencilClearValue = 0;
+            depthStencilAttachment.stencilReadOnly = false;
+            // render pass color attachment
+            WGPURenderPassColorAttachment colorAttachment{};
+            colorAttachment.view = backBufferView;
+            colorAttachment.resolveTarget = nullptr;
+            colorAttachment.loadOp = WGPULoadOp_Clear;
+            colorAttachment.storeOp = WGPUStoreOp_Store;
+            colorAttachment.clearValue = { 0.0f, 0.0f, 0.0f, 1.0 };
+            // render pass descriptor
+            WGPURenderPassDescriptor renderPassDesc{};
+            renderPassDesc.nextInChain = nullptr;
+            renderPassDesc.label = "The render pass";
+            renderPassDesc.colorAttachmentCount = 1;
+            renderPassDesc.colorAttachments = &colorAttachment;
+            renderPassDesc.depthStencilAttachment = &depthStencilAttachment;
+            //renderPassDesc.depthStencilAttachment = nullptr;
+            renderPassDesc.occlusionQuerySet = nullptr;
+            renderPassDesc.timestampWriteCount = 0;
+            renderPassDesc.timestampWrites = nullptr;
+            // begin render pass
+            WGPURenderPassEncoder renderPassEncoder = wgpuCommandEncoderBeginRenderPass(commandEncoder, &renderPassDesc); {
+                // iterate render data
+                for (size_t i = 0; i < mRenderDatas.count; i++) {
+                    // get render data
+                    WgRenderDataShape* renderData = (WgRenderDataShape*)(mRenderDatas[i]);
+                    
+                    // iterate geometry data
+                    for (uint32_t j = 0; j < renderData->mGeometryDataFill.count; j++) {
+                        // draw to stencil
+                        mBrushPipelineEmpty.set(renderPassEncoder);
+                        mBrushBindGroupEmpty.bind(renderPassEncoder, 0);
+                        renderData->mGeometryDataFill[j]->draw(renderPassEncoder);
+
+                        // draw brush
+                        renderData->mBrushPipeline->set(renderPassEncoder);
+                        renderData->mBrushBindGroup->bind(renderPassEncoder, 0);
+                        mGeometryDataBrush.draw(renderPassEncoder);
+                    }
+                }
+            }
+            // end render pass
+            wgpuRenderPassEncoderEnd(renderPassEncoder);
+            wgpuRenderPassEncoderRelease(renderPassEncoder);
+
+            // release backbuffer and present
+            wgpuTextureViewRelease(backBufferView);
+        }
+        commandsBuffer = wgpuCommandEncoderFinish(commandEncoder, &commandBufferDesc);
+        wgpuCommandEncoderRelease(commandEncoder);
+    }
+    // queue submit and command buffer release
+    wgpuQueueSubmit(mQueue, 1, &commandsBuffer);
+    wgpuCommandBufferRelease(commandsBuffer);
+    
+    // go to the next frame
+    wgpuSwapChainPresent(mSwapChain);
+
+    // clear current render datas
+    mRenderDatas.clear();
+    return true;
+}
+
+// target
+bool WgRenderer::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h) {
+    // check properties
+    assert(w > 0);
+    assert(h > 0);
+
+    // store target surface properties
+    mTargetSurface.stride = stride;
+    mTargetSurface.w = w;
+    mTargetSurface.h = h;
+
+    // update view matrix
+    mViewMatrix[ 0] = +2.0f / w; mViewMatrix[ 1] = +0.0f;     mViewMatrix[ 2] = +0.0f; mViewMatrix[ 3] = +0.0f;
+    mViewMatrix[ 4] = +0.0f;     mViewMatrix[ 5] = -2.0f / h; mViewMatrix[ 6] = +0.0f; mViewMatrix[ 7] = +0.0f;
+    mViewMatrix[ 8] = +0.0f;     mViewMatrix[ 9] = +0.0f;     mViewMatrix[10] = -1.0f; mViewMatrix[11] = +0.0f;
+    mViewMatrix[12] = -1.0f;     mViewMatrix[13] = +1.0f;     mViewMatrix[14] = +0.0f; mViewMatrix[15] = +1.0f;
+
+    // return result
+    return true;
+}
+
+// target for native window handle
+bool WgRenderer::target(void* window, uint32_t w, uint32_t h) {
+    // check properties
+    assert(window);
+    assert(w > 0);
+    assert(h > 0);
+
+    // store target surface properties
+    mTargetSurface.stride = w;
+    mTargetSurface.w = w > 0 ? w : 1;
+    mTargetSurface.h = h > 0 ? h : 1;
+
+    // update view matrix
+    mViewMatrix[ 0] = +2.0f / w; mViewMatrix[ 1] = +0.0f;     mViewMatrix[ 2] = +0.0f; mViewMatrix[ 3] = +0.0f;
+    mViewMatrix[ 4] = +0.0f;     mViewMatrix[ 5] = -2.0f / h; mViewMatrix[ 6] = +0.0f; mViewMatrix[ 7] = +0.0f;
+    mViewMatrix[ 8] = +0.0f;     mViewMatrix[ 9] = +0.0f;     mViewMatrix[10] = -1.0f; mViewMatrix[11] = +0.0f;
+    mViewMatrix[12] = -1.0f;     mViewMatrix[13] = +1.0f;     mViewMatrix[14] = +0.0f; mViewMatrix[15] = +1.0f;
+
+    #ifdef _WIN32
+    // surface descriptor from windows hwnd
+    WGPUSurfaceDescriptorFromWindowsHWND surfaceDescHwnd{};
+    surfaceDescHwnd.chain.next = nullptr;
+    surfaceDescHwnd.chain.sType = WGPUSType_SurfaceDescriptorFromWindowsHWND;
+    surfaceDescHwnd.hinstance = GetModuleHandle(NULL);
+    surfaceDescHwnd.hwnd = (HWND)window;
+    // surface descriptor
+    WGPUSurfaceDescriptor surfaceDesc{};
+    surfaceDesc.nextInChain = (const WGPUChainedStruct*)&surfaceDescHwnd;
+    surfaceDesc.label = "The surface";
+    // create surface
+    mSurface = wgpuInstanceCreateSurface(mInstance, &surfaceDesc);
+    assert(mSurface);
+    #endif
+
+    // get preferred format
+    //WGPUTextureFormat swapChainFormat = wgpuSurfaceGetPreferredFormat(mSurface, mAdapter);
+    WGPUTextureFormat swapChainFormat = WGPUTextureFormat_BGRA8Unorm;
+    //WGPUTextureFormat swapChainFormat = WGPUTextureFormat_BGRA8UnormSrgb;
+    // swapchain descriptor
+    WGPUSwapChainDescriptor swapChainDesc{};
+    swapChainDesc.nextInChain = nullptr;
+    swapChainDesc.label = "The swapchain";
+    swapChainDesc.usage = WGPUTextureUsage_RenderAttachment;
+    swapChainDesc.format = swapChainFormat;
+    swapChainDesc.width = mTargetSurface.w;
+    swapChainDesc.height = mTargetSurface.h;
+    swapChainDesc.presentMode = WGPUPresentMode_Mailbox;
+    mSwapChain = wgpuDeviceCreateSwapChain(mDevice, mSurface, &swapChainDesc);
+    assert(mSwapChain);
+
+    // depth-stencil texture
+    WGPUTextureDescriptor textureDesc{};
+    textureDesc.nextInChain = nullptr;
+    textureDesc.label = "The depth-stencil texture";
+    textureDesc.usage = WGPUTextureUsage_RenderAttachment;
+    textureDesc.dimension = WGPUTextureDimension_2D;
+    textureDesc.size = { swapChainDesc.width, swapChainDesc.height, 1 }; // window size
+    textureDesc.format = WGPUTextureFormat_Stencil8;
+    textureDesc.mipLevelCount = 1;
+    textureDesc.sampleCount = 1;
+    textureDesc.viewFormatCount = 0;
+    textureDesc.viewFormats = nullptr;
+    mStencilTex = wgpuDeviceCreateTexture(mDevice, &textureDesc);
+    assert(mStencilTex);
+
+    // depth-stencil texture view
+    WGPUTextureViewDescriptor textureViewDesc{};
+    textureViewDesc.nextInChain = nullptr;
+    textureViewDesc.label = "The depth-stencil texture view";
+    textureViewDesc.format = WGPUTextureFormat_Stencil8;
+    textureViewDesc.dimension = WGPUTextureViewDimension_2D;
+    textureViewDesc.baseMipLevel = 0;
+    textureViewDesc.mipLevelCount = 1;
+    textureViewDesc.baseArrayLayer = 0;
+    textureViewDesc.arrayLayerCount = 1;
+    textureViewDesc.aspect = WGPUTextureAspect_All;
+    mStencilTexView = wgpuTextureCreateView(mStencilTex, &textureViewDesc);
+    assert(mStencilTexView);
+
+    // update brush geometry data
+    static float vertexData[] = {
+            0.0f,     0.0f, 0.0f,
+        (float)w,     0.0f, 0.0f,
+        (float)w, (float)h, 0.0f,
+            1.0f, (float)h, 0.0f
+    };
+    static uint32_t indexData[] = { 0, 1, 2, 0, 2, 3 };
+    // update render data brush empty
+    mGeometryDataBrush.update(mDevice, mQueue, vertexData, 4, indexData, 6);
+    // update bind group brush empty
+    WgBrushDataEmpty brushDataEmpty{};
+    brushDataEmpty.updateMatrix(mViewMatrix, nullptr);
+    mBrushBindGroupEmpty.update(mQueue, brushDataEmpty);
+
+    return true;
+}
+
+// target
+Compositor* WgRenderer::target(const RenderRegion& region, ColorSpace cs) {
+    // not supported
+    return nullptr;
+}
+
+// begin composite
+bool WgRenderer::beginComposite(Compositor* cmp, CompositeMethod method, uint8_t opacity) {
+    //TODO: delete the given compositor and restore the context
+    return false;
+}
+
+// end composite
+bool WgRenderer::endComposite(Compositor* cmp) {
+    //TODO: delete the given compositor and restore the context
+    return false;
+}
+
+// generate renderer webgpu
+WgRenderer* WgRenderer::gen() {
+    // create new renderer instance
+    return new WgRenderer();
+}
+
+// initialize renderer
+bool WgRenderer::init(uint32_t threads) {
+    return true;
+}
+
+// terminate renderer
+bool WgRenderer::term() {
+    return true;
+}

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_RENDERER_H_
+#define _TVG_WG_RENDERER_H_
+
+#include "tvgWgBrushEmpty.h"
+#include "tvgWgBrushSolid.h"
+#include "tvgWgBrushLinear.h"
+#include "tvgWgBrushRadial.h"
+#include "tvgWgRenderData.h"
+
+// webgpu renderer
+class WgRenderer : public RenderMethod
+{
+private:
+    WgRenderer();
+    ~WgRenderer();
+private:
+    void initialize();
+    void release();
+public:
+    RenderData prepare(const RenderShape& rshape, RenderData data, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags, bool clipper);
+    RenderData prepare(const Array<RenderData>& scene, RenderData data, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags);
+    RenderData prepare(Surface* surface, const RenderMesh* mesh, RenderData data, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags);
+    bool preRender();
+    bool renderShape(RenderData data);
+    bool renderImage(RenderData data);
+    bool postRender();
+    bool dispose(RenderData data);
+    RenderRegion region(RenderData data);
+    RenderRegion viewport();
+    bool viewport(const RenderRegion& vp);
+    bool blend(BlendMethod method);
+    ColorSpace colorSpace();
+
+    bool clear();
+    bool sync();
+
+    bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h);
+    bool target(void* window, uint32_t w, uint32_t h); // temporary solution
+    Compositor* target(const RenderRegion& region, ColorSpace cs);
+    bool beginComposite(Compositor* cmp, CompositeMethod method, uint8_t opacity);
+    bool endComposite(Compositor* cmp);
+public:
+    static WgRenderer* gen();
+    static bool init(uint32_t threads);
+    static bool term();
+private:
+    // render targets array
+    Array<RenderData> mRenderDatas{};
+private:
+    // surface
+    Surface mTargetSurface = { nullptr, 0, 0, 0, ColorSpace::Unsupported, true };
+    float   mViewMatrix[16]{};
+    // webgpu instances (maybe, create separated entity?)
+    WGPUInstance  mInstance{};
+    WGPUAdapter   mAdapter{};
+    WGPUDevice    mDevice{};
+    WGPUQueue     mQueue{};
+    // webgpu surface (maybe, create separated entity?)
+    WGPUSurface     mSurface{};
+    WGPUSwapChain   mSwapChain{};
+    WGPUTexture     mStencilTex{};
+    WGPUTextureView mStencilTexView{};
+private:
+    // brush pipelines
+    WgBrushPipelineEmpty  mBrushPipelineEmpty;
+    WgBrushPipelineSolid  mBrushPipelineSolid;
+    WgBrushPipelineLinear mBrushPipelineLinear;
+    WgBrushPipelineRadial mBrushPipelineRadial;
+    // brush geometry
+    WgGeometryData mGeometryDataBrush;
+    WgBrushBindGroupEmpty mBrushBindGroupEmpty;
+};
+
+#endif /* _TVG_WG_RENDERER_H_ */

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgShaderSrc.h"
+#include <string>
+
+//************************************************************************
+// cShaderSource_BrushEmpty
+//************************************************************************
+const char* cShaderSource_BrushEmpty = R"(
+// vertex input
+struct VertexInput {
+    @location(0) position: vec3f
+};
+
+// Matrix
+struct Matrix {
+    transform: mat4x4f
+};
+
+// vertex output
+struct VertexOutput {
+    @builtin(position) position: vec4f
+};
+
+// uMatrix
+@group(0) @binding(0) var<uniform> uMatrix: Matrix;
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    // fill output
+    var out: VertexOutput;
+    out.position = uMatrix.transform * vec4f(in.position.xy, 0.0, 1.0);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> void {
+    // nothing to draw, just stencil value
+})";
+
+//************************************************************************
+// cShaderSource_BrushSolid
+//************************************************************************
+const char* cShaderSource_BrushSolid = R"(
+// vertex input
+struct VertexInput {
+    @location(0) position: vec3f
+};
+
+// Matrix
+struct Matrix {
+    transform: mat4x4f
+};
+
+// ColorInfo
+struct ColorInfo {
+    color: vec4f
+};
+
+// vertex output
+struct VertexOutput {
+    @builtin(position) position: vec4f
+};
+
+// uMatrix
+@group(0) @binding(0) var<uniform> uMatrix: Matrix;
+// uColorInfo
+@group(0) @binding(1) var<uniform> uColorInfo: ColorInfo;
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    // fill output
+    var out: VertexOutput;
+    out.position = uMatrix.transform * vec4f(in.position.xy, 0.0, 1.0);
+    //out.position = vec4f(in.position.xy, 0.0, 1.0);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+    return uColorInfo.color;
+})";
+
+//************************************************************************
+// cShaderSource_BrushRadial
+//************************************************************************
+const char* cShaderSource_BrushRadial = R"(
+// vertex input
+struct VertexInput {
+    @location(0) position: vec3f
+};
+
+// Matrix
+struct Matrix {
+    transform: mat4x4f
+};
+
+// GradientInfo
+const MAX_STOP_COUNT = 4;
+struct GradientInfo {
+    nStops     : vec4f,
+    centerPos  : vec2f,
+    radius     : vec2f,
+    stopPoints : vec4f,
+    stopColors : array<vec4f, MAX_STOP_COUNT>
+};
+
+// vertex output
+struct VertexOutput {
+    @builtin(position) position: vec4f,
+    @location(0) vScreenCoord: vec2f
+};
+
+// uMatrix
+@group(0) @binding(0) var<uniform> uMatrix: Matrix;
+// uGradientInfo
+@group(0) @binding(1) var<uniform> uGradientInfo: GradientInfo;
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    // fill output
+    var out: VertexOutput;
+    out.position = uMatrix.transform * vec4f(in.position.xy, 0.0, 1.0);
+    out.vScreenCoord = in.position.xy;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+    // get interpolation factor
+    let t: f32 = clamp(distance(uGradientInfo.centerPos, in.vScreenCoord) / uGradientInfo.radius.x, 0.0, 1.0);
+
+    // get stops count
+    let last: i32 = i32(uGradientInfo.nStops[0]) - 1;
+
+    // resulting color
+    var color = vec4(1.0);
+
+    // closer than first stop
+    if (t <= uGradientInfo.stopPoints[0]) {
+        color = uGradientInfo.stopColors[0];
+    }
+    
+    // further than last stop
+    if (t >= uGradientInfo.stopPoints[last]) {
+        color = uGradientInfo.stopColors[last];
+    }
+
+    // look in the middle
+    for (var i = 0i; i < last; i++) {
+        let strt = uGradientInfo.stopPoints[i];
+        let stop = uGradientInfo.stopPoints[i+1];
+        if ((t > strt) && (t < stop)) {
+            let step: f32 = (t - strt) / (stop - strt);
+            color = mix(uGradientInfo.stopColors[i], uGradientInfo.stopColors[i+1], step);
+        }
+    }
+
+    return color;
+})";
+
+//************************************************************************
+// cShaderSource_BrushRadial
+//************************************************************************
+const char* cShaderSource_BrushLinear = R"(
+// vertex input
+struct VertexInput {
+    @location(0) position: vec3f
+};
+
+// Matrix
+struct Matrix {
+    transform: mat4x4f
+};
+
+// GradientInfo
+const MAX_STOP_COUNT = 4;
+struct GradientInfo {
+    nStops       : vec4f,
+    gradStartPos : vec2f,
+    gradEndPos   : vec2f,
+    stopPoints   : vec4f,
+    stopColors   : array<vec4f, MAX_STOP_COUNT>
+};
+
+// vertex output
+struct VertexOutput {
+    @builtin(position) position: vec4f,
+    @location(0) vScreenCoord: vec2f
+};
+
+// uMatrix
+@group(0) @binding(0) var<uniform> uMatrix: Matrix;
+// uGradientInfo
+@group(0) @binding(1) var<uniform> uGradientInfo: GradientInfo;
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    // fill output
+    var out: VertexOutput;
+    out.position = uMatrix.transform * vec4f(in.position.xy, 0.0, 1.0);
+    out.vScreenCoord = in.position.xy;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+    let pos: vec2f = in.vScreenCoord;
+    let st: vec2f = uGradientInfo.gradStartPos;
+    let ed: vec2f = uGradientInfo.gradEndPos;
+
+    let ba: vec2f = ed - st;
+
+    // get interpolation factor
+    let t: f32 = clamp(dot(pos - st, ba) / dot(ba, ba), 0.0, 1.0);
+
+    // get stops count
+    let last: i32 = i32(uGradientInfo.nStops[0]) - 1;
+
+    // resulting color
+    var color = vec4(1.0);
+
+    // closer than first stop
+    if (t <= uGradientInfo.stopPoints[0]) {
+        color = uGradientInfo.stopColors[0];
+    }
+    
+    // further than last stop
+    if (t >= uGradientInfo.stopPoints[last]) {
+        color = uGradientInfo.stopColors[last];
+    }
+
+    // look in the middle
+    for (var i = 0i; i < last; i++) {
+        let strt = uGradientInfo.stopPoints[i];
+        let stop = uGradientInfo.stopPoints[i+1];
+        if ((t > strt) && (t < stop)) {
+            let step: f32 = (t - strt) / (stop - strt);
+            color = mix(uGradientInfo.stopColors[i], uGradientInfo.stopColors[i+1], step);
+        }
+    }
+
+    return color;
+})";

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#ifndef _TVG_WG_SHADER_SRC_H_
+#define _TVG_WG_SHADER_SRC_H_
+
+// brush shader module empty
+extern const char* cShaderSource_BrushEmpty;
+
+// brush shader module solid
+extern const char* cShaderSource_BrushSolid;
+
+// brush shader module radial
+extern const char* cShaderSource_BrushRadial;
+
+// brush shader module linear
+extern const char* cShaderSource_BrushLinear;
+
+#endif


### PR DESCRIPTION
WebGPU is a Render Hardware Interface built on top of the various APIs provided by the driver/OS depending on your platform. WebGPU exposes an API for performing operations, such as rendering and computation, on a Graphics Processing Unit.

[WebGPU official documentation](https://www.w3.org/TR/webgpu/)

The new canvas engine introduced:
`tvg::CanvasEngine::Wg`

In order to build you need third party libraries. Before you start please read this: [LearnWebGPU](https://eliemichel.github.io/LearnWebGPU/getting-started/hello-webgpu.html)

Currently supported:
* Drawing multiple shepes
* Color, Linear and Radial brushes

Usage example:

```
    // init glfw
    glfwInit();

    // create a windowed mode window and its opengl context
    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
    GLFWwindow* window = glfwCreateWindow(800, 800, "WebGPU base app", nullptr, nullptr);

    // get window size
    int width{}, height{};
    glfwGetWindowSize(window, &width, &height);

    // init engine webgpu
    tvg::Initializer::init(tvg::CanvasEngine::Wg, 0);

    // create wg canvas
    auto canvasWg = tvg::WgCanvas::gen();
    canvas_wg->target(glfwGetWin32Window(window), width, height);

    // Generate a shape
    auto rect = tvg::Shape::gen();
    rect->appendRect(50, 50, 200, 200, 20, 20);
    rect->fill(100, 100, 100);
    canvas_wg->push(move(rect));

    while (!glfwWindowShouldClose(window)) {
        // webgpu
        canvas_wg->draw();
        canvas_wg->sync();

        // pull events
        glfwPollEvents();
    }

    // terminate engine and window
    tvg::Initializer::term(tvg::CanvasEngine::Wg);
    glfwDestroyWindow(window);
    glfwTerminate();
```