### PR TITLE
common: add missing ifdef

### DIFF
--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -438,6 +438,7 @@ LoadModule* LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h, bool
 //loads fonts from memory - loader is cached (regardless of copy value) in order to access it while setting font
 LoadModule* LoaderMgr::loader(const char* name, const char* data, uint32_t size, TVG_UNUSED const string& mimeType, bool copy)
 {
+#ifdef THORVG_TTF_LOADER_SUPPORT
     //TODO: add check for mimetype ?
     if (auto loader = _findFromCache(name)) return loader;
 
@@ -453,5 +454,6 @@ LoadModule* LoaderMgr::loader(const char* name, const char* data, uint32_t size,
 
     TVGLOG("LOADER", "The font data \"%s\" could not be loaded.", name);
     delete(loader);
+#endif
     return nullptr;
 }

--- a/test/testSavers.cpp
+++ b/test/testSavers.cpp
@@ -100,7 +100,7 @@ TEST_CASE("Save scene into tvg", "[tvgSavers]")
 #endif
 
 
-#ifdef THORVG_GIF_SAVER_SUPPORT
+#if defined(THORVG_GIF_SAVER_SUPPORT) && defined(THORVG_LOTTIE_LOADER_SUPPORT)
 
 TEST_CASE("Save a lottie into gif", "[tvgSavers]")
 {


### PR DESCRIPTION
In the absence of support for the TTF loader
crashes occurred. Fixed.