### PR TITLE
gl_engine: optimize framebuffer creation and save some runtime memory

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -106,7 +106,6 @@ bool GlRenderer::sync()
     GL_CHECK(glDisable(GL_SCISSOR_TEST));
 
     mRenderPassStack.clear();
-    mPoolIndex = 0;
     mClearBuffer = false;
 
     delete task;
@@ -154,17 +153,19 @@ bool GlRenderer::beginComposite(Compositor* cmp, CompositeMethod method, uint8_t
     cmp->method = method;
     cmp->opacity = opacity;
 
-    if (mPoolIndex >= mComposePool.size()) {
-        mComposePool.emplace_back(make_unique<GlRenderTarget>(surface.w, surface.h));
-        mComposePool.back()->init(mTargetFboId);
+    uint32_t index = mRenderPassStack.size() - 1;
+
+    if (index >= mComposePool.count) {
+        mComposePool.push( new GlRenderTarget(surface.w, surface.h));
+        mComposePool[index]->init(mTargetFboId);
     }
-    mRenderPassStack.emplace_back(GlRenderPass(mComposePool[mPoolIndex++].get()));
+    mRenderPassStack.emplace_back(GlRenderPass(mComposePool[index]));
 
     return true;
 }
 
 
-bool GlRenderer::endComposite(TVG_UNUSED Compositor* cmp)
+bool GlRenderer::endComposite(Compositor* cmp)
 {
     if (mComposeStack.empty()) return false;
     if (mComposeStack.back().get() != cmp) return false;
@@ -441,12 +442,16 @@ GlRenderer* GlRenderer::gen()
     return new GlRenderer();
 }
 
-GlRenderer::GlRenderer() :mViewport() ,mGpuBuffer(new GlStageBuffer), mPrograms()
+GlRenderer::GlRenderer() :mViewport() ,mGpuBuffer(new GlStageBuffer), mPrograms(), mComposePool()
 {
 }
 
 GlRenderer::~GlRenderer()
 {
+    for (auto i = 0; i < mComposePool.count; i++) {
+        if (mComposePool[i]) delete mComposePool[i];
+    }
+
     --rendererCnt;
 
     if (rendererCnt == 0 && initEngineCnt == 0) _termEngine();

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -98,8 +98,7 @@ private:
     unique_ptr<GlStageBuffer> mGpuBuffer;
     vector<std::unique_ptr<GlProgram>> mPrograms;
     unique_ptr<GlRenderTarget> mRootTarget = {};
-    vector<unique_ptr<GlRenderTarget>> mComposePool = {};
-    size_t mPoolIndex = 0;
+    Array<GlRenderTarget*> mComposePool = {};
     vector<GlRenderPass> mRenderPassStack = {};
     vector<unique_ptr<Compositor>> mComposeStack = {};
 


### PR DESCRIPTION
This PR changed the GL fbo creation logical to save much more runtime memory while keep the rendering result correct.

For the same example: **MaskingMethods**

### Before, need create framebuffer 80 times:
![before](https://github.com/thorvg/thorvg/assets/26308154/aa7ea069-a521-4947-91dc-ce9c25cf9da4)

After this changes, only need create 3 times:
![after](https://github.com/thorvg/thorvg/assets/26308154/dbb309c7-0c21-4d5b-bd8b-426aeacb308b)
