### PR TITLE
sw_engine/stroke: hotfix the memory access violation

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -33,6 +33,7 @@ static bool _outlineBegin(SwOutline& outline)
     //Make a contour if lineTo/curveTo without calling close or moveTo beforehand.
     if (outline.pts.empty()) return false;
     outline.cntrs.push(outline.pts.count - 1);
+    outline.closed.push(false);
     outline.pts.push(outline.pts[outline.cntrs.last()]);
     outline.types.push(SW_CURVE_TYPE_POINT);
     return false;


### PR DESCRIPTION
ensure that the number of contour/close data is properly paired.

issue: https://github.com/thorvg/thorvg/issues/2129