### PR TITLE
fix the prototype of mpoolInit

### DIFF
--- a/src/renderer/sw_engine/tvgSwMemPool.cpp
+++ b/src/renderer/sw_engine/tvgSwMemPool.cpp
@@ -77,7 +77,7 @@ void mpoolRetDashOutline(SwMpool* mpool, unsigned idx)
 }
 
 
-SwMpool* mpoolInit(unsigned threads)
+SwMpool* mpoolInit(uint32_t threads)
 {
     auto allocSize = threads + 1;
 

--- a/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -821,8 +821,8 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage* image, const 
 
 static AASpans* _AASpans(float ymin, float ymax, const SwImage* image, const SwBBox* region)
 {
-    auto yStart = static_cast<int32_t>(ymin);
-    auto yEnd = static_cast<int32_t>(ymax);
+    auto yStart = static_cast<int>(ymin);
+    auto yEnd = static_cast<int>(ymax);
 
     if (!_arrange(image, region, yStart, yEnd)) return nullptr;
 


### PR DESCRIPTION
Hi,

While I was trying to build ThorVG for an STM32 MCU I found that in `tvgSwCommon.h` `mpoolInit` has `uint32_t` parameter while in `tvgSwCommon.cpp` it's `unsigned`. The difference caused link error on a 32 bit MCU.

