### PR TITLE
lottie/loader: Support external image with memory animation

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1236,6 +1236,7 @@ public:
      * @param[in] size The size in bytes of the memory occupied by the @p data.
      * @param[in] mimeType Mimetype or extension of data such as "jpg", "jpeg", "lottie", "svg", "svg+xml", "png", etc. In case an empty string or an unknown type is provided, the loaders will be tried one by one.
      * @param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
+     * @param[in] resourcePath Directory path to load external images.
      *
      * @retval Result::Success When succeed.
      * @retval Result::InvalidArguments In case no data are provided or the @p size is zero or less.
@@ -1247,7 +1248,7 @@ public:
      * @note If you are unsure about the MIME type, you can provide an empty value like @c "", and thorvg will attempt to figure it out.
      * @since 0.5
      */
-    Result load(const char* data, uint32_t size, const std::string& mimeType, bool copy = false) noexcept;
+    Result load(const char* data, uint32_t size, const std::string& mimeType, bool copy = false, const std::string& resourcePath = "") noexcept;
 
     /**
      * @brief Resizes the picture content to the given width and height.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1993,6 +1993,7 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32
 * \param[in] size The size in bytes of the memory occupied by the @p data.
 * \param[in] mimetype Mimetype or extension of data such as "jpg", "jpeg", "svg", "svg+xml", "lottie", "png", etc. In case an empty string or an unknown type is provided, the loaders will be tried one by one.
 * \param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
+* \param[in] resourcePath Directory path to load external images.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_SUCCESS Succeed.
@@ -2002,7 +2003,7 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32
 *
 * \warning: It's the user responsibility to release the @p data memory if the @p copy is @c true.
 */
-TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, bool copy);
+TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, bool copy, const char* resourcePath = "");
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -524,10 +524,10 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32
 }
 
 
-TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, bool copy)
+TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, bool copy, const char* resourcePath)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, size, mimetype ? mimetype : "", copy);
+    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, size, mimetype ? mimetype : "", copy, resourcePath);
 }
 
 

--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -101,7 +101,7 @@ finalize:
 }
 
 
-bool JpgLoader::open(const char* data, uint32_t size, bool copy)
+bool JpgLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
 {
     clear();
 

--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -34,7 +34,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy) override;
+    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -61,7 +61,7 @@ bool PngLoader::open(const string& path)
     return true;
 }
 
-bool PngLoader::open(const char* data, uint32_t size, bool copy)
+bool PngLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
 {
     image->opaque = NULL;
 

--- a/src/loaders/external_png/tvgPngLoader.h
+++ b/src/loaders/external_png/tvgPngLoader.h
@@ -33,7 +33,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy) override;
+    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -97,7 +97,7 @@ finalize:
 }
 
 
-bool WebpLoader::open(const char* data, uint32_t size, bool copy)
+bool WebpLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
 {
     clear();
 

--- a/src/loaders/external_webp/tvgWebpLoader.h
+++ b/src/loaders/external_webp/tvgWebpLoader.h
@@ -33,7 +33,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy) override;
+    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -67,7 +67,7 @@ bool JpgLoader::open(const string& path)
 }
 
 
-bool JpgLoader::open(const char* data, uint32_t size, bool copy)
+bool JpgLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
 {
     clear();
 

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -41,7 +41,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy) override;
+    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -206,7 +206,7 @@ bool LottieLoader::header()
 }
 
 
-bool LottieLoader::open(const char* data, uint32_t size, bool copy)
+bool LottieLoader::open(const char* data, uint32_t size, bool copy, const std::string& resourcePath)
 {
     clear();
 
@@ -225,6 +225,10 @@ bool LottieLoader::open(const char* data, uint32_t size, bool copy)
 
     this->size = size;
     this->copy = copy;
+
+    if (!resourcePath.empty()) {
+        this->dirName = strdup(resourcePath.c_str());
+    }
 
     return header();
 }

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -51,7 +51,7 @@ public:
     //Lottie Loaders
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy) override;
+    bool open(const char* data, uint32_t size, bool copy, const std::string& resourcePath) override;
     bool resize(Paint* paint, float w, float h) override;
     bool read() override;
     bool close() override;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -867,9 +867,9 @@ LottieImage* LottieParser::parseImage(const char* key)
         image->size = b64Decode(b64Data, length, &image->b64Data);
     //external image resource
     } else {
-        auto len = strlen(dirName) + strlen(subPath) + strlen(data) + 1;
+        auto len = strlen(dirName) + strlen(subPath) + strlen(data) + 2;
         image->path = static_cast<char*>(malloc(len));
-        snprintf(image->path, len, "%s%s%s", dirName, subPath, data);
+        snprintf(image->path, len, "%s/%s%s", dirName, subPath, data);
     }
 
     image->prepare();

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -102,7 +102,7 @@ finalize:
 }
 
 
-bool PngLoader::open(const char* data, uint32_t size, bool copy)
+bool PngLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
 {
     clear();
 

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -44,7 +44,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy) override;
+    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3671,7 +3671,7 @@ bool SvgLoader::header()
 }
 
 
