### PR TITLE
sw_engine: retain the compositor cache memory

### DIFF
--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -475,7 +475,6 @@ bool SwRenderer::postRender()
     }
     tasks.clear();
 
-    clearCompositors();
     return true;
 }
 


### PR DESCRIPTION
The compositor memory is likely to be reused in the next frame. To enhance performance, it is advisable to retain this memory by default.

We may consider introducing a cache policy interface in the Initializer. This would allow users to manage the Canvas memory more effectively.

Anyhow, this improves the Lottie example performance by 10%