### PR TITLE
sw_engine: fix a regression bug

### DIFF
--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -420,6 +420,8 @@ bool SwRenderer::target(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, 
 {
     if (!data || stride == 0 || w == 0 || h == 0 || w > stride) return false;
 
+    clearCompositors();
+
     if (!surface) surface = new SwSurface;
 
     surface->data = data;


### PR DESCRIPTION
invalidate cached compositors when target size is changed. compositors must be re-initialized with a new size.

regression bug by ca3c1fc1b9bc1a74b5430f3eab1952727f1762b1