### PR TITLE
ttf: ++uwp portability

### DIFF
--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -23,7 +23,7 @@
 
 #include "tvgTtfLoader.h"
 
-#if defined(_WIN32)
+#if defined(_WIN32) && (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
     #include <windows.h>
 #elif defined(__linux__)
     #include <fcntl.h>
@@ -36,7 +36,7 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-#if defined(_WIN32)
+#if defined(_WIN32) && (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
 
 static bool _map(TtfLoader* loader, const string& path)
 {

--- a/src/loaders/ttf/tvgTtfLoader.h
+++ b/src/loaders/ttf/tvgTtfLoader.h
@@ -30,7 +30,7 @@
 
 struct TtfLoader : public FontLoader
 {
-#if defined(_WIN32)
+#if defined(_WIN32) && (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
     void* mapping = nullptr;
 #endif
     TtfReader reader;


### PR DESCRIPTION
use the preprocessor directives properly.