### PR TITLE
lottie/text: Support text range selector (Phase 1)

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1057,12 +1057,13 @@ static void _updateText(LottieLayer* layer, float frameNo)
     if (!p || !text->font) return;
 
     auto scale = doc.size * 0.01f;
-    float spacing = text->spacing(frameNo) / scale;
     Point cursor = {0.0f, 0.0f};
     auto scene = Scene::gen();
     int line = 0;
 
     //text string
+    int idx = 0;
+    auto totalChars = strlen(p);
     while (true) {
         //TODO: remove nested scenes.
         //end of text, new line of the cursor position
@@ -1114,19 +1115,60 @@ static void _updateText(LottieLayer* layer, float frameNo)
                     shape->strokeFill(doc.stroke.color.rgb[0], doc.stroke.color.rgb[1], doc.stroke.color.rgb[2]);
                 }
 
+                //text range process
+                for (auto s = text->ranges.begin(); s < text->ranges.end(); ++s) {
+                    float divisor = (*s)->rangeUnit == LottieTextRange::Unit::Percent ? (100.0f / totalChars) : 1;
+                    auto offset = (*s)->offset(frameNo) / divisor;
+                    auto start = round((*s)->start(frameNo) / divisor) + offset;
+                    auto end = round((*s)->end(frameNo) / divisor) + offset;
+
+                    if (start > end) std::swap(start, end);
+
+                    if (idx < start || idx >= end) continue;
+                    auto matrix = PP(shape.get())->transform();
+
+                    shape->opacity((*s)->style.opacity(frameNo));
+
+                    auto color = (*s)->style.fillColor(frameNo);
+                    shape->fill(color.rgb[0], color.rgb[1], color.rgb[2], (*s)->style.fillOpacity(frameNo));
+
+                    rotate(matrix, (*s)->style.rotation(frameNo));
+
+                    auto glyphScale = (*s)->style.scale(frameNo) * 0.01f;
+                    tvg::scale(matrix, glyphScale.x, glyphScale.y);
+
+                    auto position = (*s)->style.position(frameNo);
+                    translate(matrix, position.x, position.y);
+
+                    shape->transform(*matrix);
+
+                    if (doc.stroke.render) {
+                        auto strokeColor = (*s)->style.strokeColor(frameNo);
+
+                        shape->strokeWidth((*s)->style.strokeWidth(frameNo) / scale);
+                        shape->strokeFill(strokeColor.rgb[0], strokeColor.rgb[1], strokeColor.rgb[2], (*s)->style.strokeOpacity(frameNo));
+                    }
+
+                    cursor.x += (*s)->style.letterSpacing(frameNo);
+                }
+
                 scene->push(std::move(shape));
 
                 p += glyph->len;
+                idx += glyph->len;
 
                 //advance the cursor position horizontally
-                cursor.x += glyph->width + spacing + doc.tracking;
+                cursor.x += glyph->width + doc.tracking;
 
                 found = true;
                 break;
             }
         }
 
-        if (!found) ++p;
+        if (!found) {
+            ++p;
+            ++idx;
+        }
     }
 }
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -148,6 +148,43 @@ struct LottieGlyph
 };
 
 
