### PR TITLE
gl_engine: fix wrong scissor value cause content not fully rendered

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -136,6 +136,7 @@ void GlBlitTask::run()
 {
     GlComposeTask::run();
 
+    GL_CHECK(glScissor(0, 0, mWidth, mHeight));
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getTargetFbo()));
     GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, getSelfFbo()));
 

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -398,7 +398,7 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
 RenderRegion GlRenderer::viewport()
 {
-    return {0, 0, INT32_MAX, INT32_MAX};
+    return {0, 0, static_cast<int32_t>(surface.w), static_cast<int32_t>(surface.h)};
 }
 
 


### PR DESCRIPTION
This PR fix some example not fully rendered.

 Root Cause:
     The scissor value may chaned by sub render task, and need to reset to surface size when root layer blit to screen.