### PR TITLE
sw_engine: removed redundant logic.

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -64,12 +64,16 @@ static void _outlineEnd(SwOutline& outline)
 {
     if (outline.pts.empty()) return;
     outline.cntrs.push(outline.pts.count - 1);
+    outline.closed.push(false);
 }
 
 
 static void _outlineMoveTo(SwOutline& outline, const Point* to, const Matrix* transform)
 {
-    if (outline.pts.count > 0) outline.cntrs.push(outline.pts.count - 1);
+    if (outline.pts.count > 0) {
+        outline.cntrs.push(outline.pts.count - 1);
+        outline.closed.push(false);
+    }
 
     outline.pts.push(mathTransform(to, transform));
     outline.types.push(SW_CURVE_TYPE_POINT);
@@ -315,21 +319,6 @@ static SwOutline* _genDashOutline(const RenderShape* rshape, const Matrix* trans
 
     dash.outline = mpoolReqDashOutline(mpool, tid);
 
-    //smart reservation
-    auto closeCnt = 0;
-    auto moveCnt = 0;
-
-    for (auto cmd = rshape->path.cmds.data; cmd < rshape->path.cmds.end(); ++cmd) {
-        if (*cmd == PathCommand::Close) ++closeCnt;
-        else if (*cmd == PathCommand::MoveTo) ++moveCnt;
-    }
-
-    //No idea exact count.... Reserve Approximitely 20x...
-    //OPTIMIZE: we can directly copy the path points when the close is occupied with a point.
-    dash.outline->pts.grow(20 * (closeCnt + ptsCnt + 1));
-    dash.outline->types.grow(20 * (closeCnt + ptsCnt + 1));
-    dash.outline->cntrs.grow(20 * (moveCnt + 1));
-
     while (cmdCnt-- > 0) {
         switch (*cmds) {
             case PathCommand::Close: {
@@ -435,28 +424,8 @@ static bool _genOutline(SwShape* shape, const RenderShape* rshape, const Matrix*
     //No actual shape data
     if (cmdCnt == 0 || ptsCnt == 0) return false;
 
-    //smart reservation
-    auto moveCnt = 0;
-    auto closeCnt = 0;
-
-    for (auto cmd = rshape->path.cmds.data; cmd < rshape->path.cmds.end(); ++cmd) {
-        if (*cmd == PathCommand::Close) ++closeCnt;
-        else if (*cmd == PathCommand::MoveTo) ++moveCnt;
-    }
-
     shape->outline = mpoolReqOutline(mpool, tid);
     auto outline = shape->outline;
-
-    //OPTIMIZE: we can directly copy the path points when the close is occupied with a point.
-    outline->pts.grow(ptsCnt + closeCnt + 1);
-    outline->types.grow(ptsCnt + closeCnt + 1);
-    outline->cntrs.grow(moveCnt + 1);
-
-    //Dash outlines are always opened.
-    //Only normal outlines use this information, it sholud be same to their contour counts.
-    outline->closed.reserve(outline->cntrs.reserved);
-
-    memset(outline->closed.data, 0x0, sizeof(bool) * outline->closed.reserved);
 
     //Generate Outlines
     while (cmdCnt-- > 0) {


### PR DESCRIPTION
Basically, sw_engine uses a desinated memory pool, this reservation is not so effective.