### PR TITLE
sw_engine raster: fixed a default alpha blending bug.

### DIFF
--- a/src/renderer/sw_engine/tvgSwRasterC.h
+++ b/src/renderer/sw_engine/tvgSwRasterC.h
@@ -101,7 +101,7 @@ static bool inline cRasterTranslucentRect(SwSurface* surface, const SwBBox& regi
 
     //32bits channels
     if (surface->channelSize == sizeof(uint32_t)) {
-        auto color = surface->join(r, g, b, 255);
+        auto color = surface->join(r, g, b, a);
         auto buffer = surface->buf32 + (region.min.y * surface->stride) + region.min.x;
         auto ialpha = 255 - a;
         for (uint32_t y = 0; y < h; ++y) {


### PR DESCRIPTION
alpha value has been missed by mistake,
a regression by c50d2fd

Issue: https://github.com/thorvg/thorvg/issues/1716