### PR TITLE
loader/svg: Fix maskContentUnits userSpaceOnUse/objectBoundingBox

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -284,8 +284,12 @@ static void _applyComposition(SvgLoaderData& loaderData, Paint* paint, const Svg
 
             bool isMaskWhite = true;
             if (auto comp = _sceneBuildHelper(loaderData, compNode, vBox, svgPath, true, 0, &isMaskWhite)) {
-                Matrix finalTransform = _compositionTransform(paint, node, compNode, SvgNodeType::Mask);
-                comp->transform(finalTransform);
+                if (!compNode->node.mask.userSpace) {
+                    Matrix finalTransform = _compositionTransform(paint, node, compNode, SvgNodeType::Mask);
+                    comp->transform(finalTransform);
+                } else {
+                    if (node->transform) comp->transform(*node->transform);
+                }
 
                 if (compNode->node.mask.type == SvgMaskType::Luminance && !isMaskWhite) {
                     paint->composite(std::move(comp), CompositeMethod::LumaMask);


### PR DESCRIPTION
Fixes #1694

@hermet Quick fix, checked only the examples in the issue.

![image](https://github.com/thorvg/thorvg/assets/4047289/acc7916f-1a61-4ffe-b67e-e434f1e65fd6)
