### PR TITLE
loader/svg: Fix empty id to null

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -89,6 +89,7 @@ static char* _skipSpace(const char* str, const char* end)
 static char* _copyId(const char* str)
 {
     if (!str) return nullptr;
+    if (strlen(str) == 0) return nullptr;
 
     return strdup(str);
 }


### PR DESCRIPTION
empty id is invalid. Therefore, set it to null and make it is not used.

issue: https://github.com/thorvg/thorvg/issues/1977