### PR TITLE
loader/lottie: Prevent leak memory when image load fails

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -911,6 +911,7 @@ LottieObject* LottieParser::parseAsset()
     }
     if (data) obj = parseImage(data, subPath, embedded);
     if (obj) obj->name = id;
+    else free(id);
     return obj;
 }
 


### PR DESCRIPTION
When image data fails to load or image parsing fails,
the id is leaked without being assigned to the name.
To prevent that, free id value when obj is nullptr.

related issue: https://github.com/thorvg/thorvg/issues/2072
BrokenLottie.7z/test3_IDX_130_RAND_18289244608080059871.json BrokenLottie.7z/test3_IDX_131_RAND_7772102071213376276.json BrokenLottie.7z/test3_IDX_132_RAND_3072617087893397532.json BrokenLottie.7z/test3_IDX_134_RAND_17738488813555566674.json BrokenLottie.7z/test3_IDX_137_RAND_13903188963759129023.json BrokenLottie.7z/test3_IDX_138_RAND_1645404078965858130.json