### PR TITLE
loader/svg: Skip to invalid polygon

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1726,6 +1726,10 @@ static bool _attrParsePolygonPoints(const char* str, SvgPolygonNode* polygon)
 {
     float num;
     while (_parseNumber(&str, nullptr, &num)) polygon->pts.push(num);
+    if (polygon->pts.count % 2 != 0) {
+        polygon->pts.clear();
+        return false;
+    }
     return true;
 }
 
@@ -1768,7 +1772,7 @@ static SvgNode* _createPolygonNode(SvgLoaderData* loader, SvgNode* parent, const
 
     if (!loader->svgParse->node) return nullptr;
 
-    func(buf, bufLength, _attrParsePolygonNode, loader);
+    if (!func(buf, bufLength, _attrParsePolygonNode, loader)) return nullptr;
     return loader->svgParse->node;
 }
 

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -358,6 +358,7 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
         if (!func((void*)data, tmpBuf, tval)) {
             if (!_isIgnoreUnsupportedLogAttributes(tmpBuf, tval)) {
                 TVGLOG("SVG", "Unsupported attributes used [Elements type: %s][Id : %s][Attribute: %s][Value: %s]", simpleXmlNodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type), ((SvgLoaderData*)data)->svgParse->node->id ? ((SvgLoaderData*)data)->svgParse->node->id : "NO_ID", tmpBuf, tval ? tval : "NONE");
+                goto error;
             }
         }
     }


### PR DESCRIPTION
If a Polygon's points array is odd, it is not a valid shape.