### PR TITLE
gl_engine: Fix compile error if only has OpenGL library on MacOS

### DIFF
--- a/examples/Example.h
+++ b/examples/Example.h
@@ -317,7 +317,19 @@ struct GlWindow : Window
 
     GlWindow(Example* example, uint32_t width, uint32_t height) : Window(tvg::CanvasEngine::Gl, example, width, height)
     {
-        window = SDL_CreateWindow("ThorVG Example (OpenGL)", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+        window = SDL_CreateWindow("ThorVG Example (OpenGLES)", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE);
+
+        if (window == nullptr) {
+            // try create OpenGLES context failed, create OpenGL context instead
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+            SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+            window = SDL_CreateWindow("ThorVG Example (OpenGL)", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE);
+        }
+
         context = SDL_GL_CreateContext(window);
     }
 

--- a/src/renderer/gl_engine/meson.build
+++ b/src/renderer/gl_engine/meson.build
@@ -36,15 +36,26 @@ if not gles_dep.found()
   gles_dep = dependency('GLESv2', required: false)
 endif
 
+link_opengl = false
+
 if not gles_dep.found()
   gles_dep = dependency('GL')
+  link_opengl = true
 endif
 
 if not gles_dep.found()
   gles_dep = meson.get_compiler('cpp').find_library('GL')
+  link_opengl = true
+endif
+
+if link_opengl
+    gl_target_define = '-DTHORVG_GL_TARGET_GL=1'
+else
+    gl_target_define = '-DTHORVG_GL_TARGET_GLES=1'
 endif
 
 engine_dep += [declare_dependency(
+    compile_args        : gl_target_define,
     dependencies        : gles_dep,
     include_directories : include_directories('.'),
     sources             : source_file,

--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -24,7 +24,15 @@
 #define _TVG_GL_COMMON_H_
 
 #include <assert.h>
-#include <GLES3/gl3.h>
+#if defined (THORVG_GL_TARGET_GLES)
+    #include <GLES3/gl3.h>
+#elif defined (THORVG_GL_TARGET_GL)
+    #if defined(__APPLE__) || defined(__MACH__)
+        #include <OpenGL/gl3.h>
+    #else
+        #include <GL/gl3.h>
+    #endif
+#endif
 #include "tvgCommon.h"
 #include "tvgRender.h"
 

--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -193,9 +193,11 @@ void GlComposeTask::run()
         mTasks[i]->run();
     }
 
+#if defined(THORVG_GL_TARGET_GLES)
+    // only OpenGLES has tiled base framebuffer and discard function
     GLenum attachments[2] = {GL_STENCIL_ATTACHMENT, GL_DEPTH_ATTACHMENT };
     GL_CHECK(glInvalidateFramebuffer(GL_FRAMEBUFFER, 2, attachments));
-
+#endif
     // reset scissor box
     GL_CHECK(glScissor(0, 0, mFbo->getWidth(), mFbo->getHeight()));
     onResolve();

--- a/src/renderer/gl_engine/tvgGlShader.cpp
+++ b/src/renderer/gl_engine/tvgGlShader.cpp
@@ -73,9 +73,12 @@ uint32_t GlShader::complileShader(uint32_t type, char* shaderSrc)
      * [2] shader source
      */
     const char* shaderPack[3];
-    // for now only support GLES version
     // but in general All Desktop GPU should use OpenGL version ( #version 330 core )
+#if defined (THORVG_GL_TARGET_GLES)
     shaderPack[0] ="#version 300 es\n";
+#elif defined (THORVG_GL_TARGET_GL)
+    shaderPack[0] ="#version 330 core\n";
+#endif
     shaderPack[1] = "precision highp float;\n precision mediump int;\n";
     shaderPack[2] = shaderSrc;
 


### PR DESCRIPTION
This PR make the GL backend can be compile and running when link with OpenGL on MacOS. Since GLES is only available in iOS.

BTW:
The Windows platform may have the same problem. 