### PR TITLE
animation/lottie: updated the frame count unit.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1708,7 +1708,7 @@ public:
      *
      * @BETA_API
      */
-    Result frame(uint32_t no) noexcept;
+    Result frame(float no) noexcept;
 
     /**
      * @brief Retrieves a picture instance associated with this animation instance.
@@ -1732,12 +1732,12 @@ public:
      *
      * @note If the Picture is not properly configured, this function will return 0.
      *
-     * @see Animation::frame(uint32_t no)
+     * @see Animation::frame(float no)
      * @see Animation::totalFrame()
      *
      * @BETA_API
      */
-    uint32_t curFrame() const noexcept;
+    float curFrame() const noexcept;
 
     /**
      * @brief Retrieves the total number of frames in the animation.
@@ -1749,7 +1749,7 @@ public:
      *
      * @BETA_API
      */
-    uint32_t totalFrame() const noexcept;
+    float totalFrame() const noexcept;
 
     /**
      * @brief Retrieves the duration of the animation in seconds.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2234,7 +2234,7 @@ TVG_API Tvg_Animation* tvg_animation_new();
 *
 * \see tvg_animation_get_total_frame()
 */
-TVG_API Tvg_Result tvg_animation_set_frame(Tvg_Animation* animation, uint32_t no);
+TVG_API Tvg_Result tvg_animation_set_frame(Tvg_Animation* animation, float no);
 
 
 /*!
@@ -2266,7 +2266,7 @@ TVG_API Tvg_Paint* tvg_animation_get_picture(Tvg_Animation* animation);
 * \see tvg_animation_get_total_frame()
 * \see tvg_animation_set_frame()
 */
-TVG_API Tvg_Result tvg_animation_get_frame(Tvg_Animation* animation, uint32_t* no);
+TVG_API Tvg_Result tvg_animation_get_frame(Tvg_Animation* animation, float* no);
 
 
 /*!
@@ -2282,7 +2282,7 @@ TVG_API Tvg_Result tvg_animation_get_frame(Tvg_Animation* animation, uint32_t* n
 * \note Frame numbering starts from 0.
 * \note If the Picture is not properly configured, this function will return 0.
 */
-TVG_API Tvg_Result tvg_animation_get_total_frame(Tvg_Animation* animation, uint32_t* cnt);
+TVG_API Tvg_Result tvg_animation_get_total_frame(Tvg_Animation* animation, float* cnt);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -728,14 +728,14 @@ TVG_API Tvg_Animation* tvg_animation_new()
 }
 
 
-TVG_API Tvg_Result tvg_animation_set_frame(Tvg_Animation* animation, uint32_t no)
+TVG_API Tvg_Result tvg_animation_set_frame(Tvg_Animation* animation, float no)
 {
     if (!animation) return TVG_RESULT_INVALID_ARGUMENT;
     return (Tvg_Result) reinterpret_cast<Animation*>(animation)->frame(no);
 }
 
 
