### PR TITLE
wg_engine: clear bbox mesh lists

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -388,7 +388,9 @@ WgRenderDataShape* WgRenderDataShapePool::allocate(WgContext& context)
 void WgRenderDataShapePool::free(WgContext& context, WgRenderDataShape* dataShape)
 {
     dataShape->meshGroupShapes.release(context);
+    dataShape->meshGroupShapesBBox.release(context);
     dataShape->meshGroupStrokes.release(context);
+    dataShape->meshGroupStrokesBBox.release(context);
     mPool.push(dataShape);
 }
 

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -74,13 +74,14 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
     auto renderDataShape = (WgRenderDataShape*)data;
     if (!renderDataShape)
         renderDataShape = mRenderDataShapePool.allocate(mContext);
-    
+
     // update geometry
-    if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Stroke))
+    if ((!data) || (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Stroke))) {
         renderDataShape->updateMeshes(mContext, rshape);
+    }
 
      // update paint settings
-    if (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Blend)) {
+    if ((!data) || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Blend))) {
         WgShaderTypeMat4x4f modelMat(transform);
         WgShaderTypeBlendSettings blendSettings(mTargetSurface.cs, opacity);
         renderDataShape->bindGroupPaint.initialize(mContext.device, mContext.queue, modelMat, blendSettings);


### PR DESCRIPTION
when cleaning the geometry of an object, it is also necessary to clean the bounding boxes and store them in the pool