### PR TITLE
lottie: Prevent memory leak when file is invalid

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -207,7 +207,7 @@ float LottieLayer::remap(float frameNo)
 
 LottieComposition::~LottieComposition()
 {
-    if (!initiated) delete(root->scene);
+    if (!initiated && root) delete(root->scene);
 
     delete(root);
     free(version);

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1316,7 +1316,10 @@ bool LottieParser::parse()
         else skip(key);
     }
 
-    if (Invalid() || !comp->root) return false;
+    if (Invalid() || !comp->root) {
+        delete(comp);
+        return false;
+    }
 
     comp->root->inFrame = comp->startFrame;
     comp->root->outFrame = comp->endFrame;


### PR DESCRIPTION
When json file is invalid in the parser,
the LottieComposition object is not released and the parse() returns false.
To prevent memory leaks, free the memory before returning false.

related issue : https://github.com/thorvg/thorvg/issues/2070