### PR TITLE
docs: Remove all warnings from doxygen

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -99,7 +99,7 @@ OUTPUT_LANGUAGE        = English
 # Possible values are: None, LTR, RTL and Context.
 # The default value is: None.
 
-OUTPUT_TEXT_DIRECTION  = None
+# OUTPUT_TEXT_DIRECTION  = None
 
 # If the BRIEF_MEMBER_DESC tag is set to YES, doxygen will include brief member
 # descriptions after the members that are listed in the file and class
@@ -1060,7 +1060,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = main-page.md
+# USE_MDFILE_AS_MAINPAGE = main-page.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -1157,13 +1157,13 @@ VERBATIM_HEADERS       = YES
 # generated with the -Duse_libclang=ON option for CMake.
 # The default value is: NO.
 
-CLANG_ASSISTED_PARSING = NO
+# CLANG_ASSISTED_PARSING = NO
 
 # If clang assisted parsing is enabled and the CLANG_ADD_INC_PATHS tag is set to
 # YES then doxygen will add the directory of each input to the include path.
 # The default value is: YES.
 
-CLANG_ADD_INC_PATHS    = YES
+# CLANG_ADD_INC_PATHS    = YES
 
 # If clang assisted parsing is enabled you can provide the compiler with command
 # line options that you would normally use when invoking the compiler. Note that
@@ -1171,7 +1171,7 @@ CLANG_ADD_INC_PATHS    = YES
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          =
+# CLANG_OPTIONS          =
 
 # If clang assisted parsing is enabled you can provide the clang parser with the
 # path to the directory containing a file called compile_commands.json. This
@@ -1184,7 +1184,7 @@ CLANG_OPTIONS          =
 # Note: The availability of this option depends on whether or not doxygen was
 # generated with the -Duse_libclang=ON option for CMake.
 
-CLANG_DATABASE_PATH    =
+# CLANG_DATABASE_PATH    =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
@@ -1331,7 +1331,7 @@ HTML_COLORSTYLE_GAMMA  = 173
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = NO
+# HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
@@ -1636,7 +1636,7 @@ FORMULA_FONTSIZE       = 10
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-FORMULA_TRANSPARENT    = YES
+# FORMULA_TRANSPARENT    = YES
 
 # The FORMULA_MACROFILE can contain LaTeX \newcommand and \renewcommand commands
 # to create new LaTeX commands to be used in formulas as building blocks. See
@@ -1949,7 +1949,7 @@ LATEX_HIDE_INDICES     = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_SOURCE_CODE      = NO
+# LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See
@@ -1965,7 +1965,7 @@ LATEX_BIB_STYLE        = plain
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_TIMESTAMP        = NO
+# LATEX_TIMESTAMP        = NO
 
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,
@@ -2039,7 +2039,7 @@ RTF_EXTENSIONS_FILE    =
 # The default value is: NO.
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
-RTF_SOURCE_CODE        = NO
+# RTF_SOURCE_CODE        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
@@ -2144,7 +2144,7 @@ DOCBOOK_OUTPUT         = docbook
 # The default value is: NO.
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
-DOCBOOK_PROGRAMLISTING = NO
+# DOCBOOK_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
@@ -2156,7 +2156,7 @@ DOCBOOK_PROGRAMLISTING = NO
 # is still experimental and incomplete at the moment.
 # The default value is: NO.
 
-GENERATE_AUTOGEN_DEF   = NO
+# GENERATE_AUTOGEN_DEF   = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to Sqlite3 output
@@ -2336,7 +2336,7 @@ EXTERNAL_PAGES         = YES
 # powerful graphs.
 # The default value is: YES.
 
-CLASS_DIAGRAMS         = NO
+# CLASS_DIAGRAMS         = NO
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The
@@ -2378,14 +2378,14 @@ DOT_NUM_THREADS        = 0
 # The default value is: Helvetica.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTNAME           = Helvetica
+# DOT_FONTNAME           = Helvetica
 
 # The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
 # dot graphs.
 # Minimum value: 4, maximum value: 24, default value: 10.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTSIZE           = 10
+# DOT_FONTSIZE           = 10
 
 # By default doxygen will tell dot to use the default font as specified with
 # DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
@@ -2633,7 +2633,7 @@ MAX_DOT_GRAPH_DEPTH    = 0
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_TRANSPARENT        = NO
+# DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -172,10 +172,10 @@ enum class CompositeMethod : uint8_t
     InvAlphaMask,       ///< Alpha Masking using the complement to the compositing target's pixels as an alpha value.
     LumaMask,           ///< Alpha Masking using the grayscale (0.2125R + 0.7154G + 0.0721*B) of the compositing target's pixels. @since 0.9
     InvLumaMask,        ///< Alpha Masking using the grayscale (0.2125R + 0.7154G + 0.0721*B) of the complement to the compositing target's pixels.
