### PR TITLE
gl_engine: remove unused alpha attribute

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -20,16 +20,10 @@
  * SOFTWARE.
  */
 
-#include <float.h>
 #include "tvgGlGpuBuffer.h"
 #include "tvgGlGeometry.h"
 #include "tvgGlTessellator.h"
 #include "tvgGlRenderTask.h"
-
-#define NORMALIZED_TOP_3D 1.0f
-#define NORMALIZED_BOTTOM_3D -1.0f
-#define NORMALIZED_LEFT_3D -1.0f
-#define NORMALIZED_RIGHT_3D 1.0f
 
 GlGeometry::~GlGeometry()
 {
@@ -74,19 +68,19 @@ bool GlGeometry::tesselate(const Surface* image, const RenderMesh* mesh, RenderU
             for (uint32_t i = 0; i < mesh->triangleCnt; i++) {
                 fillVertex.push(mesh->triangles[i].vertex[0].pt.x);
                 fillVertex.push(mesh->triangles[i].vertex[0].pt.y);
-                fillVertex.push(1.f);
+
                 fillVertex.push(mesh->triangles[i].vertex[0].uv.x);
                 fillVertex.push(mesh->triangles[i].vertex[0].uv.y);
 
                 fillVertex.push(mesh->triangles[i].vertex[1].pt.x);
                 fillVertex.push(mesh->triangles[i].vertex[1].pt.y);
-                fillVertex.push(1.f);
+
                 fillVertex.push(mesh->triangles[i].vertex[1].uv.x);
                 fillVertex.push(mesh->triangles[i].vertex[1].uv.y);
 
                 fillVertex.push(mesh->triangles[i].vertex[2].pt.x);
                 fillVertex.push(mesh->triangles[i].vertex[2].pt.y);
-                fillVertex.push(1.f);
+
                 fillVertex.push(mesh->triangles[i].vertex[2].uv.x);
                 fillVertex.push(mesh->triangles[i].vertex[2].uv.y);
 
@@ -108,25 +102,25 @@ bool GlGeometry::tesselate(const Surface* image, const RenderMesh* mesh, RenderU
             // left top point
             fillVertex.push(left);
             fillVertex.push(top);
-            fillVertex.push(1.f);
+
             fillVertex.push(0.f);
             fillVertex.push(1.f);
             // left bottom point
             fillVertex.push(left);
             fillVertex.push(bottom);
-            fillVertex.push(1.f);
+
             fillVertex.push(0.f);
             fillVertex.push(0.f);
             // right top point
             fillVertex.push(right);
             fillVertex.push(top);
-            fillVertex.push(1.f);
+
             fillVertex.push(1.f);
             fillVertex.push(1.f);
             // right bottom point
             fillVertex.push(right);
             fillVertex.push(bottom);
-            fillVertex.push(1.f);
+
             fillVertex.push(1.f);
             fillVertex.push(0.f);
 
@@ -176,10 +170,10 @@ bool GlGeometry::draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdate
     // vertex layout
     if (flag & RenderUpdateFlag::Image) {
         // image has two attribute: [pos, uv]
-        task->addVertexLayout(GlVertexLayout{0, 3, 5 * sizeof(float), vertexOffset});
-        task->addVertexLayout(GlVertexLayout{1, 2, 5 * sizeof(float), vertexOffset + 3 * sizeof(float)});
+        task->addVertexLayout(GlVertexLayout{0, 2, 4 * sizeof(float), vertexOffset});
+        task->addVertexLayout(GlVertexLayout{1, 2, 4 * sizeof(float), vertexOffset + 2 * sizeof(float)});
     } else {
-        task->addVertexLayout(GlVertexLayout{0, 3, 3 * sizeof(float), vertexOffset});
+        task->addVertexLayout(GlVertexLayout{0, 2, 2 * sizeof(float), vertexOffset});
     }
     task->setDrawRange(indexOffset, indexBuffer->count);
     task->setViewport(viewport);

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -108,7 +108,6 @@ bool GlRenderer::sync()
     GL_CHECK(glDisable(GL_SCISSOR_TEST));
 
     mRenderPassStack.clear();
-    mClearBuffer = false;
 
     delete task;
 
@@ -498,7 +497,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, uint8_t r, uint8_t g, uint8_t b, 
     if (sdata.geometry->needStencilCover(flag)) stencilTask = new GlRenderTask(mPrograms[RT_Stencil].get(), task);
 
     a = MULTIPLY(a, sdata.opacity);
-    
+
     // matrix buffer
     {
         auto matrix = sdata.geometry->getTransforMatrix();
@@ -524,7 +523,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, uint8_t r, uint8_t g, uint8_t b, 
             });
         }
     }
-    // color 
+    // color
     {
         float color[4] = {r / 255.f, g / 255.f, b / 255.f, a / 255.f};
 
@@ -678,7 +677,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
     }
 }
 
