### PR TITLE
gl_engine: fix memory out of bounds error in GlGpuBuffer

### DIFF
--- a/src/renderer/gl_engine/tvgGlGpuBuffer.cpp
+++ b/src/renderer/gl_engine/tvgGlGpuBuffer.cpp
@@ -87,7 +87,7 @@ GlStageBuffer::~GlStageBuffer()
 
 uint32_t GlStageBuffer::push(void *data, uint32_t size, bool alignGpuOffset)
 {
-    if (alignGpuOffset) alignOffset();
+    if (alignGpuOffset) alignOffset(size);
 
     uint32_t offset = mStageBuffer.count;
 
@@ -135,7 +135,7 @@ GLuint GlStageBuffer::getBufferId()
     return mGpuBuffer->getBufferId();
 }
 
-void GlStageBuffer::alignOffset()
+void GlStageBuffer::alignOffset(uint32_t size)
 {
 
     uint32_t alignment = _getGpuBufferAlign();
@@ -145,8 +145,8 @@ void GlStageBuffer::alignOffset()
 
     uint32_t offset = alignment - mStageBuffer.count % alignment;
 
-    if (mStageBuffer.count + offset > mStageBuffer.reserved) {
-        mStageBuffer.grow(max(alignment, mStageBuffer.reserved));
+    if (mStageBuffer.count + offset + size > mStageBuffer.reserved) {
+        mStageBuffer.grow(max(offset + size, mStageBuffer.reserved));
     }
 
     mStageBuffer.count += offset;

--- a/src/renderer/gl_engine/tvgGlGpuBuffer.h
+++ b/src/renderer/gl_engine/tvgGlGpuBuffer.h
@@ -64,7 +64,7 @@ public:
 
     GLuint getBufferId();
 private:
-    void alignOffset();
+    void alignOffset(uint32_t size);
 private:
     GLuint mVao = 0;
     unique_ptr<GlGpuBuffer> mGpuBuffer = {};


### PR DESCRIPTION
This PR fix a potential memory out of bounds error in GLGpuBuffer

If buffer data is larger than memory alignment, need to make sure there is enough memory in current stage buffer