### PR TITLE
loader/svg: Improve valid check for url(#id)

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -379,18 +379,27 @@ static void _parseDashArray(SvgLoaderData* loader, const char *str, SvgDash* das
 static char* _idFromUrl(const char* url)
 {
     url = _skipSpace(url, nullptr);
-    if ((*url) == '(') {
-        ++url;
-        url = _skipSpace(url, nullptr);
+
+    const char* open = strchr(url, '(');
+    const char* close = strchr(url, ')');
+
+    if (!open || !close || close < open) return nullptr;
+    if (strchr(open + 1, '(')) return nullptr;
+    if (strchr(close + 1, ')')) return nullptr;
+
+    const char* hash = strchr(open, '#');
+    if (!hash || hash > close) return nullptr;
+
+    const char* start = hash + 1;
+    const char* end = close - 1;
+    if (end <= start) return nullptr;
+
+    while (start < end && *end == ' ') --end;
+    for (const char* id = start; id != end; id++) {
+        if (*id == ' ' || *id == '\'') return nullptr;
     }
 
-    if ((*url) == '\'') ++url;
-    if ((*url) == '#') ++url;
-
-    int i = 0;
-    while (url[i] > ' ' && url[i] != ')' && url[i] != '\'') ++i;
-    
-    return strDuplicate(url, i);
+    return strDuplicate(start, end - start + 1);
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -392,7 +392,9 @@ static char* _idFromUrl(const char* url)
 
     const char* start = hash + 1;
     const char* end = close - 1;
-    if (end <= start) return nullptr;
+    start = _skipSpace(start, nullptr);
+    if (*start == ')') return strDuplicate(start, end - start + 1);
+    if (end < start) return nullptr;
 
     while (start < end && *end == ' ') --end;
     for (const char* id = start; id != end; id++) {


### PR DESCRIPTION
Improve parenthesis checking and space checking.
 - There must be only one pair of parentheses.
 - There cannot be spaces(and ') between id strings.

issue: https://github.com/thorvg/thorvg/issues/1983