### PR TITLE
Lottie loader: fix compilation on windows

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -23,6 +23,8 @@
 #ifndef _TVG_LOTTIE_MODEL_H_
 #define _TVG_LOTTIE_MODEL_H_
 
+#include <cstring>
+
 #include "tvgCommon.h"
 #include "tvgRender.h"
 #include "tvgLottieProperty.h"


### PR DESCRIPTION
strlen() was used in tvgLottieModel.h without the inclusion of cstring. This patch fixes this