-GlRenderPass* GlRenderer::currentPass() 
+GlRenderPass* GlRenderer::currentPass()
 {
     if (mRenderPassStack.empty()) return nullptr;
 

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -26,33 +26,28 @@
 #define TVG_COMPOSE_SHADER(shader) #shader
 
 const char* COLOR_VERT_SHADER = TVG_COMPOSE_SHADER(
-    layout(location = 0) in vec3 aLocation;                         \n
+    layout(location = 0) in vec2 aLocation;                         \n
     layout(std140) uniform Matrix {                                 \n
         mat4 transform;                                             \n
     } uMatrix;                                                      \n
-    out float vOpacity;                                             \n
     void main()                                                     \n
     {                                                               \n
-        gl_Position =                                               \n
-            uMatrix.transform * vec4(aLocation.xy, 0.0, 1.0);       \n
-        vOpacity = aLocation.z;                                     \n
+        gl_Position = uMatrix.transform * vec4(aLocation, 0.0, 1.0);\n
     });
 
 const char* COLOR_FRAG_SHADER = TVG_COMPOSE_SHADER(
     layout(std140) uniform ColorInfo {                       \n
         vec4 solidColor;                                     \n
     } uColorInfo;                                            \n
-    in float vOpacity;                                       \n
     out vec4 FragColor;                                      \n
     void main()                                              \n
     {                                                        \n
        vec4 uColor = uColorInfo.solidColor;                  \n
-       FragColor = vec4(uColor.xyz, uColor.w*vOpacity);      \n
+       FragColor =  uColor;                                  \n
     });
 
 const char* GRADIENT_VERT_SHADER = TVG_COMPOSE_SHADER(
-layout(location = 0) in vec3 aLocation;                                         \n
-out float vOpacity;                                                             \n
+layout(location = 0) in vec2 aLocation;                                         \n
 out vec2 vPos;                                                                  \n
 layout(std140) uniform Matrix {                                                 \n
     mat4 transform;                                                             \n
@@ -60,16 +55,14 @@ layout(std140) uniform Matrix {                                                 
                                                                                 \n
 void main()                                                                     \n
 {                                                                               \n
-    gl_Position = uMatrix.transform * vec4(aLocation.xy, 0.0, 1.0);             \n
-    vOpacity = aLocation.z;                                                     \n
-    vPos =  aLocation.xy;                                                       \n
+    gl_Position = uMatrix.transform * vec4(aLocation, 0.0, 1.0);                \n
+    vPos =  aLocation;                                                          \n
 });
 
 
 std::string STR_GRADIENT_FRAG_COMMON_VARIABLES = TVG_COMPOSE_SHADER(
 const int MAX_STOP_COUNT = 16;                                                                          \n
 in vec2 vPos;                                                                                           \n
-in float vOpacity;                                                                                      \n
 );
 
 std::string STR_GRADIENT_FRAG_COMMON_FUNCTIONS = TVG_COMPOSE_SHADER(
@@ -155,7 +148,7 @@ layout(std140) uniform GradientInfo {                                           
     vec4  nStops;                                                                                       \n
     vec2  gradStartPos;                                                                                 \n
     vec2  gradEndPos;                                                                                   \n
-    vec4  stopPoints[MAX_STOP_COUNT / 4];                                                                                   \n
+    vec4  stopPoints[MAX_STOP_COUNT / 4];                                                               \n
     vec4  stopColors[MAX_STOP_COUNT];                                                                   \n
 } uGradientInfo ;                                                                                       \n
 );
@@ -178,7 +171,7 @@ void main()                                                                     
                                                                                                         \n
     vec3 noise = 8.0 * uGradientInfo.nStops[1] * ScreenSpaceDither(pos);                                \n
     vec4 finalCol = vec4(color.xyz + noise, color.w);                                                   \n
-    FragColor = vec4(finalCol.xyz, finalCol.w* vOpacity);                                               \n
+    FragColor =  finalCol;                                                                              \n
 });
 
 std::string STR_RADIAL_GRADIENT_VARIABLES = TVG_COMPOSE_SHADER(
@@ -207,7 +200,7 @@ void main()                                                                     
                                                                                                         \n
     vec3 noise = 8.0 * uGradientInfo.nStops[1] * ScreenSpaceDither(pos);                                \n
     vec4 finalCol = vec4(color.xyz + noise, color.w);                                                   \n
-    FragColor = vec4(finalCol.xyz, finalCol.w * vOpacity);                                              \n
+    FragColor =  finalCol;                                                                              \n
 });
 
 std::string STR_LINEAR_GRADIENT_FRAG_SHADER =
