### PR TITLE
lottie/slot: Support reverting feature

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2357,7 +2357,7 @@ TVG_API Tvg_Animation* tvg_lottie_animation_new();
 * \brief Override the lottie properties through the slot data. (Experimental API)
 *
 * \param[in] animation The Tvg_Animation object to override the property with the slot.
-* \param[in] slot The lottie slot data in json.
+* \param[in] slot The Lottie slot data in json, or @c nullptr to reset.
 *
 * \return Tvg_Animation A new Tvg_LottieAnimation object.
 * \retval TVG_RESULT_SUCCESS Succeed.

--- a/src/loaders/lottie/thorvg_lottie.h
+++ b/src/loaders/lottie/thorvg_lottie.h
@@ -25,7 +25,7 @@ public:
     /**
      * @brief Override Lottie properties using slot data.
      *
-     * @param[in] slot The Lottie slot data in JSON format.
+     * @param[in] slot The Lottie slot data in JSON format to override, or @c nullptr to reset.
      *
      * @retval Result::Success When succeed.
      * @retval Result::InsufficientCondition In case the animation is not loaded.

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -44,6 +44,7 @@ public:
 
     char* dirName = nullptr;            //base resource directory
     bool copy = false;                  //"content" is owned by this loader
+    bool overriden = false;             //overridden properties with slots.
 
     LottieLoader();
     ~LottieLoader();

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -632,18 +632,47 @@ struct LottieLayer : LottieGroup
 
 struct LottieSlot
 {
+    struct Pair {
+        LottieObject* obj;
+        LottieProperty* prop;
+
+        void override(LottieObject* target, LottieProperty::Type type)
+        {
+            delete(prop);
+
+            switch (type) {
+                case LottieProperty::Type::ColorStop: {
+                    prop = static_cast<LottieGradient*>(obj)->colorStops.copy();
+                    break;
+                }
+                case LottieProperty::Type::Color: {
+                    prop = static_cast<LottieSolid*>(obj)->color.copy();
+                    break;
+                }
+                case LottieProperty::Type::TextDoc: {
+                    prop = static_cast<LottieText*>(obj)->doc.copy();
+                    break;
+                }
+                default: break;
+            }
+
+            obj->override(target);
+        }
+    };
+
     char* sid;
-    Array<LottieObject*> objs;
+    Array<Pair> pairs;
     LottieProperty::Type type;
 
     LottieSlot(char* sid, LottieObject* obj, LottieProperty::Type type) : sid(sid), type(type)
     {
-        objs.push(obj);
+        pairs.push({obj});
     }
 
     ~LottieSlot()
     {
         free(sid);
+        for (auto p = pairs.begin(); p < pairs.end(); ++p) delete((*p).prop);
     }
 };
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -478,7 +478,7 @@ void LottieParser::parseProperty(T& prop, LottieObject* obj)
             //append object if the slot already exists.
             for (auto slot = comp->slots.begin(); slot < comp->slots.end(); ++slot) {
                 if (strcmp((*slot)->sid, sid)) continue;
-                (*slot)->objs.push(obj);
+                (*slot)->pairs.push({obj});
                 return;
             }
             comp->slots.push(new LottieSlot(sid, obj, type));
@@ -1278,8 +1278,8 @@ bool LottieParser::parse(LottieSlot* slot)
     if (!obj || Invalid()) return false;
 
     //apply slot object to all targets
-    for (auto target = slot->objs.begin(); target < slot->objs.end(); ++target) {
-        (*target)->override(obj);
+    for (auto target = slot->pairs.begin(); target < slot->pairs.end(); ++target) {
+        target->override(obj, slot->type);
     }
 
     delete(obj);

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -249,10 +249,18 @@ struct LottieGenericProperty : LottieProperty
         return frame->interpolate(frame + 1, frameNo);
     }
 
+    LottieGenericProperty<T>* copy()
+    {
+        //copy, used for slot reverting
+        auto ret = new LottieGenericProperty<T>(value);
+        if (frames) ret->frames = frames;
+        else ret->value = value;
+        return ret;
+    }
+
     T& operator=(const T& other)
     {
         //shallow copy, used for slot overriding
-        delete(frames);
         if (other.frames) {
             frames = other.frames;
             const_cast<T&>(other).frames = nullptr;
@@ -452,10 +460,25 @@ struct LottieColorStop : LottieProperty
         fill->colorStops(result.data, count);
     }
 
+    LottieColorStop* copy()
+    {
+        //copy, used for slot reverting
+        auto ret = new LottieColorStop();
+        if (frames) ret->frames = frames;
+        else {
+            ret->value = {value.data};
+            ret->value.input = nullptr;
+        }
+
+        ret->count = count;
+        ret->populated = populated;
+
+        return ret;
+    }
+
     LottieColorStop& operator=(const LottieColorStop& other)
     {
         //shallow copy, used for slot overriding
-        release();
         if (other.frames) {
             frames = other.frames;
             const_cast<LottieColorStop&>(other).frames = nullptr;
@@ -592,10 +615,18 @@ struct LottieTextDoc : LottieProperty
         return frame->value;
     }
 
+    LottieTextDoc* copy()
+    {
+        //copy, used for slot reverting
+        auto ret = new LottieTextDoc();
+        if (frames) ret->frames = frames;
+        else ret->value = value;
+        return ret;
+    }
+
     LottieTextDoc& operator=(const LottieTextDoc& other)
     {
         //shallow copy, used for slot overriding
-        release();
         if (other.frames) {
             frames = other.frames;
             const_cast<LottieTextDoc&>(other).frames = nullptr;

--- a/test/capi/capiLottie.cpp
+++ b/test/capi/capiLottie.cpp
@@ -46,8 +46,19 @@ TEST_CASE("Lottie Slot", "[capiLottie]")
     //Slot override before loaded
     REQUIRE(tvg_lottie_animation_override(animation, slotJson) == TVG_RESULT_INSUFFICIENT_CONDITION);
 
-    //Slot override
+    // Animation load
     REQUIRE(tvg_picture_load(picture, TEST_DIR"/lottieslot.json") == TVG_RESULT_SUCCESS);
+
+    //Slot revert before overriding
+    REQUIRE(tvg_lottie_animation_override(animation, nullptr) == TVG_RESULT_SUCCESS);
+    
+    //Slot override
+    REQUIRE(tvg_lottie_animation_override(animation, slotJson) == TVG_RESULT_SUCCESS);
+
+    //Slot revert
+    REQUIRE(tvg_lottie_animation_override(animation, nullptr) == TVG_RESULT_SUCCESS);
+
+    //Slot override after reverting
     REQUIRE(tvg_lottie_animation_override(animation, slotJson) == TVG_RESULT_SUCCESS);
 
     //Slot override with invalid JSON

--- a/test/testLottie.cpp
+++ b/test/testLottie.cpp
@@ -47,8 +47,19 @@ TEST_CASE("Lottie Slot", "[tvgLottie]")
     //Slot override before loaded
     REQUIRE(animation->override(slotJson) == Result::InsufficientCondition);
 
-    //Slot override
+    //Animation load
     REQUIRE(picture->load(TEST_DIR"/lottieslot.json") == Result::Success);
+
+    //Slot revert before overriding
+    REQUIRE(animation->override(nullptr) == Result::Success);
+
+    //Slot override
+    REQUIRE(animation->override(slotJson) == Result::Success);
+
+    //Slot revert
+    REQUIRE(animation->override(nullptr) == Result::Success);
+
+    //Slot override after reverting
     REQUIRE(animation->override(slotJson) == Result::Success);
 
     //Slot override with invalid JSON


### PR DESCRIPTION
Support the slot reverting feature corresponding to the overriding.
`override(nullptr)` reverts all slots once called.

Usage:
```cpp
//Revert slot
if (animation->override(nullptr) == tvg::Result::Success) {
    canvas->update();
}
```