### PR TITLE
lottie: rectify the frame updates.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1802,6 +1802,9 @@ public:
      * @retval Result::InsufficientCondition if the given @p no is the same as the current frame value.
      * @retval Result::NonSupport The current Picture data does not support animations.
      *
+     * @note For efficiency, ThorVG ignores updates to the new frame value if the difference from the current frame value
+     *       is less than 0.001. In such cases, it returns @c Result::InsufficientCondition.
+     *
      * @see totalFrame()
      *
      */

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2250,6 +2250,8 @@ TVG_API Tvg_Animation* tvg_animation_new();
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION if the given @p no is the same as the current frame value.
 * \retval TVG_RESULT_NOT_SUPPORTED The picture data does not support animations.
 *
+* \note For efficiency, ThorVG ignores updates to the new frame value if the difference from the current frame value
+*       is less than 0.001. In such cases, it returns @c Result::InsufficientCondition.
 * \see tvg_animation_get_total_frame()
 */
 TVG_API Tvg_Result tvg_animation_set_frame(Tvg_Animation* animation, float no);

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -319,10 +319,15 @@ bool LottieLoader::override(const char* slot)
 
 bool LottieLoader::frame(float no)
 {
-    //no meaing to update if frame diff is less then 1ms
-    if (fabsf(this->frameNo - no) < 0.001f) return false;
+    //Skip update if frame diff is too small.
+    if (fabsf(this->frameNo - no) < 0.0009f) return false;
 
     this->done();
+
+    //This ensures that the perfect last frame is reached.
+    no *= 1000.0f;
+    no = roundf(no);
+    no *= 0.001f;
 
     this->frameNo = no;
 


### PR DESCRIPTION
Currently, tvg ignores the frame value if the difference is less than 0.001. In most cases, updating the frames when the change is less than 1ms is just an unnecessary burden on the system.

Instead, this ensures that the perfect last frame is reached.

issue: https://github.com/thorvg/thorvg/issues/2147