### PR TITLE
lottie: Fix heap-buffer-overflow in gradient populate

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -383,12 +383,16 @@ struct LottieGradient : LottieObject
     uint32_t populate(ColorStop& color)
     {
         colorStops.populated = true;
-        if (!color.input) return 0;
+        if (!color.input || color.input->count % 4 != 0) {
+            TVGERR("LOTTIE", "The given colorstop value is not correct!");
+            return 0;
+        }
 
         uint32_t alphaCnt = (color.input->count - (colorStops.count * 4)) / 2;
         Array<Fill::ColorStop> output(colorStops.count + alphaCnt);
         uint32_t cidx = 0;               //color count
         uint32_t clast = colorStops.count * 4;
+        if (clast > color.input->count) clast = color.input->count;
         uint32_t aidx = clast;           //alpha count
         Fill::ColorStop cs;
 


### PR DESCRIPTION
Invalid array access in `LottieGradient::populate`. Added preventing logic.

![Screenshot 2024-04-01 at 6 04 49 PM](https://github.com/thorvg/thorvg/assets/11167117/e32117b4-59bb-4f00-ab5f-620c586c74d6)

related issue: #2072 

> Resolving heap-buffer-overflow for 100 files

- lottieslot_IDX_19_RAND_12869611367480417304.json
- lottieslot_IDX_25_RAND_6847350414593490645.json
- lottieslot_IDX_44_RAND_15848512419441078021.json
- lottieslot_IDX_50_RAND_5807196878273210903.json
- lottieslot_IDX_55_RAND_9432165057333607863.json
- lottieslot_IDX_72_RAND_15114513152328341965.json
- lottieslot_IDX_95_RAND_17512533089551937727.json
- lottieslot_IDX_115_RAND_16109261102165821315.json
- lottieslot_IDX_118_RAND_15881926118350713257.json
- lottieslot_IDX_136_RAND_389829138177223098.json
- lottieslot_IDX_177_RAND_16025790448066370425.json
- lottieslot_IDX_257_RAND_16590272615132028700.json
- lottieslot_IDX_269_RAND_6355733993080572443.json
- lottieslot_IDX_290_RAND_5782940052166760100.json
- lottieslot_IDX_314_RAND_4121161721008894171.json
- lottieslot_IDX_322_RAND_14781833810559079611.json
- lottieslot_IDX_331_RAND_18138578377277321461.json
- lottieslot_IDX_335_RAND_3810668890965417759.json
- lottieslot_IDX_340_RAND_890768360192229506.json
- lottieslot_IDX_365_RAND_16002727035396185293.json
- lottieslot_IDX_388_RAND_9674084855534504320.json
- lottieslot_IDX_396_RAND_7048663790889268747.json
- lottieslot_IDX_481_RAND_5533583856709860217.json
- lottieslot_IDX_494_RAND_13622402706576190891.json
- lottieslot_IDX_523_RAND_8069469127718702162.json
- lottieslot_IDX_524_RAND_8007852622351744673.json
- lottieslot_IDX_526_RAND_5283107812946289348.json
- lottieslot_IDX_530_RAND_9564374638529308138.json
- lottieslot_IDX_548_RAND_1075250745224830512.json
- lottieslot_IDX_551_RAND_13975779307000336451.json
- lottieslot_IDX_572_RAND_9694604589892860805.json
- lottieslot_IDX_599_RAND_16745678971660227211.json
- lottieslot_IDX_643_RAND_4802911170159023183.json
- lottieslot_IDX_676_RAND_14270360463326789156.json
- lottieslot_IDX_681_RAND_9156968126877813840.json
- lottieslot_IDX_693_RAND_13581979673268432598.json
- lottieslot_IDX_707_RAND_15682861372400642101.json
- lottieslot_IDX_716_RAND_11834367448440714275.json
- lottieslot_IDX_749_RAND_3047173088254907970.json
- lottieslot_IDX_751_RAND_17918486207630782295.json
- lottieslot_IDX_786_RAND_10522762378512209520.json
- lottieslot_IDX_794_RAND_18114047855947486766.json
- lottieslot_IDX_796_RAND_12525647838442902678.json
- lottieslot_IDX_798_RAND_3210182909665536676.json
- lottieslot_IDX_806_RAND_7324836906375255346.json
- lottieslot_IDX_830_RAND_14897293364053685755.json
- lottieslot_IDX_835_RAND_17324730956749130541.json
- lottieslot_IDX_852_RAND_15701781312441414516.json
- lottieslot_IDX_856_RAND_5481601035849983148.json
- lottieslot_IDX_933_RAND_11642655611548375819.json
- lottieslot_IDX_955_RAND_18272704187300492198.json
- lottieslot_IDX_966_RAND_5019491844782072992.json
- lottieslot_IDX_969_RAND_8044177566861818181.json
- lottieslot_IDX_972_RAND_17592007860926860642.json
- lottieslot_IDX_989_RAND_4751417041702657177.json
- test_IDX_112_RAND_10736107084957087282.json
- test_IDX_147_RAND_13100137458239388500.json
- test_IDX_165_RAND_7064611208571699000.json
- test_IDX_213_RAND_2874633611742771339.json
- test_IDX_225_RAND_14285846035306602619.json
- test_IDX_298_RAND_11553011600060896756.json
- test_IDX_341_RAND_5346225765414581258.json
- test_IDX_347_RAND_4581997097283135351.json
- test_IDX_410_RAND_13712514958554525260.json
- test_IDX_666_RAND_6197313710501342641.json
- test_IDX_714_RAND_11153389787243958634.json
- test_IDX_836_RAND_7019143389916478132.json
- test_IDX_928_RAND_2640734728838469885.json
- test_IDX_984_RAND_1864499262634970735.json
- test2_IDX_31_RAND_16802889738923433566.json
- test2_IDX_108_RAND_3873292286373225455.json
- test2_IDX_119_RAND_9516656879568607957.json
- test2_IDX_150_RAND_2593332181528525927.json
- test2_IDX_155_RAND_9509419281706513589.json
- test2_IDX_234_RAND_9711691308854503322.json
- test2_IDX_251_RAND_3403509184410368076.json
- test2_IDX_267_RAND_8541903710322297871.json
- test2_IDX_287_RAND_4378790603132164469.json
- test2_IDX_301_RAND_11289534843001667381.json
- test2_IDX_375_RAND_6128809124101523845.json
- test2_IDX_401_RAND_624927642861839821.json
- test2_IDX_432_RAND_9518456926443136506.json
- test2_IDX_541_RAND_10960974720930957252.json
- test2_IDX_561_RAND_16714484940400917035.json
- test2_IDX_604_RAND_4282371157344378579.json
- test2_IDX_617_RAND_6690482922101232404.json
- test2_IDX_622_RAND_133504719298227484.json
- test2_IDX_644_RAND_940551425838620766.json
- test2_IDX_665_RAND_10861245892183739721.json
- test2_IDX_677_RAND_1205430493211264718.json
- test2_IDX_692_RAND_961494025256371257.json
- test2_IDX_811_RAND_9574199820182858616.json
- test2_IDX_825_RAND_418482071998379178.json
- test2_IDX_868_RAND_5317332795574096799.json
- test2_IDX_880_RAND_589638247692594489.json
- test2_IDX_977_RAND_361860770418440073.json
- test2_IDX_982_RAND_8595009495426711389.json
- test2_IDX_994_RAND_6204879847882172293.json
- test6_IDX_360_RAND_97626467826299750.json
- test6_IDX_942_RAND_8300449238848842066.json