### PR TITLE
lottie: data optimization

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -57,7 +57,7 @@ private:
     void getPathSet(LottiePathSet& path);
     void getLayerSize(float& val);
     void getValue(TextDocument& doc);
-    void getValue(PathSet& path);
+    void getValue(PathSet& path, bool optimize = false);
     void getValue(Array<Point>& pts);
     void getValue(ColorStop& color);
     void getValue(float& val);


### PR DESCRIPTION
lottie exclusively uses lines with the bezier curve. This approach consumes more points memory and requires additional computational processing. The Lottie loader converts 'CubicTo' to 'LineTo' only if possible,
specifically when the shape layer has only a single frame.

We've observed that thousands of commands can be converted with our Lottie example.