### PR TITLE
svg_loader: correct polygon's points loading 

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1724,8 +1724,11 @@ static SvgNode* _createEllipseNode(SvgLoaderData* loader, SvgNode* parent, const
 
 static bool _attrParsePolygonPoints(const char* str, SvgPolygonNode* polygon)
 {
-    float num;
-    while (_parseNumber(&str, nullptr, &num)) polygon->pts.push(num);
+    float num_x, num_y;
+    while (_parseNumber(&str, nullptr, &num_x) && _parseNumber(&str, nullptr, &num_y)) {
+        polygon->pts.push(num_x);
+        polygon->pts.push(num_y);
+    }
     return true;
 }
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1726,10 +1726,6 @@ static bool _attrParsePolygonPoints(const char* str, SvgPolygonNode* polygon)
 {
     float num;
     while (_parseNumber(&str, nullptr, &num)) polygon->pts.push(num);
-    if (polygon->pts.count % 2 != 0) {
-        polygon->pts.clear();
-        return false;
-    }
     return true;
 }
 
@@ -1772,7 +1768,7 @@ static SvgNode* _createPolygonNode(SvgLoaderData* loader, SvgNode* parent, const
 
     if (!loader->svgParse->node) return nullptr;
 
-    if (!func(buf, bufLength, _attrParsePolygonNode, loader)) return nullptr;
+    func(buf, bufLength, _attrParsePolygonNode, loader);
     return loader->svgParse->node;
 }
 

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -358,7 +358,6 @@ bool simpleXmlParseAttributes(const char* buf, unsigned bufLength, simpleXMLAttr
         if (!func((void*)data, tmpBuf, tval)) {
             if (!_isIgnoreUnsupportedLogAttributes(tmpBuf, tval)) {
                 TVGLOG("SVG", "Unsupported attributes used [Elements type: %s][Id : %s][Attribute: %s][Value: %s]", simpleXmlNodeTypeToString(((SvgLoaderData*)data)->svgParse->node->type), ((SvgLoaderData*)data)->svgParse->node->id ? ((SvgLoaderData*)data)->svgParse->node->id : "NO_ID", tmpBuf, tval ? tval : "NONE");
-                goto error;
             }
         }
     }


### PR DESCRIPTION
[Revert "loader/svg: Skip to invalid polygon"](https://github.com/thorvg/thorvg/commit/c89dd9e2366a5f363507583131a2c042d209de55) 

This reverts commit https://github.com/thorvg/thorvg/commit/75e587a9a9b8becbedc6f1ccacd88da95be1ccb4.
If incorrect data for the points in a polygon is provided,
the element should still be rendered, but only up to the point
where the error occurs—using an even number of the points that
have been successfully loaded.

[svg_loader: correct polygon's points loading](https://github.com/thorvg/thorvg/commit/54f85d9a04ee1397d8b40b8ad63f76a4a62e200c) 

Only an even number of correctly read points defining
a polygon should be loaded and passed on for rendering.
Any remaining points should be ignored.