### PR TITLE
wg_engine: vertex, index and unifroms buffers, render objects caching

### DIFF
--- a/src/renderer/wg_engine/tvgWgBindGroups.cpp
+++ b/src/renderer/wg_engine/tvgWgBindGroups.cpp
@@ -98,15 +98,19 @@ void WgBindGroupPaint::releaseLayout()
 
 void WgBindGroupPaint::initialize(WGPUDevice device, WGPUQueue queue, WgShaderTypeMat4x4f& uModelMat, WgShaderTypeBlendSettings& uBlendSettings)
 {
-    release();
-    uBufferModelMat = createBuffer(device, queue, &uModelMat, sizeof(uModelMat));
-    uBufferBlendSettings = createBuffer(device, queue, &uBlendSettings, sizeof(uBlendSettings));
-    const WGPUBindGroupEntry bindGroupEntries[] {
-        makeBindGroupEntryBuffer(0, uBufferModelMat),
-        makeBindGroupEntryBuffer(1, uBufferBlendSettings)
-    };
-    mBindGroup = createBindGroup(device, getLayout(device), bindGroupEntries, 2);
-    assert(mBindGroup);
+    if (!uBufferModelMat && !uBufferBlendSettings && !mBindGroup) {
+        uBufferModelMat = createBuffer(device, queue, &uModelMat, sizeof(uModelMat));
+        uBufferBlendSettings = createBuffer(device, queue, &uBlendSettings, sizeof(uBlendSettings));
+        const WGPUBindGroupEntry bindGroupEntries[] {
+            makeBindGroupEntryBuffer(0, uBufferModelMat),
+            makeBindGroupEntryBuffer(1, uBufferBlendSettings)
+        };
+        mBindGroup = createBindGroup(device, getLayout(device), bindGroupEntries, 2);
+        assert(mBindGroup);
+        return;
+    }
+    wgpuQueueWriteBuffer(queue, uBufferModelMat, 0, &uModelMat, sizeof(uModelMat));
+    wgpuQueueWriteBuffer(queue, uBufferBlendSettings, 0, &uBlendSettings, sizeof(uBlendSettings));
 }
 
 
@@ -138,13 +142,16 @@ void WgBindGroupSolidColor::releaseLayout()
 
 void WgBindGroupSolidColor::initialize(WGPUDevice device, WGPUQueue queue, WgShaderTypeSolidColor &uSolidColor)
 {
-    release();
-    uBufferSolidColor = createBuffer(device, queue, &uSolidColor, sizeof(uSolidColor));
-    const WGPUBindGroupEntry bindGroupEntries[] {
-        makeBindGroupEntryBuffer(0, uBufferSolidColor)
-    };
-    mBindGroup = createBindGroup(device, getLayout(device), bindGroupEntries, 1);
-    assert(mBindGroup);
+    if (!uBufferSolidColor && !mBindGroup) {
+        uBufferSolidColor = createBuffer(device, queue, &uSolidColor, sizeof(uSolidColor));
+        const WGPUBindGroupEntry bindGroupEntries[] {
+            makeBindGroupEntryBuffer(0, uBufferSolidColor)
+        };
+        mBindGroup = createBindGroup(device, getLayout(device), bindGroupEntries, 1);
+        assert(mBindGroup);
+        return;
+    }
+    wgpuQueueWriteBuffer(queue, uBufferSolidColor, 0, &uSolidColor, sizeof(uSolidColor));
 }
 
 
@@ -175,13 +182,16 @@ void WgBindGroupLinearGradient::releaseLayout()
 
 void WgBindGroupLinearGradient::initialize(WGPUDevice device, WGPUQueue queue, WgShaderTypeLinearGradient &uLinearGradient)
 {
-    release();
-    uBufferLinearGradient = createBuffer(device, queue, &uLinearGradient, sizeof(uLinearGradient));
-    const WGPUBindGroupEntry bindGroupEntries[] {
-        makeBindGroupEntryBuffer(0, uBufferLinearGradient)
-    };
-    mBindGroup = createBindGroup(device, getLayout(device), bindGroupEntries, 1);
-    assert(mBindGroup);
+    if (!uBufferLinearGradient && !mBindGroup) {
+        uBufferLinearGradient = createBuffer(device, queue, &uLinearGradient, sizeof(uLinearGradient));
+        const WGPUBindGroupEntry bindGroupEntries[] {
+            makeBindGroupEntryBuffer(0, uBufferLinearGradient)
+        };
+        mBindGroup = createBindGroup(device, getLayout(device), bindGroupEntries, 1);
+        assert(mBindGroup);
+        return;
+    }
+    wgpuQueueWriteBuffer(queue, uBufferLinearGradient, 0, &uLinearGradient, sizeof(uLinearGradient));
 }
 
 