-TVG_API Tvg_Result tvg_animation_get_frame(Tvg_Animation* animation, uint32_t* no)
+TVG_API Tvg_Result tvg_animation_get_frame(Tvg_Animation* animation, float* no)
 {
     if (!animation || !no) return TVG_RESULT_INVALID_ARGUMENT;
     *no = reinterpret_cast<Animation*>(animation)->curFrame();
@@ -743,7 +743,7 @@ TVG_API Tvg_Result tvg_animation_get_frame(Tvg_Animation* animation, uint32_t* n
 }
 
 
-TVG_API Tvg_Result tvg_animation_get_total_frame(Tvg_Animation* animation, uint32_t* cnt)
+TVG_API Tvg_Result tvg_animation_get_total_frame(Tvg_Animation* animation, float* cnt)
 {
     if (!animation || !cnt) return TVG_RESULT_INVALID_ARGUMENT;
     *cnt = reinterpret_cast<Animation*>(animation)->totalFrame();

--- a/src/bindings/wasm/tvgWasm.cpp
+++ b/src/bindings/wasm/tvgWasm.cpp
@@ -149,10 +149,9 @@ public:
         return val(animation->totalFrame());
     }
 
-    bool frame(uint32_t no)
+    bool frame(float no)
     {
         if (!canvas || !animation) return false;
-        if (animation->curFrame() == no) return true;
         if (animation->frame(no) != Result::Success) {
             errorMsg = "frame() fail";
             return false;

--- a/src/examples/Animation.cpp
+++ b/src/examples/Animation.cpp
@@ -34,10 +34,7 @@ void tvgUpdateCmds(tvg::Canvas* canvas, tvg::Animation* animation, float progres
     if (!canvas) return;
 
     //Update animation frame only when it's changed
-    auto frame = lroundf(animation->totalFrame() * progress);
-
-    if (frame != animation->curFrame()) {
-        animation->frame(frame);
+    if (animation->frame(animation->totalFrame() * progress) == tvg::Result::Success) {
         canvas->update(animation->picture());
     }
 }

--- a/src/examples/Capi.cpp
+++ b/src/examples/Capi.cpp
@@ -257,19 +257,18 @@ void transitCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progress
 {
     if (!canvas) return;
 
-    uint32_t total_frame = 0;
+    float total_frame = 0.0f;
     tvg_animation_get_total_frame(animation, &total_frame);
 
-    uint32_t new_frame = lroundf(total_frame * progress);
+    float new_frame = total_frame * progress;
 
-    uint32_t cur_frame = 0;
+    float cur_frame = 0.0f;
     tvg_animation_get_frame(animation, &cur_frame);
 
     //Update animation frame only when it's changed
-    if (new_frame == cur_frame) return;
-
-    tvg_animation_set_frame(animation, new_frame);
-    tvg_canvas_update_paint(canvas, tvg_animation_get_picture(animation));
+    if (tvg_animation_set_frame(animation, new_frame) == TVG_RESULT_SUCCESS) {
+        tvg_canvas_update_paint(canvas, tvg_animation_get_picture(animation));
+    }
 
     //Draw the canvas
     tvg_canvas_draw(canvas);

--- a/src/examples/Lottie.cpp
+++ b/src/examples/Lottie.cpp
@@ -93,14 +93,10 @@ void tvgUpdateCmds(Elm_Transit_Effect *effect, Elm_Transit* transit, double prog
     auto animation = static_cast<tvg::Animation*>(effect);
 
     //Update animation frame only when it's changed
-    auto frame = lroundf(animation->totalFrame() * progress);
-
-    if (frame != animation->curFrame()) {
-        auto before = ecore_time_get();
-        animation->frame(frame);
-        auto after = ecore_time_get();
-        updateTime += after - before;
-    }
+    auto before = ecore_time_get();
+    animation->frame(animation->totalFrame() * progress);
+    auto after = ecore_time_get();
+    updateTime += after - before;
 }
 
 void tvgDrawCmds(tvg::Canvas* canvas)

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -29,7 +29,7 @@ struct LottieComposition;
 
 struct LottieBuilder
 {
-    bool update(LottieComposition* comp, int32_t frameNo);
+    bool update(LottieComposition* comp, float progress);
     void build(LottieComposition* comp);
 };
 

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -191,7 +191,8 @@ bool LottieLoader::header()
         return false;
     }
 
-    frameDuration = (endFrame - startFrame) / frameRate;
+    frameCnt = (endFrame - startFrame);
+    frameDuration = frameCnt / frameRate;
 
     TVGLOG("LOTTIE", "info: frame rate = %f, duration = %f size = %d x %d", frameRate, frameDuration, (int)w, (int)h);
 
@@ -286,6 +287,10 @@ bool LottieLoader::read()
 
     TaskScheduler::request(this);
 
+    if (comp && TaskScheduler::threads() == 0) {
+        frameCnt = comp->frameCnt();
+    }
+
     return true;
 }
 
@@ -309,15 +314,13 @@ unique_ptr<Paint> LottieLoader::paint()
 }
 
 
-bool LottieLoader::frame(uint32_t frameNo)
+bool LottieLoader::frame(float no)
 {
-    if (this->frameNo == frameNo) return true;
+    if (mathEqual(this->frameNo, no)) return false;
 
     this->done();
 
-    if (!comp || frameNo >= comp->frameCnt()) return false;
-
-    this->frameNo = frameNo;
+    this->frameNo = no;
 
     TaskScheduler::request(this);
 
@@ -325,16 +328,13 @@ bool LottieLoader::frame(uint32_t frameNo)
 }
 
 
-uint32_t LottieLoader::totalFrame()
+float LottieLoader::totalFrame()
 {
-    this->done();
-
-    if (!comp) return 0;
-    return comp->frameCnt();
+    return frameCnt;
 }
 
 
-uint32_t LottieLoader::curFrame()
+float LottieLoader::curFrame()
 {
     return frameNo;
 }

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -35,8 +35,9 @@ class LottieLoader : public FrameModule, public Task
 public:
     const char* content = nullptr;      //lottie file data
     uint32_t size = 0;                  //lottie data size
-    uint32_t frameNo = 0;               //current frame number
-    float frameDuration;
+    float frameNo = 0.0f;               //current frame number
+    float frameCnt = 0.0f;
+    float frameDuration = 0.0f;
 
     LottieBuilder* builder = nullptr;
     LottieComposition* comp = nullptr;
@@ -57,9 +58,9 @@ public:
     unique_ptr<Paint> paint() override;
 
     //Frame Controls
-    bool frame(uint32_t frameNo) override;
-    uint32_t totalFrame() override;
-    uint32_t curFrame() override;
+    bool frame(float no) override;
+    float totalFrame() override;
+    float curFrame() override;
     float duration() override;
     void sync() override;
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -34,7 +34,7 @@
 /* External Class Implementation                                        */
 /************************************************************************/
 
-void LottieTrimpath::segment(int32_t frameNo, float& start, float& end)
+void LottieTrimpath::segment(float frameNo, float& start, float& end)
 {
     auto s = this->start(frameNo) * 0.01f;
     auto e = this->end(frameNo) * 0.01f;
@@ -77,7 +77,7 @@ void LottieTrimpath::segment(int32_t frameNo, float& start, float& end)
 }
 
 
-Fill* LottieGradient::fill(int32_t frameNo)
+Fill* LottieGradient::fill(float frameNo)
 {
     Fill* fill = nullptr;
 
@@ -145,14 +145,14 @@ void LottieLayer::prepare()
 }
 
 
-int32_t LottieLayer::remap(int32_t frameNo)
+float LottieLayer::remap(float frameNo)
 {
     if (timeRemap.frames || timeRemap.value) {
         frameNo = comp->frameAtTime(timeRemap(frameNo));
     } else {
         frameNo -= startFrame;
     }
-    return (int32_t)(frameNo / timeStretch);
+    return (frameNo / timeStretch);
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -49,17 +49,17 @@ struct LottieStroke
         return dashattr->value[no];
     }
 
-    float dashOffset(int32_t frameNo)
+    float dashOffset(float frameNo)
     {
         return dash(0)(frameNo);
     }
 
-    float dashGap(int32_t frameNo)
+    float dashGap(float frameNo)
     {
         return dash(2)(frameNo);
     }
 
-    float dashSize(int32_t frameNo)
+    float dashSize(float frameNo)
     {
         auto d = dash(1)(frameNo);
         if (d == 0.0f) return 0.1f;
@@ -177,7 +177,7 @@ struct LottieGradient
         return false;
     }
 
-    Fill* fill(int32_t frameNo);
+    Fill* fill(float frameNo);
 
     LottiePoint start = Point{0.0f, 0.0f};
     LottiePoint end = Point{0.0f, 0.0f};
@@ -248,7 +248,7 @@ struct LottieTrimpath : LottieObject
         if (start.frames || end.frames || offset.frames) statical = false;
     }
 
-    void segment(int32_t frameNo, float& start, float& end);
+    void segment(float frameNo, float& start, float& end);
 
     LottieFloat start = 0.0f;
     LottieFloat end = 0.0f;
@@ -507,7 +507,7 @@ struct LottieLayer : LottieGroup
         delete(transform);
     }
 
