### PR TITLE
lottie: matrix multiplication fix

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -913,7 +913,7 @@ static void _updatePolystar(LottieGroup* parent, LottieObject** child, float fra
     mathTranslate(&matrix, position.x, position.y);
     mathRotate(&matrix, star->rotation(frameNo, exps));
 
-    if (ctx->transform) mathMultiply(ctx->transform, &matrix);
+    if (ctx->transform) matrix = mathMultiply(ctx->transform, &matrix);
 
     auto identity = mathIdentity((const Matrix*)&matrix);
 


### PR DESCRIPTION
In case the shapes could be merged, matrix
multiplication was not stored in any variable,
resulting in one of the transformations not
being applied.

before:
<img width="128" alt="Zrzut ekranu 2024-05-20 o 14 19 10" src="https://github.com/thorvg/thorvg/assets/67589014/70dd0405-a830-475f-9355-cd609b6063e6">


after:
<img width="123" alt="Zrzut ekranu 2024-05-20 o 14 18 46" src="https://github.com/thorvg/thorvg/assets/67589014/d468c401-a431-46d4-8e0c-34a8b5ff4983">


[fix3.json](https://github.com/thorvg/thorvg/files/15376969/fix3.json)
