### PR TITLE
gl_engine: fix radial gradient not render correctly

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -569,6 +569,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
 
             gradientBlock.nStops[0] = stopCnt * 1.f;
             gradientBlock.nStops[1] = NOISE_LEVEL;
+            gradientBlock.nStops[2] = static_cast<int32_t>(fill->spread()) * 1.f;
             for (uint32_t i = 0; i < stopCnt; ++i) {
                 gradientBlock.stopPoints[i] = stops[i].offset;
                 gradientBlock.stopColors[i * 4 + 0] = stops[i].r / 255.f;
@@ -601,6 +602,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
 
             gradientBlock.nStops[0] = stopCnt * 1.f;
             gradientBlock.nStops[1] = NOISE_LEVEL;
+            gradientBlock.nStops[2] = static_cast<int32_t>(fill->spread()) * 1.f;
             for (uint32_t i = 0; i < stopCnt; ++i) {
                 gradientBlock.stopPoints[i] = stops[i].offset;
                 gradientBlock.stopColors[i * 4 + 0] = stops[i].r / 255.f;

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -90,10 +90,20 @@ float gradientStop(int index)                                                   
                                                                                                         \n
 float gradientWrap(float d)                                                                             \n
 {                                                                                                       \n
+    int spread = int(uGradientInfo.nStops[2]);                                                          \n
+                                                                                                        \n
+    if (spread == 0) { /* pad */                                                                        \n
+        return clamp(d, 0.0, 1.0);                                                                      \n
+    }                                                                                                   \n
+                                                                                                        \n
     int i = 1;                                                                                          \n
     while (d > 1.0) {                                                                                   \n
         d = d - 1.0;                                                                                    \n
         i *= -1;                                                                                        \n
+    }                                                                                                   \n
+                                                                                                        \n
+    if (spread == 2) {  /* Reflect */                                                                   \n
+        return smoothstep(0.0, 1.0, d);                                                                 \n
     }                                                                                                   \n
                                                                                                         \n
     if (i == 1)                                                                                         \n


### PR DESCRIPTION
* root cause: the gradient shader not taking into account the **FillSpread** property
 

with this fix, now RadialGradient example now renders correctly
![radial_gradient_correct](https://github.com/thorvg/thorvg/assets/26308154/80638244-876c-4d4b-bf46-5ab700bd8445)
