### PR TITLE
portability: removed a compiler waring

### DIFF
--- a/src/loaders/lottie/tvgLottieParserHandler.h
+++ b/src/loaders/lottie/tvgLottieParserHandler.h
@@ -48,8 +48,6 @@
 #include "rapidjson/document.h"
 #include "tvgCommon.h"
 
-RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(effc++)
 
 using namespace rapidjson;
 


### PR DESCRIPTION
D:\Projects\thorvg\src\loaders\lottie\tvgLottieParserHandler.h(52): warning C4083: expected ')'; found identifier 'effc' [44/46] Compiling C++ object src/thorvg-0.dll.p/loaders_lottie_tvgLottieParserHandler.cpp.obj D:\Projects\thorvg\src\loaders\lottie\tvgLottieParserHandler.h(52): warning C4083: expected ')'; found identifier 'effc' [45/46] Compiling C++ object src/thorvg-0.dll.p/loaders_lottie_tvgLottieParser.cpp.obj D:\Projects\thorvg\src\loaders\lottie\tvgLottieParserHandler.h(52): warning C4083: expected ')'; found identifier 'effc'

I'm not sure this option is really necessary.