### PR TITLE
lottie: support 'direction' in ellipses

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -553,7 +553,7 @@ static void _updateRect(LottieGroup* parent, LottieObject** child, float frameNo
 }
 
 
-static void _appendCircle(Shape* shape, float cx, float cy, float rx, float ry, Matrix* transform)
+static void _appendCircle(Shape* shape, float cx, float cy, float rx, float ry, Matrix* transform, bool clockwise)
 {
     auto rxKappa = rx * PATH_KAPPA;
     auto ryKappa = ry * PATH_KAPPA;
@@ -565,13 +565,21 @@ static void _appendCircle(Shape* shape, float cx, float cy, float rx, float ry, 
     };
 
     constexpr int ptsCnt = 13;
-    Point points[ptsCnt] = {
-        {cx, cy - ry}, //moveTo
-        {cx + rxKappa, cy - ry}, {cx + rx, cy - ryKappa}, {cx + rx, cy}, //cubicTo
-        {cx + rx, cy + ryKappa}, {cx + rxKappa, cy + ry}, {cx, cy + ry}, //cubicTo
-        {cx - rxKappa, cy + ry}, {cx - rx, cy + ryKappa}, {cx - rx, cy}, //cubicTo
-        {cx - rx, cy - ryKappa}, {cx - rxKappa, cy - ry}, {cx, cy - ry}  //cubicTo
-    };
+    Point points[ptsCnt];
+
+    if (clockwise) {
+        points[0] = {cx, cy - ry}; //moveTo
+        points[1] = {cx + rxKappa, cy - ry}; points[2] = {cx + rx, cy - ryKappa}; points[3] = {cx + rx, cy}; //cubicTo
+        points[4] = {cx + rx, cy + ryKappa}; points[5] = {cx + rxKappa, cy + ry}; points[6] = {cx, cy + ry}; //cubicTo
+        points[7] = {cx - rxKappa, cy + ry}; points[8] = {cx - rx, cy + ryKappa}; points[9] = {cx - rx, cy}; //cubicTo
+        points[10] = {cx - rx, cy - ryKappa}; points[11] = {cx - rxKappa, cy - ry}; points[12] = {cx, cy - ry}; //cubicTo
+    } else {
+        points[0] = {cx, cy - ry}; //moveTo
+        points[1] = {cx - rxKappa, cy - ry}; points[2] = {cx - rx, cy - ryKappa}; points[3] = {cx - rx, cy}; //cubicTo
+        points[4] = {cx - rx, cy + ryKappa}; points[5] = {cx - rxKappa, cy + ry}; points[6] = {cx, cy + ry}; //cubicTo
+        points[7] = {cx + rxKappa, cy + ry}; points[8] = {cx + rx, cy + ryKappa}; points[9] = {cx + rx, cy}; //cubicTo
+        points[10] = {cx + rx, cy - ryKappa}; points[11] = {cx + rxKappa, cy - ry}; points[12] = {cx, cy - ry}; //cubicTo
+    }
 
     if (transform) {
         for (int i = 0; i < ptsCnt; ++i) {
@@ -592,11 +600,11 @@ static void _updateEllipse(LottieGroup* parent, LottieObject** child, float fram
 
     if (!ctx->repeaters.empty()) {
         auto path = Shape::gen();
-        _appendCircle(path.get(), position.x, position.y, size.x * 0.5f, size.y * 0.5f, ctx->transform);
+        _appendCircle(path.get(), position.x, position.y, size.x * 0.5f, size.y * 0.5f, ctx->transform, ellipse->clockwise);
         _repeat(parent, std::move(path), ctx);
     } else {
         _draw(parent, ctx);
-        _appendCircle(ctx->merging, position.x, position.y, size.x * 0.5f, size.y * 0.5f, ctx->transform);
+        _appendCircle(ctx->merging, position.x, position.y, size.x * 0.5f, size.y * 0.5f, ctx->transform, ellipse->clockwise);
     }
 }
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1088,8 +1088,7 @@ void LottieParser::parseTimeRemap(LottieLayer* layer)
 
 uint8_t LottieParser::getDirection()
 {
-    auto v = getInt();
-    if (v == 3) return false;
+    if (getInt() == 3) return false;
     return true;
 }
 


### PR DESCRIPTION
lottie: support 'direction' in ellipses

partially solves 16699.json (without https://github.com/thorvg/thorvg/pull/2330 won't work since direction property is given before the type property))

before:
<img width="300" alt="Zrzut ekranu 2024-07-9 o 15 53 57" src="https://github.com/thorvg/thorvg/assets/67589014/fd60a1fd-2e4d-4c31-ad36-086e23d84e8e">

after:
<img width="300" alt="Zrzut ekranu 2024-07-9 o 15 49 31" src="https://github.com/thorvg/thorvg/assets/67589014/cff3ef74-d13b-4a50-8bfd-e3b149f7eb8d">
