### PR TITLE
sw_engine: fixed a bug where strokes were not showing.

### DIFF
--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -139,7 +139,9 @@ struct SwShapeTask : SwTask
             visibleFill = (alpha > 0 || rshape->fill);
             if (visibleFill || clipper) {
                 shapeReset(&shape);
-                if (!shapePrepare(&shape, rshape, transform, clipRegion, bbox, mpool, tid, clips.count > 0 ? true : false)) goto err;
+                if (!shapePrepare(&shape, rshape, transform, clipRegion, bbox, mpool, tid, clips.count > 0 ? true : false)) {
+                    visibleFill = false;
+                }
             }
         }
         //Fill

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -41,6 +41,8 @@ void GifSaver::run(unsigned tid)
     buffer = (uint32_t*)realloc(buffer, sizeof(uint32_t) * w * h);
     canvas->target(buffer, w, w, h, tvg::SwCanvas::ABGR8888S);
     canvas->push(cast(bg));
+    bg = nullptr;
+
     canvas->push(cast(animation->picture()));
 
     //use the default fps
@@ -75,8 +77,6 @@ void GifSaver::run(unsigned tid)
     }
 
     if (!gifEnd(&writer)) TVGERR("GIF_SAVER", "Failed gif encoding");
-
-    this->bg = nullptr;
 }
 
 


### PR DESCRIPTION
Basic shapes were trimmed entirely when they were outside of the canvas, even if they had a big enough stroke to be partially on the canvas.

This fixes the issue.

Issue: https://github.com/thorvg/thorvg/issues/1785