### PR TITLE
api: updated the recent changed api again.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1236,7 +1236,7 @@ public:
      * @param[in] size The size in bytes of the memory occupied by the @p data.
      * @param[in] mimeType Mimetype or extension of data such as "jpg", "jpeg", "lottie", "svg", "svg+xml", "png", etc. In case an empty string or an unknown type is provided, the loaders will be tried one by one.
      * @param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
-     * @param[in] resourcePath Directory path to load external images.
+     * @param[in] rpath A resource directory path, if the @p data needs to access any external resources.
      *
      * @retval Result::Success When succeed.
      * @retval Result::InvalidArguments In case no data are provided or the @p size is zero or less.
@@ -1248,7 +1248,7 @@ public:
      * @note If you are unsure about the MIME type, you can provide an empty value like @c "", and thorvg will attempt to figure it out.
      * @since 0.5
      */
-    Result load(const char* data, uint32_t size, const std::string& mimeType, bool copy = false, const std::string& resourcePath = "") noexcept;
+    Result load(const char* data, uint32_t size, const std::string& mimeType, const std::string& rpath = "", bool copy = false) noexcept;
 
     /**
      * @brief Resizes the picture content to the given width and height.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1993,7 +1993,7 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32
 * \param[in] size The size in bytes of the memory occupied by the @p data.
 * \param[in] mimetype Mimetype or extension of data such as "jpg", "jpeg", "svg", "svg+xml", "lottie", "png", etc. In case an empty string or an unknown type is provided, the loaders will be tried one by one.
 * \param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
-* \param[in] resourcePath Directory path to load external images.
+* \param[in] rpath A resource directory path, if the @p data needs to access any external resources.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_SUCCESS Succeed.
@@ -2003,7 +2003,7 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32
 *
 * \warning: It's the user responsibility to release the @p data memory if the @p copy is @c true.
 */
-TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, bool copy, const char* resourcePath = "");
+TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, const char* rpath, bool copy);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -524,10 +524,10 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32
 }
 
 
-TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, bool copy, const char* resourcePath)
+TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, const char* rpath, bool copy)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, size, mimetype ? mimetype : "", copy, resourcePath);
+    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, size, mimetype ? mimetype : "", rpath ? rpath : "", copy);
 }
 
 

--- a/src/examples/DataLoad.cpp
+++ b/src/examples/DataLoad.cpp
@@ -41,7 +41,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     if (canvas->push(std::move(shape)) != tvg::Result::Success) return;
 
     auto picture = tvg::Picture::gen();
-    if (picture->load(svg, strlen(svg), "svg", false) != tvg::Result::Success) return;
+    if (picture->load(svg, strlen(svg), "svg") != tvg::Result::Success) return;
 
     picture->size(WIDTH, HEIGHT);
 

--- a/src/examples/PictureJpg.cpp
+++ b/src/examples/PictureJpg.cpp
@@ -60,7 +60,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     file.close();
 
     auto picture = tvg::Picture::gen();
-    if (picture->load(data, size, "jpg", true) != tvg::Result::Success) {
+    if (picture->load(data, size, "jpg", "", true) != tvg::Result::Success) {
         cout << "Couldn't load JPG file from data." << endl;
         return;
     }

--- a/src/examples/PicturePng.cpp
+++ b/src/examples/PicturePng.cpp
@@ -66,7 +66,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     file.close();
 
     auto picture = tvg::Picture::gen();
-    if (picture->load(data, size, "png", true) != tvg::Result::Success) {
+    if (picture->load(data, size, "png", "", true) != tvg::Result::Success) {
         cout << "Couldn't load PNG file from data." << endl;
         return;
     }

--- a/src/examples/PictureWebp.cpp
+++ b/src/examples/PictureWebp.cpp
@@ -66,7 +66,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     file.close();
 
     auto picture = tvg::Picture::gen();
-    if (picture->load(data, size, "webp", true) != tvg::Result::Success) {
+    if (picture->load(data, size, "webp", "", true) != tvg::Result::Success) {
         cout << "Couldn't load WEBP file from data." << endl;
         return;
     }

--- a/src/examples/StrokeMiterlimit.cpp
+++ b/src/examples/StrokeMiterlimit.cpp
@@ -143,7 +143,7 @@ void svg(tvg::Canvas* canvas)
     std::size_t svg_text_size = svg_text.size();
     std::unique_ptr<tvg::Picture> picture = tvg::Picture::gen();
 
-    if (picture->load(svg_text.data(), svg_text_size, "svg", true) != tvg::Result::Success) {
+    if (picture->load(svg_text.data(), svg_text_size, "svg", "", true) != tvg::Result::Success) {
         cout << "Couldn't load svg text data." << endl;
         return;
     }

--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -100,7 +100,7 @@ finalize:
 }
 
 
-bool JpgLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
+bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const string& rpath, bool copy)
 {
     clear();
 

--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -36,7 +36,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
+    bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -60,7 +60,7 @@ bool PngLoader::open(const string& path)
     return true;
 }
 
-bool PngLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
+bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const string& rpath, bool copy)
 {
     image->opaque = NULL;
 

--- a/src/loaders/external_png/tvgPngLoader.h
+++ b/src/loaders/external_png/tvgPngLoader.h
@@ -34,7 +34,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
+    bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -107,7 +107,7 @@ finalize:
 }
 
 
-bool WebpLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
+bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const string& rpath, bool copy)
 {
     clear();
 

--- a/src/loaders/external_webp/tvgWebpLoader.h
+++ b/src/loaders/external_webp/tvgWebpLoader.h
@@ -34,7 +34,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
+    bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -76,7 +76,7 @@ bool JpgLoader::open(const string& path)
 }
 
 
