### PR TITLE
wg_engine: introduced scene opacity

### DIFF
--- a/src/renderer/wg_engine/tvgWgBindGroups.h
+++ b/src/renderer/wg_engine/tvgWgBindGroups.h
@@ -62,7 +62,7 @@ struct WgBindGroupSolidColor : public  WgBindGroup
     static WGPUBindGroupLayout getLayout(WGPUDevice device);
     static void releaseLayout();
 
-    WGPUBuffer uBufferSolidColor;
+    WGPUBuffer uBufferSolidColor{};
     void initialize(WGPUDevice device, WGPUQueue queue,
                     WgShaderTypeSolidColor &uSolidColor);
     void release();
@@ -75,7 +75,7 @@ struct WgBindGroupLinearGradient : public  WgBindGroup
     static WGPUBindGroupLayout getLayout(WGPUDevice device);
     static void releaseLayout();
 
-    WGPUBuffer uBufferLinearGradient;
+    WGPUBuffer uBufferLinearGradient{};
     void initialize(WGPUDevice device, WGPUQueue queue,
                     WgShaderTypeLinearGradient &uLinearGradient);
     void release();
@@ -88,7 +88,7 @@ struct WgBindGroupRadialGradient : public  WgBindGroup
     static WGPUBindGroupLayout getLayout(WGPUDevice device);
     static void releaseLayout();
 
-    WGPUBuffer uBufferRadialGradient;
+    WGPUBuffer uBufferRadialGradient{};
     void initialize(WGPUDevice device, WGPUQueue queue,
                     WgShaderTypeRadialGradient &uRadialGradient);
     void release();
@@ -107,6 +107,19 @@ struct WgBindGroupPicture : public  WgBindGroup
     void release();
 };
 
+// @group(1 or 2)
+struct WgBindGroupOpacity : public  WgBindGroup
+{
+    static WGPUBindGroupLayout layout;
+    static WGPUBindGroupLayout getLayout(WGPUDevice device);
+    static void releaseLayout();
+
+    WGPUBuffer uBufferOpacity{};
+    void initialize(WGPUDevice device, WGPUQueue queue, uint32_t uOpacity);
+    void update(WGPUDevice device, WGPUQueue queue, uint32_t uOpacity);
+    void release();
+};
+
 // @group(0 or 1)
 struct WgBindGroupBlit : public  WgBindGroup
 {
@@ -117,6 +130,22 @@ struct WgBindGroupBlit : public  WgBindGroup
     void initialize(WGPUDevice device, WGPUQueue queue,
                     WGPUSampler     uSampler,
                     WGPUTextureView uTexture);
+    void release();
+};
+
+//************************************************************************
+// bind group pools
+//************************************************************************
+
+class WgBindGroupOpacityPool
+{
+private:
+    Array<WgBindGroupOpacity*> mList;
+    Array<WgBindGroupOpacity*> mPool;
+    Array<WgBindGroupOpacity*> mUsed;
+public:
+    WgBindGroupOpacity* allocate(WgContext& context, uint32_t opacity);
+    void reset();
     void release();
 };
 

--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -235,7 +235,8 @@ void WgPipelineBlit::initialize(WGPUDevice device)
 
     // bind groups and layouts
     WGPUBindGroupLayout bindGroupLayouts[] = {
-        WgBindGroupBlit::getLayout(device)
+        WgBindGroupBlit::getLayout(device),
+        WgBindGroupOpacity::getLayout(device)
     };
 
     // stencil function
@@ -326,35 +327,39 @@ void WgPipelineComposition::initialize(WGPUDevice device, const char* shaderSrc)
 // pipelines
 //************************************************************************
 
