### PR TITLE
sw_engine: fix dashing

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -107,7 +107,7 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix* trans
     if (mathZero(len)) {
         _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
     //draw the current line fully
-    } else if (len < dash.curLen) {
+    } else if (len <= dash.curLen) {
         dash.curLen -= len;
         if (!dash.curOpGap) {
             if (dash.move) {
@@ -168,7 +168,7 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
     //draw the current line fully
     if (mathZero(len)) {
         _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
-    } else if (len < dash.curLen) {
+    } else if (len <= dash.curLen) {
         dash.curLen -= len;
         if (!dash.curOpGap) {
             if (dash.move) {


### PR DESCRIPTION
Fixing the problem with handling a specific
case where the length of the remaining line
to be drawn and the dash line length were
exactly the same.

before:
<img width="150" alt="Zrzut ekranu 2024-06-1 o 15 36 05" src="https://github.com/thorvg/thorvg/assets/67589014/937ceebe-e08c-4d69-87a7-8c09a0dd7e91">

after:
<img width="150" alt="Zrzut ekranu 2024-06-1 o 15 35 52" src="https://github.com/thorvg/thorvg/assets/67589014/8b37fb77-e4c0-464a-8d42-68b5cf220fa8">

no dash:
<img width="150" alt="Zrzut ekranu 2024-06-1 o 15 39 53" src="https://github.com/thorvg/thorvg/assets/67589014/438e0c75-33c9-463a-aa4d-70e85ad7c04a">

```
    auto shape1 = tvg::Shape::gen();
    shape1->moveTo(100, 100);
    shape1->lineTo(400, 100);
    shape1->lineTo(400, 400);
    shape1->lineTo(100, 400);
    shape1->lineTo(100, 700);
    shape1->lineTo(400, 700);
    shape1->lineTo(400, 750);
    shape1->strokeFill(255, 0, 0);
    shape1->strokeWidth(10);

    float dashPattern1[3] = {300, 600, 300};
    shape1->strokeDash(dashPattern1, 3);

    if (canvas->push(std::move(shape1)) != tvg::Result::Success) return;
```