### PR TITLE
loader/svg: Remove duplicate if-check in pathAppendArcTo

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -122,9 +122,6 @@ void _pathAppendArcTo(Array<PathCommand>* cmds, Array<Point>* pts, Point* cur, P
     sx = cur->x;
     sy = cur->y;
 
-    //If start and end points are identical, then no arc is drawn
-    if ((fabsf(x - sx) < (1.0f / 256.0f)) && (fabsf(y - sy) < (1.0f / 256.0f))) return;
-
     //Correction of out-of-range radii, see F6.6.1 (step 2)
     rx = fabsf(rx);
     ry = fabsf(ry);


### PR DESCRIPTION
The if-check to skip-rule when drawing an arc path is already checked in line 476.
In addition, since the float type equal check is performed in the range of 1/256,
unintentional skiped may occur. Therefore, remove duplicate code. https://www.w3.org/TR/SVG2/paths.html#ArcOutOfRangeParameters

test file:
SVG_FILE_147893
SVG_FILE_147939
related issue: https://github.com/thorvg/thorvg/issues/1255