### PR TITLE
renderer/loader: code refactoring.

### DIFF
--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -147,7 +147,7 @@ bool JpgLoader::read()
 }
 
 
-unique_ptr<Surface> JpgLoader::bitmap()
+Surface* JpgLoader::bitmap()
 {
     if (!image) return nullptr;
 
@@ -162,5 +162,5 @@ unique_ptr<Surface> JpgLoader::bitmap()
     surface->premultiplied = true;
     surface->owner = true;
 
-    return unique_ptr<Surface>(surface);
+    return surface;
 }

--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -38,7 +38,7 @@ public:
     bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
 
-    unique_ptr<Surface> bitmap() override;
+    Surface* bitmap() override;
 
 private:
     void clear();

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -106,7 +106,7 @@ bool PngLoader::read()
 }
 
 
-unique_ptr<Surface> PngLoader::bitmap()
+Surface* PngLoader::bitmap()
 {
     if (!content) return nullptr;
 
@@ -121,5 +121,5 @@ unique_ptr<Surface> PngLoader::bitmap()
     surface->owner = true;
     surface->premultiplied = false;
 
-    return unique_ptr<Surface>(surface);
+    return surface;
 }

--- a/src/loaders/external_png/tvgPngLoader.h
+++ b/src/loaders/external_png/tvgPngLoader.h
@@ -36,7 +36,7 @@ public:
     bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
 
-    unique_ptr<Surface> bitmap() override;
+    Surface* bitmap() override;
 
 private:
     void clear();

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -126,7 +126,7 @@ bool WebpLoader::read()
 }
 
 
-unique_ptr<Surface> WebpLoader::bitmap()
+Surface* WebpLoader::bitmap()
 {
     this->done();
 
@@ -142,5 +142,5 @@ unique_ptr<Surface> WebpLoader::bitmap()
     surface->channelSize = sizeof(uint32_t);
     surface->premultiplied = false;
     surface->owner = true;
-    return unique_ptr<Surface>(surface);
+    return surface;
 }

--- a/src/loaders/external_webp/tvgWebpLoader.h
+++ b/src/loaders/external_webp/tvgWebpLoader.h
@@ -36,7 +36,7 @@ public:
     bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
 
-    unique_ptr<Surface> bitmap() override;
+    Surface* bitmap() override;
 
 private:
     void run(unsigned tid) override;

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -125,7 +125,7 @@ bool JpgLoader::close()
 }
 
 
-unique_ptr<Surface> JpgLoader::bitmap()
+Surface* JpgLoader::bitmap()
 {
     this->done();
 
@@ -142,5 +142,5 @@ unique_ptr<Surface> JpgLoader::bitmap()
     surface->premultiplied = true;
     surface->owner = true;
 
-    return unique_ptr<Surface>(surface);
+    return surface;
 }

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -47,7 +47,7 @@ public:
     bool read() override;
     bool close() override;
 
-    unique_ptr<Surface> bitmap() override;
+    Surface* bitmap() override;
 };
 
 #endif //_TVG_JPG_LOADER_H_

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -140,7 +140,7 @@ bool PngLoader::read()
 }
 
 
-unique_ptr<Surface> PngLoader::bitmap()
+Surface* PngLoader::bitmap()
 {
     this->done();
 
@@ -157,5 +157,5 @@ unique_ptr<Surface> PngLoader::bitmap()
     surface->premultiplied = false;
     surface->owner = true;
 
-    return unique_ptr<Surface>(surface);
+    return surface;
 }

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -46,7 +46,7 @@ public:
     bool open(const char* data, uint32_t size, const string& rpath, bool copy) override;
     bool read() override;
 
-    unique_ptr<Surface> bitmap() override;
+    Surface* bitmap() override;
 };
 
 #endif //_TVG_PNG_LOADER_H_

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -79,7 +79,7 @@ bool RawLoader::read()
 }
 
 
-unique_ptr<Surface> RawLoader::bitmap()
+Surface* RawLoader::bitmap()
 {
     if (!content) return nullptr;
 
@@ -94,5 +94,5 @@ unique_ptr<Surface> RawLoader::bitmap()
     surface->premultiplied = premultiplied;
     surface->owner = true;
 
-    return unique_ptr<Surface>(surface);
+    return surface;
 }

--- a/src/loaders/raw/tvgRawLoader.h
+++ b/src/loaders/raw/tvgRawLoader.h
@@ -37,7 +37,7 @@ public:
     bool open(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy);
     bool read() override;
 
-    unique_ptr<Surface> bitmap() override;
+    Surface* bitmap() override;
 };
 
 

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -74,7 +74,7 @@ struct ImageLoader : LoadModule
     ImageLoader(FileType type) : LoadModule(type) {}
 
     virtual bool animatable() { return false; }  //true if this loader supports animation.
-    virtual unique_ptr<Surface> bitmap() { return nullptr; }
+    virtual Surface* bitmap() { return nullptr; }
     virtual Paint* paint() { return nullptr; }
 };
 

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -45,7 +45,7 @@ RenderUpdateFlag Picture::Impl::load()
         } else loader->sync();
 
         if (!surface) {
-            if ((surface = loader->bitmap().release())) {
+            if ((surface = loader->bitmap())) {
                 return RenderUpdateFlag::Image;
             }
         }


### PR DESCRIPTION
Removed internal unique_ptr usage for a more compact size.