### PR TITLE
lottie: handle roundness in path

### DIFF
--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -62,6 +62,12 @@ static inline bool mathZero(float a)
 }
 
 
+static inline bool mathZero(const Point& p)
+{
+    return mathZero(p.x) && mathZero(p.y);
+}
+
+
 static inline bool mathEqual(float a, float b)
 {
     return (fabsf(a - b) < FLT_EPSILON);
@@ -166,6 +172,12 @@ static inline float mathLength(const Point* a, const Point* b)
     if (y < 0) y = -y;
 
     return (x > y) ? (x + 0.375f * y) : (y + 0.375f * x);
+}
+
+
+static inline float mathLength(const Point& a)
+{
+    return sqrtf(a.x * a.x + a.y * a.y);
 }
 
 

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -520,15 +520,14 @@ static void _updatePath(LottieGroup* parent, LottieObject** child, float frameNo
 
     if (ctx->repeater) {
         auto p = Shape::gen();
-        path->pathset(frameNo, P(p)->rs.path.cmds, P(p)->rs.path.pts, ctx->transform, exps);
+        path->pathset(frameNo, P(p)->rs.path.cmds, P(p)->rs.path.pts, ctx->transform, ctx->roundness, exps);
         _repeat(parent, std::move(p), ctx);
     } else {
         auto merging = _draw(parent, ctx);
-        if (path->pathset(frameNo, P(merging)->rs.path.cmds, P(merging)->rs.path.pts, ctx->transform, exps)) {
+        if (path->pathset(frameNo, P(merging)->rs.path.cmds, P(merging)->rs.path.pts, ctx->transform, ctx->roundness, exps)) {
             P(merging)->update(RenderUpdateFlag::Path);
         }
-        if (ctx->roundness > 1.0f && P(merging)->rs.stroke) {
-            TVGERR("LOTTIE", "FIXME: Path roundesss should be applied properly!");
+        if (ctx->roundness > ROUNDNESS_EPSILON && P(merging)->rs.stroke) {
             P(merging)->rs.stroke->join = StrokeJoin::Round;
         }
     }
@@ -587,7 +586,7 @@ static void _updateText(LottieGroup* parent, LottieObject** child, float frameNo
                 for (auto g = glyph->children.begin(); g < glyph->children.end(); ++g) {
                     auto group = static_cast<LottieGroup*>(*g);
                     for (auto p = group->children.begin(); p < group->children.end(); ++p) {
-                        if (static_cast<LottiePath*>(*p)->pathset(frameNo, P(shape)->rs.path.cmds, P(shape)->rs.path.pts, nullptr, exps)) {
+                        if (static_cast<LottiePath*>(*p)->pathset(frameNo, P(shape)->rs.path.cmds, P(shape)->rs.path.pts, nullptr, 0.0f, exps)) {
                             P(shape)->update(RenderUpdateFlag::Path);
                         }
                     }
@@ -1032,7 +1031,7 @@ static void _updateMaskings(LottieLayer* layer, float frameNo, LottieExpressions
         auto shape = Shape::gen().release();
         shape->fill(255, 255, 255, mask->opacity(frameNo));
         shape->transform(layer->cache.matrix);
-        if (mask->pathset(frameNo, P(shape)->rs.path.cmds, P(shape)->rs.path.pts, nullptr, exps)) {
+        if (mask->pathset(frameNo, P(shape)->rs.path.cmds, P(shape)->rs.path.pts, nullptr, 0.0f, exps)) {
             P(shape)->update(RenderUpdateFlag::Path);
         }
         auto method = mask->method;

--- a/src/loaders/lottie/tvgLottieExpressions.h
+++ b/src/loaders/lottie/tvgLottieExpressions.h
@@ -109,12 +109,12 @@ public:
     }
 
     template<typename Property>
-    bool result(float frameNo, Array<PathCommand>& cmds, Array<Point>& pts, Matrix* transform, LottieExpression* exp)
+    bool result(float frameNo, Array<PathCommand>& cmds, Array<Point>& pts, Matrix* transform, float roundness, LottieExpression* exp)
     {
         auto bm_rt = evaluate(frameNo, exp);
 
         if (auto pathset = static_cast<Property*>(jerry_object_get_native_ptr(bm_rt, nullptr))) {
-            (*pathset)(frameNo, cmds, pts, transform);
+            (*pathset)(frameNo, cmds, pts, transform, roundness);
          } else {
             TVGERR("LOTTIE", "Failed dispatching PathSet!");
             return false;


### PR DESCRIPTION
Implemented rounding of corners between
bezier curves that are straight lines.

@Issue: https://github.com/thorvg/thorvg/issues/2230

before:
<img width="633" alt="before_p" src="https://github.com/thorvg/thorvg/assets/67589014/a5795403-955e-4689-8eb4-9b85d4b0b9b2">
<img width="128" alt="beforep2" src="https://github.com/thorvg/thorvg/assets/67589014/4191d202-e3fe-42d7-b8cd-827d567bfdcd">


after:
<img width="577" alt="after_p" src="https://github.com/thorvg/thorvg/assets/67589014/3153fbb5-45a2-4d53-ab49-54fea9c8f38c">
<img width="122" alt="afterp2" src="https://github.com/thorvg/thorvg/assets/67589014/784bd1a1-0c71-4fb0-a908-0119584598e1">
