### PR TITLE
infra: fix build failure using c++17 (or later) with MSVC.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,6 +124,8 @@ if get_option('log') == true
     config_h.set10('THORVG_LOG_ENABLED', true)
 endif
 
+#Miscellaneous
+config_h.set10('WIN32_LEAN_AND_MEAN', true)
 
 configure_file(
     output: 'config.h',

--- a/src/tools/lottie2gif/lottie2gif.cpp
+++ b/src/tools/lottie2gif/lottie2gif.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <thorvg.h>
 #ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
     #ifndef PATH_MAX
         #define PATH_MAX MAX_PATH

--- a/src/tools/svg2png/svg2png.cpp
+++ b/src/tools/svg2png/svg2png.cpp
@@ -24,8 +24,8 @@
 #include <thread>
 #include <thorvg.h>
 #include <vector>
-#include "lodepng.h"
 #ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
     #ifndef PATH_MAX
         #define PATH_MAX MAX_PATH
@@ -36,6 +36,7 @@
     #include <limits.h>
     #include <sys/stat.h>
 #endif
+#include "lodepng.h"
 
 #define WIDTH_8K 7680
 #define HEIGHT_8K 4320

--- a/src/tools/svg2tvg/svg2tvg.cpp
+++ b/src/tools/svg2tvg/svg2tvg.cpp
@@ -25,6 +25,7 @@
 #include <thread>
 #include <thorvg.h>
 #ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
     #ifndef PATH_MAX
         #define PATH_MAX MAX_PATH


### PR DESCRIPTION
the WIN32_LEAN_AND_MEAN definition will remove the unused features in windows.h that helps to improve the build-speed as well as fixing the issue.

Issue: https://github.com/thorvg/thorvg/issues/2225