### PR TITLE
wg_engine: blending optimization

### DIFF
--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -28,6 +28,15 @@
 #include "tvgCommon.h"
 #include "tvgRender.h"
 
+enum class WgPipelineBlendType {
+    Src = 0, // S
+    Normal,  // (Sa * S) + (255 - Sa) * D
+    Add,     // (S + D)
+    Mult,    // (S * D)
+    Min,     // min(S, D)
+    Max      // max(S, D)
+};
+
 struct WgPipelines;
 
 struct WgContext {
@@ -107,7 +116,7 @@ struct WgRenderPipeline: public WgPipeline
 {
 protected:
     WGPURenderPipeline mRenderPipeline{};
-    void allocate(WGPUDevice device,
+    void allocate(WGPUDevice device, WgPipelineBlendType blendType,
                   WGPUVertexBufferLayout vertexBufferLayouts[], uint32_t attribsCount,
                   WGPUBindGroupLayout bindGroupLayouts[], uint32_t bindGroupsCount,
                   WGPUCompareFunction stencilCompareFunction, WGPUStencilOperation stencilOperation,
@@ -116,7 +125,7 @@ public:
     void release() override;
     void set(WGPURenderPassEncoder renderPassEncoder);
 
-    static WGPUBlendState makeBlendState();
+    static WGPUBlendState makeBlendState(WgPipelineBlendType blendType);
     static WGPUColorTargetState makeColorTargetState(const WGPUBlendState* blendState);
     static WGPUVertexBufferLayout makeVertexBufferLayout(const WGPUVertexAttribute* vertexAttributes, uint32_t count, uint64_t stride);
     static WGPUVertexState makeVertexState(WGPUShaderModule shaderModule, const WGPUVertexBufferLayout* buffers, uint32_t count);
@@ -125,7 +134,7 @@ public:
     static WGPUMultisampleState makeMultisampleState();
     static WGPUFragmentState makeFragmentState(WGPUShaderModule shaderModule, WGPUColorTargetState* targets, uint32_t size);
 
-    static WGPURenderPipeline createRenderPipeline(WGPUDevice device,
+    static WGPURenderPipeline createRenderPipeline(WGPUDevice device, WgPipelineBlendType blendType,
                                                    WGPUVertexBufferLayout vertexBufferLayouts[], uint32_t attribsCount,
                                                    WGPUCompareFunction stencilCompareFunction, WGPUStencilOperation stencilOperation,
                                                    WGPUPipelineLayout pipelineLayout, WGPUShaderModule shaderModule,

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -53,7 +53,8 @@ struct WgPipelineFillStroke: public WgRenderPipeline
 
 struct WgPipelineSolid: public WgRenderPipeline
 {
-    void initialize(WGPUDevice device) override;
+    void initialize(WGPUDevice device) override {}
+    void initialize(WGPUDevice device, WgPipelineBlendType blendType);
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas,WgBindGroupPaint& groupPaint, WgBindGroupSolidColor& groupSolid)
     {
         set(encoder);
@@ -65,7 +66,8 @@ struct WgPipelineSolid: public WgRenderPipeline
 
 struct WgPipelineLinear: public WgRenderPipeline
 {
-    void initialize(WGPUDevice device) override;
+    void initialize(WGPUDevice device) override {}
+    void initialize(WGPUDevice device, WgPipelineBlendType blendType);
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas, WgBindGroupPaint& groupPaint, WgBindGroupLinearGradient& groupLinear)
     {
         set(encoder);
@@ -77,7 +79,8 @@ struct WgPipelineLinear: public WgRenderPipeline
 
 struct WgPipelineRadial: public WgRenderPipeline
 {
-    void initialize(WGPUDevice device) override;
+    void initialize(WGPUDevice device) override {}
+    void initialize(WGPUDevice device, WgPipelineBlendType blendType);
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas, WgBindGroupPaint& groupPaint, WgBindGroupRadialGradient& groupRadial)
     {
         set(encoder);
@@ -89,7 +92,8 @@ struct WgPipelineRadial: public WgRenderPipeline
 
 struct WgPipelineImage: public WgRenderPipeline
 {
-    void initialize(WGPUDevice device) override;
+    void initialize(WGPUDevice device) override {}
+    void initialize(WGPUDevice device, WgPipelineBlendType blendType);
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas, WgBindGroupPaint& groupPaint, WgBindGroupPicture& groupPicture)
     {
         set(encoder);
@@ -161,10 +165,11 @@ struct WgPipelines
     // render pipelines
     WgPipelineFillShape fillShape;
     WgPipelineFillStroke fillStroke;
-    WgPipelineSolid solid;
-    WgPipelineLinear linear;
-    WgPipelineRadial radial;
-    WgPipelineImage image;
+    // fill pipelines
+    WgPipelineSolid solid[6];
+    WgPipelineLinear linear[6];
+    WgPipelineRadial radial[6];
+    WgPipelineImage image[6];
     // compute pipelines
     WgPipelineClear computeClear;
     WgPipelineBlend computeBlend;
@@ -173,6 +178,9 @@ struct WgPipelines
 
     void initialize(WgContext& context);
     void release();
+
+    static bool isBlendMethodSupportsHW(BlendMethod blendMethod);
+    static WgPipelineBlendType blendMethodToBlendType(BlendMethod blendMethod);
 };
 
 #endif // _TVG_WG_PIPELINES_H_

--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -25,39 +25,17 @@
 
 #include "tvgWgRenderData.h"
 
-class WgRenderTarget {
+class WgRenderStorage {
 private:
-    // canvas info
+    // texture buffers
     WgBindGroupCanvas mBindGroupCanvas;
+    WGPURenderPassEncoder mRenderPassEncoder{};
     WgPipelines* mPipelines{}; // external handle
 public:
     WGPUTexture texColor{};
     WGPUTexture texStencil{};
     WGPUTextureView texViewColor{};
     WGPUTextureView texViewStencil{};
-    WgBindGroupTextureStorage bindGroupTexStorage;
-public:
-    void initialize(WgContext& context, uint32_t w, uint32_t h, uint32_t samples = 1);
-    void release(WgContext& context);
-
-    void renderShape(WGPUCommandEncoder commandEncoder, WgRenderDataShape* renderData);
-    void renderPicture(WGPUCommandEncoder commandEncoder, WgRenderDataPicture* renderData);
-private:
-    void drawShape(WGPURenderPassEncoder renderPassEncoder, WgRenderDataShape* renderData);
-    void drawStroke(WGPURenderPassEncoder renderPassEncoder, WgRenderDataShape* renderData);
-
-    WGPURenderPassEncoder beginRenderPass(WGPUCommandEncoder commandEncoder);
-    void endRenderPass(WGPURenderPassEncoder renderPassEncoder);
-};
-
-
-class WgRenderStorage {
-private:
-    // texture buffers
-    WgPipelines* mPipelines{}; // external handle
-public:
-    WGPUTexture texStorage{};
-    WGPUTextureView texViewStorage{};
     WgBindGroupTextureStorage bindGroupTexStorage;
     uint32_t width{};
     uint32_t height{};
@@ -67,16 +45,24 @@ public:
     void initialize(WgContext& context, uint32_t w, uint32_t h, uint32_t samples = 1);
     void release(WgContext& context);
 
+    void beginRenderPass(WGPUCommandEncoder commandEncoder, bool clear);
+    void endRenderPass();
+
+    void renderShape(WgRenderDataShape* renderData, WgPipelineBlendType blendType);
+    void renderPicture(WgRenderDataPicture* renderData, WgPipelineBlendType blendType);
+
     void clear(WGPUCommandEncoder commandEncoder);
-    void blend(WGPUCommandEncoder commandEncoder, WgRenderTarget* targetSrc, WgBindGroupBlendMethod* blendMethod);
     void blend(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc, WgBindGroupBlendMethod* blendMethod);
     void compose(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetMsk, WgBindGroupCompositeMethod* composeMethod, WgBindGroupOpacity* opacity);
     void antialias(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc);
 private:
+    void drawShape(WgRenderDataShape* renderData, WgPipelineBlendType blendType);
+    void drawStroke(WgRenderDataShape* renderData, WgPipelineBlendType blendType);
+
     void dispatchWorkgroups(WGPUComputePassEncoder computePassEncoder);
 
     WGPUComputePassEncoder beginComputePass(WGPUCommandEncoder commandEncoder);
-    void endRenderPass(WGPUComputePassEncoder computePassEncoder);
+    void endComputePass(WGPUComputePassEncoder computePassEncoder);
 };
 
 

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -62,7 +62,7 @@ public:
 private:
     // render handles
     WGPUCommandEncoder mCommandEncoder{};
-    WgRenderTarget mRenderTarget;
+    WgRenderStorage mRenderTarget;
     WgRenderStorage mRenderStorageRoot;
     WgRenderStorage mRenderStorageScreen;
     WgRenderStoragePool mRenderStoragePool;
@@ -76,7 +76,6 @@ private:
 
     // native window handles
     WGPUSurface mSurface{};
-private:
     WgContext mContext;
     WgPipelines mPipelines;
     Surface mTargetSurface;


### PR DESCRIPTION
[issues 1479: lottie](#1479)

To optimize blend operations hardware pipeline blend stage are used for some blend methods:
```
 BlendMethod::SrcOver
 BlendMethod::Normal
 BlendMethod::Add
 BlendMethod::Multiply
 BlendMethod::Darken
 BlendMethod::Lighten
```
For other types compute shaders are used