### PR TITLE
gl_engine: enhance the tessellation algorithm

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -42,7 +42,10 @@ bool GlGeometry::tesselate(const RenderShape& rshape, RenderUpdateFlag flag)
         fillIndex.clear();
 
         Tessellator tess{&fillVertex, &fillIndex};
-        tess.tessellate(&rshape, true);
+        if (!tess.tessellate(&rshape, true)) {
+            fillVertex.clear();
+            fillIndex.clear();
+        }
     }
 
     if (flag & (RenderUpdateFlag::Stroke | RenderUpdateFlag::Transform)) {

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -54,7 +54,7 @@ public:
     Tessellator(Array<float>* points, Array<uint32_t>* indices);
     ~Tessellator();
 
-    void tessellate(const RenderShape *rshape, bool antialias = false);
+    bool tessellate(const RenderShape *rshape, bool antialias = false);
 
     void tessellate(const Array<const RenderShape*> &shapes);
 
@@ -65,9 +65,9 @@ private:
 
     void mergeVertices();
 
-    void simplifyMesh();
+    bool simplifyMesh();
 
-    void tessMesh();
+    bool tessMesh();
 
     bool matchFillRule(int32_t winding);
 


### PR DESCRIPTION
This PR made the following changes:
* merge vertices that are close enough before tessellation
* append return branch in tessellation to prevent dead loop caused by floating point precision

Current state:
  With these changes, svg_example now runs successfully but renders incorrectly in some cases.

![image](https://github.com/thorvg/thorvg/assets/26308154/b6aeaec1-73a0-49a5-a631-18f00a045682)
