### PR TITLE
renderer/canvas: Check refresh before draw

### DIFF
--- a/src/renderer/tvgCanvas.h
+++ b/src/renderer/tvgCanvas.h
@@ -114,6 +114,7 @@ struct Canvas::Impl
 
     Result draw()
     {
+        if (refresh) update(nullptr, false);
         if (status == Status::Drawing || paints.empty() || !renderer->preRender()) return Result::InsufficientCondition;
 
         bool rendered = false;


### PR DESCRIPTION
If target() is called again after update()(or without update()) is called and the size of the buffer changes, a crash may occur.
Therefore, check the refresh variable and do draw after update().

issue: https://github.com/thorvg/thorvg/issues/2444