### PR TITLE
lottie/builder: corrected polystar rotation.

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -622,7 +622,7 @@ static void _updatePolystar(LottieGroup* parent, LottieObject** child, float fra
     mathIdentity(&matrix);
     auto position = star->position(frameNo);
     mathTranslate(&matrix, position.x, position.y);
-    mathRotate(&matrix, star->rotation(frameNo) * 2.0f);
+    mathRotate(&matrix, star->rotation(frameNo));
 
     auto identity = mathIdentity((const Matrix*)&matrix);
 


### PR DESCRIPTION
There was likely a mistake in the rotation value set; there was no reason to multiply it by 2.

Issue: https://github.com/thorvg/thorvg/issues/1773