### PR TITLE
sw_engine: fix a regression bug.

### DIFF
--- a/src/renderer/sw_engine/tvgSwMath.cpp
+++ b/src/renderer/sw_engine/tvgSwMath.cpp
@@ -50,12 +50,6 @@ bool mathSmallCubic(const SwPoint* base, SwFixed& angleIn, SwFixed& angleMid, Sw
     auto d2 = base[1] - base[2];
     auto d3 = base[0] - base[1];
 
-    if (d1 == d2 || d2 == d3) {
-        if (d3.small()) angleIn = angleMid = angleOut = 0;
-        else angleIn = angleMid = angleOut = mathAtan(d3);
-        return true;
-    }
-
     if (d1.small()) {
         if (d2.small()) {
             if (d3.small()) {


### PR DESCRIPTION
stroke line drawing has been broken at a certain case, this reverts a part of change from the old optimization:

d81f5d29fb66f8d56e6197ca35dc375befc535e9

note that this change wouldn't affect any performance.

issue: https://github.com/thorvg/thorvg/issues/2015