### PR TITLE
lottie: fixed a missing slot overriding update.

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -42,6 +42,7 @@ void LottieLoader::run(unsigned tid)
         comp = parser.comp;
         builder->build(comp);
     }
+    rebuild = false;
 }
 
 
@@ -298,14 +299,14 @@ bool LottieLoader::override(const char* slot)
 
         if (idx < 1) success = false;
         free(temp);
-        overriden = success;
-
+        rebuild = overriden = success;
     //reset slots
     } else if (overriden) {
         for (auto s = comp->slots.begin(); s < comp->slots.end(); ++s) {
             (*s)->reset();
         }
         overriden = false;
+        rebuild = true;
     }
     return success;
 }
@@ -365,6 +366,8 @@ float LottieLoader::duration()
 void LottieLoader::sync()
 {
     this->done();
+
+    if (rebuild) run(0);
 }
 
 

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -44,7 +44,8 @@ public:
 
     char* dirName = nullptr;            //base resource directory
     bool copy = false;                  //"content" is owned by this loader
-    bool overriden = false;             //overridden properties with slots.
+    bool overriden = false;             //overridden properties with slots
+    bool rebuild = false;               //require building the lottie scene
 
     LottieLoader();
     ~LottieLoader();

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -29,7 +29,9 @@
 RenderUpdateFlag Picture::Impl::load()
 {
     if (loader) {
-        if (!paint) {
+        if (paint) {
+            loader->sync();
+        } else {
             paint = loader->paint();
             if (paint) {
                 if (w != loader->w || h != loader->h) {
@@ -42,8 +44,7 @@ RenderUpdateFlag Picture::Impl::load()
                 }
                 return RenderUpdateFlag::None;
             }
-        } else loader->sync();
-
+        }
         if (!surface) {
             if ((surface = loader->bitmap())) {
                 return RenderUpdateFlag::Image;


### PR DESCRIPTION
the Lottie scene should be updated when the slot overriding is updated. Previously, it only depended on the frame update.

issue: https://github.com/thorvg/thorvg/issues/2303