### PR TITLE
renderer/shape: Apply the magic number kappa to achieve rounded corners.

### DIFF
--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -219,8 +219,8 @@ Result Shape::appendRect(float x, float y, float w, float h, float rx, float ry)
     } else if (mathEqual(rx, halfW) && mathEqual(ry, halfH)) {
         return appendCircle(x + (w * 0.5f), y + (h * 0.5f), rx, ry);
     } else {
-        auto hrx = rx * 0.5f;
-        auto hry = ry * 0.5f;
+        auto hrx = rx * PATH_KAPPA;
+        auto hry = ry * PATH_KAPPA;
         pImpl->grow(10, 17);
         pImpl->moveTo(x + rx, y);
         pImpl->lineTo(x + w - rx, y);


### PR DESCRIPTION
The magic number kappa (0.552284), which is associated with the bezier curve, has been introduced. This formula is supposed to be applied to the rounded corners of the rectangle to ensure consistent drawing results.

Issue: https://github.com/thorvg/thorvg/issues/1824