### PR TITLE
lottie: fix & enhance parsing

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -72,7 +72,7 @@ private:
     template<LottieProperty::Type type = LottieProperty::Type::Invalid, typename T> void parseProperty(T& prop, LottieObject* obj = nullptr);
     template<LottieProperty::Type type = LottieProperty::Type::Invalid, typename T> void parseSlotProperty(T& prop);
 
-    LottieObject* parseObject();
+    LottieObject* parseObject(const char* type = nullptr);
     LottieObject* parseAsset();
     LottieImage* parseImage(const char* data, const char* subPath, bool embedded, float width, float height);
     LottieLayer* parseLayer(LottieLayer* precomp);

--- a/src/loaders/lottie/tvgLottieParserHandler.cpp
+++ b/src/loaders/lottie/tvgLottieParserHandler.cpp
@@ -43,7 +43,7 @@
  */
 
 #include "tvgLottieParserHandler.h"
-
+#include "tvgStr.h"
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -184,6 +184,14 @@ int LookaheadParserHandler::peekType()
 }
 
 
+Value* LookaheadParserHandler::peekValue() {
+    if (state >= kHasNull && state <= kHasKey) {
+        return &val;
+    }
+    return nullptr;
+}
+
+
 void LookaheadParserHandler::skipOut(int depth)
 {
     do {
@@ -232,4 +240,29 @@ void LookaheadParserHandler::skip(const char* key)
     } else {
         skipOut(0);
     }
+}
+
+
+char* LookaheadParserHandler::findObjectType()
+{
+    auto level = 0;
+    for (auto p = iss.src_; *p != '\0'; ++p) {
+        if (*p == '{') level++;
+        else if (*p == '}') {
+            if (--level < 0) break;
+        } else if (level == 0) {
+            if (!strncmp(p, "\"ty\"", 4)) {
+                p += 4;
+                while (*p != '\0' && (isspace(*p) || *p == '\n')) ++p;
+                if (*p++ != ':') return nullptr;
+                while (*p != '\0' && (isspace(*p) || *p == '\n')) ++p;
+                if (*p++ != '\"') return nullptr;
+                const char* start = p;
+                while (*p != '\0' && *p != '\"') ++p;
+                if (*p == '\"') return strDuplicate(start, p - start);
+                return nullptr;
+            }
+        }
+    }
+    return nullptr;
 }

--- a/src/loaders/lottie/tvgLottieParserHandler.h
+++ b/src/loaders/lottie/tvgLottieParserHandler.h
@@ -195,6 +195,8 @@ struct LookaheadParserHandler
     void skip(const char* key);
     void skipOut(int depth);
     int peekType();
+    Value* peekValue();
+    char* findObjectType();
 };
 
 #endif //_TVG_LOTTIE_PARSER_HANDLER_H_


### PR DESCRIPTION
The object type key does not need to be provided
first. Previously, content was skipped until the
"ty" type key was found. If the key was placed at
the end, the entire object was ignored.
Now, before parsing subsequent elements, finding
the "ty" key is enforced. Since in-situ parsing
does not support backtracking, the key is searched 
with an internal function.

Introducing support for the "ty" key placed anywhere 
highlighted the use of redundant logic for parsing 
the list of shapes — this duplicate logic has been removed.

before:
<img width="400" alt="Zrzut ekranu 2024-05-30 o 01 42 45" src="https://github.com/thorvg/thorvg/assets/67589014/41c7292c-f9f5-4358-b3b2-1bf1403d409f">

after:
<img width="400" alt="Zrzut ekranu 2024-05-30 o 01 27 31" src="https://github.com/thorvg/thorvg/assets/67589014/6a1c1381-8fd1-41e9-85c7-c25de86111d5">
