### PR TITLE
common: Changing the rounded rect starting point

### DIFF
--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -215,20 +215,20 @@ Result Shape::appendRect(float x, float y, float w, float h, float rx, float ry)
         pImpl->lineTo(x + w, y + h);
         pImpl->lineTo(x, y + h);
         pImpl->close();
-    //circle
+    //rounded rectangle or circle
     } else {
         auto hrx = rx * PATH_KAPPA;
         auto hry = ry * PATH_KAPPA;
         pImpl->grow(10, 17);
-        pImpl->moveTo(x + w, y + ry);
+        pImpl->moveTo(x + rx, y);
+        pImpl->lineTo(x + w - rx, y);
+        pImpl->cubicTo(x + w - rx + hrx, y, x + w, y + ry - hry, x + w, y + ry);
         pImpl->lineTo(x + w, y + h - ry);
         pImpl->cubicTo(x + w, y + h - ry + hry, x + w - rx + hrx, y + h, x + w - rx, y + h);
         pImpl->lineTo(x + rx, y + h);
         pImpl->cubicTo(x + rx - hrx, y + h, x, y + h - ry + hry, x, y + h - ry);
         pImpl->lineTo(x, y + ry);
         pImpl->cubicTo(x, y + ry - hry, x + rx - hrx, y, x + rx, y);
-        pImpl->lineTo(x + w - rx, y);
-        pImpl->cubicTo(x + w - rx + hrx, y, x + w, y + ry - hry, x + w, y + ry);
         pImpl->close();
     }
 


### PR DESCRIPTION
According to the SVG standard, drawing a rectangle starts at (x+rx, y) point. Till now it was (x+w, y+ry). The difference was visible only for dashed strokes.