### PR TITLE
renderer/canvas: tweak the viewport behavior.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -642,7 +642,7 @@ public:
      *
      * @warning It's not allowed to change the viewport during Canvas::push() - Canvas::sync() or Canvas::update() - Canvas::sync().
      *
-     * @note The specified viewport region will be intersected with the target region.
+     * @note When resetting the target, the viewport will also be reset to the target size.
      * @note Experimental API
      */
     virtual Result viewport(int32_t x, int32_t y, int32_t w, int32_t h) noexcept;

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -760,7 +760,7 @@ TVG_API Tvg_Result tvg_canvas_sync(Tvg_Canvas* canvas);
 *
 * \warning It's not allowed to change the viewport during tvg_canvas_update() - tvg_canvas_sync() or tvg_canvas_push() - tvg_canvas_sync().
 *
-* \note The specified viewport region will be intersected with the target region.
+* \note When resetting the target, the viewport will also be reset to the target size.
 * \note Experimental API
 * \see tvg_swcanvas_set_target()
 */

--- a/src/renderer/tvgGlCanvas.cpp
+++ b/src/renderer/tvgGlCanvas.cpp
@@ -68,7 +68,7 @@ Result GlCanvas::target(int32_t id, uint32_t w, uint32_t h) noexcept
     if (!renderer) return Result::MemoryCorruption;
 
     if (!renderer->target(id, w, h)) return Result::Unknown;
-    Canvas::pImpl->vport.intersect({0, 0, (int32_t)w, (int32_t)h});
+    Canvas::pImpl->vport = {0, 0, (int32_t)w, (int32_t)h};
     renderer->viewport(Canvas::pImpl->vport);
 
     //Paints must be updated again with this new target.

--- a/src/renderer/tvgSwCanvas.cpp
+++ b/src/renderer/tvgSwCanvas.cpp
@@ -87,7 +87,7 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     if (!renderer) return Result::MemoryCorruption;
 
     if (!renderer->target(buffer, stride, w, h, static_cast<ColorSpace>(cs))) return Result::InvalidArguments;
-    Canvas::pImpl->vport.intersect({0, 0, (int32_t)w, (int32_t)h});
+    Canvas::pImpl->vport = {0, 0, (int32_t)w, (int32_t)h};
     renderer->viewport(Canvas::pImpl->vport);
 
     //Paints must be updated again with this new target.

--- a/src/renderer/tvgWgCanvas.cpp
+++ b/src/renderer/tvgWgCanvas.cpp
@@ -63,7 +63,7 @@ Result WgCanvas::target(void* window, uint32_t w, uint32_t h) noexcept
     if (!renderer) return Result::MemoryCorruption;
 
     if (!renderer->target(window, w, h)) return Result::Unknown;
-    Canvas::pImpl->vport.intersect({0, 0, (int32_t)w, (int32_t)h});
+    Canvas::pImpl->vport = {0, 0, (int32_t)w, (int32_t)h};
     renderer->viewport(Canvas::pImpl->vport);
 
     //Paints must be updated again with this new target.


### PR DESCRIPTION
Reset the viewport context when the target buffer is reset. This improves usability because the viewport is highly dependent on the target buffer.