@@ -228,19 +221,17 @@ const char* RADIAL_GRADIENT_FRAG_SHADER = STR_RADIAL_GRADIENT_FRAG_SHADER.c_str(
 
 
 const char* IMAGE_VERT_SHADER = TVG_COMPOSE_SHADER(
-    layout (location = 0) in vec3 aLocation;                                                \n
+    layout (location = 0) in vec2 aLocation;                                                \n
     layout (location = 1) in vec2 aUV;                                                      \n
     layout (std140) uniform Matrix {                                                        \n
         mat4 transform;                                                                     \n
     } uMatrix;                                                                              \n
                                                                                             \n
-    out float aOpacity;                                                                     \n
     out vec2 vUV;                                                                           \n
                                                                                             \n
     void main() {                                                                           \n
-        aOpacity = aLocation.z;                                                             \n
         vUV = aUV;                                                                          \n
-        gl_Position = uMatrix.transform * vec4(aLocation.xy, 0.0, 1.0);                     \n
+        gl_Position = uMatrix.transform * vec4(aLocation, 0.0, 1.0);                        \n
     }                                                                                       \n
 );
 
@@ -253,7 +244,6 @@ const char* IMAGE_FRAG_SHADER = TVG_COMPOSE_SHADER(
     } uColorInfo;                                                                           \n
     uniform sampler2D uTexture;                                                             \n
                                                                                             \n
-    in float aOpacity;                                                                      \n
     in vec2 vUV;                                                                            \n
                                                                                             \n
     out vec4 FragColor;                                                                     \n
@@ -278,22 +268,20 @@ const char* IMAGE_FRAG_SHADER = TVG_COMPOSE_SHADER(
             result.a = color.a;                                                             \n
         }                                                                                   \n
         float opacity = float(uColorInfo.opacity) / 255.0;                                  \n
-        FragColor = vec4(result.rgb, result.a * opacity * aOpacity);                        \n
+        FragColor = vec4(result.rgb, result.a * opacity);                                   \n
    }                                                                                        \n
 );
 
 const char* MASK_VERT_SHADER = TVG_COMPOSE_SHADER(
-layout(location = 0) in vec3 aLocation;                 \n
+layout(location = 0) in vec2 aLocation;                 \n
 layout(location = 1) in vec2 aUV;                       \n
                                                         \n
-out float vOpacity;                                     \n
 out vec2  vUV;                                          \n
                                                         \n
 void main() {                                           \n
   vUV = aUV;                                            \n
-  vOpacity = aLocation.z;                               \n
                                                         \n
-  gl_Position = vec4(aLocation.xy, 0.0, 1.0);           \n
+  gl_Position = vec4(aLocation, 0.0, 1.0);              \n
 }                                                       \n
 );
 
