### PR TITLE
lottie: fixed a memory leak

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -207,6 +207,7 @@ void LottieLayer::prepare()
        so force it to be a Null Layer and release all resource. */
     if (hidden) {
         type = LottieLayer::Null;
+        for (auto p = children.begin(); p < children.end(); ++p) delete(*p);
         children.reset();
         return;
     }


### PR DESCRIPTION
Free the children data properly,
rarely observerd this, only when a layer is hidden.