### PR TITLE
infra: revise the vector build script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -85,13 +85,16 @@ endif
 #Vectorization
 simd_type = 'none'
 
-if get_option('vector') == true
-  if host_machine.cpu_family() == 'x86' or host_machine.cpu_family() == 'x86_64'
+if get_option('simd') == true
+  if host_machine.cpu_family().startswith('x86')
     config_h.set10('THORVG_AVX_VECTOR_SUPPORT', true)
     simd_type = 'avx'
-  elif host_machine.cpu_family() == 'arm'
+  elif host_machine.cpu_family().startswith('arm')
     config_h.set10('THORVG_NEON_VECTOR_SUPPORT', true)
-    simd_type = 'neon'
+    simd_type = 'neon-arm'
+  elif host_machine.cpu().startswith('aarch')
+    config_h.set10('THORVG_NEON_VECTOR_SUPPORT', true)
+    simd_type = 'neon-aarch'
   endif
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,7 +21,7 @@ option('threads',
    value: true,
    description: 'Enable the multi-threading task scheduler in thorvg')
 
-option('vector',
+option('simd',
    type: 'boolean',
    value: false,
    description: 'Enable CPU Vectorization(SIMD) in thorvg')

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,7 +14,7 @@ if (cc.get_id() == 'clang-cl')
     if simd_type == 'avx'
         compiler_flags += ['/clang:-mavx']
     endif
-    if simd_type == 'neon'
+    if simd_type == 'neon-arm'
         compiler_flags += ['/clang:-mfpu=neon']
     endif
     if get_option('b_sanitize') == 'none'
@@ -26,7 +26,7 @@ elif (cc.get_id() != 'msvc')
     if simd_type == 'avx'
         compiler_flags += ['-mavx']
     endif
-    if simd_type == 'neon'
+    if simd_type == 'neon-arm'
         compiler_flags += ['-mfpu=neon']
     endif
     if get_option('b_sanitize') == 'none'


### PR DESCRIPTION
Note that this change renames the Meson option from 'vector' to 'simd',
separates the NEON types into 'neon-arm' and 'neon-aarch',
and designates the 'mfpu' option solely for 'neon-arm'.