### PR TITLE
lottie: Fix crash from invalid masking method

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -42,7 +42,10 @@ static char* _int2str(int num)
 
 CompositeMethod LottieParser::getMaskMethod(bool inversed)
 {
-    switch (getString()[0]) {
+    auto mode = getString();
+    if (!mode) return CompositeMethod::None;
+
+    switch (mode[0]) {
         case 'a': {
             if (inversed) return CompositeMethod::InvAlphaMask;
             else return CompositeMethod::AddMask;


### PR DESCRIPTION
This change is better for stability. Returns `None` if the `mode` attribute cannot be parsed.

<img width="880" alt="Screenshot 2024-03-27 at 6 49 00 PM" src="https://github.com/thorvg/thorvg/assets/11167117/7f14227f-f0ba-4806-81fd-848ff0ab99b9">


related issue: #2072
> Resolving crashes by segmentation fault for 3 files
- test9_IDX_135_RAND_12722319039069386985.json
- test9_IDX_207_RAND_6442145524277313594.json
- test9_IDX_743_RAND_6211786878291024908.json