### PR TITLE
wg_engine: antialiasing

### DIFF
--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -158,6 +158,24 @@ WGPUTexture WgContext::createTexture2d(WGPUTextureUsageFlags usage, WGPUTextureF
 }
 
 
+WGPUTexture WgContext::createTexture2dMS(WGPUTextureUsageFlags usage, WGPUTextureFormat format, uint32_t width, uint32_t height, uint32_t sc, char const * label)
+{
+
+    WGPUTextureDescriptor textureDesc{};
+    textureDesc.nextInChain = nullptr;
+    textureDesc.label = label;
+    textureDesc.usage = usage;
+    textureDesc.dimension = WGPUTextureDimension_2D;
+    textureDesc.size = { width, height, 1 };
+    textureDesc.format = format;
+    textureDesc.mipLevelCount = 1;
+    textureDesc.sampleCount = sc;
+    textureDesc.viewFormatCount = 0;
+    textureDesc.viewFormats = nullptr;
+    return wgpuDeviceCreateTexture(device, &textureDesc);
+}
+
+
 WGPUTextureView WgContext::createTextureView2d(WGPUTexture texture, char const * label)
 {
     WGPUTextureViewDescriptor textureViewDescColor{};

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -52,6 +52,7 @@ struct WgContext {
 
     WGPUSampler createSampler(WGPUFilterMode minFilter, WGPUMipmapFilterMode mipmapFilter);
     WGPUTexture createTexture2d(WGPUTextureUsageFlags usage, WGPUTextureFormat format, uint32_t width, uint32_t height, char const * label);
+    WGPUTexture createTexture2dMS(WGPUTextureUsageFlags usage, WGPUTextureFormat format, uint32_t width, uint32_t height, uint32_t sc, char const * label);
     WGPUTextureView createTextureView2d(WGPUTexture texture, char const * label);
     WGPUBuffer createBuffer(WGPUBufferUsageFlags usage, uint64_t size,char const * label);
 

--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -291,6 +291,26 @@ void WgPipelineCompose::initialize(WGPUDevice device)
              shaderSource, shaderLabel, pipelineLabel);
 }
 
+
+void WgPipelineAntiAliasing::initialize(WGPUDevice device)
+{
+    // bind groups and layouts
+    WGPUBindGroupLayout bindGroupLayouts[] = {
+        WgBindGroupTextureStorage::getLayout(device),
+        WgBindGroupTextureStorage::getLayout(device)
+    };
+
+    // sheder source and labels
+    auto shaderSource = cShaderSource_PipelineComputeAntiAlias;
+    auto shaderLabel = "The compute shader anti-aliasing";
+    auto pipelineLabel = "The compute pipeline anti-aliasing";
+
+    // allocate all pipeline handles
+    allocate(device,
+             bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
+             shaderSource, shaderLabel, pipelineLabel);
+}
+
 //************************************************************************
 // pipelines
 //************************************************************************
@@ -308,6 +328,7 @@ void WgPipelines::initialize(WgContext& context)
     computeClear.initialize(context.device);
     computeBlend.initialize(context.device);
     computeCompose.initialize(context.device);
+    computeAntiAliasing.initialize(context.device);
     // store pipelines to context
     context.pipelines = this;
 }
@@ -326,6 +347,7 @@ void WgPipelines::release()
     WgBindGroupPaint::releaseLayout();
     WgBindGroupCanvas::releaseLayout();
     // compute pipelines
