### PR TITLE
wg_engine: Added shape opacity value usage

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderTarget.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.cpp
@@ -99,7 +99,7 @@ void WgRenderTarget::initialize(WGPUDevice device, WGPUQueue queue, WgPipelines&
     WgShaderTypeMat4x4f viewMat(w, h);
     mBindGroupCanvasWnd.initialize(device, queue, viewMat);
     WgShaderTypeMat4x4f modelMat;
-    WgShaderTypeBlendSettings blendSettings(ColorSpace::ABGR8888);
+    WgShaderTypeBlendSettings blendSettings(ColorSpace::ABGR8888, 255);
     mBindGroupPaintWnd.initialize(device, queue, modelMat, blendSettings);
     // update pipeline geometry data
     WgVertexList wnd;
@@ -193,11 +193,11 @@ void WgRenderTarget::renderShape(WgRenderDataShape* renderData)
         // fill shape (second pass)
         WgRenderDataShapeSettings& settings = renderData->mRenderSettingsShape;
         if (settings.mFillType == WgRenderDataShapeFillType::Solid)
-            mPipelines->mPipelineSolid.use(mRenderPassEncoder, mBindGroupCanvasWnd, mBindGroupPaintWnd, settings.mBindGroupSolid);
+            mPipelines->mPipelineSolid.use(mRenderPassEncoder, mBindGroupCanvasWnd, renderData->mBindGroupPaint, settings.mBindGroupSolid);
         else if (settings.mFillType == WgRenderDataShapeFillType::Linear)
-            mPipelines->mPipelineLinear.use(mRenderPassEncoder, mBindGroupCanvasWnd, mBindGroupPaintWnd, settings.mBindGroupLinear);
+            mPipelines->mPipelineLinear.use(mRenderPassEncoder, mBindGroupCanvasWnd, renderData->mBindGroupPaint, settings.mBindGroupLinear);
         else if (settings.mFillType == WgRenderDataShapeFillType::Radial)
-            mPipelines->mPipelineRadial.use(mRenderPassEncoder, mBindGroupCanvasWnd, mBindGroupPaintWnd, settings.mBindGroupRadial);
+            mPipelines->mPipelineRadial.use(mRenderPassEncoder, mBindGroupCanvasWnd, renderData->mBindGroupPaint, settings.mBindGroupRadial);
         mGeometryDataWnd.draw(mRenderPassEncoder);
     }
 }
@@ -218,11 +218,11 @@ void WgRenderTarget::renderStroke(WgRenderDataShape* renderData)
         wgpuRenderPassEncoderSetStencilReference(mRenderPassEncoder, 0);
         WgRenderDataShapeSettings& settings = renderData->mRenderSettingsStroke;
         if (settings.mFillType == WgRenderDataShapeFillType::Solid)
-            mPipelines->mPipelineSolid.use(mRenderPassEncoder, mBindGroupCanvasWnd, mBindGroupPaintWnd, settings.mBindGroupSolid);
+            mPipelines->mPipelineSolid.use(mRenderPassEncoder, mBindGroupCanvasWnd, renderData->mBindGroupPaint, settings.mBindGroupSolid);
         else if (settings.mFillType == WgRenderDataShapeFillType::Linear)
-            mPipelines->mPipelineLinear.use(mRenderPassEncoder, mBindGroupCanvasWnd, mBindGroupPaintWnd, settings.mBindGroupLinear);
+            mPipelines->mPipelineLinear.use(mRenderPassEncoder, mBindGroupCanvasWnd, renderData->mBindGroupPaint, settings.mBindGroupLinear);
         else if (settings.mFillType == WgRenderDataShapeFillType::Radial)
