### PR TITLE
lottie/slot: Support overriding plural sids

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -309,21 +309,22 @@ bool LottieLoader::override(const char* slot)
 
     //parsing slot json
     LottieParser parser(temp, dirName);
-    auto sid = parser.sid();
-    if (!sid) {
-        free(temp);
-        return false;
+
+    auto idx = 0;
+    auto success = true;
+    while (auto sid = parser.sid(idx == 0)) {
+        for (auto s = comp->slots.begin(); s < comp->slots.end(); ++s) {
+            if (strcmp((*s)->sid, sid)) continue;
+            if (!parser.parse(*s)) success = false;
+            break;
+        }
+        ++idx;
     }
 
-    bool ret = false;
-    for (auto s = comp->slots.begin(); s < comp->slots.end(); ++s) {
-        if (strcmp((*s)->sid, sid)) continue;
-        ret = parser.parse(*s);
-        break;
-    }
+    if (idx < 1) success = false;
 
     free(temp);
-    return ret;
+    return success;
 }
 
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1238,11 +1238,13 @@ void LottieParser::postProcess(Array<LottieGlyph*>& glyphes)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-const char* LottieParser::sid()
+const char* LottieParser::sid(bool first)
 {
-    //verify json
-    if (!parseNext()) return nullptr;
-    enterObject();
+    if (first) {
+        //verify json
+        if (!parseNext()) return nullptr;
+        enterObject();
+    }
     return nextObjectKey();
 }
 

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -37,7 +37,7 @@ public:
 
     bool parse();
     bool parse(LottieSlot* slot);
-    const char* sid();
+    const char* sid(bool first = false);
 
     LottieComposition* comp = nullptr;
     const char* dirName = nullptr;       //base resource directory


### PR DESCRIPTION
Previously, slot overriding only works in single sid, the others are ignored.

This patch enables slot overriding for all sids within a single slot.

Issue: #2045 


```json
{"ball_color":{"p":{"a":0,"k":[0.1,1,0.5,1]}},"background_color":{"p":{"a":0,"k":[1,1,1,1]}}}
```

**[Before]** `background_color` not working
![Screenshot 2024-03-11 at 5 19 07 PM](https://github.com/thorvg/thorvg/assets/11167117/a1cb5ec0-8ef4-41c5-8ce3-d9b7045cba81)

**[After]** all overridden
![Screenshot 2024-03-11 at 5 18 43 PM](https://github.com/thorvg/thorvg/assets/11167117/60bdd1e5-7be9-4b81-b603-d6c23fdd223d)

