### PR TITLE
common: Changing the circle/ellipse starting point

### DIFF
--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -130,11 +130,11 @@ Result Shape::appendCircle(float cx, float cy, float rx, float ry) noexcept
     auto ryKappa = ry * PATH_KAPPA;
 
     pImpl->grow(6, 13);
-    pImpl->moveTo(cx, cy - ry);
-    pImpl->cubicTo(cx + rxKappa, cy - ry, cx + rx, cy - ryKappa, cx + rx, cy);
+    pImpl->moveTo(cx + rx, cy);
     pImpl->cubicTo(cx + rx, cy + ryKappa, cx + rxKappa, cy + ry, cx, cy + ry);
     pImpl->cubicTo(cx - rxKappa, cy + ry, cx - rx, cy + ryKappa, cx - rx, cy);
     pImpl->cubicTo(cx - rx, cy - ryKappa, cx - rxKappa, cy - ry, cx, cy - ry);
+    pImpl->cubicTo(cx + rxKappa, cy - ry, cx + rx, cy - ryKappa, cx + rx, cy);
     pImpl->close();
 
     return Result::Success;


### PR DESCRIPTION
According to the SVG standard, drawing a circle/ellipse should start at the '3 o'clock' position and proceed in a clock-wise direction. Until now, this point was set at '12 o'clock'.
The differences in the outcome were visible for dashed strokes.

issue: https://github.com/thorvg/thorvg/issues/1686

before:
![el_before](https://github.com/thorvg/thorvg/assets/67589014/9aeb1cc6-d385-4f48-ab09-f063262bfe33)

after:
![el_after](https://github.com/thorvg/thorvg/assets/67589014/6c8ab8c1-d53f-44ba-9a51-e786cf5c4a19)
