### PR TITLE
sw_engine : type cast compile error

### DIFF
--- a/src/renderer/sw_engine/tvgSwRasterNeon.h
+++ b/src/renderer/sw_engine/tvgSwRasterNeon.h
@@ -69,7 +69,7 @@ static bool neonRasterTranslucentRle(SwSurface* surface, const SwRleData* rle, u
         auto dst = &surface->buf32[span->y * surface->stride + span->x];
         auto ialpha = IA(src);
 
-        if ((((uint32_t) dst) & 0x7) != 0) {
+        if ((((uintptr_t) dst) & 0x7) != 0) {
             //fill not aligned byte
             *dst = src + ALPHA_BLEND(*dst, ialpha);
             vDst = (uint8x8_t*)(dst + 1);
@@ -116,7 +116,7 @@ static bool neonRasterTranslucentRect(SwSurface* surface, const SwBBox& region, 
     for (uint32_t y = 0; y < h; ++y) {
         auto dst = &buffer[y * surface->stride];
 
-        if ((((uint32_t) dst) & 0x7) != 0) {
+        if ((((uintptr_t) dst) & 0x7) != 0) {
             //fill not aligned byte
             *dst = color + ALPHA_BLEND(*dst, ialpha);
             vDst = (uint8x8_t*) (dst + 1);


### PR DESCRIPTION
I'm getting a compilation error when compiling on aarch64

```
w_engine_tvgSwRaster.cpp.o -MF src/libthorvg.so.0.13.99.p/renderer_sw_engine_tvgSwRaster.cpp.o.d -o src/libthorvg.so.0.13.99.p/renderer_sw_engine_tvgSwRaster.cpp.o -c ../src/renderer/sw_engine/tvgSwRaster.cpp
In file included from ../src/renderer/sw_engine/tvgSwRaster.cpp:238:
../src/renderer/sw_engine/tvgSwRasterNeon.h: In function ‘bool neonRasterTranslucentRle(SwSurface*, const SwRleData*, uint8_t, uint8_t, uint8_t, uint8_t)’:
../src/renderer/sw_engine/tvgSwRasterNeon.h:72:15: error: cast from ‘unsigned int*’ to ‘uint32_t’ {aka ‘unsigned int’} loses precision [-fpermissive]
   72 |         if ((((uint32_t) dst) & 0x7) != 0) {
      |               ^~~~~~~~~~~~~~
../src/renderer/sw_engine/tvgSwRasterNeon.h:85:32: warning: comparison of integer expressions of different signedness: ‘uint32_t’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
   85 |         for (uint32_t x = 0; x < (span->len - align) / 2; ++x)
      |                              ~~^~~~~~~~~~~~~~~~~~~~~~~~~
../src/renderer/sw_engine/tvgSwRasterNeon.h: In function ‘bool neonRasterTranslucentRect(SwSurface*, const SwBBox&, uint8_t, uint8_t, uint8_t, uint8_t)’:
../src/renderer/sw_engine/tvgSwRasterNeon.h:119:15: error: cast from ‘unsigned int*’ to ‘uint32_t’ {aka ‘unsigned int’} loses precision [-fpermissive]
  119 |         if ((((uint32_t) dst) & 0x7) != 0) {
      |               ^~~~~~~~~~~~~~
[27/172] Compiling C++ object src/libthorvg.so.0.13.99.p/renderer_sw_engine_tvgSwStroke.cpp.o
ninja: build stopped: subcommand failed.
rinechran@raspberrypi:~/project/thorvg $ cd if ((((uint32_t) dst) & 0x7) != 0) {if ((((uint32_t) dst) & 0x7) != 0) {^C
rinechran@raspberrypi:~/project/thorvg $ 
```
