### PR TITLE
gl_engine: add stencil and cover render task

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -45,6 +45,12 @@ bool GlGeometry::tesselate(const RenderShape& rshape, RenderUpdateFlag flag)
         if (!tess.tessellate(&rshape, true)) {
             fillVertex.clear();
             fillIndex.clear();
+
+            BWTessellator bwTess{&fillVertex, &fillIndex};
+
+            bwTess.tessellate(&rshape);
+
+            mStencilFill = true;
         }
     }
 
@@ -211,4 +217,13 @@ void GlGeometry::setViewport(const RenderRegion& viewport)
 float* GlGeometry::getTransforMatrix()
 {
     return mTransform;
+}
+
+bool GlGeometry::needStencilCover(RenderUpdateFlag flag)
+{
+    if (flag & RenderUpdateFlag::Stroke) return false;
+    if (flag & RenderUpdateFlag::GradientStroke) return false;
+    if (flag & RenderUpdateFlag::Image) return false;
+
+    return mStencilFill;
 }

--- a/src/renderer/gl_engine/tvgGlGeometry.h
+++ b/src/renderer/gl_engine/tvgGlGeometry.h
@@ -195,6 +195,7 @@ public:
     void updateTransform(const RenderTransform* transform, float w, float h);
     void setViewport(const RenderRegion& viewport);
     float* getTransforMatrix();
+    bool needStencilCover(RenderUpdateFlag flag);
 
 private:
     RenderRegion viewport = {};
@@ -203,6 +204,8 @@ private:
     Array<uint32_t> fillIndex = {};
     Array<uint32_t> strokeIndex = {};
     float mTransform[16];
+
+    bool mStencilFill = false;
 };
 
 #endif /* _TVG_GL_GEOMETRY_H_ */

--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -76,6 +76,8 @@ class GlRenderTask
 {
 public:
     GlRenderTask(GlProgram* program): mProgram(program) {}
+    GlRenderTask(GlProgram* program, GlRenderTask* other);
+
     virtual ~GlRenderTask() = default;
 
     virtual void run();
@@ -93,6 +95,19 @@ private:
     uint32_t mIndexCount = {};
     Array<GlVertexLayout> mVertexLayout = {};
     Array<GlBindingResource> mBindingResources = {};
+};
+
+class GlStencilCoverTask : public GlRenderTask
+{
+public:
+    GlStencilCoverTask(GlRenderTask* stencil, GlRenderTask* cover);
+    ~GlStencilCoverTask() override;
+
+    void run() override;
+
+private:
+    GlRenderTask* mStencilTask;
+    GlRenderTask* mCoverTask;
 };
 
 class GlComposeTask : public GlRenderTask 

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -46,6 +46,7 @@ public:
         RT_MaskSub,
         RT_MaskIntersect,
         RT_MaskDifference,
+        RT_Stencil,
 
         RT_None,
     };

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -453,3 +453,19 @@ void main() {                                                           \n
     }                                                                   \n
 }                                                                       \n
 );
+
+const char* STENCIL_VERT_SHADER = TVG_COMPOSE_SHADER(
+    layout(location = 0) in vec3 aLocation;                         \n
+    layout(std140) uniform Matrix {                                 \n
+        mat4 transform;                                             \n
+    } uMatrix;                                                      \n
+    void main()                                                     \n
+    {                                                               \n
+        gl_Position =                                               \n
+            uMatrix.transform * vec4(aLocation.xy, 0.0, 1.0);       \n
+    });
+
+const char* STENCIL_FRAG_SHADER = TVG_COMPOSE_SHADER(
+    out vec4 FragColor;                                             \n
+    void main() { FragColor = vec4(0.0); }                          \n
+);

--- a/src/renderer/gl_engine/tvgGlShaderSrc.h
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.h
@@ -39,5 +39,7 @@ extern const char* MASK_ADD_FRAG_SHADER;
 extern const char* MASK_SUB_FRAG_SHADER;
 extern const char* MASK_INTERSECT_FRAG_SHADER;
 extern const char* MASK_DIFF_FRAG_SHADER;
+extern const char* STENCIL_VERT_SHADER;
+extern const char* STENCIL_FRAG_SHADER;
 
 #endif /* _TVG_GL_SHADERSRC_H_ */

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -177,6 +177,23 @@ private:
     GlPoint mPtCur;
 };
 
+class BWTessellator
+{
+public:
+    BWTessellator(Array<float>* points, Array<uint32_t>* indices);
+    ~BWTessellator() = default;
+
+    void tessellate(const RenderShape *rshape);
+
+private:
+    uint32_t pushVertex(float x, float y);
+    void pushTriangle(uint32_t a, uint32_t b, uint32_t c);
+
+private:
+    Array<float>* mResPoints;
+    Array<uint32_t>* mResIndices;
+};
+
 }  // namespace tvg
 
 #endif /* _TVG_GL_TESSELLATOR_H_ */


### PR DESCRIPTION
This PR contains the following changes:

* add new render task to do stencil and cover rendering which is a fallback rendering method to handle cases that trianglation tessellation failed
* add a new tessellator to generate stencil and cover vertex mesh

**After using this fallback method, more cases can be rendered successfully:**

## Before this patch
![image](https://github.com/thorvg/thorvg/assets/26308154/b6aeaec1-73a0-49a5-a631-18f00a045682)

----

## After this patch
<img width="800" alt="截屏2024-02-06 18 44 12" src="https://github.com/thorvg/thorvg/assets/26308154/1e24c3c3-7b22-4fd7-9649-fcae982b677e">

