### PR TITLE
gl_engine: optimize tessellation performance

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -93,5 +93,11 @@ struct GlRadialGradientBlock
     alignas(16) float stopColors[4 * MAX_GRADIENT_STOPS] = {};
 };
 
+struct GlCompositor : public Compositor
+{
+    RenderRegion bbox = {};
+
+    GlCompositor(const RenderRegion& box) : bbox(box) {}
+};
 
 #endif /* _TVG_GL_COMMON_H_ */

--- a/src/renderer/gl_engine/tvgGlGeometry.h
+++ b/src/renderer/gl_engine/tvgGlGeometry.h
@@ -196,6 +196,7 @@ public:
     void setViewport(const RenderRegion& viewport);
     float* getTransforMatrix();
     GlStencilMode getStencilMode(RenderUpdateFlag flag);
+    RenderRegion getBounds() const;
 
 private:
     RenderRegion viewport = {};
@@ -204,8 +205,10 @@ private:
     Array<uint32_t> fillIndex = {};
     Array<uint32_t> strokeIndex = {};
     float mTransform[16];
+    Matrix mMatrix = {};
 
     FillRule mFillRule = FillRule::Winding;
+    RenderRegion mBounds = {};
 };
 
 #endif /* _TVG_GL_GEOMETRY_H_ */

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -93,7 +93,7 @@ private:
     GlRenderPass* currentPass();
 
     void prepareBlitTask(GlBlitTask* task);
-    void prepareCmpTask(GlRenderTask* task);
+    void prepareCmpTask(GlRenderTask* task, const RenderRegion& vp);
     void endRenderPass(Compositor* cmp);
 
     GLint mTargetFboId = 0;
@@ -105,7 +105,7 @@ private:
     unique_ptr<GlRenderTarget> mRootTarget = {};
     Array<GlRenderTarget*> mComposePool = {};
     vector<GlRenderPass> mRenderPassStack = {};
-    vector<unique_ptr<Compositor>> mComposeStack = {};
+    vector<unique_ptr<GlCompositor>> mComposeStack = {};
 
     bool mClearBuffer = true;
 };

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -108,10 +108,12 @@ class Stroker final
         bool hasMove = false;
     };
 public:
-    Stroker(Array<float>* points, Array<uint32_t>* indices);
+    Stroker(Array<float>* points, Array<uint32_t>* indices, const Matrix& matrix);
     ~Stroker() = default;
 
     void stroke(const RenderShape *rshape);
+
+    RenderRegion bounds() const;
 
 private:
     void doStroke(const PathCommand* cmds, uint32_t cmd_count, const Point* pts, uint32_t pts_count);
@@ -141,11 +143,14 @@ private:
 private:
     Array<float>* mResGlPoints;
     Array<uint32_t>* mResIndices;
+    Matrix mMatrix;
     float mStrokeWidth = 1.f;
     float mMiterLimit = 4.f;
     StrokeCap mStrokeCap = StrokeCap::Square;
     StrokeJoin mStrokeJoin = StrokeJoin::Bevel;
     State mStrokeState = {};
+    GlPoint mLeftTop = {};
+    GlPoint mRightBottom = {};
 };
 
 class DashStroke
@@ -183,7 +188,9 @@ public:
     BWTessellator(Array<float>* points, Array<uint32_t>* indices);
     ~BWTessellator() = default;
 
-    void tessellate(const RenderShape *rshape);
+    void tessellate(const RenderShape *rshape, const Matrix& matrix);
+
+    RenderRegion bounds() const;
 
 private:
     uint32_t pushVertex(float x, float y);
@@ -192,6 +199,8 @@ private:
 private:
     Array<float>* mResPoints;
     Array<uint32_t>* mResIndices;
+    GlPoint mLeftTop = {};
+    GlPoint mRightBottom = {};
 };
 
 }  // namespace tvg


### PR DESCRIPTION
This PR optimize the tessellator's performance 
* restrict the scissor box of composite task
* do not tessellate stroke or fill geometry if there is no Fill or Stroke color
* use actually transformed curve to calculate polyline count when doing curve flatten
----
 Before this patch the performance of Lottie example
![image](https://github.com/thorvg/thorvg/assets/26308154/7cf6d433-4d10-4ed1-9bd5-8412847c3e0b)
After this patch the performance of Lottie example
![image](https://github.com/thorvg/thorvg/assets/26308154/0482a8eb-6614-4800-a71b-74ca5c18ea86)
