### PR TITLE
gl_engine: append stencil attachment in GLRenderTarget

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderPass.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderPass.cpp
@@ -32,8 +32,8 @@ GlRenderTarget::~GlRenderTarget()
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
     GL_CHECK(glDeleteFramebuffers(1, &mFbo));
 
-    if (mColorTex == 0) return;
-    GL_CHECK(glDeleteTextures(1, &mColorTex));
+    if (mColorTex != 0) GL_CHECK(glDeleteTextures(1, &mColorTex));
+    if (mStencilBuffer != 0) GL_CHECK(glDeleteRenderbuffers(1, &mStencilBuffer));
 }
 
 void GlRenderTarget::init(GLint resolveId)
@@ -56,7 +56,16 @@ void GlRenderTarget::init(GLint resolveId)
 
     GL_CHECK(glBindTexture(GL_TEXTURE_2D, 0));
 
+    GL_CHECK(glGenRenderbuffers(1, &mStencilBuffer));
+
+    GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, mStencilBuffer));
+
+    GL_CHECK(glRenderbufferStorage(GL_RENDERBUFFER, GL_STENCIL_INDEX8, mWidth, mHeight));
+
+    GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, 0));
+
     GL_CHECK(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, mColorTex, 0));
+    GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, mStencilBuffer));
 
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, resolveId));
 }

--- a/src/renderer/gl_engine/tvgGlRenderPass.h
+++ b/src/renderer/gl_engine/tvgGlRenderPass.h
@@ -47,6 +47,7 @@ private:
     uint32_t mHeight = 0;
     GLuint mFbo = 0;
     GLuint mColorTex = 0;
+    GLuint mStencilBuffer = 0;
 };
 
 class GlRenderPass

--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -112,13 +112,18 @@ void GlComposeTask::run()
 
     // clear this fbo
     if (mClearBuffer) {
-        const float transparent[] = {0.f, 0.f, 0.f, 0.f};
-        GL_CHECK(glClearBufferfv(GL_COLOR, 0, transparent));
+        GL_CHECK(glClearColor(0, 0, 0, 0));
+        GL_CHECK(glClearStencil(0));
+
+        GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT));
     }
 
     for(uint32_t i = 0; i < mTasks.count; i++) {
         mTasks[i]->run();
     }
+
+    GLenum stencil_attachment = GL_STENCIL_ATTACHMENT;
+    GL_CHECK(glInvalidateFramebuffer(GL_FRAMEBUFFER, 1, &stencil_attachment));
 }
 
 GlBlitTask::GlBlitTask(GlProgram* program, GLuint target, GLuint compose, Array<GlRenderTask*>&& tasks)


### PR DESCRIPTION
This PR add stencil attachment in GLRenderTarget.

Plans to use stencil to test support for path clipping and complex path rendering when the tessellation algorithm cannot handle it.