-            mPipelines->mPipelineRadial.use(mRenderPassEncoder, mBindGroupCanvasWnd, mBindGroupPaintWnd, settings.mBindGroupRadial);
+            mPipelines->mPipelineRadial.use(mRenderPassEncoder, mBindGroupCanvasWnd, renderData->mBindGroupPaint, settings.mBindGroupRadial);
         mGeometryDataWnd.draw(mRenderPassEncoder);
     }
 }

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -75,7 +75,7 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
      // update paint settings
     if (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Blend)) {
         WgShaderTypeMat4x4f modelMat(transform);
-        WgShaderTypeBlendSettings blendSettings(mTargetSurface.cs);
+        WgShaderTypeBlendSettings blendSettings(mTargetSurface.cs, opacity);
         renderDataShape->mBindGroupPaint.initialize(mContext.device, mContext.queue, modelMat, blendSettings);
     }
 
@@ -106,7 +106,7 @@ RenderData WgRenderer::prepare(Surface* surface, const RenderMesh* mesh, RenderD
     // update paint settings
     if (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Blend)) {
         WgShaderTypeMat4x4f modelMat(transform);
-        WgShaderTypeBlendSettings blendSettings(surface->cs);
+        WgShaderTypeBlendSettings blendSettings(surface->cs, opacity);
         renderDataShape->mBindGroupPaint.initialize(mContext.device, mContext.queue, modelMat, blendSettings);
     }
     

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -33,14 +33,6 @@ struct VertexInput {
     @location(0) position: vec2f
 };
 
-// BlendSettigs
-struct BlendSettigs {
-    format : u32, // ColorSpace
-    dummy0 : f32,
-    dummy1 : f32,
-    dummy2 : f32
-};
-
 // vertex output
 struct VertexOutput {
     @builtin(position) position: vec4f
@@ -49,7 +41,6 @@ struct VertexOutput {
 // uniforms
 @group(0) @binding(0) var<uniform> uViewMat      : mat4x4f;
 @group(1) @binding(0) var<uniform> uModelMat     : mat4x4f;
-@group(1) @binding(1) var<uniform> uBlendSettigs : BlendSettigs;
 
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
@@ -77,10 +68,10 @@ struct VertexInput {
 
 // BlendSettigs
 struct BlendSettigs {
-    format : u32, // ColorSpace
-    dummy0 : f32,
-    dummy1 : f32,
-    dummy2 : f32
+    format  : u32, // ColorSpace
+    dummy0  : f32,
+    dummy1  : f32,
+    opacity : f32
 };
 
 // vertex output
@@ -110,7 +101,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     // get color
     color = uSolidColor;
 
-    return vec4f(color.rgb, color.a);
+    return vec4f(color.rgb, color.a * uBlendSettigs.opacity);
 }
 )";
 
@@ -126,10 +117,10 @@ struct VertexInput {
 
 // BlendSettigs
 struct BlendSettigs {
-    format : u32, // ColorSpace
-    dummy0 : f32,
-    dummy1 : f32,
-    dummy2 : f32
+    format  : u32, // ColorSpace
+    dummy0  : f32,
+    dummy1  : f32,
+    opacity : f32
 };
 
 // LinearGradient
@@ -200,7 +191,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
         }
     }
 
-    return vec4f(color.rgb, color.a);
+    return vec4f(color.rgb, color.a * uBlendSettigs.opacity);
 }
 )";
 
@@ -216,10 +207,10 @@ struct VertexInput {
 
 // BlendSettigs
 struct BlendSettigs {
-    format : u32, // ColorSpace
-    dummy0 : f32,
-    dummy1 : f32,
-    dummy2 : f32
+    format  : u32, // ColorSpace
+    dummy0  : f32,
+    dummy1  : f32,
+    opacity : f32
 };
 
 // RadialGradient
@@ -284,7 +275,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
         }
     }
 
-    return vec4f(color.rgb, color.a);
+    return vec4f(color.rgb, color.a * uBlendSettigs.opacity);
 }
 )";
 
