### PR TITLE
svg_loader: copy display property

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3025,6 +3025,7 @@ static void _styleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
 
 static void _copyAttr(SvgNode* to, const SvgNode* from)
 {
+    to->display = from->display;
     //Copy matrix attribute
     if (from->transform) {
         to->transform = (Matrix*)malloc(sizeof(Matrix));


### PR DESCRIPTION
The display property was not copied along with other node properties. This caused incorrect rendering
of an object with display=none if accessed through a use tag.