### PR TITLE
common: strokeTrim api

### DIFF
--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -154,6 +154,11 @@ void testCapi()
     tvg_shape_append_arc(scene_shape1, 175.0f, 600.0f, 150.0f, -45.0f, 90.0f, 1);
     tvg_shape_append_arc(scene_shape1, 175.0f, 600.0f, 150.0f, 225.0f, -90.0f, 1);
     tvg_shape_set_fill_color(scene_shape1, 0, 0, 255, 150);
+    tvg_shape_set_stroke_color(scene_shape1, 255, 255, 255, 155);
+    tvg_shape_set_stroke_width(scene_shape1, 10.0f);
+    tvg_shape_set_stroke_cap(scene_shape1, Tvg_Stroke_Cap::TVG_STROKE_CAP_ROUND);
+    tvg_shape_set_stroke_join(scene_shape1, Tvg_Stroke_Join::TVG_STROKE_JOIN_ROUND);
+    tvg_shape_set_stroke_trim(scene_shape1, 0.25f, 0.75f, true);
 
     //Set an arc with a dashed stroke
     Tvg_Paint* scene_shape2 = tvg_paint_duplicate(scene_shape1);

--- a/examples/StrokeTrim.cpp
+++ b/examples/StrokeTrim.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2024 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "Common.h"
+
+/************************************************************************/
+/* Drawing Commands                                                     */
+/************************************************************************/
+
+void tvgDrawCmds(tvg::Canvas* canvas)
+{
+    if (!canvas) return;
+
+    //Shape 1
+    auto shape1 = tvg::Shape::gen();
+    shape1->appendCircle(245, 125, 50, 120);
+    shape1->appendCircle(245, 365, 50, 120);
+    shape1->appendCircle(125, 245, 120, 50);
+    shape1->appendCircle(365, 245, 120, 50);
+    shape1->fill(0, 50, 155, 100);
+    shape1->strokeFill(0, 0, 255);
+    shape1->strokeJoin(tvg::StrokeJoin::Round);
+    shape1->strokeCap(tvg::StrokeCap::Round);
+    shape1->strokeWidth(12);
+    shape1->strokeTrim(0.0f, 0.5f, false);
+
+    auto shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
+    shape2->translate(300, 300);
+    shape2->fill(0, 155, 50, 100);
+    shape2->strokeFill(0, 255, 0);
+    shape2->strokeTrim(0.0f, 0.5f, true);
+
+    if (canvas->push(std::move(shape1)) != tvg::Result::Success) return;
+    if (canvas->push(std::move(shape2)) != tvg::Result::Success) return;
+
+}
+
+
+/************************************************************************/
+/* Sw Engine Test Code                                                  */
+/************************************************************************/
+
+static unique_ptr<tvg::SwCanvas> swCanvas;
+
+void tvgSwTest(uint32_t* buffer)
+{
+    //Create a Canvas
+    swCanvas = tvg::SwCanvas::gen();
+    swCanvas->target(buffer, WIDTH, WIDTH, HEIGHT, tvg::SwCanvas::ARGB8888);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(swCanvas.get());
+}
+
+void drawSwView(void* data, Eo* obj)
+{
+    if (swCanvas->draw() == tvg::Result::Success) {
+        swCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* GL Engine Test Code                                                  */
+/************************************************************************/
+
+static unique_ptr<tvg::GlCanvas> glCanvas;
+
+void initGLview(Evas_Object *obj)
+{
+    //Create a Canvas
+    glCanvas = tvg::GlCanvas::gen();
+
+    //Get the drawing target id
+    int32_t targetId;
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glGetIntegerv(GL_FRAMEBUFFER_BINDING, &targetId);
+
+    glCanvas->target(targetId, WIDTH, HEIGHT);
+
+    /* Push the shape into the Canvas drawing list
+       When this shape is into the canvas list, the shape could update & prepare
+       internal data asynchronously for coming rendering.
+       Canvas keeps this shape node unless user call canvas->clear() */
+    tvgDrawCmds(glCanvas.get());
+}
+
+void drawGLview(Evas_Object *obj)
+{
+    auto gl = elm_glview_gl_api_get(obj);
+    gl->glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    gl->glClear(GL_COLOR_BUFFER_BIT);
+
+    if (glCanvas->draw() == tvg::Result::Success) {
+        glCanvas->sync();
+    }
+}
+
+
+/************************************************************************/
+/* Main Code                                                            */
+/************************************************************************/
+
+int main(int argc, char **argv)
+{
+    auto tvgEngine = tvg::CanvasEngine::Sw;
+
+    if (argc > 1) {
+        if (!strcmp(argv[1], "gl")) tvgEngine = tvg::CanvasEngine::Gl;
+    }
+
+    //Threads Count
+    auto threads = std::thread::hardware_concurrency();
+    if (threads > 0) --threads;    //Allow the designated main thread capacity
+
+    //Initialize ThorVG Engine
+    if (tvg::Initializer::init(threads) == tvg::Result::Success) {
+
+        elm_init(argc, argv);
+
+        if (tvgEngine == tvg::CanvasEngine::Sw) {
+            createSwView();
+        } else {
+            createGlView();
+        }
+
+        elm_run();
+        elm_shutdown();
+
+        //Terminate ThorVG Engine
+        tvg::Initializer::term();
+
+    } else {
+        cout << "engine is not supported" << endl;
+    }
+    return 0;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -51,6 +51,7 @@ source_file = [
     'Stroke.cpp',
     'StrokeLine.cpp',
     'StrokeMiterlimit.cpp',
+    'StrokeTrim.cpp',
     'Svg.cpp',
     'Texmap.cpp',
     'Text.cpp',

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1021,7 +1021,6 @@ public:
      */
     Result strokeJoin(StrokeJoin join) noexcept;
 
-
     /**
      * @brief Sets the stroke miterlimit.
      *
@@ -1032,6 +1031,22 @@ public:
      * @since 0.11
      */
     Result strokeMiterlimit(float miterlimit) noexcept;
+
+    /**
+     * @brief Sets the trim of the stroke along the defined path segment, allowing control over which part of the stroke is visible.
+     *
+     * The values of the arguments @p begin, @p end, and @p offset are in the range of 0.0 to 1.0, representing the beginning of the path and the end, respectively.
+     *
+     * @param[in] begin Specifies the start of the segment to display along the path.
+     * @param[in] end Specifies the end of the segment to display along the path.
+     * @param[in] simultaneous Determines how to trim multiple paths within a single shape. If set to @c true (default), trimming is applied simultaneously to all paths;
+     * Otherwise, all paths are treated as a single entity with a combined length equal to the sum of their individual lengths and are trimmed as such.
+     *
+     * @retval Result::Success when succeed.
+     *
+     * @note Experimental API
+     */
+    Result strokeTrim(float begin, float end, bool simultaneous = true) noexcept;
 
     /**
      * @brief Sets the solid color for all of the figures from the path.
@@ -1072,7 +1087,6 @@ public:
      */
     Result fill(FillRule r) noexcept;
 
-
     /**
      * @brief Sets the rendering order of the stroke and the fill.
      *
@@ -1083,7 +1097,6 @@ public:
      * @since 0.10
      */
     Result order(bool strokeFirst) noexcept;
-
 
     /**
      * @brief Gets the commands data of the path.
@@ -1189,6 +1202,18 @@ public:
      * @since 0.11
      */
     float strokeMiterlimit() const noexcept;
+
+    /**
+     * @brief Gets the trim of the stroke along the defined path segment.
+     *
+     * @param[out] begin The starting point of the segment to display along the path.
+     * @param[out] end Specifies the end of the segment to display along the path.
+     *
+     * @retval @c true if trimming is applied simultaneously to all paths of the shape, @c false otherwise.
+     *
+     * @note Experimental API
+     */
+    bool strokeTrim(float* begin, float* end) const noexcept;
 
     /**
      * @brief Creates a new Shape object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1533,6 +1533,37 @@ TVG_API Tvg_Result tvg_shape_get_stroke_miterlimit(const Tvg_Paint* paint, float
 
 
 /*!
+* \brief Sets the trim of the stroke along the defined path segment, allowing control over which part of the stroke is visible. (Experimental API)
+*
+* The values of the arguments @p begin, @p end, and @p offset are in the range of 0.0 to 1.0, representing the beginning of the path and the end, respectively.
+*
+* \param[in] begin Specifies the start of the segment to display along the path.
+* \param[in] end Specifies the end of the segment to display along the path.
+* \param[in] simultaneous Determines how to trim multiple paths within a single shape. If set to @c true (default), trimming is applied simultaneously to all paths;
+* Otherwise, all paths are treated as a single entity with a combined length equal to the sum of their individual lengths and are trimmed as such.
+*
+* \return Tvg_Result enumeration.
+* \retval TVG_RESULT_SUCCESS Succeed.
+* \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
+*/
+TVG_API Tvg_Result tvg_shape_set_stroke_trim(Tvg_Paint* paint, float begin, float end, bool simultaneous);
+
+
+/*!
+* \brief Gets the trim of the stroke along the defined path segment. (Experimental API)
+*
+* \param[out] begin The starting point of the segment to display along the path.
+* \param[out] end Specifies the end of the segment to display along the path.
+* \param[out] simultaneous Determines how to trim multiple paths within a shape.
+*
+* \return Tvg_Result enumeration.
+* \retval TVG_RESULT_SUCCESS Succeed.
+* \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
+*/
+TVG_API Tvg_Result tvg_shape_get_stroke_trim(Tvg_Paint* paint, float* begin, float* end, bool* simultaneous);
+
+
+/*!
 * \brief Sets the shape's solid color.
 *
 * The parts of the shape defined as inner are colored.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -461,6 +461,21 @@ TVG_API Tvg_Result tvg_shape_get_stroke_miterlimit(const Tvg_Paint* paint, float
 }
 
 
+TVG_API Tvg_Result tvg_shape_set_stroke_trim(Tvg_Paint* paint, float begin, float end, bool simultaneous)
+{
+    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->strokeTrim(begin, end, simultaneous);
+}
+
+
+TVG_API Tvg_Result tvg_shape_get_stroke_trim(Tvg_Paint* paint, float* begin, float* end, bool* simultaneous)
+{
+    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+    if (simultaneous) *simultaneous = reinterpret_cast<Shape*>(paint)->strokeTrim(begin, end);
+    return TVG_RESULT_SUCCESS;
+}
+
+
 TVG_API Tvg_Result tvg_shape_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -916,7 +916,7 @@ static void _updateTrimpath(TVG_UNUSED LottieGroup* parent, LottieObject** child
         end = (length * end) + pbegin;
     }
 
-    P(ctx->propagator)->strokeTrim(begin, end, trimpath->type == LottieTrimpath::Type::Individual ? true : false);
+    P(ctx->propagator)->strokeTrim(begin, end, trimpath->type == LottieTrimpath::Type::Simultaneous);
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -121,11 +121,11 @@ LottieImage::~LottieImage()
 
 void LottieTrimpath::segment(float frameNo, float& start, float& end, LottieExpressions* exps)
 {
-    auto s = this->start(frameNo, exps) * 0.01f;
-    auto e = this->end(frameNo, exps) * 0.01f;
+    start = this->start(frameNo, exps) * 0.01f;
+    end = this->end(frameNo, exps) * 0.01f;
     auto o = fmodf(this->offset(frameNo, exps), 360.0f) / 360.0f;  //0 ~ 1
 
-    auto diff = fabs(s - e);
+    auto diff = fabs(start - end);
     if (mathZero(diff)) {
         start = 0.0f;
         end = 0.0f;
@@ -137,28 +137,8 @@ void LottieTrimpath::segment(float frameNo, float& start, float& end, LottieExpr
         return;
     }
 
-    s += o;
-    e += o;
-
-    auto loop = true;
-
-    //no loop
-    if (s > 1.0f && e > 1.0f) loop = false;
-    if (s < 0.0f && e < 0.0f) loop = false;
-    if (s >= 0.0f && s <= 1.0f && e >= 0.0f  && e <= 1.0f) loop = false;
-
-    if (s > 1.0f) s -= 1.0f;
-    if (s < 0.0f) s += 1.0f;
-    if (e > 1.0f) e -= 1.0f;
-    if (e < 0.0f) e += 1.0f;
-
-    if (loop) {
-        start = s > e ? s : e;
-        end = s < e ? s : e;
-    } else {
-        start = s < e ? s : e;
-        end = s > e ? s : e;
-    }
+    start += o;
+    end += o;
 }
 
 

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -331,8 +331,9 @@ static SwOutline* _genDashOutline(const RenderShape* rshape, const Matrix* trans
                 break;
             }
             case PathCommand::MoveTo: {
-                if (rshape->stroke->trim.individual) _dashMoveTo(dash, pts);
-                else _dashMoveTo(dash, offIdx, offset, pts);
+                if (rshape->stroke->trim.simultaneous) _dashMoveTo(dash, offIdx, offset, pts);
+                else _dashMoveTo(dash, pts);
+
                 ++pts;
                 break;
             }
@@ -371,7 +372,7 @@ static float _outlineLength(const RenderShape* rshape)
     const Point* close = nullptr;
     auto length = 0.0f;
     auto slength = -1.0f;
-    auto simultaneous = !rshape->stroke->trim.individual;
+    auto simultaneous = rshape->stroke->trim.simultaneous;
 
     //Compute the whole length
     while (cmdCnt-- > 0) {

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -140,7 +140,7 @@ struct RenderStroke
     struct {
         float begin = 0.0f;
         float end = 1.0f;
-        bool individual = false;
+        bool simultaneous = true;
     } trim;
 
     ~RenderStroke()

--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -362,6 +362,7 @@ Result Shape::strokeJoin(StrokeJoin join) noexcept
     return Result::Success;
 }
 
+
 Result Shape::strokeMiterlimit(float miterlimit) noexcept
 {
     // https://www.w3.org/TR/SVG2/painting.html#LineJoin
@@ -385,9 +386,23 @@ StrokeJoin Shape::strokeJoin() const noexcept
     return pImpl->rs.strokeJoin();
 }
 
+
 float Shape::strokeMiterlimit() const noexcept
 {
     return pImpl->rs.strokeMiterlimit();
+}
+
+
+Result Shape::strokeTrim(float begin, float end, bool simultaneous) noexcept
+{
+    pImpl->strokeTrim(begin, end, simultaneous);
+    return Result::Success;
+}
+
+
+bool Shape::strokeTrim(float* begin, float* end) const noexcept
+{
+    return pImpl->strokeTrim(begin, end);
 }
 
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -216,21 +216,50 @@ struct Shape::Impl
         return true;
     }
 
-    bool strokeTrim(float begin, float end, bool individual)
+    void strokeTrim(float begin, float end, bool simultaneous)
     {
         if (!rs.stroke) {
-            if (begin == 0.0f && end == 1.0f) return true;
+            if (begin == 0.0f && end == 1.0f) return;
             rs.stroke = new RenderStroke();
         }
 
-        if (mathEqual(rs.stroke->trim.begin, begin) && mathEqual(rs.stroke->trim.end, end)) return true;
+        if (mathEqual(rs.stroke->trim.begin, begin) && mathEqual(rs.stroke->trim.end, end) &&
+            rs.stroke->trim.simultaneous == simultaneous) return;
+
+        auto loop = true;
+
+        if (begin > 1.0f && end > 1.0f) loop = false;
+        if (begin < 0.0f && end < 0.0f) loop = false;
+        if (begin >= 0.0f && begin <= 1.0f && end >= 0.0f  && end <= 1.0f) loop = false;
+
+        if (begin > 1.0f) begin -= 1.0f;
+        if (begin < 0.0f) begin += 1.0f;
+        if (end > 1.0f) end -= 1.0f;
+        if (end < 0.0f) end += 1.0f;
+
+        if ((loop && begin < end) || (!loop && begin > end)) {
+            auto tmp = begin;
+            begin = end;
+            end = tmp;
+        }
 
         rs.stroke->trim.begin = begin;
         rs.stroke->trim.end = end;
-        rs.stroke->trim.individual = individual;
+        rs.stroke->trim.simultaneous = simultaneous;
         flag |= RenderUpdateFlag::Stroke;
+    }
 
-        return true;
+    bool strokeTrim(float* begin, float* end)
+    {
+        if (rs.stroke) {
+            if (begin) *begin = rs.stroke->trim.begin;
+            if (end) *end = rs.stroke->trim.end;
+            return rs.stroke->trim.simultaneous;
+        } else {
+            if (begin) *begin = 0.0f;
+            if (end) *end = 1.0f;
+            return false;
+        }
     }
 
     bool strokeCap(StrokeCap cap)

--- a/test/capi/capiShape.cpp
+++ b/test/capi/capiShape.cpp
@@ -246,7 +246,26 @@ TEST_CASE("Stroke join", "[capiStrokeJoin]")
     REQUIRE(tvg_shape_get_stroke_miterlimit(paint, &ml) == TVG_RESULT_SUCCESS);
     REQUIRE(ml == 1000.0f);
 
+    REQUIRE(tvg_paint_del(paint) == TVG_RESULT_SUCCESS);
+}
 
+TEST_CASE("Stroke trim", "[capiStrokeTrim]")
+{
+    Tvg_Paint* paint = tvg_shape_new();
+    REQUIRE(paint);
+
+    float begin, end;
+    bool simultaneous;
+
+    REQUIRE(tvg_shape_get_stroke_trim(NULL, &begin, &end, &simultaneous) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_get_stroke_trim(paint, &begin, &end, &simultaneous) == TVG_RESULT_SUCCESS);
+
+    REQUIRE(tvg_shape_set_stroke_trim(NULL, 0.33, 0.66, false) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_stroke_trim(paint, 0.33, 0.66, false) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_shape_get_stroke_trim(paint, &begin, &end, &simultaneous) == TVG_RESULT_SUCCESS);
+    REQUIRE(begin == Approx(0.33).margin(0.000001));
+    REQUIRE(end == Approx(0.66).margin(0.000001));
+    REQUIRE(simultaneous == false);
 
     REQUIRE(tvg_paint_del(paint) == TVG_RESULT_SUCCESS);
 }

--- a/test/testShape.cpp
+++ b/test/testShape.cpp
@@ -203,6 +203,17 @@ TEST_CASE("Stroking", "[tvgShape]")
     REQUIRE(shape->strokeMiterlimit() == 1000.0f);
     REQUIRE(shape->strokeMiterlimit(-0.001f) == Result::NonSupport);
 
+    //Stroke Trim
+    float begin, end;
+    REQUIRE(shape->strokeTrim(&begin, &end) == true);
+    REQUIRE(begin == Approx(0.0).margin(0.000001));
+    REQUIRE(end == Approx(1.0).margin(0.000001));
+
+    REQUIRE(shape->strokeTrim(0.3, 0.88, false) == Result::Success);
+    REQUIRE(shape->strokeTrim(&begin, &end) == false);
+    REQUIRE(begin == Approx(0.3).margin(0.000001));
+    REQUIRE(end == Approx(0.88).margin(0.000001));
+
     //Stroke Order After Stroke Setting
     REQUIRE(shape->order(true) == Result::Success);
     REQUIRE(shape->order(false) == Result::Success);


### PR DESCRIPTION
New api sets/gets the trim of the stroke
along the defined path segment, allowing
control over which part of the stroke is
visible.

@Issue: https://github.com/thorvg/thorvg/issues/2190

<img width="392" alt="Zrzut ekranu 2024-05-30 o 21 05 22" src="https://github.com/thorvg/thorvg/assets/67589014/1824caba-7bde-4ffb-8b0f-c202606ba2fc">
