### PR TITLE
gl_engine: using normal texture rendering in final color blit

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -202,25 +202,26 @@ void GlComposeTask::onResolve() {
 }
 
 GlBlitTask::GlBlitTask(GlProgram* program, GLuint target, GlRenderTarget* fbo, Array<GlRenderTask*>&& tasks)
- : GlComposeTask(program, target, fbo, std::move(tasks))
+ : GlComposeTask(program, target, fbo, std::move(tasks)), mColorTex(fbo->getColorTexture())
 {
-}
-
-void GlBlitTask::setSize(uint32_t width, uint32_t height)
-{
-    mWidth = width;
-    mHeight = height;
 }
 
 void GlBlitTask::run()
 {
     GlComposeTask::run();
 
-    GL_CHECK(glScissor(0, 0, mWidth, mHeight));
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getTargetFbo()));
-    GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, getSelfFbo()));
 
-    GL_CHECK(glBlitFramebuffer(0, 0, mWidth, mHeight, 0, 0, mWidth, mHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST));
+    if (mClearBuffer) {
+        GL_CHECK(glClearColor(0, 0, 0, 0));
+        GL_CHECK(glClear(GL_COLOR_BUFFER_BIT));
+    }
+
+    // make sure the blending is correct
+    GL_CHECK(glEnable(GL_BLEND));
+    GL_CHECK(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+
+    GlRenderTask::run();
 }
 
 GlDrawBlitTask::GlDrawBlitTask(GlProgram* program, GLuint target, GlRenderTarget* fbo, Array<GlRenderTask*>&& tasks)

--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -130,7 +130,7 @@ protected:
 
     GLuint getResolveFboId();
 
-    virtual void onResolve();
+    void onResolve();
 private:
     GLuint mTargetFbo;
     GlRenderTarget* mFbo;
@@ -143,16 +143,11 @@ public:
     GlBlitTask(GlProgram*, GLuint target, GlRenderTarget* fbo, Array<GlRenderTask*>&& tasks);
     ~GlBlitTask() override = default;
 
-    void setSize(uint32_t width, uint32_t height);
-
     void run() override;
 
-protected:
-    void onResolve() override {}
-
+    GLuint getColorTextore() const { return mColorTex; }
 private:
-    uint32_t mWidth = 0;
-    uint32_t mHeight = 0;
+    GLuint mColorTex = 0;
 };
 
 class GlDrawBlitTask : public GlComposeTask

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -47,6 +47,7 @@ public:
         RT_MaskIntersect,
         RT_MaskDifference,
         RT_Stencil,
+        RT_Blit,
 
         RT_None,
     };
@@ -90,6 +91,7 @@ private:
 
     GlRenderPass* currentPass();
 
+    void prepareBlitTask(GlBlitTask* task);
     void prepareCmpTask(GlRenderTask* task);
     void endRenderPass(Compositor* cmp);
 

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -453,3 +453,22 @@ const char* STENCIL_FRAG_SHADER = TVG_COMPOSE_SHADER(
     out vec4 FragColor;                                             \n
     void main() { FragColor = vec4(0.0); }                          \n
 );
+
+const char* BLIT_VERT_SHADER = TVG_COMPOSE_SHADER(
+    layout(location = 0) in vec2 aLocation;                         \n
+    layout(location = 1) in vec2 aUV;                               \n
+    out vec2 vUV;                                                   \n
+    void main() {                                                   \n
+        vUV = aUV;                                                  \n
+        gl_Position = vec4(aLocation, 0.0, 1.0);                    \n
+    }
+);
+
+const char* BLIT_FRAG_SHADER = TVG_COMPOSE_SHADER(
+    uniform sampler2D uSrcTexture;                                  \n
+    in vec2 vUV;                                                    \n
+    out vec4 FragColor;                                             \n
+    void main() {                                                   \n
+        FragColor = texture(uSrcTexture, vUV);                      \n
+    }
+);

--- a/src/renderer/gl_engine/tvgGlShaderSrc.h
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.h
@@ -41,5 +41,7 @@ extern const char* MASK_INTERSECT_FRAG_SHADER;
 extern const char* MASK_DIFF_FRAG_SHADER;
 extern const char* STENCIL_VERT_SHADER;
 extern const char* STENCIL_FRAG_SHADER;
+extern const char* BLIT_VERT_SHADER;
+extern const char* BLIT_FRAG_SHADER;
 
 #endif /* _TVG_GL_SHADERSRC_H_ */


### PR DESCRIPTION
This PR replace the blit logical with normal texture rendering in the final color blit pass.

Since blit msaa framebuffer to another msaa framebuffer may generate GLError in some platforms. Use normal texture rendering to blit the final color buffer onto target framebuffer.