### PR TITLE
renderer/gl_engine: Refine GlCanvas Interface

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1596,7 +1596,7 @@ public:
     };
 
     /**
-     * @brief Sets the target buffer for the rasterization.
+     * @brief Sets the drawing target for the rasterization.
      *
      * The buffer of a desirable size should be allocated and owned by the caller.
      *
@@ -1665,13 +1665,21 @@ public:
     ~GlCanvas();
 
     /**
-     * @brief Sets the target buffer for the rasterization.
+     * @brief Sets the drawing target for rasterization.
      *
-     * @warning Please do not use it, this API is not official one. It could be modified in the next version.
+     * This function specifies the drawing target where the rasterization will occur. It can target
+     * a specific framebuffer object (FBO) or the main surface.
      *
+     * @param[in] id The GL target ID, usually indicating the FBO ID. A value of @c 0 specifies the main surface.
+     * @param[in] w The width (in pixels) of the raster image.
+     * @param[in] h The height (in pixels) of the raster image.
+     *
+     * @warning This API is experimental and not officially supported. It may be modified or removed in future versions.
+     *
+     * @note Currently, this only allows the GL_RGBA8 color space format.
      * @note Experimental API
-     */
-    Result target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h) noexcept;
+    */
+    Result target(int32_t id, uint32_t w, uint32_t h) noexcept;
 
     /**
      * @brief Creates a new GlCanvas object.

--- a/src/examples/Accessor.cpp
+++ b/src/examples/Accessor.cpp
@@ -97,11 +97,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/AnimateMasking.cpp
+++ b/src/examples/AnimateMasking.cpp
@@ -133,11 +133,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Animation.cpp
+++ b/src/examples/Animation.cpp
@@ -130,11 +130,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     tvgDrawCmds(glCanvas.get());
 }

--- a/src/examples/Arc.cpp
+++ b/src/examples/Arc.cpp
@@ -126,11 +126,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Blending.cpp
+++ b/src/examples/Blending.cpp
@@ -207,11 +207,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/ClipPath.cpp
+++ b/src/examples/ClipPath.cpp
@@ -188,11 +188,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/CustomTransform.cpp
+++ b/src/examples/CustomTransform.cpp
@@ -135,11 +135,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/DataLoad.cpp
+++ b/src/examples/DataLoad.cpp
@@ -84,11 +84,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/DirectUpdate.cpp
+++ b/src/examples/DirectUpdate.cpp
@@ -127,11 +127,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Duplicate.cpp
+++ b/src/examples/Duplicate.cpp
@@ -191,11 +191,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/FillRule.cpp
+++ b/src/examples/FillRule.cpp
@@ -92,11 +92,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/GradientMasking.cpp
+++ b/src/examples/GradientMasking.cpp
@@ -175,11 +175,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/GradientStroke.cpp
+++ b/src/examples/GradientStroke.cpp
@@ -159,11 +159,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/GradientTransform.cpp
+++ b/src/examples/GradientTransform.cpp
@@ -156,11 +156,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/ImageScaleDown.cpp
+++ b/src/examples/ImageScaleDown.cpp
@@ -102,11 +102,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/ImageScaleUp.cpp
+++ b/src/examples/ImageScaleUp.cpp
@@ -102,11 +102,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/InvLumaMasking.cpp
+++ b/src/examples/InvLumaMasking.cpp
@@ -152,11 +152,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/InvMasking.cpp
+++ b/src/examples/InvMasking.cpp
@@ -157,11 +157,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/LinearGradient.cpp
+++ b/src/examples/LinearGradient.cpp
@@ -125,11 +125,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Lottie.cpp
+++ b/src/examples/Lottie.cpp
@@ -194,11 +194,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     tvgDrawCmds(glCanvas.get());
 

--- a/src/examples/LottieExtension.cpp
+++ b/src/examples/LottieExtension.cpp
@@ -137,11 +137,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     tvgDrawCmds(glCanvas.get());
 }

--- a/src/examples/LumaMasking.cpp
+++ b/src/examples/LumaMasking.cpp
@@ -152,11 +152,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Masking.cpp
+++ b/src/examples/Masking.cpp
@@ -159,11 +159,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/MaskingMethods.cpp
+++ b/src/examples/MaskingMethods.cpp
@@ -424,11 +424,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/MultiCanvas.cpp
+++ b/src/examples/MultiCanvas.cpp
@@ -156,11 +156,15 @@ void initGLview(Evas_Object *obj)
     auto objData = reinterpret_cast<ObjData*>(evas_object_data_get(obj, "objdata"));
     objData->idx = counter;
 
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     auto canvas = tvg::GlCanvas::gen();
-    canvas->target(nullptr, SIZE * BPP, SIZE, SIZE);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    canvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/MultiShapes.cpp
+++ b/src/examples/MultiShapes.cpp
@@ -85,11 +85,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Opacity.cpp
+++ b/src/examples/Opacity.cpp
@@ -141,11 +141,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Path.cpp
+++ b/src/examples/Path.cpp
@@ -104,11 +104,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/PathCopy.cpp
+++ b/src/examples/PathCopy.cpp
@@ -141,11 +141,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Performance.cpp
+++ b/src/examples/Performance.cpp
@@ -130,11 +130,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/PictureJpg.cpp
+++ b/src/examples/PictureJpg.cpp
@@ -107,11 +107,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/PicturePng.cpp
+++ b/src/examples/PicturePng.cpp
@@ -113,11 +113,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/PictureRaw.cpp
+++ b/src/examples/PictureRaw.cpp
@@ -105,11 +105,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/PictureSvg.cpp
+++ b/src/examples/PictureSvg.cpp
@@ -104,11 +104,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/PictureTvg.cpp
+++ b/src/examples/PictureTvg.cpp
@@ -84,11 +84,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/PictureWebp.cpp
+++ b/src/examples/PictureWebp.cpp
@@ -113,11 +113,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/RadialGradient.cpp
+++ b/src/examples/RadialGradient.cpp
@@ -125,11 +125,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Retaining.cpp
+++ b/src/examples/Retaining.cpp
@@ -128,11 +128,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Scene.cpp
+++ b/src/examples/Scene.cpp
@@ -132,11 +132,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/SceneBlending.cpp
+++ b/src/examples/SceneBlending.cpp
@@ -147,11 +147,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/SceneClipper.cpp
+++ b/src/examples/SceneClipper.cpp
@@ -110,11 +110,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/SceneTransform.cpp
+++ b/src/examples/SceneTransform.cpp
@@ -156,11 +156,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Shape.cpp
+++ b/src/examples/Shape.cpp
@@ -77,11 +77,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Stroke.cpp
+++ b/src/examples/Stroke.cpp
@@ -163,11 +163,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/StrokeLine.cpp
+++ b/src/examples/StrokeLine.cpp
@@ -209,11 +209,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/StrokeMiterlimit.cpp
+++ b/src/examples/StrokeMiterlimit.cpp
@@ -198,11 +198,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Svg.cpp
+++ b/src/examples/Svg.cpp
@@ -134,11 +134,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Texmap.cpp
+++ b/src/examples/Texmap.cpp
@@ -124,11 +124,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Text.cpp
+++ b/src/examples/Text.cpp
@@ -208,11 +208,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Transform.cpp
+++ b/src/examples/Transform.cpp
@@ -113,11 +113,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Tvg.cpp
+++ b/src/examples/Tvg.cpp
@@ -120,11 +120,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/examples/Update.cpp
+++ b/src/examples/Update.cpp
@@ -101,11 +101,15 @@ static unique_ptr<tvg::GlCanvas> glCanvas;
 
 void initGLview(Evas_Object *obj)
 {
-    static constexpr auto BPP = 4;
-
     //Create a Canvas
     glCanvas = tvg::GlCanvas::gen();
-    glCanvas->target(nullptr, WIDTH * BPP, WIDTH, HEIGHT);
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
 
     /* Push the shape into the Canvas drawing list
        When this shape is into the canvas list, the shape could update & prepare

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -54,11 +54,11 @@ bool GlRenderer::clear()
 }
 
 
-bool GlRenderer::target(TVG_UNUSED uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h)
+bool GlRenderer::target(int32_t id, uint32_t w, uint32_t h)
 {
     assert(w > 0 && h > 0);
 
-    surface.stride = stride;
+    surface.stride = w;
     surface.w = w;
     surface.h = h;
 
@@ -67,10 +67,7 @@ bool GlRenderer::target(TVG_UNUSED uint32_t* buffer, uint32_t stride, uint32_t w
     mViewport.w = surface.w;
     mViewport.h = surface.h;
 
-    // get current binded framebuffer id
-    // EFL seems has a seperate framebuffer for evagl view
-    //TODO: introduce a new api to specify which fbo this canvas is binded
-    GL_CHECK(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &mTargetFboId));
+    mTargetFboId = static_cast<GLint>(id);
 
     mRootTarget = make_unique<GlRenderTarget>(surface.w, surface.h);
     mRootTarget->init(mTargetFboId);

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -67,7 +67,7 @@ public:
     bool blend(BlendMethod method) override;
     ColorSpace colorSpace() override;
 
-    bool target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h);
+    bool target(int32_t id, uint32_t w, uint32_t h);
     bool sync() override;
     bool clear() override;
 

--- a/src/renderer/tvgGlCanvas.cpp
+++ b/src/renderer/tvgGlCanvas.cpp
@@ -60,14 +60,14 @@ GlCanvas::~GlCanvas()
 }
 
 
-Result GlCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h) noexcept
+Result GlCanvas::target(int32_t id, uint32_t w, uint32_t h) noexcept
 {
 #ifdef THORVG_GL_RASTER_SUPPORT
     //We know renderer type, avoid dynamic_cast for performance.
     auto renderer = static_cast<GlRenderer*>(Canvas::pImpl->renderer);
     if (!renderer) return Result::MemoryCorruption;
 
-    if (!renderer->target(buffer, stride, w, h)) return Result::Unknown;
+    if (!renderer->target(id, w, h)) return Result::Unknown;
 
     //Paints must be updated again with this new target.
     Canvas::pImpl->needRefresh();


### PR DESCRIPTION
Refactor the GlCanvas::target() interface to allow passing the drawing target ID from the user side.

Previously, it performed the drawing on the currently set FBO target.

Beta API change:

Result GlCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h) -> Result GlCanvas::target(int32_id, uint32_t w, uint32_t h)