### PR TITLE
lottie: fix access violation while updating

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1224,6 +1224,8 @@ static bool _buildComposition(LottieComposition* comp, LottieGroup* parent)
 
 bool LottieBuilder::update(LottieComposition* comp, float frameNo)
 {
+    if (comp->root->children.empty()) return false;
+
     frameNo += comp->startFrame;
     if (frameNo < comp->startFrame) frameNo = comp->startFrame;
     if (frameNo >= comp->endFrame) frameNo = (comp->endFrame - 1);


### PR DESCRIPTION
Fix access issue when iterating over children
in case of an empty container.

@Issue: https://github.com/thorvg/thorvg/issues/2283