### PR TITLE
lottie: fix repeater order

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -437,7 +437,7 @@ static void _repeat(LottieGroup* parent, unique_ptr<Shape> path, RenderContext* 
                 parent->scene->push(cast(*shape));
                 propagators.push(*shape);
             }
-        } else {
+        } else if (!shapes.empty()) {
             for (auto shape = shapes.end() - 1; shape >= shapes.begin(); --shape) {
                 parent->scene->push(cast(*shape));
                 propagators.push(*shape);

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -828,7 +828,7 @@ LottieRepeater* LottieParser::parseRepeater()
         if (parseCommon(repeater, key)) continue;
         else if (KEY_AS("c")) parseProperty<LottieProperty::Type::Float>(repeater->copies);
         else if (KEY_AS("o")) parseProperty<LottieProperty::Type::Float>(repeater->offset);
-        else if (KEY_AS("m")) repeater->inorder = getInt();
+        else if (KEY_AS("m")) repeater->inorder = getInt() == 2;
         else if (KEY_AS("tr"))
         {
             enterObject();


### PR DESCRIPTION
Assigning numbers 1 or 2 to a bool always
resulted in true. Now fixed and repeated
shapes are drawn in the proper order.

before:
<img width="700" alt="Zrzut ekranu 2024-06-18 o 17 00 46" src="https://github.com/thorvg/thorvg/assets/67589014/ee9a6219-7822-4b4e-b47f-194561d55379">

after:
<img width="700" alt="Zrzut ekranu 2024-06-18 o 17 02 38" src="https://github.com/thorvg/thorvg/assets/67589014/cba25026-9671-431c-a27f-ffc1e99b6c86">


AE:
<img width="300" alt="Zrzut ekranu 2024-06-18 o 16 50 40" src="https://github.com/thorvg/thorvg/assets/67589014/d6f9efd5-91ab-443e-b5e7-92a60db617b3">
<img width="300" alt="Zrzut ekranu 2024-06-18 o 16 50 20" src="https://github.com/thorvg/thorvg/assets/67589014/37afa2de-a1e8-4e45-8aa1-16f84d1bd1f1">

sample:
[abowe.json](https://github.com/user-attachments/files/15888508/abowe.json)
[below.json](https://github.com/user-attachments/files/15888510/below.json)
