### PR TITLE
lottie/builder: hotfix, invalid stroking scaling.

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -194,7 +194,8 @@ static void _updateTransform(TVG_UNUSED LottieGroup* parent, LottieObject** chil
 
     //FIXME: preserve the stroke width. too workaround, need a better design.
     if (P(ctx.propagator)->rs.strokeWidth() > 0.0f) {
-        ctx.propagator->strokeWidth(P(ctx.propagator)->rs.strokeWidth() / sqrt(matrix.e11 * matrix.e11 + matrix.e12 * matrix.e12));
+        auto denominator = sqrtf(matrix.e11 * matrix.e11 + matrix.e12 * matrix.e12);
+        if (denominator > 1.0f) ctx.propagator->strokeWidth(ctx.propagator->strokeWidth() / denominator);
     }
 }
 


### PR DESCRIPTION
There is a buggy workaround code that rewinds the stroke scaling.

Issue: https://github.com/thorvg/thorvg/issues/1730