### PR TITLE
Readme: Fix lottie sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,11 +260,11 @@ Currently, ThorVG provides experimental support for Lottie Animation, and while 
 
 The following code snippet demonstrates how to use ThorVG to play a Lottie animation.
 ```cpp
-auto animation = tvg::Animation::gen();     //generate an animation
-auto picture = animation->picture()         //acquire a picture which associated with the animation.
-picture->load("lottie.json");               //load a Lottie file
-auto duration = animation->duration();      //figure out the animation duration time in seconds.
-canvas->push(tvg::cast(picture));           //push the picture into the canvas
+auto animation = tvg::Animation::gen();            //generate an animation
+auto picture = animation->picture()                //acquire a picture which associated with the animation.
+picture->load("lottie.json");                      //load a Lottie file
+auto duration = animation->duration();             //figure out the animation duration time in seconds.
+canvas->push(tvg::cast<tvg::Picture>(picture));    //push the picture into the canvas
 ```
 First, an animation and a picture are generated. The Lottie file (lottie.json) is loaded into the picture, and then the picture is added to the canvas. The animation frames are controlled using the animation object to play the Lottie animation. Also you might want to know the animation duration time to run your animation loop.
 ```cpp


### PR DESCRIPTION
tvg::cast(picture) -> tvg::cast<tvg::Picture>(picture)

This change should also be applied on our tutorial site.(https://www.thorvg.org/tutorial)