### PR TITLE
loader/jpg: Fix a regression bug.

### DIFF
--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -431,7 +431,7 @@ struct Row<1>
 {
     static void idct(int* pTemp, const jpgd_block_t* pSrc)
     {
-        const int dcval = pSrc[0] * (pSrc[0] * (PASS1_BITS * 2));
+        const int dcval = pSrc[0] * PASS1_BITS * 2;
 
         pTemp[0] = dcval;
         pTemp[1] = dcval;


### PR DESCRIPTION
Fixes #1705

Hello @hermet, I found the culprit. Could you please take a look?
Reverts e3a21e39a0211f2, this should be just `pSrc[0]*4` and keep the negative values. Thanks! 