### PR TITLE
loader/svg: Fix unintended use of `float_t` type

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -709,7 +709,7 @@ static bool _toColor(const char* str, uint8_t* r, uint8_t* g, uint8_t* b, char**
         *ref = _idFromUrl((const char*)(str + 3));
         return true;
     } else if (len >= 10 && (str[0] == 'h' || str[0] == 'H') && (str[1] == 's' || str[1] == 'S') && (str[2] == 'l' || str[2] == 'L') && str[3] == '(' && str[len - 1] == ')') {
-        float_t th, ts, tb;
+        float th, ts, tb;
         const char *content, *hue, *satuation, *brightness;
         content = str + 4;
         content = _skipSpace(content, nullptr);


### PR DESCRIPTION
This broke x86_32 GCC build on Linux and Windows with this error:
```
hirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp: In function 'bool _toColor(const char*, uint8_t*, uint8_t*, uint8_t*, char**)':
thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp:716:42: error: cannot convert 'float_t*' {aka 'long double*'} to 'float*'
  716 |         if (_parseNumber(&content, &hue, &th) && hue) {
      |                                          ^~~
      |                                          |
      |                                          float_t* {aka long double*}
thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp:106:73: note:   initializing argument 3 of 'bool _parseNumber(const char**, const char**, float*)'
  106 | static bool _parseNumber(const char** content, const char** end, float* number)
      |                                                                  ~~~~~~~^~~~~~
thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp:721:48: error: cannot convert 'float_t*' {aka 'long double*'} to 'float*'
  721 |             if (_parseNumber(&hue, &satuation, &ts) && satuation && *satuation == '%') {
      |                                                ^~~
      |                                                |
      |                                                float_t* {aka long double*}
thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp:106:73: note:   initializing argument 3 of 'bool _parseNumber(const char**, const char**, float*)'
  106 | static bool _parseNumber(const char** content, const char** end, float* number)
      |                                                                  ~~~~~~~^~~~~~
thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp:726:59: error: cannot convert 'float_t*' {aka 'long double*'} to 'float*'
  726 |                 if (_parseNumber(&satuation, &brightness, &tb) && brightness && *brightness == '%') {
      |                                                           ^~~
      |                                                           |
      |                                                           float_t* {aka long double*}
thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp:106:73: note:   initializing argument 3 of 'bool _parseNumber(const char**, const char**, float*)'
  106 | static bool _parseNumber(const char** content, const char** end, float* number)
      |                                                                  ~~~~~~~^~~~~~
```

The issue was introduced in https://github.com/thorvg/thorvg/commit/0c6395cbea7495b5284cb33792798324bcc4f7da.

(If this is not the proper target branch, let me know, or feel free to merge this manually.)