### PR TITLE
lottie: Fix buffer-overflow in base64 decode

### DIFF
--- a/src/common/tvgCompressor.cpp
+++ b/src/common/tvgCompressor.cpp
@@ -458,11 +458,11 @@ size_t b64Decode(const char* encoded, const size_t len, char** decoded)
         auto value2 = B64_INDEX[(size_t)encoded[1]];
         output[idx++] = (value1 << 2) + ((value2 & 0x30) >> 4);
 
-        if (!encoded[2] || encoded[2] == '=' || encoded[2] == '.') break;
+        if (!encoded[2] || encoded[3] < 0 || encoded[2] == '=' || encoded[2] == '.') break;
         auto value3 = B64_INDEX[(size_t)encoded[2]];
         output[idx++] = ((value2 & 0x0f) << 4) + ((value3 & 0x3c) >> 2);
 
-        if (!encoded[3] || encoded[3] == '=' || encoded[3] == '.') break;
+        if (!encoded[3] || encoded[3] < 0 || encoded[3] == '=' || encoded[3] == '.') break;
         auto value4 = B64_INDEX[(size_t)encoded[3]];
         output[idx++] = ((value3 & 0x03) << 6) + value4;
         encoded += 4;


### PR DESCRIPTION
Memory buffer-overflow is reported by ubsan.

![Screenshot 2024-04-01 at 12 08 21 PM](https://github.com/thorvg/thorvg/assets/11167117/1461d23b-d311-409c-9e96-0e27c9c7ac36)

In some cases, the b64decoder attempts to access `B64_INDEX` with negative integer index. Adding a condition to verify this scenario.

![Screenshot 2024-04-01 at 11 23 16 AM](https://github.com/thorvg/thorvg/assets/11167117/31c8d74a-5dae-46b2-bdf5-45023940a11e)

related issue: #2072 

> Resolving global-buffer-overflow by segmentation fault for 51 files
- test3_IDX_28_RAND_16261639712779502311.json
- test3_IDX_35_RAND_8309361089976797197.json
- test3_IDX_62_RAND_14264694530752380586.json
- test3_IDX_64_RAND_11732237327808738464.json
- test3_IDX_72_RAND_4598263687280085861.json
- test3_IDX_81_RAND_12171893598383239596.json
- test3_IDX_87_RAND_3126791548630821255.json
- test3_IDX_96_RAND_1894973443382169464.json
- test3_IDX_104_RAND_3070988726917405495.json
- test3_IDX_114_RAND_18058571645869157452.json
- test3_IDX_127_RAND_4221562738579431624.json
- test3_IDX_146_RAND_11284023124118786523.json
- test3_IDX_165_RAND_168958409964270155.json
- test3_IDX_221_RAND_9067391663609183485.json
- test3_IDX_231_RAND_114519164216274102.json
- test3_IDX_278_RAND_7831208954810426934.json
- test3_IDX_321_RAND_7428040121719633889.json
- test3_IDX_323_RAND_14189677541268692694.json
- test3_IDX_398_RAND_9265656788483549356.json
- test3_IDX_404_RAND_6411428235889583141.json
- test3_IDX_405_RAND_14727774459982846074.json
- test3_IDX_413_RAND_4369115827771045893.json
- test3_IDX_421_RAND_3065797062948834387.json
- test3_IDX_450_RAND_716644126872997149.json
- test3_IDX_494_RAND_15825745590062083091.json
- test3_IDX_516_RAND_11065153445951437685.json
- test3_IDX_545_RAND_16459068370913838474.json
- test3_IDX_551_RAND_11643024057215888354.json
- test3_IDX_600_RAND_7996570366930437406.json
- test3_IDX_612_RAND_12595923580113570863.json
- test3_IDX_635_RAND_7960623205892609199.json
- test3_IDX_639_RAND_14823686612227949443.json
- test3_IDX_650_RAND_10759427259823287686.json
- test3_IDX_660_RAND_12931916078685654453.json
- test3_IDX_673_RAND_4099952430571517785.json
- test3_IDX_710_RAND_9479277601782243654.json
- test3_IDX_717_RAND_15510719417726139685.json
- test3_IDX_720_RAND_12625478992715998369.json
- test3_IDX_729_RAND_5406276948995337888.json
- test3_IDX_740_RAND_12171191349266080467.json
- test3_IDX_753_RAND_6889818165272315356.json
- test3_IDX_768_RAND_545332138373637849.json
- test3_IDX_778_RAND_8611030219666700867.json
- test3_IDX_783_RAND_14169247756965819866.json
- test3_IDX_799_RAND_17467701253441716246.json
- test3_IDX_836_RAND_14460376423318416822.json
- test3_IDX_875_RAND_4916460545749609275.json
- test3_IDX_878_RAND_14488167141875384038.json
- test3_IDX_971_RAND_7004356958317225819.json
- test3_IDX_990_RAND_9464530900939103031.json
- test3_IDX_998_RAND_10507372197054128122.json


