### PR TITLE
lottie: Fix crash when an invalid gradient is provided

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -381,6 +381,9 @@ struct LottieGradient : LottieObject
 {
     uint32_t populate(ColorStop& color)
     {
+        colorStops.populated = true;
+        if (!color.input) return 0;
+
         uint32_t alphaCnt = (color.input->count - (colorStops.count * 4)) / 2;
         Array<Fill::ColorStop> output(colorStops.count + alphaCnt);
         uint32_t cidx = 0;               //color count
@@ -455,7 +458,6 @@ struct LottieGradient : LottieObject
         color.input->reset();
         delete(color.input);
 
-        colorStops.populated = true;
         return output.count;
     }
 


### PR DESCRIPTION
<img width="919" alt="Screenshot 2024-03-27 at 5 30 58 PM" src="https://github.com/thorvg/thorvg/assets/11167117/f8e439ae-22f7-4e51-a3e1-3337652c85f2">

Invalid gradient causes segmentation fault in population.
Added preventing logic. The function `populate` will not proceed and return 0 when `color.input` is nullptr.

related issue: #2072 
> Resolving crashes by segmentation fault from 123 files
- lottieslot_IDX_2_RAND_6332298139641021187.json
- lottieslot_IDX_47_RAND_13313713864635949061.json
- lottieslot_IDX_89_RAND_15775210715052235439.json
- lottieslot_IDX_126_RAND_16601351284790143166.json
- lottieslot_IDX_127_RAND_2435458778335924685.json
- lottieslot_IDX_198_RAND_12222704937178303596.json
- lottieslot_IDX_246_RAND_14265115990637144842.json
- lottieslot_IDX_252_RAND_16333113645329726009.json
- lottieslot_IDX_276_RAND_4643679359098999915.json
- lottieslot_IDX_334_RAND_4516773319034023871.json
- lottieslot_IDX_349_RAND_4202171952580507889.json
- lottieslot_IDX_371_RAND_3166115179761285399.json
- lottieslot_IDX_438_RAND_1597037011116429813.json
- lottieslot_IDX_442_RAND_10168869960144848391.json
- lottieslot_IDX_488_RAND_10046951695042558533.json
- lottieslot_IDX_502_RAND_13520934972534697255.json
- lottieslot_IDX_538_RAND_11924166140672789433.json
- lottieslot_IDX_558_RAND_10425495390193297655.json
- lottieslot_IDX_575_RAND_9968416901598205214.json
- lottieslot_IDX_607_RAND_960097296672477090.json
- lottieslot_IDX_660_RAND_8132971236122420959.json
- lottieslot_IDX_665_RAND_15062573671237946809.json
- lottieslot_IDX_709_RAND_6151344143055497561.json
- lottieslot_IDX_710_RAND_11495257627007842331.json
- lottieslot_IDX_722_RAND_6529718409126373004.json
- lottieslot_IDX_792_RAND_13022281038269049661.json
- lottieslot_IDX_825_RAND_9976590591460340486.json
- lottieslot_IDX_826_RAND_11799214615267611408.json
- lottieslot_IDX_865_RAND_2182212067359912553.json
- lottieslot_IDX_897_RAND_3204982804588203035.json
- lottieslot_IDX_922_RAND_9379437252536469582.json
- lottieslot_IDX_984_RAND_4663055766565815753.json
- test_IDX_93_RAND_6394146656630731698.json
- test_IDX_108_RAND_1275192649404679881.json
- test_IDX_142_RAND_14376531888527628806.json
- test_IDX_229_RAND_15945406762434342087.json
- test_IDX_243_RAND_5750632219675554045.json
- test_IDX_264_RAND_2714315540400731957.json
- test_IDX_279_RAND_9874228314082964413.json
- test_IDX_295_RAND_787150099830323955.json
- test_IDX_327_RAND_13043241544072782647.json
- test_IDX_333_RAND_9148512686077949194.json
- test_IDX_339_RAND_11526547701917382746.json
- test_IDX_349_RAND_11571159244633715064.json
- test_IDX_365_RAND_4587186413364075974.json
- test_IDX_368_RAND_15982925261025973683.json
- test_IDX_379_RAND_6502509576509311415.json
- test_IDX_384_RAND_12960825027969416980.json
- test_IDX_391_RAND_12790362016999331788.json
- test_IDX_440_RAND_10413303825464761315.json
- test_IDX_444_RAND_10276877623487956521.json
- test_IDX_529_RAND_960424324759219794.json
- test_IDX_558_RAND_17468909795029210210.json
- test_IDX_559_RAND_7331183143233617145.json
- test_IDX_564_RAND_12747516565659879643.json
- test_IDX_586_RAND_14236045641860840010.json
- test_IDX_588_RAND_13915592200034440310.json
- test_IDX_592_RAND_16685484429278177882.json
- test_IDX_606_RAND_9411874542897427879.json
- test_IDX_653_RAND_11626324777566286765.json
- test_IDX_655_RAND_8676334722083625316.json
- test_IDX_708_RAND_9233817409776948508.json
- test_IDX_768_RAND_17321608248530138161.json
- test_IDX_814_RAND_15754660503377692751.json
- test_IDX_865_RAND_14766061800312774067.json
- test_IDX_878_RAND_11528798867557542152.json
- test_IDX_904_RAND_11106923984968852608.json
- test_IDX_936_RAND_2456369153169058136.json
- test_IDX_939_RAND_8477539562618958608.json
- test_IDX_968_RAND_10335837535089831418.json
- test2_IDX_3_RAND_17304109083372455950.json
- test2_IDX_20_RAND_12361037516278617646.json
- test2_IDX_24_RAND_10061367355181169726.json
- test2_IDX_64_RAND_17919581006361141115.json
- test2_IDX_90_RAND_2985418582637541460.json
- test2_IDX_100_RAND_16768380576420939481.json
- test2_IDX_115_RAND_4531419694509628179.json
- test2_IDX_154_RAND_17318329659255136354.json
- test2_IDX_157_RAND_11782140838232803025.json
- test2_IDX_175_RAND_2431884594419535017.json
- test2_IDX_188_RAND_13147909534045082976.json
- test2_IDX_202_RAND_7740287877026205364.json
- test2_IDX_227_RAND_12921603168399703892.json
- test2_IDX_238_RAND_17590662798394336096.json
- test2_IDX_250_RAND_1144013330817563511.json
- test2_IDX_253_RAND_17446934194287372705.json
- test2_IDX_263_RAND_3639632747492639468.json
- test2_IDX_304_RAND_16288177531326858847.json
- test2_IDX_310_RAND_18171488514279033925.json
- test2_IDX_324_RAND_10068222143507958832.json
- test2_IDX_353_RAND_11575833368038406506.json
- test2_IDX_362_RAND_9810019747678143066.json
- test2_IDX_373_RAND_16591373036549821965.json
- test2_IDX_376_RAND_1897679037206533153.json
- test2_IDX_399_RAND_11415011036140358201.json
- test2_IDX_406_RAND_11036182561391787765.json
- test2_IDX_413_RAND_3792249941355912361.json
- test2_IDX_417_RAND_1988233089133370806.json
- test2_IDX_424_RAND_12954210552408499303.json
- test2_IDX_430_RAND_5872375504782294098.json
- test2_IDX_436_RAND_15366945117731534954.json
- test2_IDX_471_RAND_2747573151866029382.json
- test2_IDX_533_RAND_14175929970704338428.json
- test2_IDX_535_RAND_3398545710588368341.json
- test2_IDX_551_RAND_14810775067170392449.json
- test2_IDX_569_RAND_3456560805256839766.json
- test2_IDX_576_RAND_6072656631706317221.json
- test2_IDX_590_RAND_3721155835193415416.json
- test2_IDX_621_RAND_4308059747203893547.json
- test2_IDX_626_RAND_13004558938535489540.json
- test2_IDX_663_RAND_3692517112699816375.json
- test2_IDX_669_RAND_16946751413272657531.json
- test2_IDX_687_RAND_2629664899575711004.json
- test2_IDX_693_RAND_13791389252479565250.json
- test2_IDX_713_RAND_18056815685321877855.json
- test2_IDX_746_RAND_17314828375027414619.json
- test2_IDX_770_RAND_11078530773242914803.json
- test2_IDX_797_RAND_17820204362500125931.json
- test2_IDX_870_RAND_261528393570656121.json
- test2_IDX_933_RAND_5793758662868838445.json
- test2_IDX_938_RAND_13195915120173669802.json
- test2_IDX_954_RAND_17743200854101488309.json
- test2_IDX_963_RAND_9966351571648461197.json