### PR TITLE
examples: fixed manual loading of binary data (jpg, png, raw ect)

### DIFF
--- a/src/examples/Blending.cpp
+++ b/src/examples/Blending.cpp
@@ -124,7 +124,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Prepare Transformed Image
     string path(EXAMPLE_DIR"/rawimage_200x300.raw");
 
-    ifstream file(path);
+    ifstream file(path, ios::binary);
     if (!file.is_open()) return ;
     auto data = (uint32_t*)malloc(sizeof(uint32_t) * (200*300));
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);

--- a/src/examples/Duplicate.cpp
+++ b/src/examples/Duplicate.cpp
@@ -116,7 +116,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Duplicate Picture - raw
     {
         string path(EXAMPLE_DIR"/rawimage_200x300.raw");
-        ifstream file(path);
+        ifstream file(path, ios::binary);
         if (!file.is_open()) return ;
         uint32_t* data = (uint32_t*)malloc(sizeof(uint32_t) * 200 * 300);
         file.read(reinterpret_cast<char*>(data), sizeof(uint32_t) * 200 * 300);

--- a/src/examples/InvLumaMasking.cpp
+++ b/src/examples/InvLumaMasking.cpp
@@ -90,7 +90,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     if (canvas->push(std::move(star)) != tvg::Result::Success) return;
 
     //Image
-    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw");
+    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw", ios::binary);
     if (!file.is_open()) return;
     auto data = (uint32_t*) malloc(sizeof(uint32_t) * (200 * 300));
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);

--- a/src/examples/InvMasking.cpp
+++ b/src/examples/InvMasking.cpp
@@ -90,7 +90,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     if (canvas->push(std::move(star)) != tvg::Result::Success) return;
 
     //Image
-    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw");
+    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw", ios::binary);
     if (!file.is_open()) return;
     auto data = (uint32_t*) malloc(sizeof(uint32_t) * (200 * 300));
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);

--- a/src/examples/LumaMasking.cpp
+++ b/src/examples/LumaMasking.cpp
@@ -90,7 +90,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     if (canvas->push(std::move(star)) != tvg::Result::Success) return;
 
     //Image
-    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw");
+    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw", ios::binary);
     if (!file.is_open()) return;
     auto data = (uint32_t*) malloc(sizeof(uint32_t) * (200 * 300));
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);

--- a/src/examples/Masking.cpp
+++ b/src/examples/Masking.cpp
@@ -92,7 +92,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     if (canvas->push(std::move(star)) != tvg::Result::Success) return;
 
     //Image
-    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw");
+    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw", ios::binary);
     if (!file.is_open()) return;
     auto data = (uint32_t*) malloc(sizeof(uint32_t) * (200 * 300));
     file.read(reinterpret_cast<char*>(data), sizeof (uint32_t) * 200 * 300);

--- a/src/examples/MaskingMethods.cpp
+++ b/src/examples/MaskingMethods.cpp
@@ -32,7 +32,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     if (!canvas) return;
 
     //Image source
-    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw");
+    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw", ios::binary);
     if (!file.is_open()) return;
     auto data = (uint32_t*) malloc(sizeof(uint32_t) * (200 * 300));
     file.read(reinterpret_cast<char*>(data), sizeof (uint32_t) * 200 * 300);

--- a/src/examples/PictureJpg.cpp
+++ b/src/examples/PictureJpg.cpp
@@ -48,7 +48,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     }
 
     //Open file manually
-    ifstream file(EXAMPLE_DIR"/test.jpg");
+    ifstream file(EXAMPLE_DIR"/test.jpg", ios::binary);
     if (!file.is_open()) return;
     auto begin = file.tellg();
     file.seekg(0, std::ios::end);

--- a/src/examples/PicturePng.cpp
+++ b/src/examples/PicturePng.cpp
@@ -54,7 +54,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     }
 
     //Open file manually
-    ifstream file(EXAMPLE_DIR"/test.png");
+    ifstream file(EXAMPLE_DIR"/test.png", ios::binary);
     if (!file.is_open()) return;
     auto begin = file.tellg();
     file.seekg(0, std::ios::end);

--- a/src/examples/PictureRaw.cpp
+++ b/src/examples/PictureRaw.cpp
@@ -40,7 +40,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     string path(EXAMPLE_DIR"/rawimage_200x300.raw");
 
-    ifstream file(path);
+    ifstream file(path, ios::binary);
     if (!file.is_open()) return ;
     auto data = (uint32_t*)malloc(sizeof(uint32_t) * (200*300));
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);

--- a/src/examples/PictureWebp.cpp
+++ b/src/examples/PictureWebp.cpp
@@ -54,7 +54,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     }
 
     //Open file manually
-    ifstream file(EXAMPLE_DIR"/test.webp");
+    ifstream file(EXAMPLE_DIR"/test.webp", ios::binary);
     if (!file.is_open()) return;
     auto begin = file.tellg();
     file.seekg(0, std::ios::end);

--- a/src/examples/Texmap.cpp
+++ b/src/examples/Texmap.cpp
@@ -41,7 +41,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     //Raw Image
     string path(EXAMPLE_DIR"/rawimage_200x300.raw");
 
-    ifstream file(path);
+    ifstream file(path, ios::binary);
     if (!file.is_open()) return ;
     auto data = (uint32_t*)malloc(sizeof(uint32_t) * (200*300));
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);

--- a/src/examples/TvgSaver.cpp
+++ b/src/examples/TvgSaver.cpp
@@ -193,7 +193,7 @@ void exportTvg()
     //prepare image source
     const int width = 200;
     const int height = 300;
-    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw");
+    ifstream file(EXAMPLE_DIR"/rawimage_200x300.raw", ios::binary);
     if (!file.is_open()) return;
     uint32_t *data = (uint32_t*) malloc(sizeof(uint32_t) * width * height);
     if (!data) return;


### PR DESCRIPTION
Loading of binary data operations must be performed in binary mode rather than text. 
The issue appears on windows platform, especially for PNG loading