### PR TITLE
sw_engine: fix max length of trimmed strokes

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -371,7 +371,7 @@ static float _outlineLength(const RenderShape* rshape)
     const Point* close = nullptr;
     auto length = 0.0f;
     auto slength = -1.0f;
-    auto simutaneous = !rshape->stroke->trim.individual;
+    auto simultaneous = !rshape->stroke->trim.individual;
 
     //Compute the whole length
     while (cmdCnt-- > 0) {
@@ -379,7 +379,7 @@ static float _outlineLength(const RenderShape* rshape)
             case PathCommand::Close: {
                 length += mathLength(pts - 1, close);
                 //retrieve the max length of the shape if the simultaneous mode.
-                if (simutaneous) {
+                if (simultaneous) {
                     if (slength < length) slength = length;
                     length = 0.0f;
                 }
@@ -403,7 +403,7 @@ static float _outlineLength(const RenderShape* rshape)
         }
         ++cmds;
     }
-    if (simutaneous && slength > length) return slength;
+    if (simultaneous && slength > length) return slength;
     else return length;
 }
 

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -370,7 +370,7 @@ static float _outlineLength(const RenderShape* rshape)
 
     const Point* close = nullptr;
     auto length = 0.0f;
-    auto slength = 0.0f;
+    auto slength = -1.0f;
     auto simutaneous = !rshape->stroke->trim.individual;
 
     //Compute the whole length
@@ -379,8 +379,8 @@ static float _outlineLength(const RenderShape* rshape)
             case PathCommand::Close: {
                 length += mathLength(pts - 1, close);
                 //retrieve the max length of the shape if the simultaneous mode.
-                if (simutaneous && slength < length) {
-                    slength = length;
+                if (simutaneous) {
+                    if (slength < length) slength = length;
                     length = 0.0f;
                 }
                 break;


### PR DESCRIPTION
The error was visible when multiple shapes were
simultaneously trimmed. The length of a single
shape was zeroed out only in selected cases,
which caused accumulation that could lead to
incorrect extension of the variable determining
the maximum length.

@issue: https://github.com/thorvg/thorvg/issues/2173

Screenshot taken just before finishing the drawing of the windows on the building to the left - pay attention to the tree and the building on the right:
<img width="451" alt="Zrzut ekranu 2024-04-15 o 22 47 13" src="https://github.com/thorvg/thorvg/assets/67589014/5df16852-9142-4bb1-b78c-e900aed58f3b">

Screenshot taken just before starting to draw the left edge of the windows in the building on the left - pay attention to the door and the tree:
<img width="470" alt="Zrzut ekranu 2024-04-15 o 22 48 40" src="https://github.com/thorvg/thorvg/assets/67589014/c10e129f-5443-476f-b143-1e335dbc007f">
