### PR TITLE
lottie/text: Support text tracking

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -606,7 +606,7 @@ static void _updateText(LottieGroup* parent, LottieObject** child, float frameNo
                 p += glyph->len; 
 
                 //advance the cursor position horizontally
-                cursor.x += glyph->width + spacing;
+                cursor.x += glyph->width + spacing + doc.tracking;
                 break;
             }
         }

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -183,7 +183,7 @@ void LottieParser::getValue(TextDocument& doc)
         else if (KEY_AS("f")) doc.name = getStringCopy();
         else if (KEY_AS("t")) doc.text = getStringCopy();
         else if (KEY_AS("j")) doc.justify = getInt();
-        else if (KEY_AS("tr")) doc.tracking = getInt();
+        else if (KEY_AS("tr")) doc.tracking = getFloat() * 0.1f;
         else if (KEY_AS("lh")) doc.height = getFloat();
         else if (KEY_AS("ls")) doc.shift = getFloat();
         else if (KEY_AS("fc")) getValue(doc.color);

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -75,8 +75,8 @@ struct TextDocument
     } stroke;
     char* name = nullptr;
     float size;
+    float tracking;
     uint8_t justify;
-    uint8_t tracking;
 };
 
 


### PR DESCRIPTION
Text Tracking value("tr") is parsed and never used. Calculate text spacing size via the tracking offset.

I checked Lottie spec docs [here](https://lottiefiles.github.io/lottie-docs/text/#text-document) for "tr" attribute. However it doesn't seem clear to explain them.

I referred original logic on [lottie-web](https://github.com/airbnb/lottie-web/blob/master/build/player/lottie_canvas.js#L10710) to calculate `trackingOffset` value.

Issue: #2223 

[Before]
![Screenshot 2024-05-08 at 6 11 33 PM](https://github.com/thorvg/thorvg/assets/11167117/bf681830-136d-466c-9933-6cee977b4a80)

[After]
![Screenshot 2024-05-08 at 6 10 59 PM](https://github.com/thorvg/thorvg/assets/11167117/f5e5fc89-0de3-42c0-b6b0-8eb74ed734c4)
