### PR TITLE
wg_engine: fix scene rendering with blend

### DIFF
--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -31,6 +31,10 @@
 #define WG_VERTEX_BUFFER_MIN_SIZE 2048
 #define WG_INDEX_BUFFER_MIN_SIZE 2048
 
+struct WgCompositor: public Compositor {
+    BlendMethod blendMethod;
+};
+
 enum class WgPipelineBlendType {
     Src = 0, // S
     Normal,  // (Sa * S) + (255 - Sa) * D

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -401,7 +401,7 @@ fn cs_main( @builtin(global_invocation_id) id: vec3u) {
         /* Add        */ case 1u:  { color = (S + D); }
         /* Screen     */ case 2u:  { color = (S + D) - (S * D); }
         /* Multiply   */ case 3u:  { color = (S * D); }
-        /* Overlay    */ case 4u:  { color = S * D; }
+        /* Overlay    */ case 4u:  { color = (Sa * Da) - 2 * (Da - S) * (Sa - D); }
         /* Difference */ case 5u:  { color = abs(S - D); }
         /* Exclusion  */ case 6u:  { color = S + D - (2 * S * D); }
         /* SrcOver    */ case 7u:  { color = S; }
@@ -469,6 +469,7 @@ fn cs_main( @builtin(global_invocation_id) id: vec3u) {
 
     let colorSrc = textureLoad(imageSrc, id.xy);
     let colorMsk = textureLoad(imageMsk, id.xy);
+    if ((length(colorSrc) == 0.0) || (length(colorMsk) == 0.0)) { return; };
     let colorDst = textureLoad(imageDst, id.xy);
 
     var color: vec3f = colorSrc.xyz;
@@ -498,7 +499,7 @@ fn cs_main( @builtin(global_invocation_id) id: vec3u) {
         /* Add        */ case 1u:  { color = (S + D); }
         /* Screen     */ case 2u:  { color = (S + D) - (S * D); }
         /* Multiply   */ case 3u:  { color = (S * D); }
-        /* Overlay    */ case 4u:  { color = S * D; }
+        /* Overlay    */ case 4u:  { color = (Sa * Da) - 2 * (Da - S) * (Sa - D); }
         /* Difference */ case 5u:  { color = abs(S - D); }
         /* Exclusion  */ case 6u:  { color = S + D - (2 * S * D); }
         /* SrcOver    */ case 7u:  { color = S; }


### PR DESCRIPTION
Fix appliance of the blend method, that setuped for scene, but not for a shape.
Overlay blend func changed to be close to spec.

Before/After
![image](https://github.com/thorvg/thorvg/assets/7770034/3fd816cd-c856-4749-b26f-d377c8ff7689)
