### PR TITLE
Windows: define WIN32_LEAN_AND_MEAN before including windows.h.

### DIFF
--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -24,7 +24,11 @@
 #include "tvgTtfLoader.h"
 
 #if defined(_WIN32) && (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
     #include <windows.h>
+    #undef WIN32_LEAN_AND_MEAN
 #elif defined(__linux__)
     #include <fcntl.h>
     #include <unistd.h>

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -24,7 +24,11 @@
 
 #ifdef _WIN32
 // TODO: cross-platform realization
-#include <windows.h>
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
+    #include <windows.h>
+    #undef WIN32_LEAN_AND_MEAN
 #endif
 
 #define WG_SSAA_SAMPLES (2)

--- a/src/tools/lottie2gif/lottie2gif.cpp
+++ b/src/tools/lottie2gif/lottie2gif.cpp
@@ -25,7 +25,11 @@
 #include <vector>
 #include <thorvg.h>
 #ifdef _WIN32
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
     #include <windows.h>
+    #undef WIN32_LEAN_AND_MEAN
     #ifndef PATH_MAX
         #define PATH_MAX MAX_PATH
     #endif

--- a/src/tools/svg2png/svg2png.cpp
+++ b/src/tools/svg2png/svg2png.cpp
@@ -26,7 +26,11 @@
 #include <vector>
 #include "lodepng.h"
 #ifdef _WIN32
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
     #include <windows.h>
+    #undef WIN32_LEAN_AND_MEAN
     #ifndef PATH_MAX
         #define PATH_MAX MAX_PATH
     #endif

--- a/src/tools/svg2tvg/svg2tvg.cpp
+++ b/src/tools/svg2tvg/svg2tvg.cpp
@@ -25,7 +25,11 @@
 #include <thread>
 #include <thorvg.h>
 #ifdef _WIN32
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
     #include <windows.h>
+    #undef WIN32_LEAN_AND_MEAN
     #ifndef PATH_MAX
         #define PATH_MAX MAX_PATH
     #endif


### PR DESCRIPTION
Fix issue #2225. It will also speed up compilation on Windows.