### PR TITLE
gl_engine: fix a compile warnings, errors.

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderPass.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderPass.cpp
@@ -32,8 +32,12 @@ GlRenderTarget::~GlRenderTarget()
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
     GL_CHECK(glDeleteFramebuffers(1, &mFbo));
 
-    if (mColorTex != 0) GL_CHECK(glDeleteTextures(1, &mColorTex));
-    if (mStencilBuffer != 0) GL_CHECK(glDeleteRenderbuffers(1, &mStencilBuffer));
+    if (mColorTex != 0) {
+        GL_CHECK(glDeleteTextures(1, &mColorTex));
+    }
+    if (mStencilBuffer != 0) {
+        GL_CHECK(glDeleteRenderbuffers(1, &mStencilBuffer));
+    }
 }
 
 void GlRenderTarget::init(GLint resolveId)

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -26,7 +26,7 @@
 #include <cstdint>
 
 #include "tvgGlGeometry.h"
-#include "tvgBezier.h"
+#include "tvgLines.h"
 
 namespace tvg
 {


### PR DESCRIPTION
../src/renderer/gl_engine/tvgGlRenderPass.cpp:35:34: warning: macro expands to multiple statements [-Wmultistatement-macros]
   35 |     if (mColorTex != 0) GL_CHECK(glDeleteTextures(1, &mColorTex));
      |                                  ^~~~~~~~~~~~~~~~
../src/renderer/gl_engine/tvgGlCommon.h:33:9: note: in definition of macro ‘GL_CHECK’
   33 |         x; \
      |         ^