### PR TITLE
lottie: optimize the rendering by preventing partial rendering b…

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -885,10 +885,6 @@ static void _updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderCon
                     _updateGroup(parent, child, frameNo, contexts, ctx);
                     break;
                 }
-                case LottieObject::Transform: {
-                    _updateTransform(parent, child, frameNo, contexts, ctx);
-                    break;
-                }
                 case LottieObject::SolidFill: {
                     _updateSolidFill(parent, child, frameNo, contexts, ctx);
                     break;
@@ -903,22 +899,6 @@ static void _updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderCon
                 }
                 case LottieObject::GradientStroke: {
                     _updateGradientStroke(parent, child, frameNo, contexts, ctx);
-                    break;
-                }
-                case LottieObject::Rect: {
-                    _updateRect(parent, child, frameNo, contexts, ctx);
-                    break;
-                }
-                case LottieObject::Ellipse: {
-                    _updateEllipse(parent, child, frameNo, contexts, ctx);
-                    break;
-                }
-                case LottieObject::Path: {
-                    _updatePath(parent, child, frameNo, contexts, ctx);
-                    break;
-                }
-                case LottieObject::Polystar: {
-                    _updatePolystar(parent, child, frameNo, contexts, ctx);
                     break;
                 }
                 case LottieObject::Image: {
@@ -939,6 +919,26 @@ static void _updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderCon
                 }
                 case LottieObject::RoundedCorner: {
                     _updateRoundedCorner(parent, child, frameNo, contexts, ctx);
+                    break;
+                }
+                case LottieObject::Transform: {
+                    _updateTransform(parent, child, frameNo, contexts, ctx);
+                    break;
+                }
+                case LottieObject::Rect: {
+                    _updateRect(parent, child, frameNo, contexts, ctx);
+                    break;
+                }
+                case LottieObject::Ellipse: {
+                    _updateEllipse(parent, child, frameNo, contexts, ctx);
+                    break;
+                }
+                case LottieObject::Path: {
+                    _updatePath(parent, child, frameNo, contexts, ctx);
+                    break;
+                }
+                case LottieObject::Polystar: {
+                    _updatePolystar(parent, child, frameNo, contexts, ctx);
                     break;
                 }
                 default: break;

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -142,13 +142,20 @@ void LottieGroup::prepare(LottieObject::Type type)
     size_t fillCnt = 0;
 
     for (auto c = children.end() - 1; c >= children.begin(); --c) {
-        if (reqFragment) break;
+        if (!mergeable && reqFragment) break;
+
         auto child = static_cast<LottieObject*>(*c);
+
+        /* Figure out if this group is a simple path drawing.
+           In that case, the rendering context can be sharable with the parent's. */
+        if (mergeable && !child->shape()) mergeable = false;
+
+        if (reqFragment) continue;
+
         /* Figure out if the rendering context should be fragmented.
            Multiple stroking or grouping with a stroking would occur this.
            This fragment resolves the overlapped stroke outlines. */
-        if (reqFragment) continue;
-        if (child->type == LottieObject::Group) {
+        if (child->type == LottieObject::Group && !static_cast<LottieGroup*>(child)->mergeable) {
             if (strokeCnt > 0 || fillCnt > 0) reqFragment = true;
         } else if (child->type == LottieObject::SolidStroke || child->type == LottieObject::GradientStroke) {
             if (strokeCnt > 0) reqFragment = true;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -98,20 +98,20 @@ struct LottieObject
         Composition = 0,
         Layer,
         Group,
-        Transform,
         SolidFill,
         SolidStroke,
         GradientFill,
         GradientStroke,
-        Rect,
-        Ellipse,
-        Path,
-        Polystar,
         Image,
         Trimpath,
         Text,
         Repeater,
-        RoundedCorner
+        RoundedCorner,
+        Transform,
+        Rect,
+        Ellipse,
+        Path,
+        Polystar
     };
 
     virtual ~LottieObject()
@@ -122,6 +122,12 @@ struct LottieObject
     virtual void override(LottieProperty* prop)
     {
         TVGERR("LOTTIE", "Unsupported slot type");
+    }
+
+    bool shape()
+    {
+        if ((int) type < (int) LottieObject::Transform) return false;
+        return true;
     }
 
     char* name = nullptr;
@@ -559,6 +565,7 @@ struct LottieGroup : LottieObject
 
     bool reqFragment = false;   //requirment to fragment the render context
     bool buildDone = false;     //completed in building the composition.
+    bool mergeable = true;      //if this group is consisted of simple (transformed) shapes.
 };
 
 


### PR DESCRIPTION
…ranches.

this optimization is to figure out if this group is a simple path drawing. In that case, the rendering context can be sharable with the parent's.