### PR TITLE
gl_engine: make stencil task support other advance logical

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -50,6 +50,13 @@
     } while(0)
 
 
+enum class GlStencilMode {
+    None,
+    FillWinding,
+    FillEvenOdd,
+    Stroke,
+};
+
 class GlGeometry;
 
 struct GlShape

--- a/src/renderer/gl_engine/tvgGlGeometry.h
+++ b/src/renderer/gl_engine/tvgGlGeometry.h
@@ -195,7 +195,7 @@ public:
     void updateTransform(const RenderTransform* transform, float w, float h);
     void setViewport(const RenderRegion& viewport);
     float* getTransforMatrix();
-    bool needStencilCover(RenderUpdateFlag flag);
+    GlStencilMode getStencilMode(RenderUpdateFlag flag);
 
 private:
     RenderRegion viewport = {};
@@ -205,7 +205,7 @@ private:
     Array<uint32_t> strokeIndex = {};
     float mTransform[16];
 
-    bool mStencilFill = false;
+    FillRule mFillRule = FillRule::Winding;
 };
 
 #endif /* _TVG_GL_GEOMETRY_H_ */

--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -100,7 +100,7 @@ private:
 class GlStencilCoverTask : public GlRenderTask
 {
 public:
-    GlStencilCoverTask(GlRenderTask* stencil, GlRenderTask* cover);
+    GlStencilCoverTask(GlRenderTask* stencil, GlRenderTask* cover, GlStencilMode mode);
     ~GlStencilCoverTask() override;
 
     void run() override;
@@ -108,6 +108,7 @@ public:
 private:
     GlRenderTask* mStencilTask;
     GlRenderTask* mCoverTask;
+    GlStencilMode mStencilMode;
 };
 
 class GlRenderTarget;


### PR DESCRIPTION
This PR enhance the GlStencilCoverTask:

* Support rendering Gradient in path Stroke mode
* Fix GlStencilCoverTask not support even-odd fill rule
* Make GlStencilCoverTask can discard overlapped area during stroke rendering

The GradientStroke case is almost correct:
![screenshot-20240317-160952](https://github.com/thorvg/thorvg/assets/26308154/69279824-2a42-45d3-a50e-8fa38751ae38)
