### PR TITLE
api: corrected return type.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -80,7 +80,7 @@ enum class Result
     InsufficientCondition, ///< The value returned in case the request cannot be processed - e.g. asking for properties of an object, which does not exist.
     FailedAllocation,      ///< The value returned in case of unsuccessful memory allocation.
     MemoryCorruption,      ///< The value returned in the event of bad memory handling - e.g. failing in pointer releasing or casting
-    NonSupport,            ///< The value returned in case of choosing unsupported options.
+    NonSupport,            ///< The value returned in case of choosing unsupported engine features(options).
     Unknown                ///< The value returned in all other cases.
 };
 
@@ -1025,7 +1025,7 @@ public:
      *
      * @param[in] miterlimit The miterlimit imposes a limit on the extent of the stroke join, when the @c StrokeJoin::Miter join style is set. The default value is 4.
      *
-     * @retval Result::Success when succeed or Result::NonSupport for @p miterlimit values less than zero.
+     * @retval Result::Success when succeed or Result::InvalidArgument for @p miterlimit values less than zero.
      * 
      * @since 0.11
      */

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -122,7 +122,7 @@ typedef enum {
     TVG_RESULT_INSUFFICIENT_CONDITION, ///< The value returned in case the request cannot be processed - e.g. asking for properties of an object, which does not exist.
     TVG_RESULT_FAILED_ALLOCATION,      ///< The value returned in case of unsuccessful memory allocation.
     TVG_RESULT_MEMORY_CORRUPTION,      ///< The value returned in the event of bad memory handling - e.g. failing in pointer releasing or casting
-    TVG_RESULT_NOT_SUPPORTED,          ///< The value returned in case of choosing unsupported options.
+    TVG_RESULT_NOT_SUPPORTED,          ///< The value returned in case of choosing unsupported engine features(options).
     TVG_RESULT_UNKNOWN                 ///< The value returned in all other cases.
 } Tvg_Result;
 
@@ -1502,8 +1502,7 @@ TVG_API Tvg_Result tvg_shape_get_stroke_join(const Tvg_Paint* paint, Tvg_Stroke_
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_SUCCESS Succeed.
-* \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-* \retval TVG_RESULT_NOT_SUPPORTED Unsupported @p miterlimit values (less than zero).
+* \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer or Unsupported @p miterlimit values (less than zero).
 *
 * \since 0.11
 */

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -447,7 +447,6 @@ TVG_API Tvg_Result tvg_shape_get_stroke_join(const Tvg_Paint* paint, Tvg_Stroke_
 
 TVG_API Tvg_Result tvg_shape_set_stroke_miterlimit(Tvg_Paint* paint, float ml)
 {
-    if (ml < 0.0f) return TVG_RESULT_NOT_SUPPORTED;
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
     return (Tvg_Result) reinterpret_cast<Shape*>(paint)->strokeMiterlimit(ml);
 }

--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -362,7 +362,7 @@ Result Shape::strokeMiterlimit(float miterlimit) noexcept
 {
     // https://www.w3.org/TR/SVG2/painting.html#LineJoin
     // - A negative value for stroke-miterlimit must be treated as an illegal value.
-    if (miterlimit < 0.0f) return Result::NonSupport;
+    if (miterlimit < 0.0f) return Result::InvalidArguments;
     // TODO Find out a reasonable max value.
     pImpl->strokeMiterlimit(miterlimit);
     return Result::Success;

--- a/test/capi/capiShape.cpp
+++ b/test/capi/capiShape.cpp
@@ -242,7 +242,7 @@ TEST_CASE("Stroke join", "[capiStrokeJoin]")
     REQUIRE(tvg_shape_get_stroke_miterlimit(paint, &ml) == TVG_RESULT_SUCCESS);
     REQUIRE(ml == 1000.0f);
 
-    REQUIRE(tvg_shape_set_stroke_miterlimit(paint, -0.001f) == TVG_RESULT_NOT_SUPPORTED);
+    REQUIRE(tvg_shape_set_stroke_miterlimit(paint, -0.001f) == TVG_RESULT_INVALID_ARGUMENT);
     REQUIRE(tvg_shape_get_stroke_miterlimit(paint, &ml) == TVG_RESULT_SUCCESS);
     REQUIRE(ml == 1000.0f);
 

--- a/test/testShape.cpp
+++ b/test/testShape.cpp
@@ -201,7 +201,7 @@ TEST_CASE("Stroking", "[tvgShape]")
     REQUIRE(shape->strokeMiterlimit() == 0.00001f);
     REQUIRE(shape->strokeMiterlimit(1000.0f) == Result::Success);
     REQUIRE(shape->strokeMiterlimit() == 1000.0f);
-    REQUIRE(shape->strokeMiterlimit(-0.001f) == Result::NonSupport);
+    REQUIRE(shape->strokeMiterlimit(-0.001f) == Result::InvalidArguments);
 
     //Stroke Trim
     float begin, end;


### PR DESCRIPTION
NonSupport indicates unsupported options due to disabled features or lack of system support. InvalidArgument indicates the case such as incorrect parameter values.