### PR TITLE
gl_engine: use glScissor to support fast clip

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -178,7 +178,7 @@ bool GlGeometry::draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdate
         task->addVertexLayout(GlVertexLayout{0, 3, 3 * sizeof(float), vertexOffset});
     }
     task->setDrawRange(indexOffset, indexBuffer->count);
-
+    task->setViewport(viewport);
     return true;
 }
 
@@ -198,6 +198,11 @@ void GlGeometry::updateTransform(const RenderTransform* transform, float w, floa
 
     MVP_MATRIX();
     MULTIPLY_MATRIX(mvp, modelMatrix, mTransform)
+}
+
+void GlGeometry::setViewport(const RenderRegion& viewport)
+{
+    this->viewport = viewport;
 }
 
 float* GlGeometry::getTransforMatrix()

--- a/src/renderer/gl_engine/tvgGlGeometry.h
+++ b/src/renderer/gl_engine/tvgGlGeometry.h
@@ -193,9 +193,11 @@ public:
     void disableVertex(uint32_t location);
     bool draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag);
     void updateTransform(const RenderTransform* transform, float w, float h);
+    void setViewport(const RenderRegion& viewport);
     float* getTransforMatrix();
 
 private:
+    RenderRegion viewport = {};
     Array<float> fillVertex = {};
     Array<float> strokeVertex = {};
     Array<uint32_t> fillIndex = {};

--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -31,6 +31,10 @@ void GlRenderTask::run()
 {
     // bind shader
     mProgram->load();
+
+    // setup scissor rect
+    GL_CHECK(glScissor(mViewport.x, mViewport.y, mViewport.w, mViewport.h));
+
     // setup attribute layout
     for (uint32_t i = 0; i < mVertexLayout.count; i++) {
         const auto &layout = mVertexLayout[i];
@@ -79,4 +83,9 @@ void GlRenderTask::setDrawRange(uint32_t offset, uint32_t count)
 {
     mIndexOffset = offset;
     mIndexCount = count;
+}
+
+void GlRenderTask::setViewport(const RenderRegion &viewport)
+{
+    mViewport = viewport;
 }

--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -81,10 +81,12 @@ public:
     void addVertexLayout(const GlVertexLayout& layout);
     void addBindResource(const GlBindingResource& binding);
     void setDrawRange(uint32_t offset, uint32_t count);
+    void setViewport(const RenderRegion& viewport);
 
     GlProgram* getProgram() { return mProgram; }
 private:
     GlProgram* mProgram;
+    RenderRegion mViewport = {};
     uint32_t mIndexOffset = {};
     uint32_t mIndexCount = {};
     Array<GlVertexLayout> mVertexLayout = {};

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -78,6 +78,7 @@ private:
     void drawPrimitive(GlShape& sdata, uint8_t r, uint8_t g, uint8_t b, uint8_t a, RenderUpdateFlag flag);
     void drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFlag flag);
 
+    RenderRegion mViewport;
     std::unique_ptr<GlStageBuffer> mGpuBuffer;
     vector<std::unique_ptr<GlProgram>> mPrograms;
     vector<std::unique_ptr<GlRenderTask>> mRenderTasks;


### PR DESCRIPTION
This PR add scissor box info in GLRenderTask, and enable `GL_SCISSOR_TEST` during rendering to support the fast path clip (Rect Clip)

The reason we choose glScissor instead of glViewport is that if drawCall is outside the viewport it is still executed in the gpu but can be discared by GL_SCISSOR_TEST