### PR TITLE
renderer/canvas: Optimize logic by removing paint verification.

### DIFF
--- a/src/renderer/tvgCanvas.h
+++ b/src/renderer/tvgCanvas.h
@@ -96,17 +96,8 @@ struct Canvas::Impl
         auto flag = RenderUpdateFlag::None;
         if (refresh || force) flag = RenderUpdateFlag::All;
 
-        //Update single paint node
         if (paint) {
-            //TODO: Leave this for backward compatibility. Remove this when 1.0 out.
-            for (auto paint2 : paints) {
-                if (paint2 == paint) {
-                    paint->pImpl->update(renderer, nullptr, clips, 255, flag);
-                    return Result::Success;
-                }
-            }
-            return Result::InvalidArguments;
-        //Update all retained paint nodes
+            paint->pImpl->update(renderer, nullptr, clips, 255, flag);
         } else {
             for (auto paint : paints) {
                 paint->pImpl->update(renderer, nullptr, clips, 255, flag);

--- a/test/testSwCanvasBase.cpp
+++ b/test/testSwCanvasBase.cpp
@@ -160,7 +160,7 @@ TEST_CASE("Update", "[tvgSwCanvasBase]")
 
     //No pushed shape
     auto shape = Shape::gen();
-    REQUIRE(canvas->update(shape.get()) == Result::InvalidArguments);
+    REQUIRE(canvas->update(shape.get()) == Result::Success);
 
     //Normal case
     auto ptr = shape.get();


### PR DESCRIPTION
Allow direct updates to the paint object without prior validation. The verification process is deemed inefficient;
users are expected to ensure the paint is updated using a canvas that contains it.

This might break the backward compatibility.