### PR TITLE
loader/svg: optimize the path conversion.

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -53,6 +53,7 @@
 #include <cstring>
 #include <math.h>
 #include <ctype.h>
+#include "tvgShape.h"
 #include "tvgSvgLoaderCommon.h"
 #include "tvgSvgPath.h"
 #include "tvgStr.h"
@@ -534,7 +535,7 @@ static char* _nextCommand(char* path, char* cmd, float* arr, int* count)
 /************************************************************************/
 
 
-bool svgPathToTvgPath(const char* svgPath, Array<PathCommand>& cmds, Array<Point>& pts)
+bool svgPathToShape(const char* svgPath, Shape* shape)
 {
     float numberArray[7];
     int numberCount = 0;
@@ -545,11 +546,16 @@ bool svgPathToTvgPath(const char* svgPath, Array<PathCommand>& cmds, Array<Point
     bool isQuadratic = false;
     char* path = (char*)svgPath;
 
+    auto& pts = P(shape)->rs.path.pts;
+    auto& cmds = P(shape)->rs.path.cmds;
+    auto lastCmds = cmds.count;
+
     while ((path[0] != '\0')) {
         path = _nextCommand(path, &cmd, numberArray, &numberCount);
         if (!path) break;
         if (!_processCommand(&cmds, &pts, cmd, numberArray, numberCount, &cur, &curCtl, &startPoint, &isQuadratic)) break;
     }
 
+    if (cmds.count > lastCmds && cmds[lastCmds] != PathCommand::MoveTo) return false;
     return true;
 }

--- a/src/loaders/svg/tvgSvgPath.h
+++ b/src/loaders/svg/tvgSvgPath.h
@@ -25,6 +25,6 @@
 
 #include <tvgCommon.h>
 
-bool svgPathToTvgPath(const char* svgPath, Array<PathCommand>& cmds, Array<Point>& pts);
+bool svgPathToShape(const char* svgPath, Shape* shape);
 
 #endif //_TVG_SVG_PATH_H_

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -396,13 +396,9 @@ static bool _recognizeShape(SvgNode* node, Shape* shape)
     switch (node->type) {
         case SvgNodeType::Path: {
             if (node->node.path.path) {
-                Array<PathCommand> cmds;
-                Array<Point> pts;
-                if (svgPathToTvgPath(node->node.path.path, cmds, pts)) {
-                    if (shape->appendPath(cmds.data, cmds.count, pts.data, pts.count) != Result::Success) {
-                        TVGERR("SVG", "Invalid path information.");
-                        return false;
-                    }
+                if (!svgPathToShape(node->node.path.path, shape)) {
+                    TVGERR("SVG", "Invalid path information.");
+                    return false;
                 }
             }
             break;


### PR DESCRIPTION
Push the path data into a given shape directly.
This will skip unnecessary memory copies.

https://github.com/thorvg/thorvg/issues/1848