### PR TITLE
png: corrected a wrong premultiplied option.

### DIFF
--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -47,9 +47,6 @@ void PngLoader::run(unsigned tid)
     surface.h = height;
     surface.cs = ColorSpace::ABGR8888;
     surface.channelSize = sizeof(uint32_t);
-
-    if (state.info_png.color.colortype == LCT_RGBA) surface.premultiplied = false;
-    else surface.premultiplied = true;
 }
 
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -59,7 +59,7 @@ struct Surface
     uint32_t w = 0, h = 0;
     ColorSpace cs = ColorSpace::Unsupported;
     uint8_t channelSize = 0;
-    bool premultiplied = 0;         //Alpha-premultiplied
+    bool premultiplied = false;         //Alpha-premultiplied
 
     Surface()
     {


### PR DESCRIPTION
this is a regresion bug by 886b6b365b6c91e9b60c89970f44be4c38de12f3