-void WgPipelines::initialize(WGPUDevice device)
+void WgPipelines::initialize(WgContext& context)
 {
-    fillShape.initialize(device);
-    fillStroke.initialize(device);
-    solid.initialize(device);
-    linear.initialize(device);
-    radial.initialize(device);
-    image.initialize(device);
-    blit.initialize(device);
-    blitColor.initialize(device);
+    fillShape.initialize(context.device);
+    fillStroke.initialize(context.device);
+    solid.initialize(context.device);
+    linear.initialize(context.device);
+    radial.initialize(context.device);
+    image.initialize(context.device);
+    blit.initialize(context.device);
+    blitColor.initialize(context.device);
     // composition pipelines
-    compAlphaMask.initialize(device, cShaderSource_PipelineCompAlphaMask);
-    compInvAlphaMask.initialize(device, cShaderSource_PipelineCompInvAlphaMask);
-    compLumaMask.initialize(device, cShaderSource_PipelineCompLumaMask);
-    compInvLumaMask.initialize(device, cShaderSource_PipelineCompInvLumaMask);
-    compAddMask.initialize(device, cShaderSource_PipelineCompAddMask);
-    compSubtractMask.initialize(device, cShaderSource_PipelineCompSubtractMask);
-    compIntersectMask.initialize(device, cShaderSource_PipelineCompIntersectMask);
-    compDifferenceMask.initialize(device, cShaderSource_PipelineCompDifferenceMask);
+    compAlphaMask.initialize(context.device, cShaderSource_PipelineCompAlphaMask);
+    compInvAlphaMask.initialize(context.device, cShaderSource_PipelineCompInvAlphaMask);
+    compLumaMask.initialize(context.device, cShaderSource_PipelineCompLumaMask);
+    compInvLumaMask.initialize(context.device, cShaderSource_PipelineCompInvLumaMask);
+    compAddMask.initialize(context.device, cShaderSource_PipelineCompAddMask);
+    compSubtractMask.initialize(context.device, cShaderSource_PipelineCompSubtractMask);
+    compIntersectMask.initialize(context.device, cShaderSource_PipelineCompIntersectMask);
+    compDifferenceMask.initialize(context.device, cShaderSource_PipelineCompDifferenceMask);
+    // store pipelines to context
+    context.pipelines = this;
 }
 
 
 void WgPipelines::release()
 {
     WgBindGroupBlit::releaseLayout();
+    WgBindGroupOpacity::releaseLayout();
     WgBindGroupPicture::releaseLayout();
     WgBindGroupRadialGradient::releaseLayout();
     WgBindGroupLinearGradient::releaseLayout();
     WgBindGroupSolidColor::releaseLayout();
+    WgBindGroupPaint::releaseLayout();
     WgBindGroupCanvas::releaseLayout();
     compDifferenceMask.release();
     compIntersectMask.release();

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -25,7 +25,7 @@
 
 #include "tvgWgBindGroups.h"
 
-struct WgPipelineFillShape: public WgPipeline
+struct WgPipelineFillShape: public WgRenderPipeline
 {
     void initialize(WGPUDevice device) override;
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas, WgBindGroupPaint& groupPaint)
@@ -36,7 +36,7 @@ struct WgPipelineFillShape: public WgPipeline
     }
 };
 
-struct WgPipelineFillStroke: public WgPipeline
+struct WgPipelineFillStroke: public WgRenderPipeline
 {
     void initialize(WGPUDevice device) override;
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas, WgBindGroupPaint& groupPaint)
@@ -47,7 +47,7 @@ struct WgPipelineFillStroke: public WgPipeline
     }
 };
 
-struct WgPipelineSolid: public WgPipeline
+struct WgPipelineSolid: public WgRenderPipeline
 {
     void initialize(WGPUDevice device) override;
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas,WgBindGroupPaint& groupPaint, WgBindGroupSolidColor& groupSolid)
@@ -59,7 +59,7 @@ struct WgPipelineSolid: public WgPipeline
     }
 };
 
-struct WgPipelineLinear: public WgPipeline
+struct WgPipelineLinear: public WgRenderPipeline
 {
     void initialize(WGPUDevice device) override;
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas, WgBindGroupPaint& groupPaint, WgBindGroupLinearGradient& groupLinear)
@@ -71,7 +71,7 @@ struct WgPipelineLinear: public WgPipeline
     }
 };
 
-struct WgPipelineRadial: public WgPipeline
+struct WgPipelineRadial: public WgRenderPipeline
 {
     void initialize(WGPUDevice device) override;
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas, WgBindGroupPaint& groupPaint, WgBindGroupRadialGradient& groupRadial)
@@ -83,7 +83,7 @@ struct WgPipelineRadial: public WgPipeline
     }
 };
 
-struct WgPipelineImage: public WgPipeline
+struct WgPipelineImage: public WgRenderPipeline
 {
     void initialize(WGPUDevice device) override;
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas, WgBindGroupPaint& groupPaint, WgBindGroupPicture& groupPicture)
@@ -95,7 +95,20 @@ struct WgPipelineImage: public WgPipeline
     }
 };
 
-struct WgPipelineBlit: public WgPipeline
+struct WgPipelineBlit: public WgRenderPipeline
+{
+    void initialize(WGPUDevice device) override;
+    void use(WGPURenderPassEncoder encoder,
+             WgBindGroupBlit& groupBlit,
+             WgBindGroupOpacity& groupOpacity)
+    {
+        set(encoder);
+        groupBlit.set(encoder, 0);
+        groupOpacity.set(encoder, 1);
+    }
+};
+
+struct WgPipelineBlitColor: public WgRenderPipeline
 {
     void initialize(WGPUDevice device) override;
     void use(WGPURenderPassEncoder encoder, WgBindGroupBlit& groupBlit)
@@ -105,17 +118,7 @@ struct WgPipelineBlit: public WgPipeline
     }
 };
 