-    uint8_t opacity(int32_t frameNo)
+    uint8_t opacity(float frameNo)
     {
         //return zero if the visibility is false.
         if (type == Null) return 255;
@@ -515,7 +515,7 @@ struct LottieLayer : LottieGroup
     }
 
     void prepare();
-    int32_t remap(int32_t frameNo);
+    float remap(float frameNo);
 
     //Optimize: compact data??
     RGB24 color;
@@ -534,16 +534,16 @@ struct LottieLayer : LottieGroup
 
     float timeStretch = 1.0f;
     uint32_t w = 0, h = 0;
-    int32_t inFrame = 0;
-    int32_t outFrame = 0;
-    uint32_t startFrame = 0;
+    float inFrame = 0.0f;
+    float outFrame = 0.0f;
+    float startFrame = 0.0f;
     char* refId = nullptr;      //pre-composition reference.
     int16_t pid = -1;           //id of the parent layer.
     int16_t id = -1;            //id of the current layer.
 
     //cached data
     struct {
-        int32_t frameNo = -1;
+        float frameNo = -1.0f;
         Matrix matrix;
         uint8_t opacity;
     } cache;
@@ -583,7 +583,7 @@ struct LottieComposition
     char* version = nullptr;
     char* name = nullptr;
     uint32_t w, h;