-    AddMask,            ///< Combines the target and source objects pixels using target alpha. (T * TA) + (S * (255 - TA)) @BETA_API
-    SubtractMask,       ///< Subtracts the source color from the target color while considering their respective target alpha. (T * TA) - (S * (255 - TA)) @BETA_API
-    IntersectMask,      ///< Computes the result by taking the minimum value between the target alpha and the source alpha and multiplies it with the target color. (T * min(TA, SA)) @BETA_API
-    DifferenceMask      ///< Calculates the absolute difference between the target color and the source color multiplied by the complement of the target alpha. abs(T - S * (255 - TA)) @BETA_API
+    AddMask,            ///< Combines the target and source objects pixels using target alpha. (T * TA) + (S * (255 - TA)) (Experimental API)
+    SubtractMask,       ///< Subtracts the source color from the target color while considering their respective target alpha. (T * TA) - (S * (255 - TA)) (Experimental API)
+    IntersectMask,      ///< Computes the result by taking the minimum value between the target alpha and the source alpha and multiplies it with the target color. (T * min(TA, SA)) (Experimental API)
+    DifferenceMask      ///< Calculates the absolute difference between the target color and the source color multiplied by the complement of the target alpha. abs(T - S * (255 - TA)) (Experimental API)
 };
 
 
@@ -186,7 +186,7 @@ enum class CompositeMethod : uint8_t
  *
  * @see Paint::blend()
  *
- * @BETA_API
+ * @note: Experimental API
  */
 enum class BlendMethod : uint8_t
 {
@@ -215,7 +215,7 @@ enum class CanvasEngine : uint8_t
     All = 0,       ///< All feasible rasterizers.
     Sw = (1 << 1), ///< CPU rasterizer.
     Gl = (1 << 2), ///< OpenGL rasterizer.
-    Wg = (1 << 3), ///< WebGPU rasterizer. @BETA_API
+    Wg = (1 << 3), ///< WebGPU rasterizer. (Experimental API)
 };
 
 
@@ -249,7 +249,7 @@ struct Matrix
  * @param pt The vertex coordinate
  * @param uv The normalized texture coordinate in the range (0.0..1.0, 0.0..1.0)
  *
