### PR TITLE
Revert "sw_engine: fine-tuning RLE performance."

### DIFF
--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -928,7 +928,7 @@ SwRleData* rleRender(SwRleData* rle, const SwOutline* outline, const SwBBox& ren
     rw.cellYCnt = rw.cellMax.y - rw.cellMin.y;
     rw.ySpan = 0;
     rw.outline = const_cast<SwOutline*>(outline);
-    rw.bandSize = rw.bufferSize / (sizeof(Cell) * 2);  //bandSize: 256
+    rw.bandSize = rw.bufferSize / (sizeof(Cell) * 8);  //bandSize: 64
     rw.bandShoot = 0;
     rw.antiAlias = antiAlias;
 
@@ -966,7 +966,10 @@ SwRleData* rleRender(SwRleData* rle, const SwOutline* outline, const SwBBox& ren
 
             if (cellMod > 0) cellStart += sizeof(Cell) - cellMod;
 
-            auto cellsMax = reinterpret_cast<Cell*>((char*)rw.buffer + rw.bufferSize);
+            auto cellEnd = rw.bufferSize;
+            cellEnd -= cellEnd % sizeof(Cell);
+
+            auto cellsMax = reinterpret_cast<Cell*>((char*)rw.buffer + cellEnd);
             rw.cells = reinterpret_cast<Cell*>((char*)rw.buffer + cellStart);
 
             if (rw.cells >= cellsMax) goto reduce_bands;


### PR DESCRIPTION
This reverts commit 51a2936b280ea832bb19caa06c68e001f44c7021.

Somehow, this breaks the Windows CI test to fail. Need to revisit...