@@ -302,7 +290,6 @@ const char* MASK_ALPHA_FRAG_SHADER = TVG_COMPOSE_SHADER(
 uniform sampler2D uSrcTexture;                          \n
 uniform sampler2D uMaskTexture;                         \n
                                                         \n
-in float vOpacity;                                      \n
 in vec2 vUV;                                            \n
                                                         \n
 out vec4 FragColor;                                     \n
@@ -312,7 +299,7 @@ void main() {                                           \n
     vec4 maskColor = texture(uMaskTexture, vUV);        \n
                                                         \n
     FragColor = vec4(srcColor.rgb,                      \n
-             srcColor.a * maskColor.a * vOpacity);      \n
+             srcColor.a * maskColor.a);                 \n
 }                                                       \n
 );
 
@@ -320,7 +307,6 @@ const char* MASK_INV_ALPHA_FRAG_SHADER = TVG_COMPOSE_SHADER(
 uniform sampler2D uSrcTexture;                              \n
 uniform sampler2D uMaskTexture;                             \n
                                                             \n
-in float vOpacity;                                          \n
 in vec2 vUV;                                                \n
                                                             \n
 out vec4 FragColor;                                         \n
@@ -330,7 +316,7 @@ void main() {                                               \n
     vec4 maskColor = texture(uMaskTexture, vUV);            \n
                                                             \n
     FragColor = vec4(srcColor.rgb,                          \n
-             srcColor.a * (1.0 - maskColor.a) * vOpacity);  \n
+             srcColor.a * (1.0 - maskColor.a));             \n
 }                                                           \n
 );
 
@@ -338,7 +324,6 @@ const char* MASK_LUMA_FRAG_SHADER = TVG_COMPOSE_SHADER(
 uniform sampler2D uSrcTexture;                                                                          \n
 uniform sampler2D uMaskTexture;                                                                         \n
                                                                                                         \n
-in float vOpacity;                                                                                      \n
 in vec2 vUV;                                                                                            \n
                                                                                                         \n
 out vec4 FragColor;                                                                                     \n
@@ -347,7 +332,7 @@ void main() {                                                                   
     vec4 srcColor = texture(uSrcTexture, vUV);                                                          \n
     vec4 maskColor = texture(uMaskTexture, vUV);                                                        \n
                                                                                                         \n
-    FragColor = srcColor * vOpacity * (0.299 * maskColor.r + 0.587 * maskColor.g + 0.114 * maskColor.b);   \n
+    FragColor = srcColor * (0.299 * maskColor.r + 0.587 * maskColor.g + 0.114 * maskColor.b);           \n
 }                                                                                                       \n
 );
 
@@ -355,7 +340,6 @@ const char* MASK_INV_LUMA_FRAG_SHADER = TVG_COMPOSE_SHADER(
 uniform sampler2D uSrcTexture;                                                      \n
 uniform sampler2D uMaskTexture;                                                     \n
                                                                                     \n
-in float vOpacity;                                                                  \n
 in vec2 vUV;                                                                        \n
                                                                                     \n
 out vec4 FragColor;                                                                 \n
@@ -365,7 +349,7 @@ void main() {                                                                   
     vec4 maskColor = texture(uMaskTexture, vUV);                                    \n
                                                                                     \n
     float luma = (0.299 * maskColor.r + 0.587 * maskColor.g + 0.114 * maskColor.b); \n
-    FragColor = srcColor * vOpacity * (1.0 - luma);                                 \n
+    FragColor = srcColor * (1.0 - luma);                                            \n
 }                                                                                   \n
 );
 
