### PR TITLE
lottie/parser: Fix the shapes parsing logic.

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -950,8 +950,19 @@ void LottieParser::parseShapes(LottieLayer* layer)
 {
     enterArray();
     while (nextArrayValue()) {
-        parseObject(layer);
-    }
+        enterObject();
+        while (auto key = nextObjectKey()) {
+            if (!strcmp(key, "it")) {
+                enterArray();
+                while (nextArrayValue()) parseObject(layer);
+            } else if (!strcmp(key, "ty")) {
+                if (auto child = parseObject()) {
+                    if (child->hidden) delete(child);
+                    else layer->children.push(child);
+                }
+            } else skip(key);
+        }
+     }
 }
 
 


### PR DESCRIPTION
Currently, it assumes "ty":"gr" for the related shapes children, which can be skipped since the children will be in the "it" scope.

Some Lottie data is missing the "ty":"gr" field,
and ThorVG couldn't display the content properly.
It can ignore it with the context understanding.