### PR TITLE
loader/svg: Add null to the end of data

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3813,10 +3813,11 @@ bool SvgLoader::open(const char* data, uint32_t size, TVG_UNUSED const string& r
     clear();
 
     if (copy) {
-        content = (char*)malloc(size);
+        content = (char*)malloc(size + 1);
         if (!content) return false;
         memcpy((char*)content, data, size);
-    } else content = data;
+        content[size] = '\0';
+    } else content = (char*)data;
 
     this->size = size;
     this->copy = copy;
@@ -3840,7 +3841,7 @@ bool SvgLoader::open(const string& path)
 
     if (filePath.empty()) return false;
 
-    content = filePath.c_str();
+    content = (char*)filePath.c_str();
     size = filePath.size();
 
     return header();

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -31,7 +31,7 @@ class SvgLoader : public ImageLoader, public Task
 public:
     string filePath;
     string svgPath = "";
-    const char* content = nullptr;
+    char* content = nullptr;
     uint32_t size = 0;
 
     SvgLoaderData loaderData;


### PR DESCRIPTION
Because memcpy() is not guaranteed to copy null at the end of the data array,
it increase the size by 1 and add null.
This prevents invalid access of string functions in parser.