-bool JpgLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
+bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const string& rpath, bool copy)
 {
     clear();
 

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -43,7 +43,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
+    bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -655,7 +655,7 @@ static void _updateImage(LottieGroup* parent, LottieObject** child, float frameN
         TaskScheduler::async(false);
 
         if (image->size > 0) {
-            if (picture->load((const char*)image->b64Data, image->size, image->mimeType, false) != Result::Success) {
+            if (picture->load((const char*)image->b64Data, image->size, image->mimeType) != Result::Success) {
                 delete(picture);
                 return;
             }

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -206,7 +206,7 @@ bool LottieLoader::header()
 }
 
 
-bool LottieLoader::open(const char* data, uint32_t size, bool copy, const std::string& resourcePath)
+bool LottieLoader::open(const char* data, uint32_t size, const std::string& rpath, bool copy)
 {
     clear();
 
@@ -226,8 +226,8 @@ bool LottieLoader::open(const char* data, uint32_t size, bool copy, const std::s
     this->size = size;
     this->copy = copy;
 
-    if (!resourcePath.empty()) {
-        this->dirName = strdup(resourcePath.c_str());
+    if (!rpath.empty()) {
+        this->dirName = strdup(rpath.c_str());
     }
 
     return header();

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -51,7 +51,7 @@ public:
     //Lottie Loaders
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy, const std::string& resourcePath) override;
+    bool open(const char* data, uint32_t size, const std::string& rpath, bool copy) override;
     bool resize(Paint* paint, float w, float h) override;
     bool read() override;
     bool close() override;

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -117,7 +117,7 @@ finalize:
 }
 
 
-bool PngLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
+bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const string& rpath, bool copy)
 {
     clear();
 

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -45,7 +45,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
+    bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3671,7 +3671,7 @@ bool SvgLoader::header()
 }
 
 
-bool SvgLoader::open(const char* data, uint32_t size, bool copy, const string& resourcePath)
+bool SvgLoader::open(const char* data, uint32_t size, TVG_UNUSED const string& rpath, bool copy)
 {
     clear();
 

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -44,7 +44,7 @@ public:
 
     using LoadModule::open;
     bool open(const string& path) override;
-    bool open(const char* data, uint32_t size, bool copy, const string& resourcePath) override;
+    bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool resize(Paint* paint, float w, float h) override;
     bool read() override;
     bool close() override;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -572,14 +572,14 @@ static unique_ptr<Picture> _imageBuildHelper(SvgLoaderData& loaderData, SvgNode*
         char *decoded = nullptr;
         if (encoding == imageMimeTypeEncoding::base64) {
             auto size = b64Decode(href, strlen(href), &decoded);
-            if (picture->load(decoded, size, mimetype, false) != Result::Success) {
+            if (picture->load(decoded, size, mimetype) != Result::Success) {
                 free(decoded);
                 TaskScheduler::async(true);
                 return nullptr;
             }
         } else {
             auto size = svgUtilURLDecode(href, &decoded);
-            if (picture->load(decoded, size, mimetype, false) != Result::Success) {
+            if (picture->load(decoded, size, mimetype) != Result::Success) {
                 free(decoded);
                 TaskScheduler::async(true);
                 return nullptr;

--- a/src/loaders/tvg/tvgTvgLoader.cpp
+++ b/src/loaders/tvg/tvgTvgLoader.cpp
@@ -148,7 +148,7 @@ bool TvgLoader::open(const string &path)
 }
 
 
-bool TvgLoader::open(const char *data, uint32_t size, bool copy,const string& resourcePath)
+bool TvgLoader::open(const char *data, uint32_t size, TVG_UNUSED const string& rpath, bool copy)
 {
     clear();
 

--- a/src/loaders/tvg/tvgTvgLoader.h
+++ b/src/loaders/tvg/tvgTvgLoader.h
@@ -46,7 +46,7 @@ public:
 
     using LoadModule::open;
     bool open(const string &path) override;
-    bool open(const char *data, uint32_t size, bool copy, const string& resourcePath) override;
+    bool open(const char *data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
     bool close() override;
     bool resize(Paint* paint, float w, float h) override;

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -37,7 +37,7 @@ public:
     virtual ~LoadModule() {}
 
     virtual bool open(const string& path) { return false; }
-    virtual bool open(const char* data, uint32_t size, bool copy, const string& resourcePath = "") { return false; }
+    virtual bool open(const char* data, uint32_t size, const string& rpath, bool copy) { return false; }
 
     //Override this if the vector-format has own resizing policy.
     virtual bool resize(Paint* paint, float w, float h) { return false; }

--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -212,12 +212,12 @@ shared_ptr<LoadModule> LoaderMgr::loader(const string& path, bool* invalid)
 }
 
 
-shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const string& mimeType, bool copy, const string& resourcePath)
+shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const string& mimeType, const string& rpath, bool copy)
 {
     //Try with the given MimeType
     if (!mimeType.empty()) {
         if (auto loader = _findByType(mimeType)) {
-            if (loader->open(data, size, copy, resourcePath)) {
+            if (loader->open(data, size, rpath, copy)) {
                 return shared_ptr<LoadModule>(loader);
             } else {
                 TVGLOG("LOADER", "Given mimetype \"%s\" seems incorrect or not supported.", mimeType.c_str());
@@ -229,7 +229,7 @@ shared_ptr<LoadModule> LoaderMgr::loader(const char* data, uint32_t size, const 
         for (int i = 0; i < static_cast<int>(FileType::Unknown); i++) {
             auto loader = _find(static_cast<FileType>(i));
             if (loader) {
-                if (loader->open(data, size, copy)) return shared_ptr<LoadModule>(loader);
+                if (loader->open(data, size, rpath, copy)) return shared_ptr<LoadModule>(loader);
                 else delete(loader);
             }
         }

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -30,7 +30,7 @@ struct LoaderMgr
     static bool init();
     static bool term();
     static shared_ptr<LoadModule> loader(const string& path, bool* invalid);
-    static shared_ptr<LoadModule> loader(const char* data, uint32_t size, const string& mimeType, bool copy, const string& resourcePath);
+    static shared_ptr<LoadModule> loader(const char* data, uint32_t size, const string& mimeType, const string& rpath, bool copy);
     static shared_ptr<LoadModule> loader(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy);
 };
 

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -156,11 +156,11 @@ Result Picture::load(const std::string& path) noexcept
 }
 
 
-Result Picture::load(const char* data, uint32_t size, const string& mimeType, bool copy, const string& resourcePath) noexcept
+Result Picture::load(const char* data, uint32_t size, const string& mimeType, const string& rpath, bool copy) noexcept
 {
     if (!data || size <= 0) return Result::InvalidArguments;
 
-    return pImpl->load(data, size, mimeType, copy, resourcePath);
+    return pImpl->load(data, size, mimeType, rpath, copy);
 }
 
 

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -162,11 +162,11 @@ struct Picture::Impl
         return Result::Success;
     }
 
-    Result load(const char* data, uint32_t size, const string& mimeType, bool copy, const string& resourcePath)
+    Result load(const char* data, uint32_t size, const string& mimeType, const string& rpath, bool copy)
     {
         if (paint || surface) return Result::InsufficientCondition;
         if (loader) loader->close();
-        loader = LoaderMgr::loader(data, size, mimeType, copy, resourcePath);
+        loader = LoaderMgr::loader(data, size, mimeType, rpath, copy);
         if (!loader) return Result::NonSupport;
         if (!loader->read()) return Result::Unknown;
         w = loader->w;

--- a/test/capi/capiPicture.cpp
+++ b/test/capi/capiPicture.cpp
@@ -105,12 +105,12 @@ TEST_CASE("Load Svg Data in Picture", "[capiPicture]")
     REQUIRE(picture);
 
     //Negative
-    REQUIRE(tvg_picture_load_data(nullptr, svg, strlen(svg), nullptr, true) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_picture_load_data(picture, nullptr, strlen(svg), "", true) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_picture_load_data(picture, svg, 0, "", true) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_picture_load_data(nullptr, svg, strlen(svg), nullptr, nullptr, true) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_picture_load_data(picture, nullptr, strlen(svg), nullptr, nullptr, true) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_picture_load_data(picture, svg, 0, nullptr, nullptr, true) == TVG_RESULT_INVALID_ARGUMENT);
 
     //Positive
-    REQUIRE(tvg_picture_load_data(picture, svg, strlen(svg), "svg", false) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_picture_load_data(picture, svg, strlen(svg), "svg", nullptr, false) == TVG_RESULT_SUCCESS);
 
     //Verify Size
     float w, h;

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -252,11 +252,11 @@ TEST_CASE("Load SVG Data", "[tvgPicture]")
     REQUIRE(picture);
 
     //Negative cases
-    REQUIRE(picture->load(nullptr, 100, "", false) == Result::InvalidArguments);
-    REQUIRE(picture->load(svg, 0, "", false) == Result::InvalidArguments);
+    REQUIRE(picture->load(nullptr, 100, "") == Result::InvalidArguments);
+    REQUIRE(picture->load(svg, 0, "") == Result::InvalidArguments);
 
     //Positive cases
-    REQUIRE(picture->load(svg, strlen(svg), "svg", false) == Result::Success);
+    REQUIRE(picture->load(svg, strlen(svg), "svg") == Result::Success);
 
     float w, h;
     REQUIRE(picture->size(&w, &h) == Result::Success);
@@ -325,8 +325,8 @@ TEST_CASE("Load PNG file from data", "[tvgPicture]")
     file.read(data, size);
     file.close();
 
-    REQUIRE(picture->load(data, size, "", false) == Result::Success);
-    REQUIRE(picture->load(data, size, "png", true) == Result::Success);
+    REQUIRE(picture->load(data, size, "") == Result::Success);
+    REQUIRE(picture->load(data, size, "png", "", true) == Result::Success);
 
     float w, h;
     REQUIRE(picture->size(&w, &h) == Result::Success);
@@ -395,8 +395,8 @@ TEST_CASE("Load JPG file from data", "[tvgPicture]")
     file.read(data, size);
     file.close();
 
-    REQUIRE(picture->load(data, size, "", false) == Result::Success);
-    REQUIRE(picture->load(data, size, "jpg", true) == Result::Success);
+    REQUIRE(picture->load(data, size, "") == Result::Success);
+    REQUIRE(picture->load(data, size, "jpg", "", true) == Result::Success);
 
     float w, h;
     REQUIRE(picture->size(&w, &h) == Result::Success);
@@ -463,8 +463,8 @@ TEST_CASE("Load TVG file from data", "[tvgPicture]")
     file.read(data, size);
     file.close();
 
-    REQUIRE(picture->load(data, size, "", false) == Result::Success);
-    REQUIRE(picture->load(data, size, "tvg", true) == Result::Success);
+    REQUIRE(picture->load(data, size, "") == Result::Success);
+    REQUIRE(picture->load(data, size, "tvg", "", true) == Result::Success);
 
     float w, h;
     REQUIRE(picture->size(&w, &h) == Result::Success);
@@ -535,8 +535,8 @@ TEST_CASE("Load WEBP file from data", "[tvgPicture]")
     file.read(data, size);
     file.close();
 
-    REQUIRE(picture->load(data, size, "", false) == Result::Success);
-    REQUIRE(picture->load(data, size, "webp", true) == Result::Success);
+    REQUIRE(picture->load(data, size, "") == Result::Success);
+    REQUIRE(picture->load(data, size, "webp", "", true) == Result::Success);
 
     float w, h;
     REQUIRE(picture->size(&w, &h) == Result::Success);


### PR DESCRIPTION
Reordered by the data packing size.
Also removed a wrong capi default parameter value.

Result Picture::load(const char* data, uint32_t size, const std::string& mimeType, bool copy = false, const std::string& rpath = "") -> Result load(const char* data, uint32_t size, const std::string& mimeType, const std::string& rpath = "", bool copy = false)

Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, bool copy, const char* resourcePath) -> Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, const char* resourcePath, bool copy);