### PR TITLE
sw_engine : addition of aarch64 neon

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,9 @@ if get_option('vector') == true
   elif host_machine.cpu_family() == 'arm'
     config_h.set10('THORVG_NEON_VECTOR_SUPPORT', true)
     simd_type = 'neon'
+  elif host_machine.cpu_family() == 'aarch64'
+    config_h.set10('THORVG_NEON_VECTOR_SUPPORT', true)
+    simd_type = 'adv_neon'
   endif
 endif
 


### PR DESCRIPTION
Even when I enable the vector option, host_machine.cpu_family() is set to aarch64, so NEON doesn't get activated