### PR TITLE
lottie: enable the expressions feature in default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -71,11 +71,6 @@ endif
 
 if lottie_loader
     config_h.set10('THORVG_LOTTIE_LOADER_SUPPORT', true)
-    #Experimental feature, enable it manually
-    lottie_expressions = false
-    if lottie_expressions
-        config_h.set10('THORVG_LOTTIE_EXPRESSIONS_SUPPORT', false)
-    endif
 endif
 
 if ttf_loader
@@ -124,6 +119,13 @@ if get_option('log') == true
     config_h.set10('THORVG_LOG_ENABLED', true)
 endif
 
+#Extra
+lottie_expressions = lottie_loader and get_option('extra').contains('lottie_expressions')
+
+if lottie_expressions
+    config_h.set10('THORVG_LOTTIE_EXPRESSIONS_SUPPORT', true)
+endif
+
 #Miscellaneous
 config_h.set10('WIN32_LEAN_AND_MEAN', true)
 
@@ -148,31 +150,32 @@ endif
 summary = '''
 
 Summary:
-    ThorVG version:          @0@
-    Build Type:              @1@
-    Prefix:                  @2@
-    Multi-Tasking:           @3@
-    SIMD Instruction:        @4@
-    Raster Engine (SW):      @5@
-    Raster Engine (GL_BETA): @6@
-    Raster Engine (WG_BETA): @7@
-    Loader (TVG):            @8@
-    Loader (SVG):            @9@
-    Loader (TTF):            @10@
-    Loader (LOTTIE):         @11@
-    Loader (PNG):            @12@
-    Loader (JPG):            @13@
-    Loader (WEBP):           @14@
-    Saver (TVG):             @15@
-    Saver (GIF):             @16@
-    Binding (CAPI):          @17@
-    Binding (WASM_BETA):     @18@
-    Log Message:             @19@
-    Tests:                   @20@
-    Examples:                @21@
-    Tool (Svg2Tvg):          @22@
-    Tool (Svg2Png):          @23@
-    Tool (Lottie2Gif):       @24@
+    ThorVG version:             @0@
+    Build Type:                 @1@
+    Prefix:                     @2@
+    Multi-Tasking:              @3@
+    SIMD Instruction:           @4@
+    Raster Engine (SW):         @5@
+    Raster Engine (GL_BETA):    @6@
+    Raster Engine (WG_BETA):    @7@
+    Loader (TVG):               @8@
+    Loader (SVG):               @9@
+    Loader (TTF):               @10@
+    Loader (LOTTIE):            @11@
+    Loader (PNG):               @12@
+    Loader (JPG):               @13@
+    Loader (WEBP):              @14@
+    Saver (TVG):                @15@
+    Saver (GIF):                @16@
+    Binding (CAPI):             @17@
+    Binding (WASM_BETA):        @18@
+    Log Message:                @19@
+    Tests:                      @20@
+    Examples:                   @21@
+    Tool (Svg2Tvg):             @22@
+    Tool (Svg2Png):             @23@
+    Tool (Lottie2Gif):          @24@
+    Extra (Lottie Expressions): @25@
 
 '''.format(
         meson.project_version(),
@@ -199,7 +202,8 @@ Summary:
         get_option('examples'),
         svg2tvg,
         svg2png,
-        lottie2gif
+        lottie2gif,
+        lottie_expressions
     )
 
 message(summary)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -39,9 +39,9 @@ option('tools',
    description: 'Enable building thorvg tools')
 
 option('examples',
-    type: 'boolean',
-    value: false,
-    description: 'Enable building examples')
+   type: 'boolean',
+   value: false,
+   description: 'Enable building examples')
 
 option('tests',
    type: 'boolean',
@@ -49,11 +49,17 @@ option('tests',
    description: 'Enable building Unit Tests')
 
 option('log',
-    type: 'boolean',
-    value: false,
-    description: 'Enable log message')
+   type: 'boolean',
+   value: false,
+   description: 'Enable log message')
 
 option('static',
-    type: 'boolean',
-    value: false,
-    description: 'Force to use static linking modules in thorvg')
+   type: 'boolean',
+   value: false,
+   description: 'Force to use static linking modules in thorvg')
+
+option('extra',
+   type: 'array',
+   choices: ['', 'lottie_expressions'],
+   value: ['lottie_expressions'],
+   description: '"Enable support for exceptionally advanced features')

