### PR TITLE
sw_engine: fix a regression bug

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -356,7 +356,7 @@ static float _outlineLength(const RenderShape* rshape)
                 break;
             }
             case PathCommand::CubicTo: {
-                length += bezLengthApprox({*(pts - 1), *pts, *(pts + 1), *(pts + 2)});
+                length += bezLength({*(pts - 1), *pts, *(pts + 1), *(pts + 2)});
                 pts += 3;
                 break;
             }


### PR DESCRIPTION
After introducing the length measurement
of approximate and exact Bezier curves in
a8c0030d807755f71a2f6d602c5adcec1738ffa3
the calculation of the outline length still
used the approximate functions, while further
calculations took the exact value into account.
This discrepancy led to the creation of artifacts.

@Issue: https://github.com/thorvg/thorvg/issues/2021