### PR TITLE
loader/svg: Add check to the limits of result of StrToFloat

### DIFF
--- a/src/common/tvgStr.cpp
+++ b/src/common/tvgStr.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "config.h"
+#include <cmath>
 #include <cstring>
 #include <memory.h>
 #include "tvgMath.h"
@@ -197,6 +198,8 @@ float strToFloat(const char *nPtr, char **endPtr)
 
 success:
     if (endPtr) *endPtr = (char *)(a);
+    if (!std::isfinite(val)) return 0.0f;
+
     return minus * val;
 
 error:


### PR DESCRIPTION
The string passed to the svg parser is not guaranteed to always be a valid string.
Certain strings may have numbers that cannot be converted.
Therefore, make sure to check whether the converted value is in the appropriate range before returning.

related issue: https://github.com/thorvg/thorvg/issues/2078#issuecomment-2037495121