### PR TITLE
gl_engine: using depth buffer to support path clip

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -70,6 +70,7 @@ struct GlShape
   ColorSpace texColorSpace = ColorSpace::ABGR8888;
   RenderUpdateFlag updateFlag = None;
   unique_ptr<GlGeometry> geometry;
+  Array<RenderData> clips;
 };
 
 #define MAX_GRADIENT_STOPS 16

--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -31,7 +31,7 @@ GlGeometry::~GlGeometry()
 
 bool GlGeometry::tesselate(const RenderShape& rshape, RenderUpdateFlag flag)
 {
-    if (flag & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform)) {
+    if (flag & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
         fillVertex.clear();
         fillIndex.clear();
 

--- a/src/renderer/gl_engine/tvgGlRenderPass.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderPass.cpp
@@ -35,8 +35,8 @@ GlRenderTarget::~GlRenderTarget()
     if (mColorTex != 0) {
         GL_CHECK(glDeleteTextures(1, &mColorTex));
     }
-    if (mStencilBuffer != 0) {
-        GL_CHECK(glDeleteRenderbuffers(1, &mStencilBuffer));
+    if (mDepthStencilBuffer != 0) {
+        GL_CHECK(glDeleteRenderbuffers(1, &mDepthStencilBuffer));
     }
 }
 
@@ -52,16 +52,16 @@ void GlRenderTarget::init(GLint resolveId)
     GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, mColorBuffer));
     GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_RGBA8, mWidth, mHeight));
 
-    GL_CHECK(glGenRenderbuffers(1, &mStencilBuffer));
+    GL_CHECK(glGenRenderbuffers(1, &mDepthStencilBuffer));
 
-    GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, mStencilBuffer));
+    GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, mDepthStencilBuffer));
 
-    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_STENCIL_INDEX8, mWidth, mHeight));
+    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, mWidth, mHeight));
 
     GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, 0));
 
     GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, mColorBuffer));
-    GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, mStencilBuffer));
+    GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, mDepthStencilBuffer));
 
     // resolve target
     GL_CHECK(glGenTextures(1, &mColorTex));

--- a/src/renderer/gl_engine/tvgGlRenderPass.h
+++ b/src/renderer/gl_engine/tvgGlRenderPass.h
@@ -51,7 +51,7 @@ private:
     uint32_t mHeight = 0;
     GLuint mFbo = 0;
     GLuint mColorBuffer = 0;
-    GLuint mStencilBuffer = 0;
+    GLuint mDepthStencilBuffer = 0;
     GLuint mResolveFbo = 0;
     GLuint mColorTex = 0;
 };

--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -176,17 +176,22 @@ void GlComposeTask::run()
     if (mClearBuffer) {
         GL_CHECK(glClearColor(0, 0, 0, 0));
         GL_CHECK(glClearStencil(0));
+        GL_CHECK(glClearDepthf(1.0));
+        GL_CHECK(glDepthMask(1));
 
-        GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT));
+        GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+        GL_CHECK(glDepthMask(0));
     }
 
     for(uint32_t i = 0; i < mTasks.count; i++) {
         mTasks[i]->run();
     }
 
-    GLenum stencil_attachment = GL_STENCIL_ATTACHMENT;
-    GL_CHECK(glInvalidateFramebuffer(GL_FRAMEBUFFER, 1, &stencil_attachment));
+    GLenum attachments[2] = {GL_STENCIL_ATTACHMENT, GL_DEPTH_ATTACHMENT };
+    GL_CHECK(glInvalidateFramebuffer(GL_FRAMEBUFFER, 2, attachments));
 
+    // reset scissor box
+    GL_CHECK(glScissor(0, 0, mFbo->getWidth(), mFbo->getHeight()));
     onResolve();
 }
 
@@ -217,6 +222,7 @@ void GlBlitTask::run()
         GL_CHECK(glClear(GL_COLOR_BUFFER_BIT));
     }
 
