### PR TITLE
common: fix composition while masking

### DIFF
--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -76,8 +76,21 @@ struct Shape::Impl
         //Composition test
         const Paint* target;
         auto method = shape->composite(&target);
-        if (!target || method == tvg::CompositeMethod::ClipPath) return false;
-        if (target->pImpl->opacity == 255 || target->pImpl->opacity == 0) return false;
+        if (!target || method == CompositeMethod::ClipPath) return false;
+        if (target->pImpl->opacity == 255 || target->pImpl->opacity == 0) {
+            if (target->identifier() == TVG_CLASS_ID_SHAPE) {
+                auto shape = static_cast<const Shape*>(target);
+                if (!shape->fill()) {
+                    uint8_t r, g, b, a;
+                    shape->fillColor(&r, &g, &b, &a);
+                    if (a == 0 || a == 255) {
+                        if (method == CompositeMethod::LumaMask || method == CompositeMethod::InvLumaMask) {
+                            if ((r == 255 && g == 255 && b == 255) || (r == 0 && g == 0 && b == 0)) return false;
+                        } else return false;
+                    }
+                }
+            }
+        }
 
         return true;
     }


### PR DESCRIPTION
Using a mask (any type) with alpha set to less
than 255 through the fill(r, g, b, a) API resulted in incorrect compositions of fill and stroke.
Incorrect results were also observed for luma masks, as their alpha is calculated based on the other color channels.

@issue: https://github.com/thorvg/thorvg/issues/1653

modyfied InvLumaMasking.cpp example:

```
    // rect
    auto shape = tvg::Shape::gen();
    shape->appendRect(0, 0, 200, 200);
    shape->fill(255, 0, 0);
    shape->strokeWidth(50);
    shape->strokeFill(255, 255, 0);

    //Mask
    auto mask = tvg::Shape::gen();
    mask->appendCircle(200, 200, 125, 125);
    mask->fill(255, 50, 255);

    //Nested Mask
    auto nMask = tvg::Shape::gen();
    nMask->appendCircle(220, 220, 125, 125);
    nMask->fill(255, 50, 255);

    mask->composite(std::move(nMask), tvg::CompositeMethod::InvLumaMask);
    shape->composite(std::move(mask), tvg::CompositeMethod::InvLumaMask);
    canvas->push(std::move(shape)); 
    
    // star
    auto star = tvg::Shape::gen();
    star->fill(80, 80, 80);
    star->moveTo(599, 34);
    star->lineTo(653, 143);
    star->lineTo(774, 160);
    star->lineTo(687, 244);
    star->lineTo(707, 365);
    star->lineTo(599, 309);
    star->lineTo(497, 365);
    star->lineTo(512, 245);
    star->lineTo(426, 161);
    star->lineTo(546, 143);
    star->close();
    star->strokeWidth(20);
    star->strokeFill(255, 255, 255);

    //Mask3
    auto mask3 = tvg::Shape::gen();
    mask3->appendCircle(600, 200, 125, 125);
    mask3->fill(0, 255, 255);
    star->composite(std::move(mask3), tvg::CompositeMethod::InvLumaMask);
    if (canvas->push(std::move(star)) != tvg::Result::Success) return;
```

before:
<img width="390" alt="Zrzut ekranu 2024-04-19 o 01 56 06" src="https://github.com/thorvg/thorvg/assets/67589014/4f3bc78b-5246-4020-966f-57256a3f1c53">


after:
<img width="394" alt="Zrzut ekranu 2024-04-19 o 01 36 45" src="https://github.com/thorvg/thorvg/assets/67589014/1d9ee15c-47b7-4f42-bba4-3ae745898424">


Modyfied Masking.cpp example:
```
    //Star
    auto star = tvg::Shape::gen();
    star->fill(80, 80, 80);
    star->moveTo(599, 34);
    star->lineTo(653, 143);
    star->lineTo(774, 160);
    star->lineTo(687, 244);
    star->lineTo(707, 365);
    star->lineTo(599, 309);
    star->lineTo(497, 365);
    star->lineTo(512, 245);
    star->lineTo(426, 161);
    star->lineTo(546, 143);
    star->close();
    star->strokeWidth(30);
    star->strokeJoin(tvg::StrokeJoin::Miter);
    star->strokeFill(255, 255, 255);

    //Mask3
    auto mask3 = tvg::Shape::gen();
    mask3->appendCircle(600, 200, 125, 125);
    mask3->fill(255, 255, 255, 200);       //AlphaMask RGB channels are unused.
    star->composite(std::move(mask3), tvg::CompositeMethod::AlphaMask);
    if (canvas->push(std::move(star)) != tvg::Result::Success) return;

```
before: 
<img width="180" alt="Zrzut ekranu 2024-04-19 o 02 00 55" src="https://github.com/thorvg/thorvg/assets/67589014/dfe5adaa-e967-4079-a6ea-46be17a0a60c">

after:
<img width="157" alt="Zrzut ekranu 2024-04-19 o 02 00 37" src="https://github.com/thorvg/thorvg/assets/67589014/6437b99d-95e0-42e2-a95a-86b0578af3fe">

