### PR TITLE
jpg/tvgJpgd: fix warning

### DIFF
--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -1457,6 +1457,7 @@ void jpeg_decoder::locate_sof_marker()
 
     switch (c) {
         case M_SOF2: m_progressive_flag = true;
+            /* fallthrough */
         case M_SOF0:  /* baseline DCT */
         case M_SOF1: { /* extended sequential DCT */
           read_sof_marker();


### PR DESCRIPTION
fix fallthrough warning:
```
thorvg/src/loaders/jpg/tvgJpgd.cpp: In member function ‘void jpeg_decoder::locate_sof_marker()’:
thorvg/src/loaders/jpg/tvgJpgd.cpp:1460:32: warning: this statement may fall through [-Wimplicit-fallthrough=]
 1460 |             m_progressive_flag = true;
      |             ~~~~~~~~~~~~~~~~~~~^~~~~~
thorvg/src/loaders/jpg/tvgJpgd.cpp:1461:9: note: here
 1461 |         case M_SOF0:  /* baseline DCT */
      |         ^~~~
```

Reference from: https://stackoverflow.com/questions/45129741/gcc-7-wimplicit-fallthrough-warnings-and-portable-way-to-clear-them