### PR TITLE
gl_engine: fix gradient rendering error

### DIFF
--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -2154,7 +2154,7 @@ void BWTessellator::tessellate(const RenderShape *rshape)
 
                 float step = 1.f / stepCount;
 
-                for (uint32_t s = 1; s < static_cast<uint32_t>(stepCount); s++) {
+                for (uint32_t s = 1; s <= static_cast<uint32_t>(stepCount); s++) {
                     auto pt = bezPointAt(curve, step * s);
                     auto currIndex = pushVertex(pt.x, pt.y);
 


### PR DESCRIPTION
This PR fix the gradient effect not rendered correct:

* Fix error when handle GradientTransform calculation. And move the inv calculation into gradient vertex shader.
* Fix cubic tessellation not close the last point

----
## Before:
![image](https://github.com/thorvg/thorvg/assets/26308154/8dcf4372-5cbf-4acd-a960-35cfd8675e4e)

![image](https://github.com/thorvg/thorvg/assets/26308154/de7d9b1c-50d4-4338-a46d-b2a8c9adde4c)


----
## After
I think now the SVG example is correct:
![gl_engine](https://github.com/thorvg/thorvg/assets/26308154/5272aab4-f5ad-406a-b45b-a76fc57715a9)