+    GL_CHECK(glDisable(GL_DEPTH_TEST));
     // make sure the blending is correct
     GL_CHECK(glEnable(GL_BLEND));
     GL_CHECK(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
@@ -236,4 +242,44 @@ void GlDrawBlitTask::run()
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getTargetFbo()));
 
     GlRenderTask::run();
+}
+
+GlClipTask::GlClipTask(GlRenderTask* clip, GlRenderTask* mask)
+ :GlRenderTask(nullptr), mClipTask(clip), mMaskTask(mask) {}
+
+void GlClipTask::run()
+{
+    GL_CHECK(glEnable(GL_STENCIL_TEST));
+    GL_CHECK(glDepthFunc(GL_ALWAYS));
+    GL_CHECK(glColorMask(0, 0, 0, 0));
+    // draw clip path as normal stencil mask
+    GL_CHECK(glStencilFuncSeparate(GL_FRONT, GL_ALWAYS, 0x1, 0xFF));
+    GL_CHECK(glStencilOpSeparate(GL_FRONT, GL_KEEP, GL_KEEP, GL_INCR_WRAP));
+
+    GL_CHECK(glStencilFuncSeparate(GL_BACK, GL_ALWAYS, 0x1, 0xFF));
+    GL_CHECK(glStencilOpSeparate(GL_BACK, GL_KEEP, GL_KEEP, GL_DECR_WRAP));
+
+    mClipTask->run();
+
+
+    // draw clip mask
+    GL_CHECK(glDepthMask(1));
+    GL_CHECK(glStencilFunc(GL_EQUAL, 0x0, 0xFF));
+    GL_CHECK(glStencilOp(GL_REPLACE, GL_KEEP, GL_REPLACE));
+
+    mMaskTask->run();
+
+    GL_CHECK(glColorMask(1, 1, 1, 1));
+    GL_CHECK(glDepthMask(0));
+    GL_CHECK(glDepthFunc(GL_LESS));
+    GL_CHECK(glDisable(GL_STENCIL_TEST));
+}
+
+void GlClipClearTask::run()
+{
+    GL_CHECK(glDisable(GL_SCISSOR_TEST));
+    GL_CHECK(glDepthMask(1));
+    GL_CHECK(glClear(GL_DEPTH_BUFFER_BIT));
+    GL_CHECK(glDepthMask(0));
+    GL_CHECK(glEnable(GL_SCISSOR_TEST));
 }

--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -159,5 +159,27 @@ public:
     void run() override;
 };
 
+class GlClipTask : public GlRenderTask
+{
+public:
+    GlClipTask(GlRenderTask* clip, GlRenderTask* mask);
+    ~GlClipTask() override = default;
+
+    void run() override;
+
+private:
+    GlRenderTask* mClipTask;
+    GlRenderTask* mMaskTask;
+};
+
+class GlClipClearTask : public GlRenderTask
+{
+public:
+    GlClipClearTask(): GlRenderTask(nullptr) {}
+    ~GlClipClearTask() override = default;
+
+    void run() override;
+};
+
 
 #endif /* _TVG_GL_RENDER_TASK_H_ */

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -88,6 +88,7 @@ private:
     void initShaders();
     void drawPrimitive(GlShape& sdata, uint8_t r, uint8_t g, uint8_t b, uint8_t a, RenderUpdateFlag flag);
     void drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFlag flag);
+    void drawClip(Array<RenderData>& clips);
 
     GlRenderPass* currentPass();
 


### PR DESCRIPTION
This PR implement ClipPath in GLEngine by using depth test with the following changes:

* Append depth buffer attachment in tvgGlRenderPass
* using depth test if Shape has path clip

### PictureRaw
![picture_raw](https://github.com/thorvg/thorvg/assets/26308154/c266f49e-d1f8-4611-a006-ba1a093cd739)
### ClipPath
![clip_path](https://github.com/thorvg/thorvg/assets/26308154/a81d685f-2427-4d7c-8c9c-b089b1dc9067)
