### PR TITLE
wg_engine: Text support

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -264,10 +264,19 @@ void WgRenderDataPaint::release(WgContext& context)
 // WgRenderDataShape
 //***********************************************************************
 
+void WgRenderDataShape::updateBBox(WgPoint pmin, WgPoint pmax)
+{
+    pMin.x = std::min(pMin.x, pmin.x);
+    pMin.y = std::min(pMin.y, pmin.y);
+    pMax.x = std::max(pMax.x, pmax.x);
+    pMax.y = std::max(pMax.y, pmax.y);
+}
+
+
 void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rshape)
 {
     releaseMeshes(context);
-    strokeFirst = false;
+    strokeFirst = rshape.stroke ? rshape.stroke->strokeFirst : false;
 
     static WgPolyline polyline;
     polyline.clear();
@@ -296,6 +305,7 @@ void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rsha
     }
     // proceed last polyline
     updateMeshes(context, &polyline, rshape.stroke);
+    meshDataBBox.update(context, pMin, pMax);
 }
 
 
@@ -308,6 +318,7 @@ void WgRenderDataShape::updateMeshes(WgContext& context, const WgPolyline* polyl
         polyline->getBBox(pmin, pmax);
         meshGroupShapes.append(context, polyline);
         meshGroupShapesBBox.append(context, pmin, pmax);
+        updateBBox(pmin, pmax);
     }
     // generate strokes geometry
     if ((polyline->pts.count >= 1) && rstroke) {
@@ -342,12 +353,15 @@ void WgRenderDataShape::releaseMeshes(WgContext &context)
     meshGroupStrokes.release(context);
     meshGroupShapesBBox.release(context);
     meshGroupShapes.release(context);
+    pMin = {0.0f, 0.0f };
+    pMax = {0.0f, 0.0f };
 }
 
 
 void WgRenderDataShape::release(WgContext& context)
 {
     releaseMeshes(context);
+    meshDataBBox.release(context);
     renderSettingsStroke.release(context);
     renderSettingsShape.release(context);
     WgRenderDataPaint::release(context);

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -97,10 +97,15 @@ struct WgRenderDataShape: public WgRenderDataPaint
     WgRenderSettings renderSettingsStroke{};
     WgMeshDataGroup meshGroupShapes{};
     WgMeshDataGroup meshGroupShapesBBox{};
+    WgMeshData meshDataBBox{};
     WgMeshDataGroup meshGroupStrokes{};
     WgMeshDataGroup meshGroupStrokesBBox{};
+    WgPoint pMin{};
+    WgPoint pMax{};
     bool strokeFirst{};
+    FillRule fillRule{};
 
+    void updateBBox(WgPoint pmin, WgPoint pmax);
     void updateMeshes(WgContext& context, const RenderShape& rshape);
     void updateMeshes(WgContext& context, const WgPolyline* polyline, const RenderStroke* rstroke);
     void releaseMeshes(WgContext& context);

--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -64,7 +64,8 @@ public:
         WgBindGroupOpacity* opacity);
     void antialias(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc);
 private:
-    void drawShape(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
+    void drawShapeWinding(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
+    void drawShapeEvenOdd(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
     void drawStroke(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
 
     void dispatchWorkgroups(WGPUComputePassEncoder computePassEncoder);

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -93,6 +93,7 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
         WgShaderTypeMat4x4f modelMat(transform);
         WgShaderTypeBlendSettings blendSettings(mTargetSurface.cs, opacity);
         renderDataShape->bindGroupPaint.initialize(mContext.device, mContext.queue, modelMat, blendSettings);
+        renderDataShape->fillRule = rshape.rule;
     }
 
     // setup fill settings


### PR DESCRIPTION
https://github.com/thorvg/thorvg/issues/1479

EvenOdd fill rule reorganized: using global bbox of whole path for fill.

![image](https://github.com/thorvg/thorvg/assets/7770034/36462352-24fd-4c7c-a746-bf2d6edd8a13)