- * @BETA_API
+ * @note: Experimental API
  */
 struct Vertex
 {
@@ -263,7 +263,7 @@ struct Vertex
  *
  * @param vertex The three vertices that make up the polygon
  *
- * @BETA_API
+ * @note: Experimental API
  */
 struct Polygon
 {
@@ -375,7 +375,7 @@ public:
      *
      * @return Result::Success when the blending method is successfully set.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     Result blend(BlendMethod method) const noexcept;
 
@@ -428,7 +428,7 @@ public:
      *
      * @return The blending method
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     BlendMethod blend() const noexcept;
 
@@ -574,7 +574,7 @@ public:
      * @warning  Please avoid accessing the paints during Canvas update/draw. You can access them after calling sync().
      * @see Canvas::sync()
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     std::list<Paint*>& paints() noexcept;
 
@@ -1301,7 +1301,7 @@ public:
      * @note The Polygons are copied internally, so modifying them after calling Mesh::mesh has no affect.
      * @warning Please do not use it, this API is not official one. It could be modified in the next version.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     Result mesh(const Polygon* triangles, uint32_t triangleCnt) noexcept;
 
@@ -1315,7 +1315,7 @@ public:
      * @note Modifying the triangles returned by this method will modify them directly within the mesh.
      * @warning Please do not use it, this API is not official one. It could be modified in the next version.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     uint32_t mesh(const Polygon** triangles) const noexcept;
 
@@ -1382,7 +1382,7 @@ public:
      * @see Scene::push()
      * @see Scene::clear()
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     std::list<Paint*>& paints() noexcept;
 
@@ -1437,8 +1437,8 @@ public:
     {
         ABGR8888 = 0,      ///< The channels are joined in the order: alpha, blue, green, red. Colors are alpha-premultiplied. (a << 24 | b << 16 | g << 8 | r)
         ARGB8888,          ///< The channels are joined in the order: alpha, red, green, blue. Colors are alpha-premultiplied. (a << 24 | r << 16 | g << 8 | b)
-        ABGR8888S,         ///< @BETA_API The channels are joined in the order: alpha, blue, green, red. Colors are un-alpha-premultiplied.
-        ARGB8888S,         ///< @BETA_API The channels are joined in the order: alpha, red, green, blue. Colors are un-alpha-premultiplied.
+        ABGR8888S,         ///< The channels are joined in the order: alpha, blue, green, red. Colors are un-alpha-premultiplied. (Experimental API)
+        ARGB8888S,         ///< The channels are joined in the order: alpha, red, green, blue. Colors are un-alpha-premultiplied. (Experimental API)
     };
 
     /**
@@ -1514,7 +1514,7 @@ public:
  *
  * @warning Please do not use it. This class is not fully supported yet.
  *
- * @BETA_API
+ * @note: Experimental API
  */
 class TVG_API GlCanvas final : public Canvas
 {
@@ -1526,7 +1526,7 @@ public:
      *
      * @warning Please do not use it, this API is not official one. It could be modified in the next version.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     Result target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h) noexcept;
 
@@ -1535,7 +1535,7 @@ public:
      *
      * @return A new GlCanvas object.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     static std::unique_ptr<GlCanvas> gen() noexcept;
 
@@ -1550,7 +1550,7 @@ public:
  *
  * @warning Please do not use it. This class is not fully supported yet.
  *
- * @BETA_API
+ * @note: Experimental API
  */
 class TVG_API WgCanvas final : public Canvas
 {
@@ -1562,7 +1562,7 @@ public:
      *
      * @warning Please do not use it, this API is not official one. It could be modified in the next version.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     Result target(void* window, uint32_t w, uint32_t h) noexcept;
 
@@ -1571,7 +1571,7 @@ public:
      *
      * @return A new WgCanvas object.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     static std::unique_ptr<WgCanvas> gen() noexcept;
 
@@ -1634,7 +1634,7 @@ public:
  *
  * This class supports the display and control of animation frames.
  *
- * @BETA_API
+ * @note: Experimental API
  */
 
 class TVG_API Animation
@@ -1653,7 +1653,7 @@ public:
      *
      * @see totalFrame()
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     Result frame(float no) noexcept;
 
@@ -1668,7 +1668,7 @@ public:
      *
      * @warning The picture instance is owned by Animation. It should not be deleted manually.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     Picture* picture() const noexcept;
 
@@ -1682,7 +1682,7 @@ public:
      * @see Animation::frame(float no)
      * @see Animation::totalFrame()
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     float curFrame() const noexcept;
 
@@ -1694,7 +1694,7 @@ public:
      * @note Frame numbering starts from 0.
      * @note If the Picture is not properly configured, this function will return 0.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     float totalFrame() const noexcept;
 
@@ -1705,7 +1705,7 @@ public:
      *
      * @note If the Picture is not properly configured, this function will return 0.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     float duration() const noexcept;
 
@@ -1714,7 +1714,7 @@ public:
      *
      * @return A new Animation object.
      *
-     * @BETA_API
+     * @note: Experimental API
      */
     static std::unique_ptr<Animation> gen() noexcept;
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -146,7 +146,7 @@ typedef enum {
  *
  * \ingroup ThorVGCapi_Paint
  *
- * @BETA_API
+ * @note: Experimental API
  */
 typedef enum {
     TVG_BLEND_METHOD_NORMAL = 0,        ///< Perform the alpha blending(default). S if (Sa == 255), otherwise (Sa * S) + (255 - Sa) * D
@@ -983,7 +983,7 @@ TVG_API Tvg_Result tvg_paint_get_identifier(const Tvg_Paint* paint, Tvg_Identifi
  * \return Tvg_Result enumeration.
  * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
  *
- * @BETA_API
+ * @note: Experimental API
  */
 TVG_API Tvg_Result tvg_paint_set_blend_method(const Tvg_Paint* paint, Tvg_Blend_Method method);
 
@@ -1001,7 +1001,7 @@ TVG_API Tvg_Result tvg_paint_set_blend_method(const Tvg_Paint* paint, Tvg_Blend_
  * \return Tvg_Result enumeration.
  * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
  *
- * @BETA_API
+ * @note: Experimental API
  */
 TVG_API Tvg_Result tvg_paint_get_blend_method(const Tvg_Paint* paint, Tvg_Blend_Method* method);
 


### PR DESCRIPTION
Fixed all warnings on building doxygen, wrong annotations are replaced from both `thorvg.h` and `thorvg_capi.h`.
Also I found unnecessary configs from `Doxyfile` and I commented it out.

@issue: #1754 

now it's clean without any warnings!