### PR TITLE
web: Support viewport API

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -165,6 +165,17 @@ public:
         return true;
     }
 
+    bool viewport(float x, float y, float width, float height)
+    {
+        if (!canvas || !animation) return false;
+        if (canvas->viewport(x, y, width, height) != Result::Success) {
+            errorMsg = "viewport() fail";
+            return false;
+        }
+
+        return true;
+    }
+
     void resize(int width, int height)
     {
         if (!canvas || !animation) return;
@@ -339,6 +350,7 @@ EMSCRIPTEN_BINDINGS(thorvg_bindings)
         .function("load", &TvgLottieAnimation ::load)
         .function("update", &TvgLottieAnimation ::update)
         .function("frame", &TvgLottieAnimation ::frame)
+        .function("viewport", &TvgLottieAnimation ::viewport)
         .function("resize", &TvgLottieAnimation ::resize)
         .function("save", &TvgLottieAnimation ::save);
 }

--- a/web/src/lottie-player.ts
+++ b/web/src/lottie-player.ts
@@ -285,6 +285,37 @@ export class LottiePlayer extends LitElement {
     }
   }
 
+  private _viewport(): void {
+    const { left, right, top, bottom } = this.getBoundingClientRect();
+    const windowWidth = window.innerWidth;
+    const windowHeight = window.innerHeight;
+
+    let x = 0;
+    let y = 0;
+    let width = this._canvas!.width;
+    let height = this._canvas!.height;
+
+    if (left < 0) {
+      x = Math.abs(left);
+      width -= x;
+    }
+
+    if (top < 0) {
+      y = Math.abs(top);
+      height -= y;
+    }
+
+    if (right > windowWidth) {
+      width -= right - windowWidth;
+    }
+
+    if (bottom > windowHeight) {
+      height -= bottom - windowHeight;
+    }
+
+    this._TVG.viewport(x, y, width, height);
+  }
+
   private _observerCallback(entries: IntersectionObserverEntry[]) {
     const entry = entries[0];
     const target = entry.target as LottiePlayer;
@@ -355,6 +386,7 @@ export class LottiePlayer extends LitElement {
 
   private _render(): void {
     this._TVG.resize(this._canvas!.width, this._canvas!.height);
+    this._viewport();
     const isUpdated = this._TVG.update();
 
     if (!isUpdated) {


### PR DESCRIPTION
Update web player to support viewport API. In rendering, the player will automatically detect visible element boundary and call viewport API.


https://github.com/thorvg/thorvg/assets/11167117/37a43935-1b2e-4876-8738-0939d0db53a5

Issue: #2292