### PR TITLE
lottie: Fix invalid font match

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1306,7 +1306,7 @@ static void _attachFont(LottieComposition* comp, LottieLayer* parent)
         for (uint32_t i = 0; i < comp->fonts.count; ++i) {
             auto font = comp->fonts[i];
             auto len2 = strlen(font->name);
-            if (!strncmp(font->name, doc.name, len < len2 ? len : len2)) {
+            if (len == len2 && !strcmp(font->name, doc.name)) {
                 text->font = font;
                 break;
             }


### PR DESCRIPTION
When lottie has similar font names, it incorrectly matches fonts due to a logic bug.

This error causes an infinite loop when searching for glyphs. (The program hangs out)

[text-grouping-line.json](https://github.com/user-attachments/files/15546077/text-grouping-line.json)

Breaks from font iteration(at `_attachFont`) only when composition's font and text font are exactly matched, keep looping otherwise.