@@ -212,13 +222,16 @@ void WgBindGroupRadialGradient::releaseLayout()
 
 void WgBindGroupRadialGradient::initialize(WGPUDevice device, WGPUQueue queue, WgShaderTypeRadialGradient &uRadialGradient)
 {
-    release();
-    uBufferRadialGradient = createBuffer(device, queue, &uRadialGradient, sizeof(uRadialGradient));
-    const WGPUBindGroupEntry bindGroupEntries[] {
-        makeBindGroupEntryBuffer(0, uBufferRadialGradient)
-    };
-    mBindGroup = createBindGroup(device, getLayout(device), bindGroupEntries, 1);
-    assert(mBindGroup);
+    if (!uBufferRadialGradient && !mBindGroup) {
+        uBufferRadialGradient = createBuffer(device, queue, &uRadialGradient, sizeof(uRadialGradient));
+        const WGPUBindGroupEntry bindGroupEntries[] {
+            makeBindGroupEntryBuffer(0, uBufferRadialGradient)
+        };
+        mBindGroup = createBindGroup(device, getLayout(device), bindGroupEntries, 1);
+        assert(mBindGroup);
+        return;
+    }
+    wgpuQueueWriteBuffer(queue, uBufferRadialGradient, 0, &uRadialGradient, sizeof(uRadialGradient));
 }
 
 

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -28,6 +28,9 @@
 #include "tvgCommon.h"
 #include "tvgRender.h"
 
+#define WG_VERTEX_BUFFER_MIN_SIZE 2048
+#define WG_INDEX_BUFFER_MIN_SIZE 2048
+
 enum class WgPipelineBlendType {
     Src = 0, // S
     Normal,  // (Sa * S) + (255 - Sa) * D
@@ -64,12 +67,16 @@ struct WgContext {
     WGPUTexture createTexture2dMS(WGPUTextureUsageFlags usage, WGPUTextureFormat format, uint32_t width, uint32_t height, uint32_t sc, char const * label);
     WGPUTextureView createTextureView2d(WGPUTexture texture, char const * label);
     WGPUBuffer createBuffer(WGPUBufferUsageFlags usage, uint64_t size, char const * label);
-    void createOrUpdateBuffer(WGPUBuffer& buffer, WGPUBufferUsageFlags usage, const void *data, uint64_t size, char const * label);
 
     void releaseSampler(WGPUSampler& sampler);
     void releaseTexture(WGPUTexture& texture);
     void releaseTextureView(WGPUTextureView& textureView);
     void releaseBuffer(WGPUBuffer& buffer);
+
+    void allocateVertexBuffer(WGPUBuffer& buffer, const void *data, uint64_t size);
+    void allocateIndexBuffer(WGPUBuffer& buffer, const void *data, uint64_t size);
+    void releaseVertexBuffer(WGPUBuffer& buffer);
+    void releaseIndexBuffer(WGPUBuffer& buffer);
 };
 
 struct WgBindGroup

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -37,7 +37,19 @@ struct WgMeshData {
     void release(WgContext& context);
 };
 
+class WgMeshDataPool {
+private:
+    Array<WgMeshData*> mPool;
+    Array<WgMeshData*> mList;
+public:
+    WgMeshData* allocate(WgContext& context);
+    void free(WgContext& context, WgMeshData* meshData);
+    void release(WgContext& context);
+};
+
 struct WgMeshDataGroup {
+    static WgMeshDataPool* MeshDataPool;
+
     Array<WgMeshData*> meshes{};
 
     void update(WgContext& context, WgGeometryDataGroup* geometryDataGroup);
@@ -69,6 +81,7 @@ struct WgRenderDataPaint
 {
     WgBindGroupPaint bindGroupPaint{};
 
+    virtual ~WgRenderDataPaint() {};
     virtual void release(WgContext& context);
     virtual uint32_t identifier() { return TVG_CLASS_ID_UNDEFINED; };
 };
@@ -87,6 +100,16 @@ struct WgRenderDataShape: public WgRenderDataPaint
     void releaseMeshes(WgContext& context);
     void release(WgContext& context) override;
     uint32_t identifier() override { return TVG_CLASS_ID_SHAPE; };
+};
+
+class WgRenderDataShapePool {
+private:
+    Array<WgRenderDataShape*> mPool;
+    Array<WgRenderDataShape*> mList;
+public:
+    WgRenderDataShape* allocate(WgContext& context);
+    void free(WgContext& context, WgRenderDataShape* dataShape);
+    void release(WgContext& context);
 };
 
 struct WgRenderDataPicture: public WgRenderDataPaint

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -69,6 +69,7 @@ private:
     WgBindGroupOpacityPool mOpacityPool;
     WgBindGroupBlendMethodPool mBlendMethodPool;
     WgBindGroupCompositeMethodPool mCompositeMethodPool;
+    WgRenderDataShapePool mRenderDataShapePool;
 
     // render tree stacks
     Array<Compositor*> mCompositorStack;


### PR DESCRIPTION
[issues 1479: lottie](#1479)

Vertex, Index and uniform buffers now updates instead of recreate. Implemented pools form mesh objects and render shapes data

it increase performance in 30-40% in massive animations scenes