### PR TITLE
capi: remove the incorrectly named API

### DIFF
--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -111,13 +111,6 @@ TVG_API Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas)
 }
 
 
-TVG_API Tvg_Result tvg_canvas_est_viewport(Tvg_Canvas* canvas, int32_t x, int32_t y, int32_t w, int32_t h)
-{
-    if (!canvas) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->viewport(x, y, w, h);
-}
-
-
 TVG_API Tvg_Result tvg_canvas_update_paint(Tvg_Canvas* canvas, Tvg_Paint* paint)
 {
     if (!canvas || !paint) return TVG_RESULT_INVALID_ARGUMENT;


### PR DESCRIPTION
There was a typo in the name (tvg_canvas_est_viewport), which made it seem like it was missing. The correctly named API has already been added, so this one can be removed.