### PR TITLE
common: fix data parsing

### DIFF
--- a/src/loaders/svg/tvgXmlParser.h
+++ b/src/loaders/svg/tvgXmlParser.h
@@ -25,9 +25,9 @@
 
 #include "tvgSvgLoaderCommon.h"
 
-#define NUMBER_OF_XML_ENTITIES 8
-const char* const xmlEntity[] = {"&quot;", "&nbsp;", "&apos;", "&amp;", "&lt;", "&gt;", "&#035;", "&#039;"};
-const int xmlEntityLength[] = {6, 6, 6, 5, 4, 4, 6, 6};
+#define NUMBER_OF_XML_ENTITIES 9
+const char* const xmlEntity[] = {"&#10;", "&quot;", "&nbsp;", "&apos;", "&amp;", "&lt;", "&gt;", "&#035;", "&#039;"};
+const int xmlEntityLength[] = {5, 6, 6, 6, 5, 4, 4, 6, 6};
 
 enum class SimpleXMLType
 {


### PR DESCRIPTION
The appearance of xml entities was handled
by the svg parser, but they may also be present
in the embedded data. Thus, while decoding base64, these elements must be removed.

@Issue: https://github.com/thorvg/thorvg/issues/2273

before:
<img width="478" alt="Zrzut ekranu 2024-05-17 o 12 54 50" src="https://github.com/thorvg/thorvg/assets/67589014/2bdd8687-566e-41f7-a8c3-862f7e91e5f2">

after:
<img width="497" alt="Zrzut ekranu 2024-05-17 o 12 54 18" src="https://github.com/thorvg/thorvg/assets/67589014/8f351365-1d3b-46c0-806d-43ce0c2d3ae5">