-struct WgPipelineBlitColor: public WgPipeline
-{
-    void initialize(WGPUDevice device) override;
-    void use(WGPURenderPassEncoder encoder, WgBindGroupBlit& groupBlit)
-    {
-        set(encoder);
-        groupBlit.set(encoder, 0);
-    }
-};
-
-struct WgPipelineComposition: public WgPipeline
+struct WgPipelineComposition: public WgRenderPipeline
 {
     void initialize(WGPUDevice device) override {};
     void initialize(WGPUDevice device, const char* shaderSrc);
@@ -147,7 +150,7 @@ struct WgPipelines
     WgPipelineComposition compIntersectMask;
     WgPipelineComposition compDifferenceMask;
 
-    void initialize(WGPUDevice device);
+    void initialize(WgContext& context);
     void release();
 
     WgPipelineComposition* getCompositionPipeline(CompositeMethod method);

--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -43,7 +43,7 @@ public:
     WGPUTextureView textureViewStencil{};
     WgBindGroupBlit bindGroupBlit;
 public:
-    void initialize(WgContext& context, WgPipelines& pipelines, uint32_t w, uint32_t h);
+    void initialize(WgContext& context, uint32_t w, uint32_t h);
     void release(WgContext& context);
 
     void beginRenderPass(WGPUCommandEncoder commandEncoder, WGPUTextureView colorAttachement, bool clear);
@@ -54,9 +54,21 @@ public:
     void renderStroke(WgRenderDataShape* renderData);
     void renderPicture(WgRenderDataPicture* renderData);
 
-    void blit(WgContext& context, WgRenderTarget* renderTargetSrc);
+    void blit(WgContext& context, WgRenderTarget* renderTargetSrc, WgBindGroupOpacity* bindGroupOpacity);
     void blitColor(WgContext& context, WgRenderTarget* renderTargetSrc);
     void compose(WgContext& context, WgRenderTarget* renderTargetSrc, WgRenderTarget* renderTargetMsk, CompositeMethod method);
 };
+
+
+class WgRenderTargetPool {
+private:
+   Array<WgRenderTarget*> mList;
+   Array<WgRenderTarget*> mPool;
+public:
+   WgRenderTarget* allocate(WgContext& context, uint32_t w, uint32_t h);
+   void free(WgContext& context, WgRenderTarget* renderTarget);
+   void release(WgContext& context);
+};
+
 
 #endif

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -62,12 +62,12 @@ public:
 
     // render handles
     WGPUCommandEncoder mCommandEncoder{};
-    Array<WgRenderTarget*> mRenderTargetStack;
-    Array<WgRenderTarget*> mRenderTargetPool;
     Array<Compositor*> mCompositorStack;
+    Array<WgRenderTarget*> mRenderTargetStack;
 
-    WgRenderTarget* allocateRenderTarget();
-    void releaseRenderTarget(WgRenderTarget* renderTarget);
+    // render object pools
+    WgRenderTargetPool mRenderTargetPool;
+    WgBindGroupOpacityPool mBindGroupOpacityPool;
 private:
     WgContext mContext;
     WgPipelines mPipelines;

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -352,8 +352,9 @@ struct VertexOutput {
     @location(0) texCoord: vec2f
 };
 
-@group(0) @binding(0) var uSamplerSrc     : sampler;
-@group(0) @binding(1) var uTextureViewSrc : texture_2d<f32>;
+@group(0) @binding(0) var uSamplerSrc       : sampler;
+@group(0) @binding(1) var uTextureViewSrc   : texture_2d<f32>;
+@group(1) @binding(0) var<uniform> uOpacity : f32;
 
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
@@ -366,7 +367,9 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {
-    return textureSample(uTextureViewSrc, uSamplerSrc, in.texCoord.xy);
+    let color: vec4f = textureSample(uTextureViewSrc, uSamplerSrc, in.texCoord.xy);
+    return vec4f(color.rgb, uOpacity);
+    //return vec4f(color.rgb, 0.5);
 };
 )";
 


### PR DESCRIPTION
[issues 1479: opacity](#1479)

Supported opacity value for scene

Usage example:

    //Create a Scene
    auto scene = tvg::Scene::gen();
    scene->opacity(100);

    //Prepare Circle
    auto shape1 = tvg::Shape::gen();
    shape1->appendCircle(400, 400, 250, 250);
    shape1->fill(255, 255, 0);
    shape1->opacity(100);
    scene->push(std::move(shape1));

    //Round rectangle
    auto shape2 = tvg::Shape::gen();
    shape2->appendRect(450, 100, 200, 200, 50, 50);
    shape2->fill(0, 255, 0);
    shape2->strokeWidth(10);
    shape2->strokeFill(255, 255, 255);
    scene->push(std::move(shape2));

    canvas->push(std::move(scene));