### PR TITLE
gl_engine: updated GLES minimum requirement from v2 to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ meson setup builddir -Dbindings="capi"
 ## Dependencies
 ThorVG offers versatile support for image loading, accommodating both static and external loaders. This flexibility ensures that, even in environments without external libraries, users can still leverage static loaders as a reliable alternative. At its foundation, the ThorVG core library is engineered to function autonomously, free from external dependencies. However, it is important to note that ThorVG also encompasses a range of optional feature extensions, each with its specific set of dependencies. The dependencies associated with these selective features are outlined as follows:
 
-* GL renderer: [EGL](https://www.khronos.org/egl), [GLESv2](https://www.khronos.org/opengles/)
+* GL renderer: [EGL](https://www.khronos.org/egl), [GLESv3](https://www.khronos.org/opengles/)
 * External PNG support: [libpng](https://github.com/glennrp/libpng)
 * External JPG support: [turbojpeg](https://github.com/libjpeg-turbo/libjpeg-turbo)
 * External WebP support: [libwebp](https://developers.google.com/speed/webp/download)

--- a/src/renderer/gl_engine/meson.build
+++ b/src/renderer/gl_engine/meson.build
@@ -21,7 +21,7 @@ source_file = [
    'tvgGlTessellator.h',
 ]
 
-gles_dep = meson.get_compiler('cpp').find_library('GLESv2')
+gles_dep = meson.get_compiler('cpp').find_library('GLESv3')
 
 external_dep = [gles_dep]
 


### PR DESCRIPTION
GLES v3 was introduced many years ago;
we are now dropping support for GLES v2.

issue: https://github.com/thorvg/thorvg/issues/2269