### PR TITLE
gl_engine: fix a compiler warning.

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -448,7 +448,7 @@ GlRenderer::GlRenderer() :mViewport() ,mGpuBuffer(new GlStageBuffer), mPrograms(
 
 GlRenderer::~GlRenderer()
 {
-    for (auto i = 0; i < mComposePool.count; i++) {
+    for (uint32_t i = 0; i < mComposePool.count; i++) {
         if (mComposePool[i]) delete mComposePool[i];
     }
 


### PR DESCRIPTION
../src/renderer/gl_engine/tvgGlRenderer.cpp:450:24: warning: comparison of integer expressions of different signedness: ‘int’ and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]
  450 |     for (auto i = 0; i < mComposePool.count; i++) {
      |