@@ -301,10 +292,10 @@ struct VertexInput {
 
 // BlendSettigs
 struct BlendSettigs {
-    format : u32, // ColorSpace
-    dummy0 : f32,
-    dummy1 : f32,
-    dummy2 : f32
+    format  : u32, // ColorSpace
+    dummy0  : f32,
+    dummy1  : f32,
+    opacity : f32
 };
 
 // vertex output
@@ -340,6 +331,6 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     } else if (format == 3u) { /* FMT_ARGB8888S */
         result = vec4(color.bgr * color.a, color.a);
     }
-    return vec4f(result.rgb, result.a);
+    return vec4f(result.rgb, result.a * uBlendSettigs.opacity);
 };
 )";

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -40,16 +40,4 @@ extern const char* cShaderSource_PipelineRadial;
 // pipeline shader module image
 extern const char* cShaderSource_PipelineImage;
 
-extern const char* MASK_ALPHA_FRAG_SHADER;
-extern const char* MASK_INV_ALPHA_FRAG_SHADER;
-extern const char* MASK_LUMA_FRAG_SHADER;
-extern const char* MASK_INV_LUMA_FRAG_SHADER;
-extern const char* MASK_ADD_FRAG_SHADER;
-extern const char* MASK_SUB_FRAG_SHADER;
-extern const char* MASK_INTERSECT_FRAG_SHADER;
-extern const char* MASK_DIFF_FRAG_SHADER;
-
-// pipeline shader module compose
-extern const char* cShaderSource_Pipeline;
-
 #endif // _TVG_WG_SHADER_SRC_H_

--- a/src/renderer/wg_engine/tvgWgShaderTypes.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.cpp
@@ -86,18 +86,18 @@ void WgShaderTypeMat4x4f::update(size_t w, size_t h)
 }
 
 
-WgShaderTypeBlendSettings::WgShaderTypeBlendSettings(const ColorSpace colorSpace)
+WgShaderTypeBlendSettings::WgShaderTypeBlendSettings(const ColorSpace colorSpace, uint8_t o)
 {
-    update(colorSpace);
+    update(colorSpace, o);
 }
 
 
-void WgShaderTypeBlendSettings::update(const ColorSpace colorSpace)
+void WgShaderTypeBlendSettings::update(const ColorSpace colorSpace, uint8_t o)
 {
     format = (uint32_t)colorSpace;
     dummy0 = 0.0f;
     dummy1 = 0.0f;
-    dummy2 = 0.0f;
+    opacity = o / 255.0f;
 }
 
 

--- a/src/renderer/wg_engine/tvgWgShaderTypes.h
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.h
@@ -53,11 +53,11 @@ struct WgShaderTypeBlendSettings
     uint32_t format{}; // ColorSpace
     float dummy0{};
     float dummy1{};
-    float dummy2{};
+    float opacity{};
 
     WgShaderTypeBlendSettings() {};
-    WgShaderTypeBlendSettings(const ColorSpace colorSpace);
-    void update(const ColorSpace colorSpace);
+    WgShaderTypeBlendSettings(const ColorSpace colorSpace, uint8_t o);
+    void update(const ColorSpace colorSpace, uint8_t o);
 };
 
 // struct SolidColor {


### PR DESCRIPTION
[issues 1479: Opacity](#1479)

Usage example:

    // prepare a shape (Rectangle + Rectangle + Circle + Circle) with opacity
    auto shape1 = tvg::Shape::gen();
    shape1->appendRect(0, 0, 200, 200);                //x, y, w, h
    shape1->appendRect(100, 100, 300, 300, 100, 100);  //x, y, w, h, rx, ry
    shape1->appendCircle(400, 400, 100, 100);          //cx, cy, radiusW, radiusH
    shape1->appendCircle(400, 500, 170, 100);          //cx, cy, radiusW, radiusH
    shape1->fill(255, 255, 0);                         //r, g, b
    shape1->opacity(128)                               //opacity
    canvas->push(std::move(shape1));