### PR TITLE
wg_engine: fill spread

### DIFF
--- a/src/renderer/wg_engine/tvgWgShaderTypes.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.cpp
@@ -127,8 +127,8 @@ void WgShaderTypeLinearGradient::update(const LinearGradient* linearGradient)
     const Fill::ColorStop* stops = nullptr;
     auto stopCnt = linearGradient->colorStops(&stops);
     
-    nStops[0] = stopCnt;
-    nStops[1] = 0.5f;
+    nStops = stopCnt;
+    spread = uint32_t(linearGradient->spread());
     
     for (uint32_t i = 0; i < stopCnt; ++i) {
         stopPoints[i] = stops[i].offset;
@@ -153,8 +153,8 @@ void WgShaderTypeRadialGradient::update(const RadialGradient* radialGradient)
     const Fill::ColorStop* stops = nullptr;
     auto stopCnt = radialGradient->colorStops(&stops);
 
-    nStops[0] = stopCnt;
-    nStops[1] = 0.5f;
+    nStops = stopCnt;
+    spread = uint32_t(radialGradient->spread());
 
     for (uint32_t i = 0; i < stopCnt; ++i) {
         stopPoints[i] = stops[i].offset;

--- a/src/renderer/wg_engine/tvgWgShaderTypes.h
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.h
@@ -73,7 +73,10 @@ struct WgShaderTypeSolidColor
 
 // const MAX_LINEAR_GRADIENT_STOPS = 4;
 // struct LinearGradient {
-//     nStops       : vec4f,
+//     nStops       : u32,
+//     spread       : u32,
+//     dummy0       : u32,
+//     dummy1       : u32,
 //     gradStartPos : vec2f,
 //     gradEndPos   : vec2f,
 //     stopPoints   : vec4f,
@@ -82,11 +85,14 @@ struct WgShaderTypeSolidColor
 #define MAX_LINEAR_GRADIENT_STOPS 4
 struct WgShaderTypeLinearGradient
 {
-    alignas(16) float nStops[4]{};
-    alignas(16) float startPos[2]{};
-    alignas(8)  float endPos[2]{};
-    alignas(8)  float stopPoints[MAX_LINEAR_GRADIENT_STOPS]{};
-    alignas(16) float stopColors[4 * MAX_LINEAR_GRADIENT_STOPS]{};
+    uint32_t nStops{};
+    uint32_t spread{};
+    uint32_t dummy0{}; // allign with WGSL struct
+    uint32_t dummy1{}; // allign with WGSL struct
+    float startPos[2]{};
+    float endPos[2]{};
+    float stopPoints[MAX_LINEAR_GRADIENT_STOPS]{};
+    float stopColors[4 * MAX_LINEAR_GRADIENT_STOPS]{};
 
     WgShaderTypeLinearGradient(const LinearGradient* linearGradient);
     void update(const LinearGradient* linearGradient);
@@ -94,7 +100,10 @@ struct WgShaderTypeLinearGradient
 
 // const MAX_RADIAL_GRADIENT_STOPS = 4;
 // struct RadialGradient {
-//     nStops     : vec4f,
+//     nStops     : u32,
+//     spread     : u32,
+//     dummy0     : u32,
+//     dummy1     : u32,
 //     centerPos  : vec2f,
 //     radius     : vec2f,
 //     stopPoints : vec4f,
@@ -103,11 +112,14 @@ struct WgShaderTypeLinearGradient
 #define MAX_RADIAL_GRADIENT_STOPS 4
 struct WgShaderTypeRadialGradient
 {
-    alignas(16) float nStops[4]{};
-    alignas(16) float centerPos[2]{};
-    alignas(8)  float radius[2]{};
-    alignas(8)  float stopPoints[MAX_RADIAL_GRADIENT_STOPS]{};
-    alignas(16) float stopColors[4 * MAX_RADIAL_GRADIENT_STOPS]{};
+    uint32_t nStops{};
+    uint32_t spread{};
+    uint32_t dummy0{}; // allign with WGSL struct
+    uint32_t dummy1{}; // allign with WGSL struct
+    float centerPos[2]{};
+    float radius[2]{};
+    float stopPoints[MAX_RADIAL_GRADIENT_STOPS]{};
+    float stopColors[4 * MAX_RADIAL_GRADIENT_STOPS]{};
 
     WgShaderTypeRadialGradient(const RadialGradient* radialGradient);
     void update(const RadialGradient* radialGradient);


### PR DESCRIPTION
[issues 1479: LinearGradient, RadialGradient](#1479)

Introduced fill spreads for linear and radial fills: Pad, Reflect, Repeat

Pad:
![pad](https://github.com/thorvg/thorvg/assets/7770034/56dd6ad9-8423-4800-96db-231882db7492)

Reflect:
![Reflect](https://github.com/thorvg/thorvg/assets/7770034/36dd29f8-7c8a-4688-a1de-284b79b8abd0)

Repeat:
![Repeat](https://github.com/thorvg/thorvg/assets/7770034/0e0bf62c-02c6-4fde-85c8-c4648bf791e9)
