### PR TITLE
capi: added missing lottie header

### DIFF
--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -20,8 +20,10 @@
  * SOFTWARE.
  */
 
+#include "config.h"
 #include <string>
 #include <thorvg.h>
+#include <thorvg_lottie.h>
 #include "thorvg_capi.h"
 
 using namespace std;


### PR DESCRIPTION
Currently, the Lottie Animation API is not working due to the missing header.