### PR TITLE
sw_engine: ++exception handling

### DIFF
--- a/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -924,6 +924,9 @@ static void _calcAAEdge(AASpans *aaSpans, int32_t eidx)
 
     //Calculates AA Edges
     for (y++; y < yEnd; y++) {
+
+        if (lines[y].x[0] == INT32_MAX) continue;
+
         //Ready tx
         if (eidx == 0) {
             tx[0] = pEdge.x;


### PR DESCRIPTION
prevent the out of range anti-aliasing frames.

issue: https://github.com/thorvg/thorvg/issues/2401