### PR TITLE
bindings/capi: Fix incompatible parameter

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2347,7 +2347,7 @@ TVG_API Tvg_Result tvg_animation_set_segment(Tvg_Animation* animation, float beg
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION In case the animation is not loaded.
 * \retval TVG_RESULT_INVALID_ARGUMENT When the given parameters are @c nullptr.
 */
-TVG_API Tvg_Result tvg_animation_get_segment(Tvg_Animation* animation, float* begin, float* end = nullptr);
+TVG_API Tvg_Result tvg_animation_get_segment(Tvg_Animation* animation, float* begin, float* end);
 
 
 /*!

--- a/test/capi/capiAnimation.cpp
+++ b/test/capi/capiAnimation.cpp
@@ -128,7 +128,7 @@ TEST_CASE("Animation Segment", "[capiAnimation]")
     REQUIRE(end == 1.0f);
 
     //Get only segment begin
-    REQUIRE(tvg_animation_get_segment(animation, &begin) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_animation_get_segment(animation, &begin, nullptr) == TVG_RESULT_SUCCESS);
     REQUIRE(begin == 0.0f);
 
     //Get only segment end


### PR DESCRIPTION
C API doesn't support default parameter, removed it.

Issue: #2228