+struct LottieTextStyle
+{
+    LottieColor fillColor = RGB24{255, 255, 255};
+    LottieColor strokeColor = RGB24{255, 255, 255};
+    LottiePosition position = Point{0, 0};
+    LottiePoint scale = Point{100, 100};
+    LottieFloat letterSpacing = 0.0f;
+    LottieFloat strokeWidth = 0.0f;
+    LottieFloat rotation = 0.0f;
+    LottieOpacity fillOpacity = 255;
+    LottieOpacity strokeOpacity = 255;
+    LottieOpacity opacity = 255;
+};
+
+
+struct LottieTextRange
+{
+    enum Based : uint8_t { Chars = 1, CharsExcludingSpaces, Words, Lines };
+    enum Shape : uint8_t { Square = 1, RampUp, RampDown, Triangle, Round, Smooth };
+    enum Unit : uint8_t { Percent = 1, Index };
+
+    LottieTextStyle style;
+    LottieFloat offset = 0.0f;
+    LottieFloat maxEase = 0.0f;
+    LottieFloat minEase = 0.0f;
+    LottieFloat maxAmount = 0.0f;
+    LottieFloat smoothness = 0.0f;
+    LottieFloat start = 0.0f;
+    LottieFloat end = 0.0f;
+    Based based = Chars;
+    Shape shape = Square;
+    Unit rangeUnit = Percent;
+    bool expressible = false;
+    bool randomize = false;
+};
+
+
 struct LottieFont
 {
     enum Origin : uint8_t { Local = 0, CssURL, ScriptURL, FontURL, Embedded };
@@ -195,7 +232,12 @@ struct LottieText : LottieObject
 
     LottieTextDoc doc;
     LottieFont* font;
-    LottieFloat spacing = 0.0f;  //letter spacing
+    Array<LottieTextRange*> ranges;
+
+    ~LottieText()
+    {
+        for (auto r = ranges.begin(); r < ranges.end(); ++r) delete(*r);
+    }
 };
 
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1120,15 +1120,46 @@ void LottieParser::parseTextRange(LottieText* text)
     enterArray();
     while (nextArrayValue()) {
         enterObject();
+
+        auto selector = new LottieTextRange;
+
         while (auto key = nextObjectKey()) {
-            if (KEY_AS("a")) {  //text style
+            if (KEY_AS("s")) { // text range selector
                 enterObject();
                 while (auto key = nextObjectKey()) {
-                    if (KEY_AS("t")) parseProperty<LottieProperty::Type::Float>(text->spacing);
+                    if (KEY_AS("t")) selector->expressible = (bool) getInt();
+                    else if (KEY_AS("xe")) parseProperty<LottieProperty::Type::Float>(selector->maxEase);
+                    else if (KEY_AS("ne")) parseProperty<LottieProperty::Type::Float>(selector->minEase);
+                    else if (KEY_AS("a")) parseProperty<LottieProperty::Type::Float>(selector->maxAmount);
+                    else if (KEY_AS("b")) selector->based = (LottieTextRange::Based) getInt();
+                    else if (KEY_AS("rn")) selector->randomize = (bool) getInt();
+                    else if (KEY_AS("sh")) selector->shape = (LottieTextRange::Shape) getInt();
+                    else if (KEY_AS("o")) parseProperty<LottieProperty::Type::Float>(selector->offset);
+                    else if (KEY_AS("r")) selector->rangeUnit = (LottieTextRange::Unit) getInt();
+                    else if (KEY_AS("sm")) parseProperty<LottieProperty::Type::Float>(selector->smoothness);
+                    else if (KEY_AS("s")) parseProperty<LottieProperty::Type::Float>(selector->start);
+                    else if (KEY_AS("e")) parseProperty<LottieProperty::Type::Float>(selector->end);
+                    else skip(key);
+                }
+            } else if (KEY_AS("a")) { // text style
+                enterObject();
+                while (auto key = nextObjectKey()) {
+                    if (KEY_AS("t")) parseProperty<LottieProperty::Type::Float>(selector->style.letterSpacing);
+                    else if (KEY_AS("fc")) parseProperty<LottieProperty::Type::Color>(selector->style.fillColor);
+                    else if (KEY_AS("fo")) parseProperty<LottieProperty::Type::Color>(selector->style.fillOpacity);
+                    else if (KEY_AS("sw")) parseProperty<LottieProperty::Type::Float>(selector->style.strokeWidth);
+                    else if (KEY_AS("sc")) parseProperty<LottieProperty::Type::Color>(selector->style.strokeColor);
+                    else if (KEY_AS("so")) parseProperty<LottieProperty::Type::Opacity>(selector->style.strokeOpacity);
+                    else if (KEY_AS("o")) parseProperty<LottieProperty::Type::Opacity>(selector->style.opacity);
+                    else if (KEY_AS("p")) parseProperty<LottieProperty::Type::Position>(selector->style.position);
+                    else if (KEY_AS("s")) parseProperty<LottieProperty::Type::Position>(selector->style.scale);
+                    else if (KEY_AS("r")) parseProperty<LottieProperty::Type::Float>(selector->style.rotation);
                     else skip(key);
                 }
             } else skip(key);
         }
+
+        text->ranges.push(selector);
     }
 }
 


