### PR TITLE
lottie: ++stability

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -262,7 +262,8 @@ bool LottieLoader::read()
 
 Paint* LottieLoader::paint()
 {
-    this->done();
+    done();
+
     if (!comp) return nullptr;
     comp->initiated = true;
     return comp->root->scene;
@@ -271,6 +272,8 @@ Paint* LottieLoader::paint()
 
 bool LottieLoader::override(const char* slot)
 {
+    if (!comp) done();
+
     if (!comp || comp->slots.count == 0) return false;
 
     auto success = true;


### PR DESCRIPTION
ensure that the loading has been completed before overriding.