### PR TITLE
test: resolve compiler warnings on msvc.

### DIFF
--- a/test/capi/capiShape.cpp
+++ b/test/capi/capiShape.cpp
@@ -260,8 +260,8 @@ TEST_CASE("Stroke trim", "[capiStrokeTrim]")
     REQUIRE(tvg_shape_get_stroke_trim(NULL, &begin, &end, &simultaneous) == TVG_RESULT_INVALID_ARGUMENT);
     REQUIRE(tvg_shape_get_stroke_trim(paint, &begin, &end, &simultaneous) == TVG_RESULT_SUCCESS);
 
-    REQUIRE(tvg_shape_set_stroke_trim(NULL, 0.33, 0.66, false) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_shape_set_stroke_trim(paint, 0.33, 0.66, false) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_shape_set_stroke_trim(NULL, 0.33f, 0.66f, false) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_stroke_trim(paint, 0.33f, 0.66f, false) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_shape_get_stroke_trim(paint, &begin, &end, &simultaneous) == TVG_RESULT_SUCCESS);
     REQUIRE(begin == Approx(0.33).margin(0.000001));
     REQUIRE(end == Approx(0.66).margin(0.000001));

--- a/test/testShape.cpp
+++ b/test/testShape.cpp
@@ -209,7 +209,7 @@ TEST_CASE("Stroking", "[tvgShape]")
     REQUIRE(begin == Approx(0.0).margin(0.000001));
     REQUIRE(end == Approx(1.0).margin(0.000001));
 
-    REQUIRE(shape->strokeTrim(0.3, 0.88, false) == Result::Success);
+    REQUIRE(shape->strokeTrim(0.3f, 0.88f, false) == Result::Success);
     REQUIRE(shape->strokeTrim(&begin, &end) == false);
     REQUIRE(begin == Approx(0.3).margin(0.000001));
     REQUIRE(end == Approx(0.88).margin(0.000001));


### PR DESCRIPTION
warning C4305: 'argument': truncation from 'double' to 'float'