### PR DESCRIPTION
Issue: #2178 (Partial support of Text Range Selector)

New supported properties of this patch:

### [Text Range selector](https://lottiefiles.github.io/lottie-docs/text/#text-range-selector) (Units)

I referred to [lottie-web](https://github.com/airbnb/lottie-web/blob/master/build/player/lottie_canvas_worker.js#L11470) for the offset calculating logic.

  - Percent  ([range_selector_text_style_fill_color_percent.json](https://github.com/user-attachments/files/15912127/range_selector_text_style_fill_color_percent.json))
  - Index ([range_selector_text_style_fill_color_index.json](https://github.com/user-attachments/files/15912136/range_selector_text_style_fill_color_index.json))

### Text Range > [Text Style](https://lottiefiles.github.io/lottie-docs/text/#text-style)
  - Fill Color ([range_selector_text_style_fill_color_blue.json](https://github.com/user-attachments/files/15912144/range_selector_text_style_fill_color_blue.json))

![CleanShot 2024-06-20 at 18 57 02@2x](https://github.com/thorvg/thorvg/assets/11167117/c4180256-7f80-4ceb-94b3-e8441b1f3182)

  - Fill Opacity (_lottie-web not working_, [range_selector_text_style_fill_opacity_50.json](https://github.com/user-attachments/files/15942670/range_selector_text_style_fill_opacity_50.json))

![CleanShot 2024-06-23 at 14 41 32@2x](https://github.com/thorvg/thorvg/assets/11167117/05e8f542-ed8f-4abd-afca-00c51bb4cc97)


  - Storke Color ([range_selector_text_stroke_color_yellow.json](https://github.com/user-attachments/files/15912150/range_selector_text_stroke_color_yellow.json))

![CleanShot 2024-06-20 at 18 59 11@2x](https://github.com/thorvg/thorvg/assets/11167117/f7fe2cda-208c-4244-a386-84eea384c656)


  - Stroke Width ([range_selector_text_stroke_width_thick.json](https://github.com/user-attachments/files/15912156/range_selector_text_stroke_width_thick.json))

![CleanShot 2024-06-20 at 18 59 36@2x](https://github.com/thorvg/thorvg/assets/11167117/a6f8689a-07fd-4df0-9ab0-fb11b990ccde)

  - Stroke Opacity (_lottie-web not working_, [range_selector_text_style_stroke_opacity_50.json](https://github.com/user-attachments/files/15942686/range_selector_text_style_stroke_opacity_50.json))

![CleanShot 2024-06-23 at 14 40 19@2x](https://github.com/thorvg/thorvg/assets/11167117/1a0e6e9d-c18e-4b52-9a08-c8eafe4765f9)

  - Opacity ([range_selector_text_style_opacity_50_index.json](https://github.com/user-attachments/files/15942665/range_selector_text_style_opacity_50_index.json))

![CleanShot 2024-06-20 at 18 58 10@2x](https://github.com/thorvg/thorvg/assets/11167117/c934963a-ad50-4222-aff2-10dbf935d1a5)

  - Transform > Rotation ([range_selector_text_rotation_50.json](https://github.com/user-attachments/files/15912159/range_selector_text_rotation_50.json))

![CleanShot 2024-06-20 at 19 01 26@2x](https://github.com/thorvg/thorvg/assets/11167117/4b660062-ab0b-4572-b51e-04ddceceab87)

  - Transform > Position ([range_selector_text_position.json](https://github.com/user-attachments/files/15942856/range_selector_text_position.json))

![CleanShot 2024-06-20 at 19 02 18@2x](https://github.com/thorvg/thorvg/assets/11167117/ab37624e-49c9-4856-a3af-c582bda05114)

  - Transform > Scale ([range_selector_text_scale_50.json](https://github.com/user-attachments/files/15912162/range_selector_text_scale_50.json))

![CleanShot 2024-06-23 at 15 54 19@2x](https://github.com/thorvg/thorvg/assets/11167117/e2a4abf1-31c5-4ba0-ac6a-df999043b9dd)


