### PR TITLE
sw_engine: fixing stroke outline

### DIFF
--- a/src/renderer/sw_engine/tvgSwStroke.cpp
+++ b/src/renderer/sw_engine/tvgSwStroke.cpp
@@ -377,9 +377,6 @@ static void _lineTo(SwStroke& stroke, const SwPoint& to)
     //a zero-length lineto is a no-op; avoid creating a spurious corner
     if (delta.zero()) return;
 
-    //compute length of line
-    auto angle = mathAtan(delta);
-
     /* The lineLength is used to determine the intersection of strokes outlines.
        The scale needs to be reverted since the stroke width has not been scaled.
        An alternative option is to scale the width of the stroke properly by
@@ -387,6 +384,7 @@ static void _lineTo(SwStroke& stroke, const SwPoint& to)
     delta.x = static_cast<SwCoord>(delta.x / stroke.sx);
     delta.y = static_cast<SwCoord>(delta.y / stroke.sy);
     auto lineLength = mathLength(delta);
+    auto angle = mathAtan(delta);
 
     delta = {static_cast<SwCoord>(stroke.width), 0};
     mathRotate(delta, angle + SW_ANGLE_PI2);


### PR DESCRIPTION
In the case of non-uniform scaling for
thick strokes, artifacts were visible.
The calculations took into account the angle
resulting from the already transformed points,
whereas the untransformed points should have
been considered - the transformation is taken
into account in the next step.

@issue: https://github.com/thorvg/thorvg/issues/1915

before:
<img src="https://github.com/thorvg/thorvg/assets/67589014/58084b5b-48b8-4a82-bfcf-2cdde7e08012" width="300"/>

after:
<img src="https://github.com/thorvg/thorvg/assets/67589014/bed529da-770c-497d-a7bb-72469a5cb07b" width="300"/>
