### PR TITLE
ThorVG API: Revise the Canvas::clear() API

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -597,6 +597,21 @@ public:
     virtual Result push(std::unique_ptr<Paint> paint) noexcept;
 
     /**
+     * @brief Clear the target buffer that used for the drawing.
+     *
+     * @param[in] r The red color channel value in the range [0 ~ 255].
+     * @param[in] g The green color channel value in the range [0 ~ 255].
+     * @param[in] b The blue color channel value in the range [0 ~ 255].
+     * @param[in] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque.
+     *
+     * @return Result::Success when succeed, Result::InsufficientCondition otherwise.
+     * 
+     * @note Clearing a buffer is effective only for the current frame.
+     * @note Experimental_API
+     */
+    virtual Result clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept;
+
+    /**
      * @brief Clear the internal canvas resources that used for the drawing.
      *
      * This API sets the total number of paints pushed into the canvas to zero.

--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -106,16 +106,25 @@ GlComposeTask::~GlComposeTask()
     mTasks.clear();
 }
 
+void GlComposeTask::clear(GLfloat clearColor[4]) {
+    mClearColor[0] = clearColor[0];
+    mClearColor[1] = clearColor[1];
+    mClearColor[2] = clearColor[2];
+    mClearColor[3] = clearColor[3];
+    mClear = true;
+}
+
 void GlComposeTask::run()
 {
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getSelfFbo()));
 
     // clear this fbo
     GLenum color_buffer = GL_COLOR_ATTACHMENT0;
-    const float transparent[] = {0.f, 0.f, 0.f, 0.f};
-
     GL_CHECK(glDrawBuffers(1, &color_buffer));
-    GL_CHECK(glClearBufferfv(GL_COLOR, 0, transparent));
+    if (mClear) {
+        GL_CHECK(glClearBufferfv(GL_COLOR, 0, mClearColor));
+        mClear = false;
+    }
 
     for(uint32_t i = 0; i < mTasks.count; i++) {
         mTasks[i]->run();

--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -103,12 +103,15 @@ public:
 
     void run() override;
 
+    void clear(GLfloat clearColor[4]);
 protected:
     GLuint getTargetFbo() { return mTargetFbo; }
 
     GLuint getSelfFbo() { return mSelfFbo; }
 
 private:
+    GLfloat mClearColor[4]{};
+    GLboolean mClear{};
     GLuint mTargetFbo;
     GLuint mSelfFbo;
     Array<GlRenderTask*> mTasks;

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -47,13 +47,13 @@ static void _termEngine()
 
 #define NOISE_LEVEL 0.5f
 
-bool GlRenderer::clear()
-{
-    //TODO: (Request) to clear target
-    // Will be adding glClearColor for input buffer
+bool GlRenderer::clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+    mClearColor[0] = r / 255.0f;
+    mClearColor[1] = b / 255.0f;
+    mClearColor[2] = b / 255.0f;
+    mClearColor[3] = a / 255.0f;
     return true;
-}
-
+};
 
 bool GlRenderer::target(TVG_UNUSED uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h)
 {
@@ -94,9 +94,8 @@ bool GlRenderer::sync()
     assert(mRenderPassStack.size() == 1);
 
     auto task = mRenderPassStack.front().endRenderPass<GlBlitTask>(nullptr, mTargetFboId);
-
     task->setSize(surface.w, surface.h);
-
+    task->clear(mClearColor);
     task->run();
 
     mGpuBuffer->unbind();

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -60,7 +60,7 @@ public:
 
     bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h);
     bool sync() override;
-    bool clear() override;
+    bool clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a) override;
 
     Compositor* target(const RenderRegion& region, ColorSpace cs) override;
     bool beginComposite(Compositor* cmp, CompositeMethod method, uint8_t opacity) override;
@@ -84,6 +84,7 @@ private:
     void prepareCmpTask(GlRenderTask* task);
     void endRenderPass(Compositor* cmp);
 
+    GLfloat mClearColor[4]{};
     GLint mTargetFboId = 0;
     RenderRegion mViewport;
     std::unique_ptr<GlStageBuffer> mGpuBuffer;

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -560,7 +560,7 @@ bool rasterShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8
 bool rasterImage(SwSurface* surface, SwImage* image, const RenderMesh* mesh, const Matrix* transform, const SwBBox& bbox, uint8_t opacity);
 bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id);
-bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
+bool rasterClear(SwSurface* surface, uint32_t val, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
 void rasterPixel32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len);
 void rasterGrayscale8(uint8_t *dst, uint8_t val, uint32_t offset, int32_t len);
 void rasterUnpremultiply(Surface* surface);

--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -1792,7 +1792,7 @@ bool rasterCompositor(SwSurface* surface)
 }
 
 
-bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_t h)
+bool rasterClear(SwSurface* surface, uint32_t val, uint32_t x, uint32_t y, uint32_t w, uint32_t h)
 {
     if (!surface || !surface->buf32 || surface->stride == 0 || surface->w == 0 || surface->h == 0) return false;
 
@@ -1800,11 +1800,11 @@ bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_
     if (surface->channelSize == sizeof(uint32_t)) {
         //full clear
         if (w == surface->stride) {
-            rasterPixel32(surface->buf32, 0x00000000, surface->stride * y, w * h);
+            rasterPixel32(surface->buf32, val, surface->stride * y, w * h);
         //partial clear
         } else {
             for (uint32_t i = 0; i < h; i++) {
-                rasterPixel32(surface->buf32, 0x00000000, (surface->stride * y + x) + (surface->stride * i), w);
+                rasterPixel32(surface->buf32, val, (surface->stride * y + x) + (surface->stride * i), w);
             }
         }
     //8 bits

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -374,13 +374,11 @@ SwRenderer::~SwRenderer()
     if (rendererCnt == 0 && initEngineCnt == 0) _termEngine();
 }
 
-
-bool SwRenderer::clear()
+bool SwRenderer::clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
-    if (surface) return rasterClear(surface, 0, 0, surface->w, surface->h);
-    return false;
+    if (surface) return rasterClear(surface, surface->join(r, g, b, a), 0, 0, surface->w, surface->h);
+    return true;
 }
-
 
 bool SwRenderer::sync()
 {
@@ -668,7 +666,7 @@ Compositor* SwRenderer::target(const RenderRegion& region, ColorSpace cs)
     cmp->w = cmp->compositor->image.w;
     cmp->h = cmp->compositor->image.h;
 
-    rasterClear(cmp, x, y, w, h);
+    rasterClear(cmp, 0x00, x, y, w, h);
 
     //Switch render target
     surface = cmp;

--- a/src/renderer/sw_engine/tvgSwRenderer.h
+++ b/src/renderer/sw_engine/tvgSwRenderer.h
@@ -50,7 +50,7 @@ public:
     bool blend(BlendMethod method) override;
     ColorSpace colorSpace() override;
 
-    bool clear() override;
+    bool clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a) override;
     bool sync() override;
     bool target(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs);
     bool mempool(bool shared);

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -49,6 +49,12 @@ Result Canvas::push(unique_ptr<Paint> paint) noexcept
 }
 
 
+Result Canvas::clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept
+{
+    return pImpl->clear(r, g, b, a);
+}
+
+
 Result Canvas::clear(bool free) noexcept
 {
     return pImpl->clear(free);

--- a/src/renderer/tvgCanvas.h
+++ b/src/renderer/tvgCanvas.h
@@ -76,11 +76,16 @@ struct Canvas::Impl
         return update(p, true);
     }
 
-    Result clear(bool free)
+    Result clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
     {
         //Clear render target
-        if (!renderer || !renderer->clear()) return Result::InsufficientCondition;
+        if (!renderer || !renderer->clear(r, g, b, a)) return Result::InsufficientCondition;
 
+        return Result::Success;
+    }
+
+    Result clear(bool free)
+    {
         clearPaints(free);
 
         return Result::Success;

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -260,7 +260,7 @@ public:
     virtual bool blend(BlendMethod method) = 0;
     virtual ColorSpace colorSpace() = 0;
 
-    virtual bool clear() = 0;
+    virtual bool clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a) = 0;
     virtual bool sync() = 0;
 
     virtual Compositor* target(const RenderRegion& region, ColorSpace cs) = 0;

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -221,6 +221,15 @@ ColorSpace WgRenderer::colorSpace() {
     return ColorSpace::Unsupported;
 }
 
+bool WgRenderer::clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+    mClearColor.r = r / 255.0;
+    mClearColor.g = g / 255.0;
+    mClearColor.b = b / 255.0;
+    mClearColor.a = a / 255.0;
+    mClear = true;
+    return true;
+};
+
 bool WgRenderer::clear() {
     return true;
 }
@@ -254,9 +263,9 @@ bool WgRenderer::sync() {
             WGPURenderPassColorAttachment colorAttachment{};
             colorAttachment.view = backBufferView;
             colorAttachment.resolveTarget = nullptr;
-            colorAttachment.loadOp = WGPULoadOp_Clear;
+            colorAttachment.loadOp = mClear ? WGPULoadOp_Clear : WGPULoadOp_Load;
             colorAttachment.storeOp = WGPUStoreOp_Store;
-            colorAttachment.clearValue = { 0.0f, 0.0f, 0.0f, 1.0 };
+            colorAttachment.clearValue = mClearColor;
             // render pass descriptor
             WGPURenderPassDescriptor renderPassDesc{};
             renderPassDesc.nextInChain = nullptr;
@@ -320,6 +329,7 @@ bool WgRenderer::sync() {
     // go to the next frame
     wgpuSwapChainPresent(mSwapChain);
 
+    mClear = false;
     mRenderDatas.clear();
     return true;
 }

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -50,6 +50,7 @@ public:
     bool blend(BlendMethod method);
     ColorSpace colorSpace();
 
+    bool clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a) override;
     bool clear();
     bool sync();
 
@@ -77,6 +78,8 @@ private:
     WGPUSwapChain mSwapChain{};
     WGPUTexture mStencilTex{};
     WGPUTextureView mStencilTexView{};
+    WGPUColor mClearColor{};
+    bool mClear = false;
 private:
     WgPipelineEmpty mPipelineEmpty;
     WgPipelineStroke mPipelineStroke;

--- a/test/capi/capiSwCanvas.cpp
+++ b/test/capi/capiSwCanvas.cpp
@@ -129,7 +129,7 @@ TEST_CASE("Canvas update, clear and reuse", "[capiSwCanvas]")
     REQUIRE(tvg_canvas_update_paint(canvas, paint) == TVG_RESULT_SUCCESS);
 
     //negative
-    REQUIRE(tvg_canvas_clear(canvas, false) == TVG_RESULT_INSUFFICIENT_CONDITION);
+    REQUIRE(tvg_canvas_clear(canvas, false) == TVG_RESULT_SUCCESS);
 
     uint32_t buffer[25];
     REQUIRE(tvg_swcanvas_set_target(canvas, buffer, 5, 5, 5, TVG_COLORSPACE_ARGB8888) == TVG_RESULT_SUCCESS);

--- a/test/testSwCanvasBase.cpp
+++ b/test/testSwCanvasBase.cpp
@@ -93,14 +93,14 @@ TEST_CASE("Clear", "[tvgSwCanvasBase]")
     auto canvas2 = SwCanvas::gen();
     REQUIRE(canvas2);
 
-    //Try 0: Negative
-    REQUIRE(canvas->clear() == Result::InsufficientCondition);
-    REQUIRE(canvas->clear(false) == Result::InsufficientCondition);
-    REQUIRE(canvas->clear() == Result::InsufficientCondition);
+    //Try 0: Clear
+    REQUIRE(canvas->clear() == Result::Success);
+    REQUIRE(canvas->clear(false) == Result::Success);
+    REQUIRE(canvas->clear() == Result::Success);
 
-    REQUIRE(canvas2->clear(false) == Result::InsufficientCondition);
-    REQUIRE(canvas2->clear() == Result::InsufficientCondition);
-    REQUIRE(canvas2->clear(false) == Result::InsufficientCondition);
+    REQUIRE(canvas2->clear(false) == Result::Success);
+    REQUIRE(canvas2->clear() == Result::Success);
+    REQUIRE(canvas2->clear(false) == Result::Success);
 
     uint32_t buffer[100*100];
     REQUIRE(canvas->target(buffer, 100, 100, 100, SwCanvas::Colorspace::ARGB8888) == Result::Success);


### PR DESCRIPTION
[issues 1779: Revise the Canvas::clear() API](https://github.com/thorvg/thorvg/issues/1779)

new api function was added

    /**
     * @brief Clear the target buffer that used for the drawing.
     *
     * @param[in] r The red color channel value in the range [0 ~ 255]. The default value is 0.
     * @param[in] g The green color channel value in the range [0 ~ 255]. The default value is 0.
     * @param[in] b The blue color channel value in the range [0 ~ 255]. The default value is 0.
     * @param[in] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque. The default value is 0.
     *
     * @return Result::Success when succeed, Result::InsufficientCondition otherwise.
     */
    virtual Result clear(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept;