### PR TITLE
wg_engine: stroke first

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -214,6 +214,7 @@ void WgRenderDataPaint::release(WgContext& context)
 void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rshape)
 {
     releaseMeshes(context);
+    strokeFirst = false;
     // update shapes geometry
     WgGeometryDataGroup shapes;
     if(rshape.rule == tvg::FillRule::EvenOdd) {
@@ -232,6 +233,7 @@ void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rsha
     meshBBoxShapes.update(context, &box);
     // update strokes geometry
     if (rshape.stroke) {
+        strokeFirst = rshape.stroke->strokeFirst;
         WgGeometryDataGroup strokes;
         strokes.stroke(rshape);
         strokes.getBBox(pmin, pmax);

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -81,6 +81,7 @@ struct WgRenderDataShape: public WgRenderDataPaint
     WgMeshDataGroup meshGroupStrokes{};
     WgMeshData meshBBoxShapes{};
     WgMeshData meshBBoxStrokes{};
+    bool strokeFirst{};
 
     void updateMeshes(WgContext& context, const RenderShape& rshape);
     void releaseMeshes(WgContext& context);

--- a/src/renderer/wg_engine/tvgWgRenderTarget.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.cpp
@@ -69,8 +69,11 @@ void WgRenderTarget::renderShape(WGPUCommandEncoder commandEncoder, WgRenderData
     assert(renderData);
     assert(commandEncoder);
     WGPURenderPassEncoder renderPassEncoder = beginRenderPass(commandEncoder);
+    if (renderData->strokeFirst)
+        drawStroke(renderPassEncoder, renderData);
     drawShape(renderPassEncoder, renderData);
-    drawStroke(renderPassEncoder, renderData);
+    if (!renderData->strokeFirst)
+        drawStroke(renderPassEncoder, renderData);
     endRenderPass(renderPassEncoder);
 }
 


### PR DESCRIPTION
[issues 1479: strokes](#1479)

Introduced order setting

    auto star = tvg::Shape::gen();
    star->fill(80, 80, 80);
    star->moveTo(599, 34);
    star->lineTo(653, 143);
    star->lineTo(774, 160);
    star->lineTo(687, 244);
    star->lineTo(707, 365);
    star->lineTo(599, 309);
    star->lineTo(497, 365);
    star->lineTo(512, 245);
    star->lineTo(426, 161);
    star->lineTo(546, 143);
    star->close();
    star->strokeWidth(10);
    star->strokeJoin(tvg::StrokeJoin::Round);
    star->strokeFill(255, 255, 255);
    star->order(true); // stroke first
    if (canvas->push(std::move(star)) != tvg::Result::Success) return;

result example:
   star->order(**true**); // _left shape_
   star->order(**false**); // _right shape_
![Untitled](https://github.com/thorvg/thorvg/assets/7770034/2d38e4bb-3e56-4f28-ae19-a025dfcdf416)
