### PR TITLE
sw_engine: fix fastTrack condition

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -420,6 +420,7 @@ static bool _axisAlignedRect(const SwOutline* outline)
 {
     //Fast Track: axis-aligned rectangle?
     if (outline->pts.count != 5) return false;
+    if (outline->types[2] == SW_CURVE_TYPE_CUBIC) return false;
 
     auto pt1 = outline->pts.data + 0;
     auto pt2 = outline->pts.data + 1;


### PR DESCRIPTION
When checking the fastTrack condition,
it's necessary to exclude the outlines
with a Bezier curve (Move-Cubic-Line,
Move-Cubic-Close, Move-Line-Cubic).

@Issue: https://github.com/thorvg/thorvg/issues/2379

sample:
```
    auto shape1 = tvg::Shape::gen();
    shape1->moveTo(15,15);
    shape1->lineTo(1, 15);
    shape1->cubicTo(1, 1 , 15, 1 ,15 ,15);
    shape1->fill(255, 255, 255, 200);
    shape1->strokeWidth(0.6);
    shape1->strokeFill(255, 0, 0);
    shape1->scale(10);

    canvas->push(std::move(shape1));

    shape1 = tvg::Shape::gen();
    shape1->moveTo(1,30);
    shape1->cubicTo(1, 16 , 15, 16 ,15 ,30);
    shape1->close();
    shape1->fill(255, 255, 255, 200);
    shape1->strokeWidth(0.6);
    shape1->strokeFill(255, 0, 0);
    shape1->scale(10);

    canvas->push(std::move(shape1));
```
    
before:
<img width="86" alt="Zrzut ekranu 2024-06-9 o 23 45 43" src="https://github.com/thorvg/thorvg/assets/67589014/5cb3e13b-3570-46d0-b5b1-8f0ef141d301">

after:
<img width="87" alt="Zrzut ekranu 2024-06-9 o 23 45 30" src="https://github.com/thorvg/thorvg/assets/67589014/6a4c480f-501b-4684-b2c2-f93095f62738">

