### PR TITLE
gl_engine: fix GradientStroke ignored by tessellator

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -45,7 +45,7 @@ bool GlGeometry::tesselate(const RenderShape& rshape, RenderUpdateFlag flag)
         mBounds = bwTess.bounds();
     }
 
-    if (flag & (RenderUpdateFlag::Stroke | RenderUpdateFlag::Transform)) {
+    if (flag & (RenderUpdateFlag::Stroke | RenderUpdateFlag::GradientStroke | RenderUpdateFlag::Transform)) {
         strokeVertex.clear();
         strokeIndex.clear();
 

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -415,9 +415,9 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
     rshape.fillColor(nullptr, nullptr, nullptr, &alphaF);
     rshape.strokeFill(nullptr, nullptr, nullptr, &alphaS);
 
-    if ( ((sdata->updateFlag & RenderUpdateFlag::Gradient) == 0) &&
-         ((sdata->updateFlag & RenderUpdateFlag::Color) && alphaF == 0) &&
-         ((sdata->updateFlag & RenderUpdateFlag::Stroke) && alphaS == 0) )
+    if ( ((flags & RenderUpdateFlag::Gradient) == 0) &&
+         ((flags & RenderUpdateFlag::Color) && alphaF == 0) &&
+         ((flags & RenderUpdateFlag::Stroke) && alphaS == 0) )
     {
         return sdata;
     }
@@ -441,7 +441,7 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
         mViewport.h,
     });
 
-    if (sdata->updateFlag & (RenderUpdateFlag::Color | RenderUpdateFlag::Stroke | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Path))
+    if (sdata->updateFlag & (RenderUpdateFlag::Color | RenderUpdateFlag::Stroke | RenderUpdateFlag::Gradient | RenderUpdateFlag::GradientStroke | RenderUpdateFlag::Transform | RenderUpdateFlag::Path))
     {
         if (!sdata->geometry->tesselate(rshape, sdata->updateFlag)) return sdata;
     }


### PR DESCRIPTION
This PR fix the GlRenderer not take GradientStroke into consider when prepare Geometry vertices.

-----
After this fix, the gradient_stroke.svg can be rendered
![image](https://github.com/thorvg/thorvg/assets/26308154/869f2dfb-4b90-4489-be81-9a9f7446526b)