--- a/src/loaders/lottie/jerryscript/jerry-core/ecma/operations/ecma-iterator-object.cpp
+++ b/src/loaders/lottie/jerryscript/jerry-core/ecma/operations/ecma-iterator-object.cpp
@@ -130,13 +130,13 @@ ecma_op_create_iterator_object (ecma_value_t iterated_value, /**< value from cre
                                 ecma_iterator_kind_t kind) /**< iterator kind*/
 {
   /* 1. */
-  JERRY_ASSERT (iterator_type == ECMA_OBJECT_CLASS_ARRAY_ITERATOR || iterator_type == ECMA_OBJECT_CLASS_SET_ITERATOR
-                || iterator_type == ECMA_OBJECT_CLASS_MAP_ITERATOR
 #ifdef JERRY_BUILTIN_REGEXP
-                || iterator_type == ECMA_OBJECT_CLASS_REGEXP_STRING_ITERATOR
+  JERRY_ASSERT (iterator_type == ECMA_OBJECT_CLASS_ARRAY_ITERATOR || iterator_type == ECMA_OBJECT_CLASS_SET_ITERATOR || iterator_type == ECMA_OBJECT_CLASS_MAP_ITERATOR ||
+                iterator_type == ECMA_OBJECT_CLASS_REGEXP_STRING_ITERATOR || iterator_type == ECMA_OBJECT_CLASS_STRING_ITERATOR);
+#else
+  JERRY_ASSERT (iterator_type == ECMA_OBJECT_CLASS_ARRAY_ITERATOR || iterator_type == ECMA_OBJECT_CLASS_SET_ITERATOR || iterator_type == ECMA_OBJECT_CLASS_MAP_ITERATOR ||
+                iterator_type == ECMA_OBJECT_CLASS_STRING_ITERATOR);
 #endif
-                || iterator_type == ECMA_OBJECT_CLASS_STRING_ITERATOR);
-  JERRY_ASSERT (kind < ECMA_ITERATOR__COUNT);
 
   /* 2. */
   ecma_object_t *object_p =

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -52,6 +52,8 @@ static const char* EXP_VALUE = "value";
 static const char* EXP_INDEX = "index";
 static const char* EXP_EFFECT= "effect";
 
+static LottieExpressions* exps = nullptr;   //singleton instance engine
+
 
 static void contentFree(void *native_p, struct jerry_object_native_info_t *info_p)
 {
@@ -1267,8 +1269,6 @@ void LottieExpressions::update(float curTime)
 
 LottieExpressions* LottieExpressions::instance()
 {
-    static LottieExpressions* exps = nullptr;
-
     //FIXME: Threads support
     if (TaskScheduler::threads() > 1) {
         TVGLOG("LOTTIE", "Lottie Expressions are not supported with tvg threads");
@@ -1283,7 +1283,10 @@ LottieExpressions* LottieExpressions::instance()
 
 void LottieExpressions::retrieve(LottieExpressions* instance)
 {
-    if (--engineRefCnt == 0) delete(instance);
+    if (--engineRefCnt == 0) {
+        delete(instance);
+        exps = nullptr;
+    }
 }
 
 

--- a/test/testAnimation.cpp
+++ b/test/testAnimation.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Animation Basic", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     //Negative cases
     REQUIRE(animation->frame(0.0f) == Result::InsufficientCondition);
@@ -55,7 +55,7 @@ TEST_CASE("Animation Lottie", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/invalid.json") == Result::InvalidArguments);
     REQUIRE(picture->load(TEST_DIR"/test.json") == Result::Success);
@@ -76,7 +76,7 @@ TEST_CASE("Animation Lottie2", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test2.json") == Result::Success);
 
@@ -93,7 +93,7 @@ TEST_CASE("Animation Lottie3", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test3.json") == Result::Success);
     
@@ -108,7 +108,7 @@ TEST_CASE("Animation Lottie4", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test4.json") == Result::Success);
 
@@ -123,7 +123,7 @@ TEST_CASE("Animation Lottie5", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test5.json") == Result::Success);
     
@@ -138,7 +138,7 @@ TEST_CASE("Animation Lottie6", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test6.json") == Result::Success);
 
@@ -153,7 +153,7 @@ TEST_CASE("Animation Lottie7", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test7.json") == Result::Success);
 
@@ -168,7 +168,7 @@ TEST_CASE("Animation Lottie8", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test8.json") == Result::Success);
 
@@ -183,7 +183,7 @@ TEST_CASE("Animation Lottie9", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test9.json") == Result::Success);
 
@@ -198,7 +198,7 @@ TEST_CASE("Animation Segment", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     float begin, end;
 

--- a/test/testLottie.cpp
+++ b/test/testLottie.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Lottie Slot", "[tvgLottie]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     const char* slotJson = R"({"gradient_fill":{"p":{"a":0,"k":[0,0.1,0.1,0.2,1,1,0.1,0.2,0.1,1]}}})";
 
@@ -78,7 +78,7 @@ TEST_CASE("Lottie Marker", "[tvgLottie]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier == Picture::identifier);
+    REQUIRE(picture->identifier() == Picture::identifier());
 
     //Set marker name before loaded
     REQUIRE(animation->segment("sectionC") == Result::InsufficientCondition);


### PR DESCRIPTION
this commit introduces an additional build options:

- lottie expressions: this advanced feature in Lottie can significantly increase binary size. Users now have the option to enable or disable it based on their requirements.

Note that, this change introduces one config definitions:

- THORVG_LOTTIE_EXPRESSIONS_SUPPORT