+    computeAntiAliasing.release();
     computeCompose.release();
     computeBlend.release();
     computeClear.release();

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -106,8 +106,7 @@ struct WgPipelineImage: public WgRenderPipeline
 struct WgPipelineClear: public WgComputePipeline
 {
     void initialize(WGPUDevice device) override;
-    void use(WGPUComputePassEncoder encoder,
-             WgBindGroupTextureStorage& groupTexDst)
+    void use(WGPUComputePassEncoder encoder, WgBindGroupTextureStorage& groupTexDst)
     {
         set(encoder);
         groupTexDst.set(encoder, 0);
@@ -118,10 +117,7 @@ struct WgPipelineClear: public WgComputePipeline
 struct WgPipelineBlend: public WgComputePipeline
 {
     void initialize(WGPUDevice device) override;
-    void use(WGPUComputePassEncoder encoder,
-             WgBindGroupTextureStorage& groupTexSrc,
-             WgBindGroupTextureStorage& groupTexDst,
-             WgBindGroupBlendMethod& blendMethod)
+    void use(WGPUComputePassEncoder encoder, WgBindGroupTextureStorage& groupTexSrc, WgBindGroupTextureStorage& groupTexDst, WgBindGroupBlendMethod& blendMethod)
     {
         set(encoder);
         groupTexSrc.set(encoder, 0);
@@ -134,17 +130,25 @@ struct WgPipelineBlend: public WgComputePipeline
 struct WgPipelineCompose: public WgComputePipeline
 {
     void initialize(WGPUDevice device) override;
-    void use(WGPUComputePassEncoder encoder,
-             WgBindGroupTextureStorage& groupTexSrc,
-             WgBindGroupTextureStorage& groupTexMsk,
-             WgBindGroupCompositeMethod& groupComposeMethod,
-             WgBindGroupOpacity& groupOpacity)
+    void use(WGPUComputePassEncoder encoder, WgBindGroupTextureStorage& groupTexSrc, WgBindGroupTextureStorage& groupTexMsk, WgBindGroupCompositeMethod& groupComposeMethod, WgBindGroupOpacity& groupOpacity)
     {
         set(encoder);
         groupTexSrc.set(encoder, 0);
         groupTexMsk.set(encoder, 1);
         groupComposeMethod.set(encoder, 2);
         groupOpacity.set(encoder, 3);
+    }
+};
+
+
+struct WgPipelineAntiAliasing: public WgComputePipeline
+{
+    void initialize(WGPUDevice device) override;
+    void use(WGPUComputePassEncoder encoder, WgBindGroupTextureStorage& groupTexSrc, WgBindGroupTextureStorage& groupTexDst)
+    {
+        set(encoder);
+        groupTexSrc.set(encoder, 0);
+        groupTexDst.set(encoder, 1);
     }
 };
 
@@ -165,6 +169,7 @@ struct WgPipelines
     WgPipelineClear computeClear;
     WgPipelineBlend computeBlend;
     WgPipelineCompose computeCompose;
+    WgPipelineAntiAliasing computeAntiAliasing;
 
     void initialize(WgContext& context);
     void release();

--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -37,7 +37,7 @@ public:
     WGPUTextureView texViewStencil{};
     WgBindGroupTextureStorage bindGroupTexStorage;
 public:
-    void initialize(WgContext& context, uint32_t w, uint32_t h);
+    void initialize(WgContext& context, uint32_t w, uint32_t h, uint32_t samples = 1);
     void release(WgContext& context);
 
     void renderShape(WGPUCommandEncoder commandEncoder, WgRenderDataShape* renderData);
@@ -64,13 +64,14 @@ public:
     uint32_t workgroupsCountX{};
     uint32_t workgroupsCountY{};
 public:
-    void initialize(WgContext& context, uint32_t w, uint32_t h);
+    void initialize(WgContext& context, uint32_t w, uint32_t h, uint32_t samples = 1);
     void release(WgContext& context);
 
     void clear(WGPUCommandEncoder commandEncoder);
     void blend(WGPUCommandEncoder commandEncoder, WgRenderTarget* targetSrc, WgBindGroupBlendMethod* blendMethod);
     void blend(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc, WgBindGroupBlendMethod* blendMethod);
     void compose(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetMsk, WgBindGroupCompositeMethod* composeMethod, WgBindGroupOpacity* opacity);
+    void antialias(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc);
 private:
     void dispatchWorkgroups(WGPUComputePassEncoder computePassEncoder);
 

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -64,6 +64,7 @@ private:
     WGPUCommandEncoder mCommandEncoder{};
     WgRenderTarget mRenderTarget;
     WgRenderStorage mRenderStorageRoot;
+    WgRenderStorage mRenderStorageScreen;
     WgRenderStoragePool mRenderStoragePool;
     WgBindGroupOpacityPool mOpacityPool;
     WgBindGroupBlendMethodPool mBlendMethodPool;

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -44,5 +44,6 @@ extern const char* cShaderSource_PipelineImage;
 extern const char* cShaderSource_PipelineComputeClear;
 extern const char* cShaderSource_PipelineComputeBlend;
 extern const char* cShaderSource_PipelineComputeCompose;
+extern const char* cShaderSource_PipelineComputeAntiAlias;
 
 #endif // _TVG_WG_SHADER_SRC_H_


### PR DESCRIPTION
[issues 1479: antialiasing](#1479)

Anti-aliasing implementation
Implements antialiasing as a post process on compute shaders and original render target with scale of **x2** (hardcoded, can be changed as a constant)
Can be modified to setup as an external setting