### PR TITLE
infra: fix macos build crash

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -16,6 +16,12 @@ jobs:
       with:
         submodules: true
 
+    - name: Unbreak Python in Github Actions
+      run: |
+        find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+        sudo rm -rf /Library/Frameworks/Python.framework/
+        brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
+
     - name: Install Packages
       run: |
         export HOMEBREW_NO_INSTALL_FROM_API=1
@@ -35,6 +41,12 @@ jobs:
       with:
         submodules: true
 
+    - name: Unbreak Python in Github Actions
+      run: |
+        find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+        sudo rm -rf /Library/Frameworks/Python.framework/
+        brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
+
     - name: Install Packages
       run: |
         brew update
@@ -51,6 +63,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+
+    - name: Unbreak Python in Github Actions
+      run: |
+        find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+        sudo rm -rf /Library/Frameworks/Python.framework/
+        brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
 
     - name: Install Packages
       run: |


### PR DESCRIPTION
Github action recently hits an error, it's about meson downloading bug via brew. Meson has a dependency `python` and python installation is failed randomly with this log.

<img width="511" alt="Screenshot 2023-11-15 at 12 42 47 PM" src="https://github.com/thorvg/thorvg/assets/11167117/df461f32-9238-4323-844f-c96f71b4a608">

So I added few commands before downloading meson.
```sh
find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
sudo rm -rf /Library/Frameworks/Python.framework/
brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
```

It prevents python installation bug due to duplicated sym link.