### PR TITLE
sw_engine: fix stroke miterlimit precision

### DIFF
--- a/src/renderer/sw_engine/tvgSwStroke.cpp
+++ b/src/renderer/sw_engine/tvgSwStroke.cpp
@@ -238,7 +238,7 @@ static void _outside(SwStroke& stroke, int32_t side, SwFixed lineLength)
     } else {
         //this is a mitered (pointed) or beveled (truncated) corner
         auto rotate = SIDE_TO_ROTATE(side);
-        auto bevel = (stroke.join == StrokeJoin::Bevel) ? true : false;
+        auto bevel = stroke.join == StrokeJoin::Bevel;
         SwFixed phi = 0;
         SwFixed thcos = 0;
 
@@ -816,7 +816,7 @@ void strokeReset(SwStroke* stroke, const RenderShape* rshape, const Matrix* tran
 
     stroke->width = HALF_STROKE(rshape->strokeWidth());
     stroke->cap = rshape->strokeCap();
-    stroke->miterlimit = static_cast<SwFixed>(rshape->strokeMiterlimit()) << 16;
+    stroke->miterlimit = static_cast<SwFixed>(rshape->strokeMiterlimit() * 65536.0f);
 
     //Save line join: it can be temporarily changed when stroking curves...
     stroke->joinSaved = stroke->join = rshape->strokeJoin();


### PR DESCRIPTION
Since the value was casted to int the results
were different than expected.

before:
<img width="304" alt="Zrzut ekranu 2024-06-20 o 16 30 30" src="https://github.com/thorvg/thorvg/assets/67589014/d7be2b12-ae7e-4cf9-81d9-98111adfd478">

after:
<img width="319" alt="Zrzut ekranu 2024-06-20 o 16 30 52" src="https://github.com/thorvg/thorvg/assets/67589014/7d3e6873-1f51-40e1-a850-16d858ea93ac">

sample:
```
<svg viewBox="0 -20 108 100">
          <path
            stroke="red"
            stroke-width="4"
            transform="scale(2)"
            fill="none"
            stroke-linejoin="miter"
            stroke-miterlimit="7"
            id="p1"
            d="M 16 20 L 21 5 l 0 50  " />

          <path
            stroke="blue"
            opacity="0.4"
            stroke-width="4"
            transform="scale(2)"
            fill="none"
            stroke-linejoin="miter"
            stroke-miterlimit="6.9"
            id="p1"
            d="M 16 20 L 21 5 l 0 50  " />

        </svg>```
        
        