### PR TITLE
renderer: ensure paints retain composition context

### DIFF
--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -133,7 +133,6 @@ struct Scene::Impl
         if (needComp) {
             cmp = renderer->target(bounds(renderer), renderer->colorSpace());
             renderer->beginComposite(cmp, CompositeMethod::None, opacity);
-            needComp = false;
         }
 
         for (auto paint : paints) {

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -56,7 +56,6 @@ struct Shape::Impl
         if (needComp) {
             cmp = renderer->target(bounds(renderer), renderer->colorSpace());
             renderer->beginComposite(cmp, CompositeMethod::None, opacity);
-            needComp = false;
         }
         ret = renderer->renderShape(rd);
         if (cmp) renderer->endComposite(cmp);


### PR DESCRIPTION
This commit addresses an issue where paints lost their composition context when drawings occurred without any updates.

Now, paints will consistently retain the composition context, ensuring accurate rendering.

Issue: https://github.com/thorvg/thorvg/issues/2058