### PR TITLE
Lottie: Set up a lazy Lottie frame.

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1133,20 +1133,13 @@ bool LottieBuilder::update(LottieComposition* comp, float frameNo)
 
     //Update root layer
     auto root = comp->root;
-
-    //Prepare render data
-    if (!root->scene) {
-        auto scene = Scene::gen();
-        root->scene = scene.get();
-        comp->scene->push(std::move(scene));
-    } else {
-        root->scene->clear();
-    }
+    root->scene->clear();
 
     //update children layers
     for (auto child = root->children.end() - 1; child >= root->children.data; --child) {
         _updateLayer(root, static_cast<LottieLayer*>(*child), frameNo);
     }
+
     return true;
 }
 
@@ -1155,12 +1148,14 @@ void LottieBuilder::build(LottieComposition* comp)
 {
     if (!comp || !comp->root || comp->scene) return;
 
+    //Prepare render data
     comp->scene = Scene::gen().release();
-    if (!comp->scene) return;
+
+    auto scene = Scene::gen();
+    comp->root->scene = scene.get();
+    comp->scene->push(std::move(scene));
 
     _buildComposition(comp, comp->root);
-
-    if (!update(comp, 0)) return;
 
     //viewport clip
     auto clip = Shape::gen();

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -51,7 +51,7 @@ void LottieLoader::run(unsigned tid)
 {
     //update frame
     if (comp && comp->scene) {
-        builder->update(comp, frameNo);
+        updated = builder->update(comp, frameNo);
     //initial loading
     } else {
         if (!comp) {
@@ -296,7 +296,12 @@ bool LottieLoader::read()
 Paint* LottieLoader::paint()
 {
     this->done();
+
     if (!comp) return nullptr;
+
+    //frame is not updated yet?
+    if (!updated) run(0);
+
     comp->initiated = true;
     return comp->scene;
 }

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -44,6 +44,7 @@ public:
 
     char* dirName = nullptr;            //base resource directory
     bool copy = false;                  //"content" is owned by this loader
+    bool updated = false;               //scene updated
 
     LottieLoader();
     ~LottieLoader();


### PR DESCRIPTION
Do not set up frame 0 during loading time;
allow users to start with an arbitrary frame number if they choose.