### PR TITLE
test for text loading from memory + issues caught during testing

### DIFF
--- a/examples/Text.cpp
+++ b/examples/Text.cpp
@@ -58,12 +58,12 @@ void tvgDrawCmds(tvg::Canvas* canvas)
     auto size = file.tellg();
     file.seekg(0, std::ios::beg);
     auto data = (char*)malloc(size);
-    if (!data) return;
-    file.read(data, size);
-    file.close();
-    if (tvg::Text::load("SentyCloud", data, size, "ttf", true) != tvg::Result::Success) {
-        cout << "Error while loading TTF from memory. Did you enable TTF Loader?" << endl;
+    if (data && file.read(data, size)) {
+        if (tvg::Text::load("SentyCloud", data, size, "ttf", true) != tvg::Result::Success) {
+            cout << "Error while loading TTF from memory. Did you enable TTF Loader?" << endl;
+        }
     }
+    file.close();
     free(data);
 
     auto text = tvg::Text::gen();

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1588,6 +1588,7 @@ public:
      * @retval Result::InvalidArguments If no name is provided or if @p size is zero while @p data points to a valid memory location.
      * @retval Result::NonSupport When trying to load a file with an unsupported extension.
      * @retval Result::Unknown If an error occurs at a later stage.
+     * @retval Result::InsufficientCondition If attempting to unload the font data that has not been previously loaded.
      *
      * @warning: It's the user responsibility to release the @p data memory.
      *

--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -436,23 +436,22 @@ LoadModule* LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h, bool
 
 
 //loads fonts from memory - loader is cached (regardless of copy value) in order to access it while setting font
-LoadModule* LoaderMgr::loader(const char* name, const char* data, uint32_t size, const string& mimeType, bool copy)
+LoadModule* LoaderMgr::loader(const char* name, const char* data, uint32_t size, TVG_UNUSED const string& mimeType, bool copy)
 {
     //TODO: add check for mimetype ?
     if (auto loader = _findFromCache(name)) return loader;
 
-    if (auto loader = _findByType(mimeType)) {
-        if (loader->open(data, size, "", copy)) {
-            loader->hashpath = strdup(name);
-            loader->pathcache = true;
-            ScopedLock lock(key);
-            _activeLoaders.back(loader);
-            return loader;
-        } else {
-            TVGLOG("LOADER", "The font data \"%s\" could not be loaded.", name);
-            delete(loader);
-        }
+    //function is dedicated for ttf loader (the only supported font loader)
+    auto loader = new TtfLoader;
+    if (loader->open(data, size, "", copy)) {
+        loader->hashpath = strdup(name);
+        loader->pathcache = true;
+        ScopedLock lock(key);
+        _activeLoaders.back(loader);
+        return loader;
     }
 
+    TVGLOG("LOADER", "The font data \"%s\" could not be loaded.", name);
+    delete(loader);
     return nullptr;
 }

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -78,7 +78,7 @@ Result Text::load(const char* name, const char* data, uint32_t size, const strin
     //unload font
     if (!data) {
         if (LoaderMgr::retrieve(name)) return Result::Success;
-        return Result::InvalidArguments;
+        return Result::InsufficientCondition;
     }
 
     if (!LoaderMgr::loader(name, data, size, mimeType, copy)) return Result::NonSupport;


### PR DESCRIPTION
 issues caught during testing:
 - wrong returned value while unloading
 - lack of support for unprovided mimetype
 - missing file.close in Text example