### PR TITLE
lottie/api: specify clear result for override API

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2359,7 +2359,8 @@ TVG_API Tvg_Animation* tvg_lottie_animation_new();
 *
 * \return Tvg_Animation A new Tvg_LottieAnimation object.
 * \retval TVG_RESULT_SUCCESS Succeed.
-* \retval TVG_RESULT_INSUFFICIENT_CONDITION When the given @p slot is invalid
+* \retval TVG_RESULT_INSUFFICIENT_CONDITION In case the animation is not loaded.
+* \retval TVG_RESULT_INVALID_ARGUMENT When the given @p slot is invalid
 * \retval TVG_RESULT_NOT_SUPPORTED The Lottie Animation is not supported.
 */
 TVG_API Tvg_Result tvg_lottie_animation_override(Tvg_Animation* animation, const char* slot);

--- a/src/loaders/lottie/thorvg_lottie.h
+++ b/src/loaders/lottie/thorvg_lottie.h
@@ -28,7 +28,8 @@ public:
      * @param[in] slot The Lottie slot data in JSON format.
      *
      * @retval Result::Success When succeed.
-     * @retval Result::InsufficientCondition When the given parameter is invalid.
+     * @retval Result::InsufficientCondition In case the animation is not loaded.
+     * @retval Result::InvalidArguments When the given parameter is invalid.
      *
      * @note Experimental API
      */

--- a/src/loaders/lottie/tvgLottieAnimation.cpp
+++ b/src/loaders/lottie/tvgLottieAnimation.cpp
@@ -46,7 +46,7 @@ Result LottieAnimation::override(const char* slot) noexcept
         return Result::Success;
     }
 
-    return Result::InsufficientCondition;
+    return Result::InvalidArguments;
 }
 
 


### PR DESCRIPTION
In case the given JSON is invalid, it's more closed to `Result::InvalidArguments`.