### PR TITLE
lottie/slot: Fix slot resetting bug

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -712,16 +712,19 @@ struct LottieSlot
                 case LottieProperty::Type::ColorStop: {
                     static_cast<LottieGradient*>(pair->obj)->colorStops.release();
                     static_cast<LottieGradient*>(pair->obj)->colorStops = *static_cast<LottieColorStop*>(pair->prop);
+                    static_cast<LottieColorStop*>(pair->prop)->frames = nullptr;
                     break;
                 }
                 case LottieProperty::Type::Color: {
                     static_cast<LottieSolid*>(pair->obj)->color.release();
                     static_cast<LottieSolid*>(pair->obj)->color = *static_cast<LottieColor*>(pair->prop);
+                    static_cast<LottieColor*>(pair->prop)->frames = nullptr;
                     break;
                 }
                 case LottieProperty::Type::TextDoc: {
                     static_cast<LottieText*>(pair->obj)->doc.release();
                     static_cast<LottieText*>(pair->obj)->doc = *static_cast<LottieTextDoc*>(pair->prop);
+                    static_cast<LottieTextDoc*>(pair->prop)->frames = nullptr;
                     break;
                 }
                 default: break;


### PR DESCRIPTION
When resetting back to animated property, system causes an UAF because frames have been freed.

Mark frames in nullptr at the case, so it doesn't use frame data after freed.

Issue: #2255 

![CleanShot 2024-05-13 at 17 24 14@2x](https://github.com/thorvg/thorvg/assets/11167117/3183426b-d89b-4ad5-ac28-ee9f600bd0a1)


**Current, when back to animated property.**

![CleanShot 2024-05-13 at 17 29 35@2x](https://github.com/thorvg/thorvg/assets/11167117/b56d83b8-d4da-40e1-9df0-cc1e585b2a8e)

**Seems resetting well now.**

![CleanShot 2024-05-13 at 17 25 48](https://github.com/thorvg/thorvg/assets/11167117/9b691d02-6008-47da-87b5-040b2e9914a3)