-    int32_t startFrame, endFrame;
+    float startFrame, endFrame;
     float frameRate;
     Array<LottieObject*> assets;
     Array<LottieInterpolator*> interpolators;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -382,7 +382,7 @@ void LottieParser::parseKeyFrame(T& prop)
                 }
             }
         } else if (!strcmp(key, "t")) {
-            frame.no = lroundf(getFloat());
+            frame.no = getFloat();
         } else if (!strcmp(key, "s")) {
             getValue(frame.value);
         } else if (!strcmp(key, "e")) {
@@ -1003,9 +1003,9 @@ LottieLayer* LottieParser::parseLayer()
         }
         else if (!strcmp(key, "ao")) layer->autoOrient = getInt();
         else if (!strcmp(key, "shapes")) parseShapes(layer);
-        else if (!strcmp(key, "ip")) layer->inFrame = lroundf(getFloat());
-        else if (!strcmp(key, "op")) layer->outFrame = lroundf(getFloat());
-        else if (!strcmp(key, "st")) layer->startFrame = lroundf(getFloat());
+        else if (!strcmp(key, "ip")) layer->inFrame = getFloat();
+        else if (!strcmp(key, "op")) layer->outFrame = getFloat();
+        else if (!strcmp(key, "st")) layer->startFrame = getFloat();
         else if (!strcmp(key, "bm")) layer->blendMethod = getBlendMethod();
         else if (!strcmp(key, "parent")) layer->pid = getInt();
         else if (!strcmp(key, "tm")) parseTimeRemap(layer);
@@ -1091,8 +1091,8 @@ bool LottieParser::parse()
     while (auto key = nextObjectKey()) {
         if (!strcmp(key, "v")) comp->version = getStringCopy();
         else if (!strcmp(key, "fr")) comp->frameRate = getFloat();
-        else if (!strcmp(key, "ip")) comp->startFrame = lroundf(getFloat());
-        else if (!strcmp(key, "op")) comp->endFrame = lroundf(getFloat());
+        else if (!strcmp(key, "ip")) comp->startFrame = getFloat();
+        else if (!strcmp(key, "op")) comp->endFrame = getFloat();
         else if (!strcmp(key, "w")) comp->w = getInt();
         else if (!strcmp(key, "h")) comp->h = getInt();
         else if (!strcmp(key, "nm")) comp->name = getStringCopy();

--- a/src/renderer/tvgAnimation.cpp
+++ b/src/renderer/tvgAnimation.cpp
@@ -62,7 +62,7 @@ Animation::Animation() : pImpl(new Impl)
 }
 
 
-Result Animation::frame(uint32_t no) noexcept
+Result Animation::frame(float no) noexcept
 {
     auto loader = pImpl->picture->pImpl->loader.get();
 
@@ -80,7 +80,7 @@ Picture* Animation::picture() const noexcept
 }
 
 
-uint32_t Animation::curFrame() const noexcept
+float Animation::curFrame() const noexcept
 {
     auto loader = pImpl->picture->pImpl->loader.get();
 
@@ -91,7 +91,7 @@ uint32_t Animation::curFrame() const noexcept
 }
 
 
