### PR TITLE
infra/window: Remove version fix of meson

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Install Packages
       run: |
-        pip install meson==0.58.0 ninja
+        pip install meson ninja
 
     - name: Build
       run: |
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install Packages
       run: |
-        pip install meson==0.58.0 ninja
+        pip install meson ninja
 
     - name: Build
       run: |
@@ -59,7 +59,7 @@ jobs:
 
     - name: Install Packages
       run: |
-        pip install meson==0.58.0 ninja
+        pip install meson ninja
 
     - name: Build
       run: |
@@ -71,3 +71,4 @@ jobs:
       with:
         name: UnitTestReport
         path: build/meson-logs/testlog.txt
+


### PR DESCRIPTION
Version 0.58 find missing libraries and causes an error. (ex: libwebp 1.0).
There is no need to fix the current version, so always use the latest version.