### PR TITLE
Revert "svg: removed an unnecessary nested scene."

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -864,9 +864,12 @@ Scene* svgSceneBuild(SvgLoaderData& loaderData, Box vBox, float w, float h, Aspe
     auto viewBoxClip = Shape::gen();
     viewBoxClip->appendRect(0, 0, w, h);
 
+    auto compositeLayer = Scene::gen();
+    compositeLayer->composite(std::move(viewBoxClip), CompositeMethod::ClipPath);
+    compositeLayer->push(std::move(docNode));
+
     auto root = Scene::gen();
-    root->composite(std::move(viewBoxClip), CompositeMethod::ClipPath);
-    root->push(std::move(docNode));
+    root->push(std::move(compositeLayer));
 
     loaderData.doc->node.doc.vx = vBox.x;
     loaderData.doc->node.doc.vy = vBox.y;


### PR DESCRIPTION
A regression bug is occured.
clipper is also required to be transformed with loader->resize()...

This reverts commit e62a8668e79852cbe4e74cc83c982fd298a01b73.