### PR TITLE
loader/svg: Fix invalid syntax check

### DIFF
--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -314,7 +314,10 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
             if ((*keyEnd == '=') || (isspace((unsigned char)*keyEnd))) break;
         }
         if (keyEnd == itrEnd) goto error;
-        if (keyEnd == key) continue;
+        if (keyEnd == key) {  // There is no key. This case is invalid, but explores the following syntax.
+            itr = keyEnd + 1;
+            continue;
+        }
 
         if (*keyEnd == '=') value = keyEnd + 1;
         else {


### PR DESCRIPTION
If the key is not parsed and the '=' keyword is located next,
keep to parse the following syntax.

related issue:
https://github.com/thorvg/thorvg/issues/2116