### PR TITLE
lottie: fix interpolation issue

### DIFF
--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -548,7 +548,13 @@ struct LottiePathSet : LottieProperty
                 t = (frameNo - frame->no) / ((frame + 1)->no - frame->no);
                 if (frame->interpolator) t = frame->interpolator->progress(t);
                 if (frame->hold) path = &(frame + ((t < 1.0f) ? 0 : 1))->value;
-                else interpolate = true;
+                else {
+                    if (frame->value.ptsCnt != (frame + 1)->value.ptsCnt) {
+                        path = &frame->value;
+                        TVGLOG("LOTTIE", "Different numbers of points in consecutive frames - interpolation omitted.");
+                    }
+                    else interpolate = true;
+                }
             }
         }
 


### PR DESCRIPTION
Interpolation between closed and open curves
is allowed. Since these curves have a different
number of points, this caused an error. The current behavior enforces both curves to be treated as opened.

@Issue: https://github.com/thorvg/thorvg/issues/2287

[sample](https://github.com/thorvg/thorvg/files/15440592/interp.json)

tvg:
![tvg](https://github.com/thorvg/thorvg/assets/67589014/43e35bb4-7eed-4e61-b840-0e606eb727ae)

web:
![web](https://github.com/thorvg/thorvg/assets/67589014/53844136-7004-48b9-96fd-6a92b9b48fd8)


