### PR TITLE
gl_engine: fix rendering error caused by viewport and stencil state

### DIFF
--- a/examples/Lottie.cpp
+++ b/examples/Lottie.cpp
@@ -217,6 +217,8 @@ void drawGLview(Evas_Object *obj)
     gl->glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     gl->glClear(GL_COLOR_BUFFER_BIT);
 
+    glCanvas->update();
+
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }

--- a/examples/LottieExtension.cpp
+++ b/examples/LottieExtension.cpp
@@ -194,6 +194,8 @@ void drawGLview(Evas_Object *obj)
     gl->glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     gl->glClear(GL_COLOR_BUFFER_BIT);
 
+    glCanvas->update();
+
     if (glCanvas->draw() == tvg::Result::Success) {
         glCanvas->sync();
     }

--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -128,7 +128,7 @@ void GlStencilCoverTask::run()
 
     if (mStencilMode == GlStencilMode::FillEvenOdd) {
         GL_CHECK(glStencilFunc(GL_EQUAL, 0x01, 0x01));
-        GL_CHECK(glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE));
+        GL_CHECK(glStencilOp(GL_REPLACE, GL_KEEP, GL_REPLACE));
     } else {
         GL_CHECK(glStencilFunc(GL_NOTEQUAL, 0x0, 0xFF));
         GL_CHECK(glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE));
@@ -137,17 +137,6 @@ void GlStencilCoverTask::run()
     GL_CHECK(glColorMask(1, 1, 1, 1));
 
     mCoverTask->run();
-
-    if (mStencilMode == GlStencilMode::FillEvenOdd) {
-        GL_CHECK(glStencilFunc(GL_NOTEQUAL, 0x0, 0xFF));
-        GL_CHECK(glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE));
-
-        GL_CHECK(glColorMask(0, 0, 0, 0));
-
-        mStencilTask->run();
-
-        GL_CHECK(glColorMask(1, 1, 1, 1));
-    }
 
     GL_CHECK(glDisable(GL_STENCIL_TEST));
 }
@@ -171,6 +160,7 @@ GlComposeTask::~GlComposeTask()
 void GlComposeTask::run()
 {
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getSelfFbo()));
+    GL_CHECK(glViewport(0, 0, mFbo->getWidth(), mFbo->getHeight()));
 
     // clear this fbo
     if (mClearBuffer) {
@@ -216,6 +206,7 @@ void GlBlitTask::run()
     GlComposeTask::run();
 
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getTargetFbo()));
+    GL_CHECK(glViewport(mTargetViewport.x, mTargetViewport.y, mTargetViewport.w, mTargetViewport.h));
 
     if (mClearBuffer) {
         GL_CHECK(glClearColor(0, 0, 0, 0));

--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -146,8 +146,11 @@ public:
     void run() override;
 
     GLuint getColorTextore() const { return mColorTex; }
+
+    void setTargetViewport(const RenderRegion& vp) { mTargetViewport = vp; }
 private:
     GLuint mColorTex = 0;
+    RenderRegion mTargetViewport = {};
 };
 
 class GlDrawBlitTask : public GlComposeTask

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -98,6 +98,7 @@ private:
 
     GLint mTargetFboId = 0;
     RenderRegion mViewport;
+    RenderRegion mTargetViewport;
     //TODO: remove all unique_ptr / replace the vector with tvg::Array
     unique_ptr<GlStageBuffer> mGpuBuffer;
     vector<std::unique_ptr<GlProgram>> mPrograms;


### PR DESCRIPTION
This PR fix some error inside GLRenderer:
* glViewport not controlled by framebuffer, and need to set manually when target framebuffer is changed.
* change even-odd stencil operation, so no need to do third draw call to clear stencil buffer

Also fix the Lottie and LottieExtension example not call `Canvas::Update` when choose Gl backend;

----
The **Lottie** example rendered by the gl engine now runs successfully but suffers from some rendering errors
![image](https://github.com/thorvg/thorvg/assets/26308154/99b23194-c6b5-4afb-b384-9e3e7e888742)
