### PR TITLE
gl_engine: hotfix for the main surface drawing issue.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1675,6 +1675,7 @@ public:
      * @param[in] h The height (in pixels) of the raster image.
      *
      * @warning This API is experimental and not officially supported. It may be modified or removed in future versions.
+     * @warning Drawing on the main surface is currently not permitted. If the identifier (@p id) is set to @c 0, the operation will be aborted.
      *
      * @note Currently, this only allows the GL_RGBA8 color space format.
      * @note Experimental API

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -56,7 +56,7 @@ bool GlRenderer::clear()
 
 bool GlRenderer::target(int32_t id, uint32_t w, uint32_t h)
 {
-    assert(w > 0 && h > 0);
+    if (id == GL_INVALID_VALUE || w == 0 || h == 0) return false;
 
     surface.stride = w;
     surface.w = w;
@@ -68,6 +68,11 @@ bool GlRenderer::target(int32_t id, uint32_t w, uint32_t h)
     mViewport.h = surface.h;
 
     mTargetFboId = static_cast<GLint>(id);
+
+    //TODO: It's not allow to draw onto the main surface. Need to confirm the policy.
+    if (mTargetFboId == 0) {
+        GL_CHECK(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &mTargetFboId));
+    }
 
     mRootTarget = make_unique<GlRenderTarget>(surface.w, surface.h);
     mRootTarget->init(mTargetFboId);


### PR DESCRIPTION
GL might need to generate a default target FBO
when the given target ID indicates the main surface.

However, users may want to draw visuals directly onto the main surface.

This policy must be reviewed thoroughly.