### PR TITLE
wg_engine: fix fill rule usage

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -65,8 +65,7 @@ public:
         WgBindGroupOpacity* opacity);
     void antialias(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc);
 private:
-    void drawShapeWinding(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
-    void drawShapeEvenOdd(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
+    void drawShape(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
     void drawStroke(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
 
     void dispatchWorkgroups(WGPUComputePassEncoder computePassEncoder);


### PR DESCRIPTION
Fix wrong application of fill rule in a cases of terminated path (.close()/.moveTo())
IF avoid visual artifacts
Before/After:

![alien](https://github.com/thorvg/thorvg/assets/7770034/a01d25fa-104c-4651-b051-f1fbb28e9ec9)
![hamburger](https://github.com/thorvg/thorvg/assets/7770034/f21f38d4-4d33-406e-a588-03c281afe016)
