### PR TITLE
lottie/builder: revert the clipper cache.

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -817,12 +817,8 @@ static void _updatePrecomp(LottieLayer* precomp, float frameNo)
 
     //clip the layer viewport
     if (precomp->w > 0 && precomp->h > 0) {
-        if (!precomp->cache.clipper) {
-            precomp->cache.clipper = Shape::gen().release();
-            PP(precomp->cache.clipper)->ref();
-            precomp->cache.clipper->appendRect(0, 0, static_cast<float>(precomp->w), static_cast<float>(precomp->h));
-        }
-        auto clipper = precomp->cache.clipper;
+        auto clipper = Shape::gen().release();
+        clipper->appendRect(0, 0, static_cast<float>(precomp->w), static_cast<float>(precomp->h));
         clipper->transform(precomp->cache.matrix);
 
         //TODO: remove the intermediate scene....

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -156,8 +156,6 @@ LottieLayer::~LottieLayer()
 
     delete(matte.target);
     delete(transform);
-
-    if (cache.clipper && PP(cache.clipper)->unref() == 0) delete(cache.clipper);
 }
 
 void LottieLayer::prepare()

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -524,9 +524,6 @@ struct LottieLayer : LottieGroup
         float frameNo = -1.0f;
         Matrix matrix;
         uint8_t opacity;
-
-        //tvg render data
-        tvg::Shape* clipper = nullptr; 
     } cache;
 
     Type type = Null;


### PR DESCRIPTION
This ia a buggy,
We will revisit this optimization with a perfect solution.