@@ -373,7 +357,6 @@ const char* MASK_ADD_FRAG_SHADER = TVG_COMPOSE_SHADER(
 uniform sampler2D uSrcTexture;                                      \n
 uniform sampler2D uMaskTexture;                                     \n
                                                                     \n
-in float vOpacity;                                                  \n
 in vec2 vUV;                                                        \n
                                                                     \n
 out vec4 FragColor;                                                 \n
@@ -384,7 +367,7 @@ void main() {                                                       \n
                                                                     \n
     vec4 color = srcColor + maskColor * (1.0 - srcColor.a);         \n
                                                                     \n
-    FragColor = min(color, vec4(1.0, 1.0, 1.0, 1.0 * vOpacity)) ;   \n
+    FragColor = min(color, vec4(1.0, 1.0, 1.0, 1.0)) ;              \n
 }                                                                   \n
 );
 
@@ -392,7 +375,6 @@ const char* MASK_SUB_FRAG_SHADER = TVG_COMPOSE_SHADER(
 uniform sampler2D uSrcTexture;                                          \n
 uniform sampler2D uMaskTexture;                                         \n
                                                                         \n
-in float vOpacity;                                                      \n
 in vec2 vUV;                                                            \n
                                                                         \n
 out vec4 FragColor;                                                     \n
@@ -405,7 +387,7 @@ void main() {                                                           \n
     if (a <= 0.0) {                                                     \n
         FragColor = vec4(0.0, 0.0, 0.0, 0.0);                           \n
     } else {                                                            \n
-        FragColor = vec4(srcColor.rgb, srcColor.a * vOpacity * a);      \n
+        FragColor = vec4(srcColor.rgb, srcColor.a * a);                 \n
     }                                                                   \n
 }                                                                       \n
 );
@@ -414,7 +396,6 @@ const char* MASK_INTERSECT_FRAG_SHADER = TVG_COMPOSE_SHADER(
 uniform sampler2D uSrcTexture;                                          \n
 uniform sampler2D uMaskTexture;                                         \n
                                                                         \n
-in float vOpacity;                                                      \n
 in vec2 vUV;                                                            \n
                                                                         \n
 out vec4 FragColor;                                                     \n
@@ -425,7 +406,7 @@ void main() {                                                           \n
                                                                         \n
     float intAlpha = srcColor.a * maskColor.a;                          \n
                                                                         \n
-    FragColor = vec4(maskColor.rgb, maskColor.a * vOpacity * intAlpha); \n
+    FragColor = vec4(maskColor.rgb, maskColor.a * intAlpha);            \n
 }                                                                       \n
 );
 
@@ -433,7 +414,6 @@ const char* MASK_DIFF_FRAG_SHADER = TVG_COMPOSE_SHADER(
 uniform sampler2D uSrcTexture;                                          \n
 uniform sampler2D uMaskTexture;                                         \n
                                                                         \n
-in float vOpacity;                                                      \n
 in vec2 vUV;                                                            \n
                                                                         \n
 out vec4 FragColor;                                                     \n
@@ -447,22 +427,22 @@ void main() {                                                           \n
     if (da == 0.0) {                                                    \n
         FragColor = vec4(0.0, 0.0, 0.0, 0.0);                           \n
     } else if (da > 0.0) {                                              \n
-        FragColor = vec4(srcColor.rgb, srcColor.a * da * vOpacity);     \n
+        FragColor = vec4(srcColor.rgb, srcColor.a * da);                \n
     } else {                                                            \n
-        FragColor = vec4(maskColor.rgb, maskColor.a * (-da) * vOpacity);\n
+        FragColor = vec4(maskColor.rgb, maskColor.a * (-da));           \n
     }                                                                   \n
 }                                                                       \n
 );
 
 const char* STENCIL_VERT_SHADER = TVG_COMPOSE_SHADER(
-    layout(location = 0) in vec3 aLocation;                         \n
+    layout(location = 0) in vec2 aLocation;                         \n
     layout(std140) uniform Matrix {                                 \n
         mat4 transform;                                             \n
     } uMatrix;                                                      \n
     void main()                                                     \n
     {                                                               \n
         gl_Position =                                               \n
-            uMatrix.transform * vec4(aLocation.xy, 0.0, 1.0);       \n
+            uMatrix.transform * vec4(aLocation, 0.0, 1.0);          \n
     });
 
 const char* STENCIL_FRAG_SHADER = TVG_COMPOSE_SHADER(

--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -25,7 +25,6 @@
 #include "tvgGlList.h"
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <cstdint>
 
@@ -816,12 +815,11 @@ static float _downScaleFloat(float v)
     return v / 1000.f;
 }
 