-bool SvgLoader::open(const char* data, uint32_t size, bool copy)
+bool SvgLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
 {
     clear();
 

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -44,7 +44,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy) override;
+    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
     bool resize(Paint* paint, float w, float h) override;
     bool read() override;
     bool close() override;

--- a/src/loaders/tvg/tvgTvgLoader.cpp
+++ b/src/loaders/tvg/tvgTvgLoader.cpp
@@ -148,7 +148,7 @@ bool TvgLoader::open(const string &path)
 }
 
 
-bool TvgLoader::open(const char *data, uint32_t size, bool copy)
+bool TvgLoader::open(const char *data, uint32_t size, bool copy,const string& resourcePath)
 {
     clear();
 

--- a/src/loaders/tvg/tvgTvgLoader.h
+++ b/src/loaders/tvg/tvgTvgLoader.h
@@ -46,7 +46,7 @@ public:
 
     using LoadModule::open;
     bool open(const string &path) override;
-    bool open(const char *data, uint32_t size, bool copy) override;
+    bool open(const char *data, uint32_t size, bool copy, const string& resourcePath) override;
     bool read() override;
     bool close() override;
     bool resize(Paint* paint, float w, float h) override;

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -37,7 +37,7 @@ public:
     virtual ~LoadModule() {}
 
     virtual bool open(const string& path) { return false; }
-    virtual bool open(const char* data, uint32_t size, bool copy) { return false; }
+    virtual bool open(const char* data, uint32_t size, bool copy, const string& resourcePath = "") { return false; }
 
     //Override this if the vector-format has own resizing policy.
     virtual bool resize(Paint* paint, float w, float h) { return false; }

--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -212,12 +212,12 @@ shared_ptr<LoadModule> LoaderMgr::loader(const string& path, bool* invalid)
 }
 
 
-shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const string& mimeType, bool copy)
+shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const string& mimeType, bool copy, const string& resourcePath)
 {
     //Try with the given MimeType
     if (!mimeType.empty()) {
         if (auto loader = _findByType(mimeType)) {
-            if (loader->open(data, size, copy)) {
+            if (loader->open(data, size, copy, resourcePath)) {
                 return shared_ptr<LoadModule>(loader);
             } else {
                 TVGLOG("LOADER", "Given mimetype \"%s\" seems incorrect or not supported.", mimeType.c_str());

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -30,7 +30,7 @@ struct LoaderMgr
     static bool init();
     static bool term();
     static shared_ptr<LoadModule> loader(const string& path, bool* invalid);
-    static shared_ptr<LoadModule> loader(const char* data, uint32_t size, const string& mimeType, bool copy);
+    static shared_ptr<LoadModule> loader(const char* data, uint32_t size, const string& mimeType, bool copy, const string& resourcePath);
     static shared_ptr<LoadModule> loader(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy);
 };
 

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -91,11 +91,11 @@ Result Picture::load(const std::string& path) noexcept
 }
 
 
-Result Picture::load(const char* data, uint32_t size, const string& mimeType, bool copy) noexcept
+Result Picture::load(const char* data, uint32_t size, const string& mimeType, bool copy, const string& resourcePath) noexcept
 {
     if (!data || size <= 0) return Result::InvalidArguments;
 
-    return pImpl->load(data, size, mimeType, copy);
+    return pImpl->load(data, size, mimeType, copy, resourcePath);
 }
 
 

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -218,11 +218,11 @@ struct Picture::Impl
         return Result::Success;
     }
 
-    Result load(const char* data, uint32_t size, const string& mimeType, bool copy)
+    Result load(const char* data, uint32_t size, const string& mimeType, bool copy, const string& resourcePath)
     {
         if (paint || surface) return Result::InsufficientCondition;
         if (loader) loader->close();
-        loader = LoaderMgr::loader(data, size, mimeType, copy);
+        loader = LoaderMgr::loader(data, size, mimeType, copy, resourcePath);
         if (!loader) return Result::NonSupport;
         if (!loader->read()) return Result::Unknown;
         w = loader->w;


### PR DESCRIPTION
tvgLottie wasn't able to load external image when loading through memory (not file), added new parameter `resourcePath`(optional, default = `""`).

API:
Result Picture::load(const char* data, uint32_t size, const string& mimeType, bool copy)
-> Result Picture::load(const char* data, uint32_t size, const string& mimeType, bool copy, const string& resourcePath)

New parameter:
- `resourcePath`: absolute directory path where resource directory is included.

Example:
Animation and asset directory are located in `/home/anims` and lottie has assets like
```json
"assets": [
    {
      "id": "image_0",
      "w": 200,
      "h": 300,
      "u": "images/",
      "p": "img_0.png",
      "e": 0
    }
  ]
```
The parameter `resourcePath` should be `/home/anims` then tvgLottieLoader will load external image `/home/anims/images/img_0.png`

Usage:
```cpp
picture->load(data, size, "lottie", true, "/absolute/path/to/dir")
```


Issue: #1793