### PR TITLE
gl_engine: use stencil and cover tessellator by default

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -41,17 +41,12 @@ bool GlGeometry::tesselate(const RenderShape& rshape, RenderUpdateFlag flag)
         fillVertex.clear();
         fillIndex.clear();
 
-        Tessellator tess{&fillVertex, &fillIndex};
-        if (!tess.tessellate(&rshape, true)) {
-            fillVertex.clear();
-            fillIndex.clear();
 
-            BWTessellator bwTess{&fillVertex, &fillIndex};
+        BWTessellator bwTess{&fillVertex, &fillIndex};
 
-            bwTess.tessellate(&rshape);
+        bwTess.tessellate(&rshape);
 
-            mStencilFill = true;
-        }
+        mStencilFill = true;
     }
 
     if (flag & (RenderUpdateFlag::Stroke | RenderUpdateFlag::Transform)) {


### PR DESCRIPTION
Since we choose multisample antialiasing, use stencil then cover to render polygon can get better performance.
Also the code is much easier to understand.