### PR TITLE
wg_engine: animation optimizations (part 1)

### DIFF
--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -158,7 +158,7 @@ WGPUTexture WgContext::createTexture2d(WGPUTextureUsageFlags usage, WGPUTextureF
 }
 
 
-WGPUTextureView WgContext::createTextureView2d(WGPUTexture texture, WGPU_NULLABLE char const * label)
+WGPUTextureView WgContext::createTextureView2d(WGPUTexture texture, char const * label)
 {
     WGPUTextureViewDescriptor textureViewDescColor{};
     textureViewDescColor.nextInChain = nullptr;
@@ -174,6 +174,18 @@ WGPUTextureView WgContext::createTextureView2d(WGPUTexture texture, WGPU_NULLABL
 };
 
 
+WGPUBuffer WgContext::createBuffer(WGPUBufferUsageFlags usage, uint64_t size,char const * label)
+{
+    WGPUBufferDescriptor bufferDesc{};
+    bufferDesc.nextInChain = nullptr;
+    bufferDesc.label = label;
+    bufferDesc.usage = usage;
+    bufferDesc.size = size;
+    bufferDesc.mappedAtCreation = false;
+    return wgpuDeviceCreateBuffer(device, &bufferDesc);
+}
+
+
 void WgContext::releaseSampler(WGPUSampler& sampler)
 {
     if (sampler) {
@@ -181,6 +193,7 @@ void WgContext::releaseSampler(WGPUSampler& sampler)
         sampler = nullptr;
     }
 }
+
 
 void WgContext::releaseTexture(WGPUTexture& texture)
 {
@@ -195,8 +208,20 @@ void WgContext::releaseTexture(WGPUTexture& texture)
 
 void WgContext::releaseTextureView(WGPUTextureView& textureView)
 {
-    if (textureView) wgpuTextureViewRelease(textureView);
-    textureView = nullptr;
+    if (textureView) {
+        wgpuTextureViewRelease(textureView);
+        textureView = nullptr;
+    }
+}
+
+
+void WgContext::releaseBuffer(WGPUBuffer& buffer)
+{
+    if (buffer) { 
+        wgpuBufferDestroy(buffer);
+        wgpuBufferRelease(buffer);
+        buffer = nullptr;
+    }
 }
 
 

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -52,10 +52,13 @@ struct WgContext {
 
     WGPUSampler createSampler(WGPUFilterMode minFilter, WGPUMipmapFilterMode mipmapFilter);
     WGPUTexture createTexture2d(WGPUTextureUsageFlags usage, WGPUTextureFormat format, uint32_t width, uint32_t height, char const * label);
-    WGPUTextureView createTextureView2d(WGPUTexture texture, WGPU_NULLABLE char const * label);
+    WGPUTextureView createTextureView2d(WGPUTexture texture, char const * label);
+    WGPUBuffer createBuffer(WGPUBufferUsageFlags usage, uint64_t size,char const * label);
+
     void releaseSampler(WGPUSampler& sampler);
     void releaseTexture(WGPUTexture& texture);
     void releaseTextureView(WGPUTextureView& textureView);
+    void releaseBuffer(WGPUBuffer& buffer);
 };
 
 struct WgBindGroup


### PR DESCRIPTION
[issues 1479: update](#1479)

gpu vertex buffers reallocations optimization.
recreate buffers only if size is changed