### PR TITLE
wasm: fix a regression bug.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1648,8 +1648,8 @@ public:
      * @param[in] no The index of the animation frame to be displayed. The index should be less than the totalFrame().
      *
      * @retval Result::Success Successfully set the frame.
-     * @retval Result::InsufficientCondition No animatable data loaded from the Picture.
-     * @retval Result::NonSupport The Picture data does not support animations.
+     * @retval Result::InsufficientCondition if the given @p no is the same as the current frame value.
+     * @retval Result::NonSupport The current Picture data does not support animations.
      *
      * @see totalFrame()
      *

--- a/src/bindings/wasm/tvgWasm.cpp
+++ b/src/bindings/wasm/tvgWasm.cpp
@@ -152,13 +152,9 @@ public:
     bool frame(float no)
     {
         if (!canvas || !animation) return false;
-        if (animation->frame(no) != Result::Success) {
-            errorMsg = "frame() fail";
-            return false;
+        if (animation->frame(no) == Result::Success) {
+            updated = true;
         }
-
-        updated = true;
-
         return true;
     }
 


### PR DESCRIPTION
The Animation::frame() method has been modified.
It will now return InsufficientCondition,
if the frame value is the same as the previous one.

In addition to this change, we have also updated its usage accordingly.