### PR TITLE
lottie: hotfix memory leaks by a regression

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1122,8 +1122,9 @@ static void _updatePrecomp(LottieLayer* precomp, float frameNo, LottieExpression
 
     frameNo = precomp->remap(frameNo, exps);
 
-    for (auto child = precomp->children.end() - 1; child >= precomp->children.begin(); --child) {
-        _updateLayer(precomp, static_cast<LottieLayer*>(*child), frameNo, exps);
+    for (auto c = precomp->children.end() - 1; c >= precomp->children.begin(); --c) {
+        auto child = static_cast<LottieLayer*>(*c);
+        if (!child->matteSrc) _updateLayer(precomp, child, frameNo, exps);
     }
 
     //clip the layer viewport


### PR DESCRIPTION
A regression bug by a recent change:
1ee79a6c2afafb6b16b14abc969b60c1dbc7a065