### PR TITLE
sw_engine: Fine-tuning RLE performance.

### DIFF
--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -928,7 +928,7 @@ SwRleData* rleRender(SwRleData* rle, const SwOutline* outline, const SwBBox& ren
     rw.cellYCnt = rw.cellMax.y - rw.cellMin.y;
     rw.ySpan = 0;
     rw.outline = const_cast<SwOutline*>(outline);
-    rw.bandSize = rw.bufferSize / (sizeof(Cell) * 8);  //bandSize: 64
+    rw.bandSize = rw.bufferSize / (sizeof(Cell) * 2);  //bandSize: 256
     rw.bandShoot = 0;
     rw.antiAlias = antiAlias;
 
@@ -966,10 +966,7 @@ SwRleData* rleRender(SwRleData* rle, const SwOutline* outline, const SwBBox& ren
 
             if (cellMod > 0) cellStart += sizeof(Cell) - cellMod;
 
-            auto cellEnd = rw.bufferSize;
-            cellEnd -= cellEnd % sizeof(Cell);
-
-            auto cellsMax = reinterpret_cast<Cell*>((char*)rw.buffer + cellEnd);
+            auto cellsMax = reinterpret_cast<Cell*>((char*)rw.buffer + rw.bufferSize);
             rw.cells = reinterpret_cast<Cell*>((char*)rw.buffer + cellStart);
 
             if (rw.cells >= cellsMax) goto reduce_bands;


### PR DESCRIPTION
the arranged value is examined with the local test, improved the speed twice for a corner-case - extreamly huge size shape.
test resource: [notification.json](https://github.com/user-attachments/files/15605543/notification.json)