### PR TITLE
lottie/builder: fix crash by null reference

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -912,7 +912,9 @@ void LottieParser::parseAssets()
 {
     enterArray();
     while (nextArrayValue()) {
-        comp->assets.push(parseAsset());
+        auto asset = parseAsset();
+        if (asset) comp->assets.push(asset);
+        else TVGERR("LOTTIE", "Invalid Asset!");
     }
 }
 


### PR DESCRIPTION
Found crash point:

`tvgLottieBuilder.cpp` line: 957
```cpp
if (strcmp(layer->refId, (*asset)->name)) continue;
```
LottieObject* `*asset` references NULL in some case, and added condition to check whether asset is null.
```cpp
if (*asset == nullptr || strcmp(layer->refId, (*asset)->name)) continue;
```


Crashed file here, and now works well with this patch:

> [1313.json](https://github.com/thorvg/thorvg/files/13594350/1313.json)
> [1577.json](https://github.com/thorvg/thorvg/files/13594351/1577.json)
> [2121.json](https://github.com/thorvg/thorvg/files/13594352/2121.json)
> [2472.json](https://github.com/thorvg/thorvg/files/13594356/2472.json)
> [7924.json](https://github.com/thorvg/thorvg/files/13594358/7924.json)
> [8906.json](https://github.com/thorvg/thorvg/files/13594359/8906.json)
> [11835.json](https://github.com/thorvg/thorvg/files/13594361/11835.json)
> [12206.json](https://github.com/thorvg/thorvg/files/13594363/12206.json)
> [13242.json](https://github.com/thorvg/thorvg/files/13594365/13242.json)
> [16432.json](https://github.com/thorvg/thorvg/files/13594366/16432.json)
> [16620.json](https://github.com/thorvg/thorvg/files/13594369/16620.json)
> [16717.json](https://github.com/thorvg/thorvg/files/13594370/16717.json)
> [16719.json](https://github.com/thorvg/thorvg/files/13594371/16719.json)
> [16852.json](https://github.com/thorvg/thorvg/files/13594373/16852.json)
> [16853.json](https://github.com/thorvg/thorvg/files/13594374/16853.json)
> [16854.json](https://github.com/thorvg/thorvg/files/13594376/16854.json)
> [16856.json](https://github.com/thorvg/thorvg/files/13594378/16856.json)

