### PR TITLE
lottie: add 'tp' tag support

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -354,7 +354,7 @@ LottieLayer::~LottieLayer()
         delete(*m);
     }
 
-    delete(matte.target);
+    matte.target = nullptr;
     delete(transform);
 }
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -561,6 +561,7 @@ struct LottieLayer : LottieGroup
     float outFrame = 0.0f;
     float startFrame = 0.0f;
     char* refId = nullptr;      //pre-composition reference.
+    int16_t mid = -1;           //id of the matte layer.
     int16_t pid = -1;           //id of the parent layer.
     int16_t id = -1;            //id of the current layer.
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1229,6 +1229,7 @@ LottieLayer* LottieParser::parseLayer()
         else if (KEY_AS("h") || KEY_AS("sh")) getLayerSize(layer->h);
         else if (KEY_AS("sc")) layer->color = getColor(getString());
         else if (KEY_AS("tt")) layer->matte.type = getMatteType();
+        else if (KEY_AS("tp")) layer->mid = getInt();
         else if (KEY_AS("masksProperties")) parseMasks(layer);
         else if (KEY_AS("hd")) layer->hidden = getBool();
         else if (KEY_AS("refId")) layer->refId = getStringCopy();
@@ -1264,21 +1265,9 @@ LottieLayer* LottieParser::parseLayers()
 
     enterArray();
     while (nextArrayValue()) {
-        if (auto layer = parseLayer()) {
-            if (layer->matte.type == CompositeMethod::None) {
-                root->children.push(layer);
-            } else {
-                //matte source must be located in the right previous.
-                auto matte = static_cast<LottieLayer*>(root->children.last());
-                if (matte->matteSrc) {
-                    layer->matte.target = matte;
-                } else {
-                    TVGLOG("LOTTIE", "Matte Source(%s) is not designated?", matte->name);
-                }
-                root->children.last() = layer;
-            }
-        }
+        if (auto layer = parseLayer()) root->children.push(layer);
     }
+
     root->prepare();
     return root;
 }


### PR DESCRIPTION
So far it hasn't been possible to specify
a matte layer - by default, it was the layer
above the calling layer. The 'tp' tag support
has been introduced, enabling referencing any
layer by its index.
In cases where the layer referencing the matte
was the first one, a segmentation fault was
observed. This issue has now been resolved.

@Issue: https://github.com/thorvg/thorvg/issues/2325