### PR TITLE
sw_engine: Increasing accuracy for dashed curves

### DIFF
--- a/src/common/tvgBezier.h
+++ b/src/common/tvgBezier.h
@@ -44,6 +44,8 @@ void bezSplitAt(const Bezier& cur, float at, Bezier& left, Bezier& right);
 Point bezPointAt(const Bezier& bz, float t);
 float bezAngleAt(const Bezier& bz, float t);
 
+float bezLengthApprox(const Bezier& cur);
+float bezAtApprox(const Bezier& bz, float at, float length);
 }
 
 #endif //_TVG_BEZIER_H_

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -158,7 +158,7 @@ struct LottieVectorFrame
 
         if (hasTangent) {
             Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
-            t = bezAt(bz, t * length, length);
+            t = bezAtApprox(bz, t * length, length);
             return bezPointAt(bz, t);
         } else {
             return mathLerp(value, next->value, t);
@@ -171,14 +171,14 @@ struct LottieVectorFrame
         auto t = (frameNo - no) / (next->no - no);
         if (interpolator) t = interpolator->progress(t);
         Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
-        t = bezAt(bz, t * length, length);
+        t = bezAtApprox(bz, t * length, length);
         return -bezAngleAt(bz, t);
     }
 
     void prepare(LottieVectorFrame* next)
     {
         Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
-        length = bezLength(bz);
+        length = bezLengthApprox(bz);
     }
 };
 

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -37,13 +37,8 @@ struct Line
 
 static float _lineLength(const Point& pt1, const Point& pt2)
 {
-    /* approximate sqrt(x*x + y*y) using alpha max plus beta min algorithm.
-       With alpha = 1, beta = 3/8, giving results with the largest error less
-       than 7% compared to the exact value. */
     Point diff = {pt2.x - pt1.x, pt2.y - pt1.y};
-    if (diff.x < 0) diff.x = -diff.x;
-    if (diff.y < 0) diff.y = -diff.y;
-    return (diff.x > diff.y) ? (diff.x + diff.y * 0.375f) : (diff.y + diff.x * 0.375f);
+    return sqrtf(diff.x * diff.x + diff.y * diff.y);
 }
 
 
@@ -388,7 +383,7 @@ static float _outlineLength(const RenderShape* rshape)
                 break;
             }
             case PathCommand::CubicTo: {
-                length += bezLength({*(pts - 1), *pts, *(pts + 1), *(pts + 2)});
+                length += bezLengthApprox({*(pts - 1), *pts, *(pts + 1), *(pts + 2)});
                 pts += 3;
                 break;
             }


### PR DESCRIPTION
Dashed curves require greater precision in calculating their lengths. Otherwise, it results in visual
discrepancies compared to the expected outcomes.

issue: https://github.com/thorvg/thorvg/issues/1686

before:
<img src="https://github.com/thorvg/thorvg/assets/67589014/d3d90f12-3cfa-4aca-8300-50798680e8fb" width="400">

after:
<img src="https://github.com/thorvg/thorvg/assets/67589014/051c5937-6698-459b-9cee-fc51ed01aea9" width="400">

