### PR TITLE
examples/lottie: do not scan samples recursively.

### DIFF
--- a/src/examples/Lottie.cpp
+++ b/src/examples/Lottie.cpp
@@ -108,7 +108,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
 
     if (canvas->push(std::move(shape)) != tvg::Result::Success) return;
 
-    eina_file_dir_list(EXAMPLE_DIR"/lottie", EINA_TRUE, lottieDirCallback, canvas);
+    eina_file_dir_list(EXAMPLE_DIR"/lottie", EINA_FALSE, lottieDirCallback, canvas);
 
     //Run animation loop
     for (auto& animation : animations) {


### PR DESCRIPTION
lottie/extensions will be only accessed by LottieExtension