### PR TITLE
ttf_loader: fixing font scaling factor

### DIFF
--- a/examples/Text.cpp
+++ b/examples/Text.cpp
@@ -62,7 +62,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     canvas->push(std::move(text));
 
     auto text2 = tvg::Text::gen();
-    text2->font("Arial", 30, "italic");
+    text2->font("Arial", 40, "italic");
     text2->text("Font = \"Arial\", Size = 40, Style=Italic");
     text2->translate(0, 150);
     text2->fill(255, 255, 255);
@@ -97,26 +97,26 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     canvas->push(std::move(text6));
 
     auto text7 = tvg::Text::gen();
-    text7->font("Arial", 15);
+    text7->font("Arial", 25);
     text7->text("Transformed Text - 30'");
     text7->fill(0, 0, 0);
-    text7->translate(600, 400);
+    text7->translate(500, 400);
     text7->rotate(30);
     canvas->push(std::move(text7));
 
     auto text8 = tvg::Text::gen();
-    text8->font("Arial", 15);
+    text8->font("Arial", 25);
     text8->fill(0, 0, 0);
     text8->text("Transformed Text - 90'");
-    text8->translate(600, 400);
+    text8->translate(500, 400);
     text8->rotate(90);
     canvas->push(std::move(text8));
 
     auto text9 = tvg::Text::gen();
-    text9->font("Arial", 15);
+    text9->font("Arial", 25);
     text9->fill(0, 0, 0);
     text9->text("Transformed Text - 180'");
-    text9->translate(800, 400);
+    text9->translate(750, 400);
     text9->rotate(180);
     canvas->push(std::move(text9));
 
@@ -124,7 +124,7 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     float x, y, w, h;
 
     auto text10 = tvg::Text::gen();
-    text10->font("Arial", 50);
+    text10->font("Arial", 70);
     text10->text("Linear Text");
     text10->translate(0, 350);
     text10->bounds(&x, &y, &w, &h);

--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -203,12 +203,11 @@ void TtfLoader::clear()
 /************************************************************************/
 
 
-bool TtfLoader::resize(Paint* paint, float sx, TVG_UNUSED float sy)
+bool TtfLoader::resize(Paint* paint, float fontSize, TVG_UNUSED float unused)
 {
     if (!paint) return false;
     auto shift = 0.0f;
-    auto dpi = 96.0f / 72.0f;   //dpi base?
-    scale = sx * dpi / reader.metrics.unitsPerEm;
+    scale = fontSize / reader.metrics.unitsPerEm;
     if (italic) shift = -scale * 0.18f;  //experimental decision.
     Matrix m = {scale, shift, -(shift * reader.metrics.minw), 0, scale, 0, 0, 0, 1};
     paint->transform(m);


### PR DESCRIPTION
Currently, both svg and ttf loaders assume
a PPI value of 96. Considering a dynamic
determination of PPI for specific devices
should be a global and consistent approach
across all loaders.