### PR TITLE
scene viewport

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1394,6 +1394,36 @@ public:
     std::list<Paint*>& paints() noexcept;
 
     /**
+     * @brief Sets the scene's viewport.
+     *
+     * Allows specifying a rectangular viewport for the scene by providing the coordinates of its top-left corner and its dimensions.
+     *
+     * @param[in] x The horizontal coordinate of the upper left corner of the viewport.
+     * @param[in] y The vertical coordinate of the upper left corner of the viewport.
+     * @param[in] w The width of the viewport.
+     * @param[in] h The height of the viewport.
+     *
+     * @retval Result::InvalidArguments if the provided width @p w or height @p h are less than 0, Result::Success otherwise.
+     *
+     * @note Experimental API
+     */
+    Result viewport(int32_t x, int32_t y, int32_t w, int32_t h) noexcept;
+
+    /**
+     * @brief Gets the scene's viewport.
+     *
+     * @param[out] x The horizontal coordinate of the upper left corner of the viewport.
+     * @param[out] y The vertical coordinate of the upper left corner of the viewport.
+     * @param[out] w The width of the viewport.
+     * @param[out] h The height of the viewport.
+     *
+     * @retval Result::InsufficientCondition if the viewport was not set, Result::Success otherwise.
+     *
+     * @note Experimental API
+     */
+    Result viewport(int32_t* x, int32_t* y, int32_t* w, int32_t* h) noexcept;
+
+    /**
      * @brief Sets the total number of the paints pushed into the scene to be zero.
      * Depending on the value of the @p free argument, the paints are freed or not.
      *

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -38,6 +38,13 @@ RenderUpdateFlag Picture::Impl::load()
                         h = loader->h;
                     }
                     loader->resize(paint, w, h);
+                    if (paint->identifier() == TVG_CLASS_ID_SCENE) {
+                        auto scene = static_cast<Scene*>(paint);
+                        int32_t vx, vy;
+                        if (scene->viewport(&vx, &vy, nullptr, nullptr) == Result::Success) {
+                            scene->viewport(vx, vy, static_cast<int32_t>(w), static_cast<int32_t>(h));
+                        }
+                    }
                     resizing = false;
                 }
                 return RenderUpdateFlag::None;

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -100,6 +100,13 @@ struct Picture::Impl
         } else if (paint) {
             if (resizing) {
                 loader->resize(paint, w, h);
+                if (paint->identifier() == TVG_CLASS_ID_SCENE) {
+                    auto scene = static_cast<Scene*>(paint);
+                    int32_t vx, vy;
+                    if (scene->viewport(&vx, &vy, nullptr, nullptr) == Result::Success) {
+                        scene->viewport(vx, vy, static_cast<int32_t>(w), static_cast<int32_t>(h));
+                    }
+                }
                 resizing = false;
             }
             needComp = needComposition(opacity) ? true : false;

--- a/src/renderer/tvgScene.cpp
+++ b/src/renderer/tvgScene.cpp
@@ -73,3 +73,18 @@ list<Paint*>& Scene::paints() noexcept
 {
     return pImpl->paints;
 }
+
+
+Result Scene::viewport(int32_t x, int32_t y, int32_t w, int32_t h) noexcept
+{
+    if (w < 0 || h < 0) return Result::InvalidArguments;
+    pImpl->viewport(x, y, w, h);
+    return Result::Success;
+}
+
+
+Result Scene::viewport(int32_t* x, int32_t* y, int32_t* w, int32_t* h) noexcept
+{
+    if (pImpl->viewport(x, y, w, h)) return Result::Success;
+    return Result::InsufficientCondition;
+}


### PR DESCRIPTION
[common: scene viewport api introduced](https://github.com/thorvg/thorvg/commit/b4cd8e5207b7f83a6206001f06beba2bbd8229a2) 

New api can be used to replace clipping with a rectangle.
Scenes with viewport set can be still clipped/masked.

@issue: https://github.com/thorvg/thorvg/issues/2172


[loaders: use viewport in svg/lottie loader](https://github.com/thorvg/thorvg/commit/7d821888511029378cbc7a668c248db0c6149171) 

The viewport api is used to replace the rectangular cliping.