### PR TITLE
api: revise the engine initializer for the 1.0 release.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -212,6 +212,7 @@ enum class BlendMethod : uint8_t
  */
 enum class CanvasEngine : uint8_t
 {
+    All = 0,       ///< All feasible rasterizers.
     Sw = (1 << 1), ///< CPU rasterizer.
     Gl = (1 << 2), ///< OpenGL rasterizer.
     Wg = (1 << 3), ///< WebGPU rasterizer. @BETA_API
@@ -1588,19 +1589,18 @@ public:
      * You can indicate the number of threads, the count of which is designated @p threads.
      * In the initialization step, TVG will generate/spawn the threads as set by @p threads count.
      *
-     * @param[in] engine The engine types to initialize. This is relative to the Canvas types, in which it will be used. For multiple backends bitwise operation is allowed.
      * @param[in] threads The number of additional threads. Zero indicates only the main thread is to be used.
+     * @param[in] engine The engine types to initialize. This is relative to the Canvas types, in which it will be used. For multiple backends bitwise operation is allowed.
      *
      * @retval Result::Success When succeed.
      * @retval Result::FailedAllocation An internal error possibly with memory allocation.
-     * @retval Result::InvalidArguments If unknown engine type chosen.
      * @retval Result::NonSupport In case the engine type is not supported on the system.
      * @retval Result::Unknown Others.
      *
      * @note The Initializer keeps track of the number of times it was called. Threads count is fixed at the first init() call.
      * @see Initializer::term()
      */
-    static Result init(CanvasEngine engine, uint32_t threads) noexcept;
+    static Result init(uint32_t threads, CanvasEngine engine = tvg::CanvasEngine::All) noexcept;
 
     /**
      * @brief Terminates TVG engines.
@@ -1609,14 +1609,13 @@ public:
      *
      * @retval Result::Success When succeed.
      * @retval Result::InsufficientCondition In case there is nothing to be terminated.
-     * @retval Result::InvalidArguments If unknown engine type chosen.
      * @retval Result::NonSupport In case the engine type is not supported on the system.
      * @retval Result::Unknown Others.
      *
      * @note Initializer does own reference counting for multiple calls.
      * @see Initializer::init()
      */
-    static Result term(CanvasEngine engine) noexcept;
+    static Result term(CanvasEngine engine = tvg::CanvasEngine::All) noexcept;
 
     _TVG_DISABLE_CTOR(Initializer);
 };

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -38,7 +38,7 @@ extern "C" {
 
 TVG_API Tvg_Result tvg_engine_init(Tvg_Engine engine_method, unsigned threads)
 {
-    return (Tvg_Result) Initializer::init(CanvasEngine(engine_method), threads);
+    return (Tvg_Result) Initializer::init(threads, CanvasEngine(engine_method));
 }
 
 

--- a/src/bindings/wasm/tvgWasm.cpp
+++ b/src/bindings/wasm/tvgWasm.cpp
@@ -47,7 +47,7 @@ public:
     ~TvgWasm()
     {
         free(buffer);
-        Initializer::term(CanvasEngine::Sw);
+        Initializer::term();
     }
 
     static unique_ptr<TvgWasm> create()
@@ -276,7 +276,7 @@ private:
     {
         errorMsg = NoError;
 
-        if (Initializer::init(CanvasEngine::Sw, 0) != Result::Success) {
+        if (Initializer::init(0) != Result::Success) {
             errorMsg = "init() fail";
             return;
         }

--- a/src/examples/Accessor.cpp
+++ b/src/examples/Accessor.cpp
@@ -128,24 +128,18 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
-
     //Threads Count
     auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -159,7 +153,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/AnimateMasking.cpp
+++ b/src/examples/AnimateMasking.cpp
@@ -162,17 +162,10 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -180,7 +173,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -203,7 +196,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Animation.cpp
+++ b/src/examples/Animation.cpp
@@ -157,17 +157,10 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -175,7 +168,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -193,7 +186,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
     } else {
         cout << "engine is not supported" << endl;
     }

--- a/src/examples/Arc.cpp
+++ b/src/examples/Arc.cpp
@@ -157,17 +157,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -175,7 +168,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -189,7 +182,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Blending.cpp
+++ b/src/examples/Blending.cpp
@@ -238,17 +238,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -256,7 +249,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -270,7 +263,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/ClipPath.cpp
+++ b/src/examples/ClipPath.cpp
@@ -219,17 +219,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -237,7 +230,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -251,7 +244,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Common.h
+++ b/src/examples/Common.h
@@ -47,6 +47,8 @@ void win_del(void *data, Evas_Object *o, void *ev)
 
 static Eo* createSwView(uint32_t w = 800, uint32_t h = 800)
 {
+    cout << "tvg engine: software" << endl;
+
     WIDTH = w;
     HEIGHT = h;
 
@@ -80,6 +82,8 @@ void drawGLview(Evas_Object *obj);
 
 static Eo* createGlView(uint32_t w = 800, uint32_t h = 800)
 {
+    cout << "tvg engine: opengl" << endl;
+
     WIDTH = w;
     HEIGHT = h;
 

--- a/src/examples/CustomTransform.cpp
+++ b/src/examples/CustomTransform.cpp
@@ -172,17 +172,10 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -190,7 +183,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -213,7 +206,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/DirectUpdate.cpp
+++ b/src/examples/DirectUpdate.cpp
@@ -159,17 +159,10 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -177,7 +170,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -200,7 +193,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Duplicate.cpp
+++ b/src/examples/Duplicate.cpp
@@ -206,17 +206,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -224,7 +217,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -238,7 +231,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/FillRule.cpp
+++ b/src/examples/FillRule.cpp
@@ -123,17 +123,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -141,7 +134,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -155,7 +148,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/GradientMasking.cpp
+++ b/src/examples/GradientMasking.cpp
@@ -206,24 +206,18 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
-
     //Threads Count
     auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -237,7 +231,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/GradientStroke.cpp
+++ b/src/examples/GradientStroke.cpp
@@ -190,17 +190,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -208,7 +201,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
         elm_init(argc, argv);
 
         if (tvgEngine == tvg::CanvasEngine::Sw) {
@@ -221,7 +214,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/GradientTransform.cpp
+++ b/src/examples/GradientTransform.cpp
@@ -193,17 +193,10 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -211,7 +204,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -234,7 +227,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/ImageScaleDown.cpp
+++ b/src/examples/ImageScaleDown.cpp
@@ -148,21 +148,18 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
+    //Threads Count
+    auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, 0) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -185,7 +182,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/ImageScaleUp.cpp
+++ b/src/examples/ImageScaleUp.cpp
@@ -148,21 +148,18 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
+    //Threads Count
+    auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, 0) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -185,7 +182,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/InvLumaMasking.cpp
+++ b/src/examples/InvLumaMasking.cpp
@@ -183,25 +183,17 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
-
     //Threads Count
     auto threads = std::thread::hardware_concurrency();
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -215,7 +207,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/InvMasking.cpp
+++ b/src/examples/InvMasking.cpp
@@ -188,17 +188,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -206,7 +199,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -220,7 +213,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/LinearGradient.cpp
+++ b/src/examples/LinearGradient.cpp
@@ -156,17 +156,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -174,7 +167,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -188,7 +181,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Lottie.cpp
+++ b/src/examples/Lottie.cpp
@@ -243,17 +243,10 @@ Eina_Bool animatorGlCb(void *data)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -261,7 +254,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, 4) == tvg::Result::Success) {
+    if (tvg::Initializer::init(4) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -277,7 +270,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvg::CanvasEngine::Sw);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/LumaMasking.cpp
+++ b/src/examples/LumaMasking.cpp
@@ -183,17 +183,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -201,7 +194,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -215,7 +208,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Masking.cpp
+++ b/src/examples/Masking.cpp
@@ -190,17 +190,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -208,7 +201,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -222,7 +215,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/MaskingMethods.cpp
+++ b/src/examples/MaskingMethods.cpp
@@ -455,17 +455,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -473,7 +466,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -487,7 +480,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/MultiCanvas.cpp
+++ b/src/examples/MultiCanvas.cpp
@@ -215,17 +215,10 @@ void tvgGlTest(const char* name, const char* path, void* data)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -233,7 +226,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -253,7 +246,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/MultiShapes.cpp
+++ b/src/examples/MultiShapes.cpp
@@ -116,17 +116,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -134,7 +127,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -148,7 +141,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Opacity.cpp
+++ b/src/examples/Opacity.cpp
@@ -172,17 +172,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -190,7 +183,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
 
         elm_init(argc, argv);
@@ -205,7 +198,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Path.cpp
+++ b/src/examples/Path.cpp
@@ -135,17 +135,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -153,7 +146,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -167,7 +160,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/PathCopy.cpp
+++ b/src/examples/PathCopy.cpp
@@ -172,17 +172,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -190,7 +183,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -204,7 +197,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Performance.cpp
+++ b/src/examples/Performance.cpp
@@ -159,21 +159,18 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
+    //Threads Count
+    auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, 0) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -196,7 +193,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/PictureJpg.cpp
+++ b/src/examples/PictureJpg.cpp
@@ -138,24 +138,18 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
-
     //Threads Count
     auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -169,7 +163,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
 
     } else {

--- a/src/examples/PicturePng.cpp
+++ b/src/examples/PicturePng.cpp
@@ -144,24 +144,18 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
-
     //Threads Count
     auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -175,7 +169,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
 
     } else {

--- a/src/examples/PictureRaw.cpp
+++ b/src/examples/PictureRaw.cpp
@@ -136,17 +136,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -154,7 +147,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -168,7 +161,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/PictureTvg.cpp
+++ b/src/examples/PictureTvg.cpp
@@ -115,24 +115,18 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
-
     //Threads Count
     auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -146,7 +140,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/PictureWebp.cpp
+++ b/src/examples/PictureWebp.cpp
@@ -145,24 +145,18 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
-
     //Threads Count
     auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -176,7 +170,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
 
     } else {

--- a/src/examples/RadialGradient.cpp
+++ b/src/examples/RadialGradient.cpp
@@ -156,17 +156,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -174,7 +167,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -188,7 +181,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Retaining.cpp
+++ b/src/examples/Retaining.cpp
@@ -167,17 +167,10 @@ Eina_Bool timerGlCb(void *data)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -185,7 +178,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -201,7 +194,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Scene.cpp
+++ b/src/examples/Scene.cpp
@@ -163,17 +163,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -181,7 +174,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
 
         elm_init(argc, argv);
@@ -196,7 +189,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/SceneBlending.cpp
+++ b/src/examples/SceneBlending.cpp
@@ -178,17 +178,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -196,7 +189,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
 
         elm_init(argc, argv);
@@ -211,7 +204,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/SceneClipper.cpp
+++ b/src/examples/SceneClipper.cpp
@@ -141,17 +141,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -159,7 +152,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -173,7 +166,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/SceneTransform.cpp
+++ b/src/examples/SceneTransform.cpp
@@ -193,17 +193,10 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -211,7 +204,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -234,7 +227,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Shape.cpp
+++ b/src/examples/Shape.cpp
@@ -108,17 +108,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -126,7 +119,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -140,7 +133,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Stroke.cpp
+++ b/src/examples/Stroke.cpp
@@ -194,17 +194,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -212,7 +205,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -226,7 +219,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/StrokeLine.cpp
+++ b/src/examples/StrokeLine.cpp
@@ -240,17 +240,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -258,7 +251,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
 
         elm_init(argc, argv);
@@ -273,7 +266,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/StrokeMiterlimit.cpp
+++ b/src/examples/StrokeMiterlimit.cpp
@@ -229,24 +229,18 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
     }
 
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
-
     //Threads Count
     auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -260,7 +254,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
 
     } else {

--- a/src/examples/Svg.cpp
+++ b/src/examples/Svg.cpp
@@ -165,17 +165,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -183,7 +176,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -197,7 +190,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Svg2.cpp
+++ b/src/examples/Svg2.cpp
@@ -115,17 +115,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -133,7 +126,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -147,7 +140,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Texmap.cpp
+++ b/src/examples/Texmap.cpp
@@ -155,17 +155,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -173,7 +166,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -187,7 +180,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Transform.cpp
+++ b/src/examples/Transform.cpp
@@ -150,17 +150,10 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -168,7 +161,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -191,7 +184,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Tvg.cpp
+++ b/src/examples/Tvg.cpp
@@ -151,17 +151,10 @@ void drawGLview(Evas_Object *obj)
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -169,7 +162,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -183,7 +176,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/TvgSaver.cpp
+++ b/src/examples/TvgSaver.cpp
@@ -266,29 +266,17 @@ void exportTvg()
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
-
-    if (argc > 1) {
-        if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
-    }
-
     //Threads Count
     auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         exportTvg();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/examples/Update.cpp
+++ b/src/examples/Update.cpp
@@ -138,17 +138,10 @@ void transitGlCb(Elm_Transit_Effect *effect, Elm_Transit* transit, double progre
 
 int main(int argc, char **argv)
 {
-    tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
+    auto tvgEngine = tvg::CanvasEngine::Sw;
 
     if (argc > 1) {
         if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
-    }
-
-    //Initialize ThorVG Engine
-    if (tvgEngine == tvg::CanvasEngine::Sw) {
-        cout << "tvg engine: software" << endl;
-    } else {
-        cout << "tvg engine: opengl" << endl;
     }
 
     //Threads Count
@@ -156,7 +149,7 @@ int main(int argc, char **argv)
     if (threads > 0) --threads;    //Allow the designated main thread capacity
 
     //Initialize ThorVG Engine
-    if (tvg::Initializer::init(tvgEngine, threads) == tvg::Result::Success) {
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
 
         elm_init(argc, argv);
 
@@ -179,7 +172,7 @@ int main(int argc, char **argv)
         elm_shutdown();
 
         //Terminate ThorVG Engine
-        tvg::Initializer::term(tvgEngine);
+        tvg::Initializer::term();
 
     } else {
         cout << "engine is not supported" << endl;

--- a/src/renderer/tvgInitializer.cpp
+++ b/src/renderer/tvgInitializer.cpp
@@ -92,26 +92,25 @@ static bool _buildVersionInfo()
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Result Initializer::init(CanvasEngine engine, uint32_t threads) noexcept
+Result Initializer::init(uint32_t threads, CanvasEngine engine) noexcept
 {
     auto nonSupport = true;
-    if (static_cast<int>(engine) == 0) return Result::InvalidArguments;
 
-    if (engine & CanvasEngine::Sw) {
+    if (engine == CanvasEngine::All || engine & CanvasEngine::Sw) {
         #ifdef THORVG_SW_RASTER_SUPPORT
             if (!SwRenderer::init(threads)) return Result::FailedAllocation;
             nonSupport = false;
         #endif
     }
 
-    if (engine & CanvasEngine::Gl) {
+    if (engine == CanvasEngine::All || engine & CanvasEngine::Gl) {
         #ifdef THORVG_GL_RASTER_SUPPORT
             if (!GlRenderer::init(threads)) return Result::FailedAllocation;
             nonSupport = false;
         #endif
     }
 
-    if (engine & CanvasEngine::Wg) {
+    if (engine == CanvasEngine::All || engine & CanvasEngine::Wg) {
         #ifdef THORVG_WG_RASTER_SUPPORT
             if (!WgRenderer::init(threads)) return Result::FailedAllocation;
             nonSupport = false;
@@ -137,23 +136,22 @@ Result Initializer::term(CanvasEngine engine) noexcept
     if (_initCnt == 0) return Result::InsufficientCondition;
 
     auto nonSupport = true;
-    if (static_cast<int>(engine) == 0) return Result::InvalidArguments;
 
-    if (engine & CanvasEngine::Sw) {
+    if (engine == CanvasEngine::All || engine & CanvasEngine::Sw) {
         #ifdef THORVG_SW_RASTER_SUPPORT
             if (!SwRenderer::term()) return Result::InsufficientCondition;
             nonSupport = false;
         #endif
     }
 
-    if (engine & CanvasEngine::Gl) {
+    if (engine == CanvasEngine::All || engine & CanvasEngine::Gl) {
         #ifdef THORVG_GL_RASTER_SUPPORT
             if (!GlRenderer::term()) return Result::InsufficientCondition;
             nonSupport = false;
         #endif
     }
 
-    if (engine & CanvasEngine::Wg) {
+    if (engine == CanvasEngine::All || engine & CanvasEngine::Wg) {
         #ifdef THORVG_WG_RASTER_SUPPORT
             if (!WgRenderer::term()) return Result::InsufficientCondition;
             nonSupport = false;

--- a/src/tools/svg2png/svg2png.cpp
+++ b/src/tools/svg2png/svg2png.cpp
@@ -169,14 +169,12 @@ public:
 private:
     void createCanvas()
     {
-        //Canvas Engine
-        tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
-
         //Threads Count
         auto threads = thread::hardware_concurrency();
+        if (threads > 0) --threads; 
 
         //Initialize ThorVG Engine
-        if (tvg::Initializer::init(tvgEngine, threads) != tvg::Result::Success) {
+        if (tvg::Initializer::init(threads, tvg::CanvasEngine::Sw) != tvg::Result::Success) {
             cout << "Error: Engine is not supported" << endl;
         }
 

--- a/src/tools/svg2tvg/svg2tvg.cpp
+++ b/src/tools/svg2tvg/svg2tvg.cpp
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <vector>
+#include <thread>
 #include <thorvg.h>
 #ifdef _WIN32
     #include <windows.h>
@@ -62,7 +63,11 @@ private:
 
    bool convert(string& in, string& out)
    {
-      if (Initializer::init(CanvasEngine::Sw, 0) != Result::Success) return false;
+       //Threads Count
+      auto threads = std::thread::hardware_concurrency();
+      if (threads > 0) --threads;    //Allow the designated main thread capacity
+
+      if (Initializer::init(threads, CanvasEngine::Sw) != Result::Success) return false;
 
       auto picture = Picture::gen();
       if (picture->load(in) != Result::Success) return false;

--- a/test/testAccessor.cpp
+++ b/test/testAccessor.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Accessor Creation", "[tvgAccessor]")
 
 TEST_CASE("Set", "[tvgAccessor]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -74,7 +74,7 @@ TEST_CASE("Set", "[tvgAccessor]")
     picture = accessor->set(std::move(picture), f);
     REQUIRE(picture);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 #endif

--- a/test/testAnimation.cpp
+++ b/test/testAnimation.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Animation Basic", "[tvgAnimation]")
 
 TEST_CASE("Animation Lottie", "[tvgAnimation]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 1) == Result::Success);
+    REQUIRE(Initializer::init(1) == Result::Success);
 
     auto animation = Animation::gen();
     REQUIRE(animation);
@@ -65,12 +65,12 @@ TEST_CASE("Animation Lottie", "[tvgAnimation]")
     REQUIRE(animation->duration() == Approx(4).margin(004004));
     REQUIRE(animation->frame(20) == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Animation Lottie2", "[tvgAnimation]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto animation = Animation::gen();
     REQUIRE(animation);
@@ -82,12 +82,12 @@ TEST_CASE("Animation Lottie2", "[tvgAnimation]")
 
     REQUIRE(animation->frame(20) == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Animation Lottie3", "[tvgAnimation]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto animation = Animation::gen();
     REQUIRE(animation);
@@ -97,12 +97,12 @@ TEST_CASE("Animation Lottie3", "[tvgAnimation]")
 
     REQUIRE(picture->load(TEST_DIR"/test3.json") == Result::Success);
     
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Animation Lottie4", "[tvgAnimation]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto animation = Animation::gen();
     REQUIRE(animation);
@@ -112,12 +112,12 @@ TEST_CASE("Animation Lottie4", "[tvgAnimation]")
 
     REQUIRE(picture->load(TEST_DIR"/test4.json") == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Animation Lottie5", "[tvgAnimation]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto animation = Animation::gen();
     REQUIRE(animation);
@@ -127,12 +127,12 @@ TEST_CASE("Animation Lottie5", "[tvgAnimation]")
 
     REQUIRE(picture->load(TEST_DIR"/test5.json") == Result::Success);
     
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Animation Lottie6", "[tvgAnimation]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto animation = Animation::gen();
     REQUIRE(animation);
@@ -142,12 +142,12 @@ TEST_CASE("Animation Lottie6", "[tvgAnimation]")
 
     REQUIRE(picture->load(TEST_DIR"/test6.json") == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Animation Lottie7", "[tvgAnimation]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto animation = Animation::gen();
     REQUIRE(animation);
@@ -157,12 +157,12 @@ TEST_CASE("Animation Lottie7", "[tvgAnimation]")
 
     REQUIRE(picture->load(TEST_DIR"/test7.json") == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Animation Lottie8", "[tvgAnimation]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto animation = Animation::gen();
     REQUIRE(animation);
@@ -172,12 +172,12 @@ TEST_CASE("Animation Lottie8", "[tvgAnimation]")
 
     REQUIRE(picture->load(TEST_DIR"/test8.json") == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Animation Lottie9", "[tvgAnimation]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto animation = Animation::gen();
     REQUIRE(animation);
@@ -187,7 +187,7 @@ TEST_CASE("Animation Lottie9", "[tvgAnimation]")
 
     REQUIRE(picture->load(TEST_DIR"/test9.json") == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 #endif

--- a/test/testInitializer.cpp
+++ b/test/testInitializer.cpp
@@ -29,27 +29,27 @@ using namespace tvg;
 
 TEST_CASE("Basic initialization", "[tvgInitializer]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Multiple initialization", "[tvgInitializer]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Negative termination", "[tvgInitializer]")
 {
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::InsufficientCondition);
+    REQUIRE(Initializer::term() == Result::InsufficientCondition);
 }
 
 TEST_CASE("Invalid engine", "[tvgInitializer]")
 {
-    REQUIRE(Initializer::init(CanvasEngine(0), 0) == Result::InvalidArguments);
+    REQUIRE(Initializer::init(0, CanvasEngine(100)) == Result::NonSupport);
 }

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -72,7 +72,7 @@ TEST_CASE("Load RAW Data", "[tvgPicture]")
 
 TEST_CASE("Load RAW file and render", "[tvgPicture]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -95,7 +95,7 @@ TEST_CASE("Load RAW file and render", "[tvgPicture]")
 
     REQUIRE(canvas->push(std::move(picture)) == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 
     free(data);
 }
@@ -266,7 +266,7 @@ TEST_CASE("Load SVG Data", "[tvgPicture]")
 
 TEST_CASE("Load SVG file and render", "[tvgPicture]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -286,7 +286,7 @@ TEST_CASE("Load SVG file and render", "[tvgPicture]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 
     delete[] buffer;
 }
@@ -338,7 +338,7 @@ TEST_CASE("Load PNG file from data", "[tvgPicture]")
 
 TEST_CASE("Load PNG file and render", "[tvgPicture]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -355,7 +355,7 @@ TEST_CASE("Load PNG file and render", "[tvgPicture]")
 
     REQUIRE(canvas->push(std::move(picture)) == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 #endif
@@ -408,7 +408,7 @@ TEST_CASE("Load JPG file from data", "[tvgPicture]")
 
 TEST_CASE("Load JPG file and render", "[tvgPicture]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -423,7 +423,7 @@ TEST_CASE("Load JPG file and render", "[tvgPicture]")
 
     REQUIRE(canvas->push(std::move(picture)) == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 #endif
@@ -476,7 +476,7 @@ TEST_CASE("Load TVG file from data", "[tvgPicture]")
 
 TEST_CASE("Load TVG file and render", "[tvgPicture]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -496,7 +496,7 @@ TEST_CASE("Load TVG file and render", "[tvgPicture]")
     REQUIRE(pictureTest->load(TEST_DIR"/test.tvg") == Result::Success);
     REQUIRE(canvas->push(std::move(pictureTest)) == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 
     delete[] buffer;
 }
@@ -548,7 +548,7 @@ TEST_CASE("Load WEBP file from data", "[tvgPicture]")
 
 TEST_CASE("Load WEBP file and render", "[tvgPicture]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -565,7 +565,7 @@ TEST_CASE("Load WEBP file and render", "[tvgPicture]")
 
     REQUIRE(canvas->push(std::move(picture)) == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 #endif

--- a/test/testSavers.cpp
+++ b/test/testSavers.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Save empty shape", "[tvgSavers]")
 
 TEST_CASE("Save svg into tvg", "[tvgSavers]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto picture = Picture::gen();
     REQUIRE(picture);
@@ -61,12 +61,12 @@ TEST_CASE("Save svg into tvg", "[tvgSavers]")
     REQUIRE(saver->save(std::move(picture), TEST_DIR"/tag.tvg") == Result::Success);
     REQUIRE(saver->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Save scene into tvg", "[tvgSavers]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto picture = tvg::Picture::gen();
     REQUIRE(picture);
@@ -92,7 +92,7 @@ TEST_CASE("Save scene into tvg", "[tvgSavers]")
     REQUIRE(saver->save(std::move(picture), TEST_DIR"/test.tvg") == Result::Success);
     REQUIRE(saver->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 
     free(data);
 }

--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -84,7 +84,7 @@ TEST_CASE("Scene Clear", "[tvgScene]")
 
 TEST_CASE("Scene Clear And Reuse Shape", "[tvgScene]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -107,5 +107,5 @@ TEST_CASE("Scene Clear And Reuse Shape", "[tvgScene]")
     //Reuse shape.
     REQUIRE(pScene->push(std::unique_ptr<Shape>(pShape)) == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }

--- a/test/testSwCanvas.cpp
+++ b/test/testSwCanvas.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Missing Initialization", "[tvgSwCanvas]")
 
 TEST_CASE("Basic Creation", "[tvgSwCanvas]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0, CanvasEngine::Sw) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -51,7 +51,7 @@ TEST_CASE("Basic Creation", "[tvgSwCanvas]")
 
 TEST_CASE("Target Buffer", "[tvgSwCanvas]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0, CanvasEngine::Sw) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -71,7 +71,7 @@ TEST_CASE("Target Buffer", "[tvgSwCanvas]")
 
 TEST_CASE("Memory Pool", "[tvgSwCanvas]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0, CanvasEngine::Sw) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);

--- a/test/testSwCanvasBase.cpp
+++ b/test/testSwCanvasBase.cpp
@@ -29,7 +29,7 @@ using namespace tvg;
 
 TEST_CASE("Pushing Paints", "[tvgSwCanvasBase]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -80,12 +80,12 @@ TEST_CASE("Pushing Paints", "[tvgSwCanvasBase]")
        ++idx;
     }
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Clear", "[tvgSwCanvasBase]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -134,12 +134,12 @@ TEST_CASE("Clear", "[tvgSwCanvasBase]")
     REQUIRE(canvas2->clear(false) == Result::Success);
     REQUIRE(canvas2->clear() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Update", "[tvgSwCanvasBase]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -168,12 +168,12 @@ TEST_CASE("Update", "[tvgSwCanvasBase]")
     //Invalid shape
     REQUIRE(canvas->update(ptr) == Result::InsufficientCondition);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Synchronized Drawing", "[tvgSwCanvasBase]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -205,13 +205,13 @@ TEST_CASE("Synchronized Drawing", "[tvgSwCanvasBase]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Asynchronized Drawing", "[tvgSwCanvasBase]")
 {
     //Use multi-threading
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 2) == Result::Success);
+    REQUIRE(Initializer::init(2) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -231,5 +231,5 @@ TEST_CASE("Asynchronized Drawing", "[tvgSwCanvasBase]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -32,7 +32,7 @@ using namespace std;
 
 TEST_CASE("Basic draw", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -90,12 +90,12 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Image Draw", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -373,14 +373,14 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 
     free(data);
 }
 
 TEST_CASE("Rect Draw", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -433,12 +433,12 @@ TEST_CASE("Rect Draw", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("RLE Draw", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -491,12 +491,12 @@ TEST_CASE("RLE Draw", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Filling Draw", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -540,12 +540,12 @@ TEST_CASE("Filling Draw", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Filling Opaque Draw", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -589,12 +589,12 @@ TEST_CASE("Filling Opaque Draw", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Filling AlphaMask", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -648,12 +648,12 @@ TEST_CASE("Filling AlphaMask", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Filling InvAlphaMask", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -707,12 +707,12 @@ TEST_CASE("Filling InvAlphaMask", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Filling LumaMask", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -766,12 +766,12 @@ TEST_CASE("Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Filling ClipPath", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -825,12 +825,12 @@ TEST_CASE("Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("RLE Filling Draw", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -874,12 +874,12 @@ TEST_CASE("RLE Filling Draw", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("RLE Filling Opaque Draw", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -923,12 +923,12 @@ TEST_CASE("RLE Filling Opaque Draw", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("RLE Filling AlphaMask", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -982,12 +982,12 @@ TEST_CASE("RLE Filling AlphaMask", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("RLE Filling InvAlphaMask", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -1041,12 +1041,12 @@ TEST_CASE("RLE Filling InvAlphaMask", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("RLE Filling LumaMask", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -1100,12 +1100,12 @@ TEST_CASE("RLE Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("RLE Filling InvLumaMask", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -1159,12 +1159,12 @@ TEST_CASE("RLE Filling InvLumaMask", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("RLE Filling ClipPath", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -1218,12 +1218,12 @@ TEST_CASE("RLE Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Blending Shapes", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -1271,12 +1271,12 @@ TEST_CASE("Blending Shapes", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 TEST_CASE("Blending Images", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -1352,14 +1352,14 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 
     free(data);
 }
 
 TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
 {
-    REQUIRE(Initializer::init(CanvasEngine::Sw, 0) == Result::Success);
+    REQUIRE(Initializer::init(0) == Result::Success);
 
     auto canvas = SwCanvas::gen();
     REQUIRE(canvas);
@@ -1476,7 +1476,7 @@ TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
-    REQUIRE(Initializer::term(CanvasEngine::Sw) == Result::Success);
+    REQUIRE(Initializer::term() == Result::Success);
 }
 
 #endif


### PR DESCRIPTION
This change introduces the CanvasEngine::All type to automatically initialize the engines available on the current system.

These revisions improve the usability of these APIs.

Addtions:
- enum class CanvasEngine::All

Modifications:
- Result Initializer::init(CanvasEngine engine, uint32_t threads) -> Result Initializer::init(uint32_t threads, CanvasEngine engine = tvg::CanvasEngine::All)

https://github.com/thorvg/thorvg/issues/1372