### PR TITLE
gl_engine: fix svg gradient position not correct

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -65,7 +65,7 @@ struct GlShape
   unique_ptr<GlGeometry> geometry;
 };
 
-#define MAX_GRADIENT_STOPS 4
+#define MAX_GRADIENT_STOPS 16
 
 struct GlLinearGradientBlock
 {


### PR DESCRIPTION
This PR enhance the gradient render in GL backend:
* change the color and stop size to 16 in shader and buffer block
* calculate transform when upload gradient info to gpu pipeline

| lineargrad1.svg | radialgrad1.svg |
| ---------------| ----------------|
|  <img src="https://github.com/thorvg/thorvg/assets/26308154/87ecba98-4b81-4112-9df3-34a38de23fe3" width="200" /> |  <img src="https://github.com/thorvg/thorvg/assets/26308154/ff88cd52-2313-451f-92ba-c80ee7f72cd2" width="200" /> |