### PR TITLE
wg_engine: winding fill rule

### DIFF
--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -84,6 +84,7 @@ struct WgGeometryData
     // webgpu did not support triangle fans primitives type
     // so we can emulate triangle fans using indexing
     void computeTriFansIndexes();
+    void computeContour(WgGeometryData* data);
 
     void appendCubic(WgPoint p1, WgPoint p2, WgPoint p3);
     void appendBox(WgPoint pmin, WgPoint pmax);
@@ -92,7 +93,17 @@ struct WgGeometryData
     void appendImageBox(float w, float h);
     void appendBlitBox();
     void appendMesh(const RenderMesh* rmesh);
+
+    bool getClosestIntersection(WgPoint p1, WgPoint p2, WgPoint& pi, uint32_t& index);
+    bool isCW(WgPoint p1, WgPoint p2, WgPoint p3);
+
+    uint32_t getIndexMinX();
+    uint32_t getIndexMaxX();
+    uint32_t getIndexMinY();
+    uint32_t getIndexMaxY();
+
     void close();
+    void clear();
 };
 
 struct WgGeometryDataGroup
@@ -103,6 +114,7 @@ struct WgGeometryDataGroup
     void getBBox(WgPoint& pmin, WgPoint& pmax);
     void tesselate(const RenderShape& rshape);
     void stroke(const RenderShape& rshape);
+    void contours(WgGeometryDataGroup& outlines);
     void release();
 private:
     static void decodePath(const RenderShape& rshape, WgGeometryDataGroup* outlines);

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -216,7 +216,13 @@ void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rsha
     releaseMeshes(context);
     // update shapes geometry
     WgGeometryDataGroup shapes;
-    shapes.tesselate(rshape);
+    if(rshape.rule == tvg::FillRule::EvenOdd) {
+        shapes.tesselate(rshape);
+    } else if(rshape.rule == tvg::FillRule::Winding) {
+        WgGeometryDataGroup lines;
+        lines.tesselate(rshape);
+        shapes.contours(lines);
+    }
     meshGroupShapes.update(context, &shapes);
     // update shapes bbox
     WgPoint pmin{}, pmax{};


### PR DESCRIPTION
[issues 1479: FillRule](#1479)

Introduced fill rule winding
This rule makes sense only if path have some self intersections. In all other cases shapes are filled by even-odd behavor.