### PR TITLE
examples: Support mac os to execute all

### DIFF
--- a/src/examples/all.sh
+++ b/src/examples/all.sh
@@ -4,7 +4,14 @@ GREEN='\033[32m'
 NC='\033[0m'
 
 INTERVAL=${1:-2}
-EXAMPLES=`find . -executable -type f | sort | uniq`
+CHECK_OS="`uname -s`"
+
+if [[ "$CHECK_OS" = "Darwin"* ]]; then
+	EXAMPLES=`find . -perm +111 -type f | sort | uniq`
+else
+	EXAMPLES=`find . -executable -type f | sort | uniq`
+fi
+
 for EXAMPLE in $EXAMPLES
 do
 	if [[ $EXAMPLE == *.sh ]]; then


### PR DESCRIPTION
We can now call `examples/all.sh` on the mac os.

Added condition to detect OS and it replaces find command so the mac doesn't cause error.