### PR TITLE
renderer: ensure canvas rendering continues despite invalid scene parts

### DIFF
--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -1928,8 +1928,8 @@ bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint
 
 bool rasterImage(SwSurface* surface, SwImage* image, const RenderMesh* mesh, const Matrix* transform, const SwBBox& bbox, uint8_t opacity)
 {
-    //Verify Boundary
-    if (bbox.max.x < 0 || bbox.max.y < 0 || bbox.min.x >= static_cast<SwCoord>(surface->w) || bbox.min.y >= static_cast<SwCoord>(surface->h)) return false;
+    //Outside of the viewport, skip the rendering
+    if (bbox.max.x < 0 || bbox.max.y < 0 || bbox.min.x >= static_cast<SwCoord>(surface->w) || bbox.min.y >= static_cast<SwCoord>(surface->h)) return true;
 
     if (mesh && mesh->triangleCnt > 0) return _rasterTexmapPolygonMesh(surface, image, mesh, transform, &bbox, opacity);
     else return _rasterImage(surface, image, transform, bbox, opacity);

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -128,6 +128,7 @@ struct Scene::Impl
     bool render(RenderMethod* renderer)
     {
         Compositor* cmp = nullptr;
+        auto ret = true;
 
         if (needComp) {
             cmp = renderer->target(bounds(renderer), renderer->colorSpace());
@@ -136,12 +137,12 @@ struct Scene::Impl
         }
 
         for (auto paint : paints) {
-            if (!paint->pImpl->render(renderer)) return false;
+            ret &= paint->pImpl->render(renderer);
         }
 
         if (cmp) renderer->endComposite(cmp);
 
-        return true;
+        return ret;
     }
 
     RenderRegion bounds(RenderMethod* renderer) const


### PR DESCRIPTION
Previously, the logic was set to halt rendering when any part of the paints, particularly bitmap-based images, failed to render.

This update modifies the behavior to continue drawing the scene, allowing for the successful rendering of other elements.

issue: https://github.com/thorvg/thorvg/issues/1951