### PR TITLE
picture: added ability to support premultiplied for picture raw loader

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1279,7 +1279,7 @@ public:
      *
      * @since 0.9
      */
-    Result load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept;
+    Result load(uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy) noexcept;
 
     /**
      * @brief Sets or removes the triangle mesh to deform the image.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1976,7 +1976,7 @@ TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path);
 *
 * \since 0.9
 */
-TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, bool copy);
+TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, bool premultiplied, bool copy);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -517,10 +517,10 @@ TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path)
 }
 
 
-TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, bool copy)
+TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, bool premultiplied, bool copy)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, w, h, copy);
+    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, w, h, premultiplied, copy);
 }
 
 

--- a/src/examples/Blending.cpp
+++ b/src/examples/Blending.cpp
@@ -132,7 +132,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Lighten
     auto picture = tvg::Picture::gen();
-    if (picture->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (picture->load(data, 200, 300, true, true) != tvg::Result::Success) return;
     picture->translate(800, 700);
     picture->rotate(40);
     picture->blend(tvg::BlendMethod::Lighten);
@@ -147,7 +147,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //ColorBurn
     auto picture2 = tvg::Picture::gen();
-    if (picture2->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (picture2->load(data, 200, 300, true, true) != tvg::Result::Success) return;
     picture2->translate(600, 250);
     picture2->blend(tvg::BlendMethod::ColorBurn);
     picture2->opacity(150);
@@ -155,14 +155,14 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //HardLight
     auto picture3 = tvg::Picture::gen();
-    if (picture3->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (picture3->load(data, 200, 300, true, true) != tvg::Result::Success) return;
     picture3->translate(700, 150);
     picture3->blend(tvg::BlendMethod::HardLight);
     canvas->push(std::move(picture3));
 
     //SoftLight
     auto picture4 = tvg::Picture::gen();
-    if (picture4->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (picture4->load(data, 200, 300, true, true) != tvg::Result::Success) return;
     picture4->translate(350, 600);
     picture4->rotate(90);
     picture4->blend(tvg::BlendMethod::SoftLight);

--- a/src/examples/Duplicate.cpp
+++ b/src/examples/Duplicate.cpp
@@ -123,7 +123,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
         file.close();
 
         auto picture1 = tvg::Picture::gen();
-        if (picture1->load(data, 200, 300, true) != tvg::Result::Success) return;
+        if (picture1->load(data, 200, 300, true, true) != tvg::Result::Success) return;
         picture1->scale(0.8);
         picture1->translate(400, 450);
 

--- a/src/examples/InvLumaMasking.cpp
+++ b/src/examples/InvLumaMasking.cpp
@@ -97,7 +97,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     file.close();
 
     auto image = tvg::Picture::gen();
-    if (image->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (image->load(data, 200, 300, true, true) != tvg::Result::Success) return;
     image->translate(500, 400);
 
     //Mask4

--- a/src/examples/InvMasking.cpp
+++ b/src/examples/InvMasking.cpp
@@ -97,7 +97,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     file.close();
 
     auto image = tvg::Picture::gen();
-    if (image->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (image->load(data, 200, 300, true, true) != tvg::Result::Success) return;
     image->translate(500, 400);
     free(data);
 

--- a/src/examples/LumaMasking.cpp
+++ b/src/examples/LumaMasking.cpp
@@ -97,7 +97,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     file.close();
 
     auto image = tvg::Picture::gen();
-    if (image->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (image->load(data, 200, 300, true, true) != tvg::Result::Success) return;
     image->translate(500, 400);
 
     //Mask4

--- a/src/examples/Masking.cpp
+++ b/src/examples/Masking.cpp
@@ -99,7 +99,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     file.close();
 
     auto image = tvg::Picture::gen();
-    if (image->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (image->load(data, 200, 300, true, true) != tvg::Result::Success) return;
     image->translate(500, 400);
 
     //Mask4

--- a/src/examples/MaskingMethods.cpp
+++ b/src/examples/MaskingMethods.cpp
@@ -243,7 +243,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     {
         //Transformed Image + Shape Mask Add
         auto image = tvg::Picture::gen();
-        if (image->load(data, 200, 300, true) != tvg::Result::Success) return;
+        if (image->load(data, 200, 300, true, true) != tvg::Result::Success) return;
         image->translate(150, 650);
         image->scale(0.5f);
         image->rotate(45);
@@ -261,7 +261,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
          //Transformed Image + Shape Mask Subtract
         auto image2 = tvg::Picture::gen();
-        if (image2->load(data, 200, 300, true) != tvg::Result::Success) return;
+        if (image2->load(data, 200, 300, true, true) != tvg::Result::Success) return;
         image2->translate(400, 650);
         image2->scale(0.5f);
         image2->rotate(45);
@@ -279,7 +279,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
         //Transformed Image + Shape Mask Intersect
         auto image3 = tvg::Picture::gen();
-        if (image3->load(data, 200, 300, true) != tvg::Result::Success) return;
+        if (image3->load(data, 200, 300, true, true) != tvg::Result::Success) return;
         image3->translate(650, 650);
         image3->scale(0.5f);
         image3->rotate(45);
@@ -297,7 +297,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
         //Transformed Image + Shape Mask Difference
         auto image4 = tvg::Picture::gen();
-        if (image4->load(data, 200, 300, true) != tvg::Result::Success) return;
+        if (image4->load(data, 200, 300, true, true) != tvg::Result::Success) return;
         image4->translate(900, 650);
         image4->scale(0.5f);
         image4->rotate(45);
@@ -316,7 +316,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     {
         //Transformed Image + Shape Mask Add
         auto image = tvg::Picture::gen();
-        if (image->load(data, 200, 300, true) != tvg::Result::Success) return;
+        if (image->load(data, 200, 300, true, true) != tvg::Result::Success) return;
         image->translate(150, 850);
         image->scale(0.5f);
         image->rotate(45);
@@ -334,7 +334,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
          //Transformed Image + Shape Mask Subtract
         auto image2 = tvg::Picture::gen();
-        if (image2->load(data, 200, 300, true) != tvg::Result::Success) return;
+        if (image2->load(data, 200, 300, true, true) != tvg::Result::Success) return;
         image2->translate(400, 850);
         image2->scale(0.5f);
         image2->rotate(45);
@@ -352,7 +352,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
         //Transformed Image + Shape Mask Intersect
         auto image3 = tvg::Picture::gen();
-        if (image3->load(data, 200, 300, true) != tvg::Result::Success) return;
+        if (image3->load(data, 200, 300, true, true) != tvg::Result::Success) return;
         image3->translate(650, 850);
         image3->scale(0.5f);
         image3->rotate(45);
@@ -370,7 +370,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
         //Transformed Image + Shape Mask Difference
         auto image4 = tvg::Picture::gen();
-        if (image4->load(data, 200, 300, true) != tvg::Result::Success) return;
+        if (image4->load(data, 200, 300, true, true) != tvg::Result::Success) return;
         image4->translate(900, 850);
         image4->scale(0.5f);
         image4->rotate(45);

--- a/src/examples/PictureRaw.cpp
+++ b/src/examples/PictureRaw.cpp
@@ -47,12 +47,12 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     file.close();
 
     auto picture = tvg::Picture::gen();
-    if (picture->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (picture->load(data, 200, 300, true, true) != tvg::Result::Success) return;
     picture->translate(400, 250);
     canvas->push(std::move(picture));
 
     auto picture2 = tvg::Picture::gen();
-    if (picture2->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (picture2->load(data, 200, 300, true, true) != tvg::Result::Success) return;
 
     picture2->translate(400, 200);
     picture2->rotate(47);

--- a/src/examples/Texmap.cpp
+++ b/src/examples/Texmap.cpp
@@ -49,7 +49,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     //Picture
     auto picture = tvg::Picture::gen();
-    if (picture->load(data, 200, 300, true) != tvg::Result::Success) return;
+    if (picture->load(data, 200, 300, true, true) != tvg::Result::Success) return;
 
     //Composing Meshes
     tvg::Polygon triangles[4];

--- a/src/examples/TvgSaver.cpp
+++ b/src/examples/TvgSaver.cpp
@@ -50,7 +50,7 @@ void tvgDrawStar(tvg::Shape* star)
 unique_ptr<tvg::Paint> tvgTexmap(uint32_t * data, int width, int heigth)
 {
     auto texmap = tvg::Picture::gen();
-    if (texmap->load(data, width, heigth, true) != tvg::Result::Success) return nullptr;
+    if (texmap->load(data, width, heigth, true, true) != tvg::Result::Success) return nullptr;
     texmap->translate(100, 100);
 
     //Composing Meshes
@@ -79,7 +79,7 @@ unique_ptr<tvg::Paint> tvgTexmap(uint32_t * data, int width, int heigth)
 unique_ptr<tvg::Paint> tvgClippedImage(uint32_t * data, int width, int heigth)
 {
     auto image = tvg::Picture::gen();
-    if (image->load(data, width, heigth, true) != tvg::Result::Success) return nullptr;
+    if (image->load(data, width, heigth, true, true) != tvg::Result::Success) return nullptr;
     image->translate(400, 0);
     image->scale(2);
 

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -43,13 +43,14 @@ RawLoader::~RawLoader()
 }
 
 
-bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, bool copy)
+bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy)
 {
     if (!data || w == 0 || h == 0) return false;
 
     this->w = (float)w;
     this->h = (float)h;
     this->copy = copy;
+    this->premultiplied = premultiplied;
 
     if (copy) {
         content = (uint32_t*)malloc(sizeof(uint32_t) * w * h);
@@ -88,7 +89,7 @@ unique_ptr<Surface> RawLoader::bitmap()
     surface->h = static_cast<uint32_t>(h);
     surface->cs = cs;
     surface->channelSize = sizeof(uint32_t);
-    surface->premultiplied = true;
+    surface->premultiplied = premultiplied;
     surface->owner = true;
 
     return unique_ptr<Surface>(surface);

--- a/src/loaders/raw/tvgRawLoader.h
+++ b/src/loaders/raw/tvgRawLoader.h
@@ -28,11 +28,12 @@ class RawLoader : public LoadModule
 public:
     uint32_t* content = nullptr;
     bool copy = false;
+    bool premultiplied = false;
 
     ~RawLoader();
 
     using LoadModule::open;
-    bool open(const uint32_t* data, uint32_t w, uint32_t h, bool copy) override;
+    bool open(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/tvg/tvgTvgBinInterpreter.cpp
+++ b/src/loaders/tvg/tvgTvgBinInterpreter.cpp
@@ -404,7 +404,7 @@ static bool _parsePicture(TvgBinBlock block, Paint* paint)
             auto size = w * h * SIZE(uint32_t);
             if (block.length != 2 * SIZE(uint32_t) + size) return false;
 
-            picture->load((uint32_t*) ptr, w, h, true);
+            picture->load((uint32_t*) ptr, w, h, true, true);
 
             return true;
         }

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -38,7 +38,7 @@ public:
 
     virtual bool open(const string& path) { return false; }
     virtual bool open(const char* data, uint32_t size, bool copy) { return false; }
-    virtual bool open(const uint32_t* data, uint32_t w, uint32_t h, bool copy) { return false; }
+    virtual bool open(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy) { return false; }
 
     //Override this if the vector-format has own resizing policy.
     virtual bool resize(Paint* paint, float w, float h) { return false; }

--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -238,11 +238,11 @@ shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const 
 }
 
 
-shared_ptr<LoadModule> LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h, bool copy)
+shared_ptr<LoadModule> LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h, bool premultiplied, bool copy)
 {
     //function is dedicated for raw images only
     auto loader = new RawLoader;
-    if (loader->open(data, w, h, copy)) return shared_ptr<LoadModule>(loader);
+    if (loader->open(data, w, h, premultiplied, copy)) return shared_ptr<LoadModule>(loader);
     else delete(loader);
 
     return nullptr;

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -31,7 +31,7 @@ struct LoaderMgr
     static bool term();
     static shared_ptr<LoadModule> loader(const string& path, bool* invalid);
     static shared_ptr<LoadModule> loader(const char* data, uint32_t size, const string& mimeType, bool copy);
-    static shared_ptr<LoadModule> loader(const uint32_t* data, uint32_t w, uint32_t h, bool copy);
+    static shared_ptr<LoadModule> loader(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy);
 };
 
 #endif //_TVG_LOADER_H_

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -99,11 +99,11 @@ Result Picture::load(const char* data, uint32_t size, const string& mimeType, bo
 }
 
 
-Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool copy) noexcept
+Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy) noexcept
 {
     if (!data || w <= 0 || h <= 0) return Result::InvalidArguments;
 
-    return pImpl->load(data, w, h, copy);
+    return pImpl->load(data, w, h, premultiplied, copy);
 }
 
 

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -230,11 +230,11 @@ struct Picture::Impl
         return Result::Success;
     }
 
-    Result load(uint32_t* data, uint32_t w, uint32_t h, bool copy)
+    Result load(uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy)
     {
         if (paint || surface) return Result::InsufficientCondition;
         if (loader) loader->close();
-        loader = LoaderMgr::loader(data, w, h, copy);
+        loader = LoaderMgr::loader(data, w, h, premultiplied, copy);
         if (!loader) return Result::FailedAllocation;
         this->w = loader->w;
         this->h = loader->h;

--- a/test/capi/capiPicture.cpp
+++ b/test/capi/capiPicture.cpp
@@ -45,13 +45,13 @@ TEST_CASE("Load Raw file in Picture", "[capiPicture]")
 
     if (data && fread(data, sizeof(uint32_t), 200*300, fp) > 0) {
         //Negative
-        REQUIRE(tvg_picture_load_raw(picture, nullptr, 100, 100, true) == TVG_RESULT_INVALID_ARGUMENT);
-        REQUIRE(tvg_picture_load_raw(nullptr, data, 200, 300, true) == TVG_RESULT_INVALID_ARGUMENT);
-        REQUIRE(tvg_picture_load_raw(picture, data, 0, 0, true) == TVG_RESULT_INVALID_ARGUMENT);
+        REQUIRE(tvg_picture_load_raw(picture, nullptr, 100, 100, true, true) == TVG_RESULT_INVALID_ARGUMENT);
+        REQUIRE(tvg_picture_load_raw(nullptr, data, 200, 300, true, true) == TVG_RESULT_INVALID_ARGUMENT);
+        REQUIRE(tvg_picture_load_raw(picture, data, 0, 0, true, true) == TVG_RESULT_INVALID_ARGUMENT);
 
         //Positive
-        REQUIRE(tvg_picture_load_raw(picture, data, 200, 300, true) == TVG_RESULT_SUCCESS);
-        REQUIRE(tvg_picture_load_raw(picture, data, 200, 300, false) == TVG_RESULT_SUCCESS);
+        REQUIRE(tvg_picture_load_raw(picture, data, 200, 300, true, true) == TVG_RESULT_SUCCESS);
+        REQUIRE(tvg_picture_load_raw(picture, data, 200, 300, true, false) == TVG_RESULT_SUCCESS);
 
         //Verify Size
         float w, h;

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -52,14 +52,14 @@ TEST_CASE("Load RAW Data", "[tvgPicture]")
     file.close();
 
     //Negative cases
-    REQUIRE(picture->load(nullptr, 200, 300, false) == Result::InvalidArguments);
-    REQUIRE(picture->load(data, 0, 0, false) == Result::InvalidArguments);
-    REQUIRE(picture->load(data, 200, 0, false) == Result::InvalidArguments);
-    REQUIRE(picture->load(data, 0, 300, false) == Result::InvalidArguments);
+    REQUIRE(picture->load(nullptr, 200, 300, true, false) == Result::InvalidArguments);
+    REQUIRE(picture->load(data, 0, 0, true, false) == Result::InvalidArguments);
+    REQUIRE(picture->load(data, 200, 0, true, false) == Result::InvalidArguments);
+    REQUIRE(picture->load(data, 0, 300, true, false) == Result::InvalidArguments);
 
     //Positive cases
-    REQUIRE(picture->load(data, 200, 300, false) == Result::Success);
-    REQUIRE(picture->load(data, 200, 300, true) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, true, true) == Result::Success);
 
     float w, h;
     REQUIRE(picture->size(&w, &h) == Result::Success);
@@ -90,7 +90,7 @@ TEST_CASE("Load RAW file and render", "[tvgPicture]")
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
 
-    REQUIRE(picture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture->size(100, 150) == Result::Success);
 
     REQUIRE(canvas->push(std::move(picture)) == Result::Success);
@@ -111,7 +111,7 @@ TEST_CASE("Texture mesh", "[tvgPicture]")
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
 
-    REQUIRE(picture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
 
     //Composing Meshes
     tvg::Polygon triangles[4];
@@ -176,7 +176,7 @@ TEST_CASE("Picture Size", "[tvgPicture]")
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
 
-    REQUIRE(picture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
 
     REQUIRE(picture->size(nullptr, nullptr) == Result::Success);
     REQUIRE(picture->size(100, 100) == Result::Success);
@@ -193,7 +193,7 @@ TEST_CASE("Picture Size", "[tvgPicture]")
     file2.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 250 * 375);
     file2.close();
 
-    REQUIRE(picture->load(data, 250, 375, false) == Result::Success);
+    REQUIRE(picture->load(data, 250, 375, true, false) == Result::Success);
 
     REQUIRE(picture->size(&w, &h) == Result::Success);
     REQUIRE(picture->size(w, h) == Result::Success);
@@ -213,7 +213,7 @@ TEST_CASE("Picture Duplication", "[tvgPicture]")
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
 
-    REQUIRE(picture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture->size(100, 100) == Result::Success);
 
     auto dup = tvg::cast<Picture>(picture->duplicate());

--- a/test/testSavers.cpp
+++ b/test/testSavers.cpp
@@ -77,7 +77,7 @@ TEST_CASE("Save scene into tvg", "[tvgSavers]")
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
 
-    REQUIRE(picture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture->translate(50, 0) == Result::Success);
     REQUIRE(picture->scale(2) == Result::Success);
 

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     //Not transformed images
     auto basicPicture = Picture::gen();
     REQUIRE(basicPicture);
-    REQUIRE(basicPicture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(basicPicture->load(data, 200, 300, true, false) == Result::Success);
     auto rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
     REQUIRE(rectMask->appendRect(10, 10, 30, 30) == Result::Success);
@@ -179,7 +179,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     // Transformed images
     basicPicture = Picture::gen();
     REQUIRE(basicPicture);
-    REQUIRE(basicPicture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(basicPicture->load(data, 200, 300, true, false) == Result::Success);
 
     REQUIRE(basicPicture->rotate(45) == Result::Success);
     rectMask = tvg::Shape::gen();
@@ -244,7 +244,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     // Upscaled images
     basicPicture = Picture::gen();
     REQUIRE(basicPicture);
-    REQUIRE(basicPicture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(basicPicture->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(basicPicture->scale(2) == Result::Success);
     rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
@@ -308,7 +308,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     // Downscaled images
     basicPicture = Picture::gen();
     REQUIRE(basicPicture);
-    REQUIRE(basicPicture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(basicPicture->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(basicPicture->scale(0.2f) == Result::Success);
     rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
@@ -1298,7 +1298,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
 
     auto picture = Picture::gen();
     REQUIRE(picture);
-    REQUIRE(picture->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture->composite(std::move(clipper), CompositeMethod::ClipPath) == Result::Success);
     REQUIRE(canvas->push(std::move(picture)) == Result::Success);
@@ -1306,7 +1306,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     //scaled images
     auto picture2 = Picture::gen();
     REQUIRE(picture2);
-    REQUIRE(picture2->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture2->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture2->scale(2) == Result::Success);
     REQUIRE(picture2->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(canvas->push(std::move(picture2)) == Result::Success);
@@ -1318,7 +1318,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
 
     auto picture3 = Picture::gen();
     REQUIRE(picture3);
-    REQUIRE(picture3->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture3->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture3->scale(2) == Result::Success);
     REQUIRE(picture3->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture3->composite(std::move(clipper2), CompositeMethod::ClipPath) == Result::Success);
@@ -1327,14 +1327,14 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     //normal image
     auto picture4 = Picture::gen();
     REQUIRE(picture4);
-    REQUIRE(picture4->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture4->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture4->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(canvas->push(std::move(picture4)) == Result::Success);
 
     //texmap image
     auto picture5 = Picture::gen();
     REQUIRE(picture5);
-    REQUIRE(picture5->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture5->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture5->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture5->rotate(45.0f) == Result::Success);
     REQUIRE(canvas->push(std::move(picture5)) == Result::Success);
@@ -1342,7 +1342,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     //texmap image with half-translucent
     auto picture6 = Picture::gen();
     REQUIRE(picture6);
-    REQUIRE(picture6->load(data, 200, 300, false) == Result::Success);
+    REQUIRE(picture6->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture6->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture6->rotate(45.0f) == Result::Success);
     REQUIRE(picture6->opacity(127) == Result::Success);


### PR DESCRIPTION
[issues 1479: picture raw loader to support premultiplied](https://github.com/thorvg/thorvg/issues/1764)

api changes:
    Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool copy);
    Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy);

capi changes
    TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, bool copy);
    TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, bool premultiplied, bool copy);