### PR TITLE
loaders: ensure a null terminator at the end of the data

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -182,10 +182,11 @@ bool LottieLoader::header()
 bool LottieLoader::open(const char* data, uint32_t size, const std::string& rpath, bool copy)
 {
     if (copy) {
-        content = (char*)malloc(size);
+        content = (char*)malloc(size + 1);
         if (!content) return false;
-        memcpy((char*)content, data, size);
-    } else content = data;
+        memcpy(content, data, size);
+        content[size] = '\0';
+    } else content = (char*)data;
 
     this->size = size;
     this->copy = copy;

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -33,7 +33,7 @@ struct LottieBuilder;
 class LottieLoader : public FrameModule, public Task
 {
 public:
-    const char* content = nullptr;      //lottie file data
+    char* content = nullptr;            //lottie file data
     uint32_t size = 0;                  //lottie data size
     float frameNo = 0.0f;               //current frame number
     float frameCnt = 0.0f;


### PR DESCRIPTION
strlen does not count the null terminator - using it to determine the size of loaded data that is copied results in not copying the null terminator and may lead to memory corruption.