### PR TITLE
test: fix margin value

### DIFF
--- a/test/capi/capiAnimation.cpp
+++ b/test/capi/capiAnimation.cpp
@@ -81,15 +81,15 @@ TEST_CASE("Animation Lottie", "[capiAnimation]")
 
     float frame;
     REQUIRE(tvg_animation_get_total_frame(animation, &frame) == TVG_RESULT_SUCCESS);
-    REQUIRE(frame == Approx(120).margin(004004));
+    REQUIRE(frame == Approx(120).margin(0.001f));
 
     REQUIRE(tvg_animation_set_frame(animation, frame - 1) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_animation_get_frame(animation, &frame) == TVG_RESULT_SUCCESS);
-    REQUIRE(frame == Approx(119).margin(004004));
+    REQUIRE(frame == Approx(119).margin(0.001f));
 
     float duration;
     REQUIRE(tvg_animation_get_duration(animation, &duration) == TVG_RESULT_SUCCESS);
-    REQUIRE(duration == Approx(4).margin(004004));
+    REQUIRE(duration == Approx(4.004).margin(0.001f)); //120/29.97
 
     REQUIRE(tvg_animation_del(animation) == TVG_RESULT_SUCCESS);
 

--- a/test/testAnimation.cpp
+++ b/test/testAnimation.cpp
@@ -60,9 +60,9 @@ TEST_CASE("Animation Lottie", "[tvgAnimation]")
     REQUIRE(picture->load(TEST_DIR"/invalid.json") == Result::InvalidArguments);
     REQUIRE(picture->load(TEST_DIR"/test.json") == Result::Success);
 
-    REQUIRE(animation->totalFrame() == Approx(120).margin(004004));
+    REQUIRE(animation->totalFrame() == Approx(120).margin(0.001f));
     REQUIRE(animation->curFrame() == 0);
-    REQUIRE(animation->duration() == Approx(4).margin(004004));
+    REQUIRE(animation->duration() == Approx(4.004).margin(0.001f)); //120/29.97
     REQUIRE(animation->frame(20) == Result::Success);
 
     REQUIRE(Initializer::term() == Result::Success);


### PR DESCRIPTION
The precision margin for the comparison
has been set to 0.01f instead of 004004.