### PR TITLE
renderer/scene: ++safety

### DIFF
--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -66,7 +66,7 @@ struct Scene::Impl
     RenderData rd = nullptr;
     Scene* scene = nullptr;
     uint8_t opacity;                     //for composition
-    bool needComp;                       //composite or not
+    bool needComp = false;               //composite or not
 
     Impl(Scene* s) : scene(s)
     {
@@ -148,6 +148,7 @@ struct Scene::Impl
         if (needComp) {
             cmp = renderer.target(bounds(renderer), renderer.colorSpace());
             renderer.beginComposite(cmp, CompositeMethod::None, opacity);
+            needComp = false;
         }
 
         for (auto paint : paints) {

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -38,7 +38,7 @@ struct Shape::Impl
     Shape* shape;
     uint8_t flag = RenderUpdateFlag::None;
     uint8_t opacity;                    //for composition
-    bool needComp;                      //composite or not
+    bool needComp = false;              //composite or not
 
     Impl(Shape* s) : shape(s)
     {
@@ -59,6 +59,7 @@ struct Shape::Impl
         if (needComp) {
             cmp = renderer.target(bounds(renderer), renderer.colorSpace());
             renderer.beginComposite(cmp, CompositeMethod::None, opacity);
+            needComp = false;
         }
         ret = renderer.renderShape(rd);
         if (cmp) renderer.endComposite(cmp);


### PR DESCRIPTION
these member values can be accesssed without update() call.