-uint32_t Animation::totalFrame() const noexcept
+float Animation::totalFrame() const noexcept
 {
     auto loader = pImpl->picture->pImpl->loader.get();
 

--- a/src/renderer/tvgFrameModule.h
+++ b/src/renderer/tvgFrameModule.h
@@ -33,10 +33,9 @@ class FrameModule: public LoadModule
 public:
     virtual ~FrameModule() {}
 
-    virtual bool frame(uint32_t frameNo) = 0;   //set the current frame number
-
-    virtual uint32_t totalFrame() = 0;      //return the total frame count
-    virtual uint32_t curFrame() = 0;        //return the current frame number
+    virtual bool frame(float no) = 0;       //set the current frame number
+    virtual float totalFrame() = 0;         //return the total frame count
+    virtual float curFrame() = 0;           //return the current frame number
     virtual float duration() = 0;           //return the animation duration in seconds
 
     virtual bool animatable() override { return true; }

--- a/test/capi/capiAnimation.cpp
+++ b/test/capi/capiAnimation.cpp
@@ -40,16 +40,16 @@ TEST_CASE("Animation Basic", "[capiAnimation]")
 
     //Negative cases
     REQUIRE(tvg_animation_set_frame(animation, 0) == TVG_RESULT_INSUFFICIENT_CONDITION);
-    uint32_t frame = 0;
+    auto frame = 0.0f;
     REQUIRE(tvg_animation_set_frame(animation, frame) == TVG_RESULT_INSUFFICIENT_CONDITION);
 
     REQUIRE(tvg_animation_get_frame(animation, nullptr) == TVG_RESULT_INVALID_ARGUMENT);
     REQUIRE(tvg_animation_get_frame(animation, &frame) == TVG_RESULT_SUCCESS);
-    REQUIRE(frame == 0);
+    REQUIRE(frame == 0.0f);
 
     REQUIRE(tvg_animation_get_total_frame(animation, nullptr) == TVG_RESULT_INVALID_ARGUMENT);
     REQUIRE(tvg_animation_get_total_frame(animation, &frame) == TVG_RESULT_SUCCESS);
-    REQUIRE(frame == 0);
+    REQUIRE(frame == 0.0f);
 
     REQUIRE(tvg_animation_get_duration(animation, nullptr) == TVG_RESULT_INVALID_ARGUMENT);
     float duration = 0.0f;
@@ -79,13 +79,13 @@ TEST_CASE("Animation Lottie", "[capiAnimation]")
     REQUIRE(tvg_picture_load(picture, TEST_DIR"/invalid.json") == TVG_RESULT_INVALID_ARGUMENT);
     REQUIRE(tvg_picture_load(picture, TEST_DIR"/test.json") == TVG_RESULT_SUCCESS);
 
-    uint32_t frame;
+    float frame;
     REQUIRE(tvg_animation_get_total_frame(animation, &frame) == TVG_RESULT_SUCCESS);
-    REQUIRE(frame == 120);
+    REQUIRE(frame == Approx(120).margin(004004));
 
     REQUIRE(tvg_animation_set_frame(animation, frame - 1) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_animation_get_frame(animation, &frame) == TVG_RESULT_SUCCESS);
-    REQUIRE(frame == 119);
+    REQUIRE(frame == Approx(119).margin(004004));
 
     float duration;
     REQUIRE(tvg_animation_get_duration(animation, &duration) == TVG_RESULT_SUCCESS);

--- a/test/testAnimation.cpp
+++ b/test/testAnimation.cpp
@@ -39,9 +39,9 @@ TEST_CASE("Animation Basic", "[tvgAnimation]")
     REQUIRE(picture->identifier == Picture::identifier);
 
     //Negative cases
-    REQUIRE(animation->frame(0) == Result::InsufficientCondition);
-    REQUIRE(animation->curFrame() == 0);
-    REQUIRE(animation->totalFrame() == 0);
+    REQUIRE(animation->frame(0.0f) == Result::InsufficientCondition);
+    REQUIRE(animation->curFrame() == 0.0f);
+    REQUIRE(animation->totalFrame() == 0.0f);
     REQUIRE(animation->duration() == 0.0f);
 }
 
@@ -60,7 +60,7 @@ TEST_CASE("Animation Lottie", "[tvgAnimation]")
     REQUIRE(picture->load(TEST_DIR"/invalid.json") == Result::InvalidArguments);
     REQUIRE(picture->load(TEST_DIR"/test.json") == Result::Success);
 
-    REQUIRE(animation->totalFrame() == 120);
+    REQUIRE(animation->totalFrame() == Approx(120).margin(004004));
     REQUIRE(animation->curFrame() == 0);
     REQUIRE(animation->duration() == Approx(4).margin(004004));
     REQUIRE(animation->frame(20) == Result::Success);


### PR DESCRIPTION
replace the frame count unit from the int32_t to float since animations could smoothly interpolate key-frames.

This notificably improve the animation smoothness in Lottie

Beta API changes:
Result Animation::frame(uint32_t no) -> Result Animation::frame(float no) 
uint32_t Animation::curFrame() const -> float Animation::curFrame() const 
uint32_t Animation::totalFrame() const -> float Animation::totalFrame() const