-static uint32_t _pushVertex(Array<float> *array, float x, float y, float z)
+static uint32_t _pushVertex(Array<float> *array, float x, float y)
 {
     array->push(x);
     array->push(y);
-    array->push(z);
-    return (array->count - 3) / 3;
+    return (array->count - 2) / 2;
 }
 
 enum class Orientation
@@ -1628,11 +1626,11 @@ void Tessellator::emitTriangle(detail::Vertex *p1, detail::Vertex *p2, detail::V
 {
     // check if index is generated
     if (p1->index == 0xFFFFFFFF)
-        p1->index = detail::_pushVertex(resGlPoints, detail::_downScaleFloat(p1->point.x), detail::_downScaleFloat(p1->point.y), 1.f);
+        p1->index = detail::_pushVertex(resGlPoints, detail::_downScaleFloat(p1->point.x), detail::_downScaleFloat(p1->point.y));
     if (p2->index == 0xFFFFFFFF)
-        p2->index = detail::_pushVertex(resGlPoints, detail::_downScaleFloat(p2->point.x), detail::_downScaleFloat(p2->point.y), 1.f);
+        p2->index = detail::_pushVertex(resGlPoints, detail::_downScaleFloat(p2->point.x), detail::_downScaleFloat(p2->point.y));
     if (p3->index == 0xFFFFFFFF)
-        p3->index = detail::_pushVertex(resGlPoints, detail::_downScaleFloat(p3->point.x), detail::_downScaleFloat(p3->point.y), 1.f);
+        p3->index = detail::_pushVertex(resGlPoints, detail::_downScaleFloat(p3->point.x), detail::_downScaleFloat(p3->point.y));
 
     resIndices->push(p1->index);
     resIndices->push(p2->index);
@@ -1743,10 +1741,10 @@ void Stroker::strokeLineTo(const GlPoint &curr)
     auto c = curr + normal * strokeRadius();
     auto d = curr - normal * strokeRadius();
 
-    auto ia = detail::_pushVertex(mResGlPoints, a.x, a.y, 1.f);
-    auto ib = detail::_pushVertex(mResGlPoints, b.x, b.y, 1.f);
-    auto ic = detail::_pushVertex(mResGlPoints, c.x, c.y, 1.f);
-    auto id = detail::_pushVertex(mResGlPoints, d.x, d.y, 1.f);
+    auto ia = detail::_pushVertex(mResGlPoints, a.x, a.y);
+    auto ib = detail::_pushVertex(mResGlPoints, b.x, b.y);
+    auto ic = detail::_pushVertex(mResGlPoints, c.x, c.y);
+    auto id = detail::_pushVertex(mResGlPoints, d.x, d.y);
 
     /**
      *   a --------- c
@@ -1867,9 +1865,9 @@ void Stroker::strokeRound(const GlPoint &prev, const GlPoint &curr, const GlPoin
     // Fixme: just use bezier curve to calculate step count
     auto count = detail::_bezierCurveCount(detail::_bezFromArc(prev, curr, strokeRadius()));
 
-    auto c = detail::_pushVertex(mResGlPoints, center.x, center.y, 1.f);
+    auto c = detail::_pushVertex(mResGlPoints, center.x, center.y);
 
-    auto pi = detail::_pushVertex(mResGlPoints, prev.x, prev.y, 1.f);
+    auto pi = detail::_pushVertex(mResGlPoints, prev.x, prev.y);
 
     float step = 1.f / (count - 1);
 
@@ -1884,7 +1882,7 @@ void Stroker::strokeRound(const GlPoint &prev, const GlPoint &curr, const GlPoin
 
         auto out = center + o_dir * strokeRadius();
 
-        auto oi = detail::_pushVertex(mResGlPoints, out.x, out.y, 1.f);
+        auto oi = detail::_pushVertex(mResGlPoints, out.x, out.y);
 
         this->mResIndices->push(c);
         this->mResIndices->push(pi);
@@ -1912,12 +1910,12 @@ void Stroker::strokeMiter(const GlPoint &prev, const GlPoint &curr, const GlPoin
 
     auto join = center + pe;
 
-    auto c = detail::_pushVertex(mResGlPoints, center.x, center.y, 1.f);
+    auto c = detail::_pushVertex(mResGlPoints, center.x, center.y);
 
-    auto cp1 = detail::_pushVertex(mResGlPoints, prev.x, prev.y, 1.f);
-    auto cp2 = detail::_pushVertex(mResGlPoints, curr.x, curr.y, 1.f);
+    auto cp1 = detail::_pushVertex(mResGlPoints, prev.x, prev.y);
+    auto cp2 = detail::_pushVertex(mResGlPoints, curr.x, curr.y);
 
-    auto e = detail::_pushVertex(mResGlPoints, join.x, join.y, 1.f);
+    auto e = detail::_pushVertex(mResGlPoints, join.x, join.y);
 
     this->mResIndices->push(c);
     this->mResIndices->push(cp1);
@@ -1930,9 +1928,9 @@ void Stroker::strokeMiter(const GlPoint &prev, const GlPoint &curr, const GlPoin
 
 void Stroker::strokeBevel(const GlPoint &prev, const GlPoint &curr, const GlPoint &center)
 {
-    auto a = detail::_pushVertex(mResGlPoints, prev.x, prev.y, 1.f);
-    auto b = detail::_pushVertex(mResGlPoints, curr.x, curr.y, 1.f);
-    auto c = detail::_pushVertex(mResGlPoints, center.x, center.y, 1.f);
+    auto a = detail::_pushVertex(mResGlPoints, prev.x, prev.y);
+    auto b = detail::_pushVertex(mResGlPoints, curr.x, curr.y);
+    auto c = detail::_pushVertex(mResGlPoints, center.x, center.y);
 
     mResIndices->push(a);
     mResIndices->push(b);
@@ -2132,7 +2130,7 @@ void BWTessellator::tessellate(const RenderShape *rshape)
             case PathCommand::MoveTo: {
                 firstIndex = pushVertex(pts->x, pts->y);
                 prevIndex = 0;
-                pts++;                
+                pts++;
             } break;
             case PathCommand::LineTo: {
                 if (prevIndex == 0) {
@@ -2171,7 +2169,7 @@ void BWTessellator::tessellate(const RenderShape *rshape)
 
                 pts += 3;
             } break;
-            case PathCommand::Close: 
+            case PathCommand::Close:
             default:
                 break;
         }
@@ -2180,7 +2178,7 @@ void BWTessellator::tessellate(const RenderShape *rshape)
 
 uint32_t BWTessellator::pushVertex(float x, float y)
 {
-    return detail::_pushVertex(mResPoints, x, y, 1.f);
+    return detail::_pushVertex(mResPoints, x, y);
 }
 
 void BWTessellator::pushTriangle(uint32_t a, uint32_t b, uint32_t c)


### PR DESCRIPTION
Since we choose MSAA, no need to calculate edge alpha during fragment stage. So this commit removed the alpha attribute and related code:

* Remove the alpha attribute in vertex data.
* Change position type from `vec3` to `vec2` in all shader code.
* Remove alhpa multiplication in all fragment shaders