### PR TITLE
lottie: parse a number despite an incorrect type

### DIFF
--- a/src/loaders/lottie/tvgLottieParserHandler.cpp
+++ b/src/loaders/lottie/tvgLottieParserHandler.cpp
@@ -86,10 +86,14 @@ bool LookaheadParserHandler::nextArrayValue()
 
 int LookaheadParserHandler::getInt()
 {
-    if (state != kHasNumber || !val.IsInt()) {
+    if (state != kHasNumber) {
         Error();
         return 0;
     }
+
+    // attempt to parse as float as a backup
+    if (!val.IsInt() && val.IsNumber()) return (int)getFloat();
+
     auto result = val.GetInt();
     parseNext();
     return result;


### PR DESCRIPTION
It may happen that a number which should be an int is actually a float. In such cases, a parsing error occurred and the animation was not rendered. Now,
an attempt is made to parse the number as a float
first, and only if this fails, the parsing is concluded with an error.

@Issue: https://github.com/thorvg/thorvg/issues/2389