### PR TITLE
gl_engine: fix gradient color interpretation error

### DIFF
--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -131,7 +131,7 @@ vec4 gradient(float t)                                                          
         {                                                                                               \n
             float stopi = gradientStop(i);                                                              \n
             float stopi1 = gradientStop(i + 1);                                                         \n
-            if (t > stopi && t <stopi1)                                                                 \n
+            if (t >= stopi && t <= stopi1)                                                              \n
             {                                                                                           \n
                 col = (uGradientInfo.stopColors[i] * (1. - gradientStep(stopi, stopi1, t)));            \n
                 col += (uGradientInfo.stopColors[i + 1] * gradientStep(stopi, stopi1, t));              \n


### PR DESCRIPTION
This PR: Fix when gradient position is same as some starting or ending point of a gradient stop, the output color is blank

---- 
After this patch:
![gradient_bad_case](https://github.com/thorvg/thorvg/assets/26308154/136549a5-8388-4bca-81e0-fef8433ecdab)
