### PR TITLE
lottie: Corrected the Time Remapping Range

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -598,7 +598,6 @@ struct LottieComposition
     {
         auto p = timeInSec / duration();
         if (p < 0.0f) p = 0.0f;
-        else if (p > 1.0f) p = 1.0f;
         return p * frameCnt();
     }
 


### PR DESCRIPTION
enable exceeding the range of normalized values in time remapping.

the issue came from a misunderstanding of the lottie spec.

issue: https://github.com/thorvg/thorvg/issues/1809