### PR TITLE
examples: fix crash in window creation

### DIFF
--- a/examples/Example.h
+++ b/examples/Example.h
@@ -268,7 +268,7 @@ struct SwWindow : Window
 
     SwWindow(Example* example, uint32_t width, uint32_t height) : Window(tvg::CanvasEngine::Sw, example, width, height)
     {
-        window = SDL_CreateWindow("ThorVG Example (Software)", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE);
+        window = SDL_CreateWindow("ThorVG Example (Software)", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
     }
 
     bool ready() override
@@ -317,7 +317,7 @@ struct GlWindow : Window
 
     GlWindow(Example* example, uint32_t width, uint32_t height) : Window(tvg::CanvasEngine::Gl, example, width, height)
     {
-        window = SDL_CreateWindow("ThorVG Example (OpenGL)", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE);
+        window = SDL_CreateWindow("ThorVG Example (OpenGL)", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
         context = SDL_GL_CreateContext(window);
     }
 


### PR DESCRIPTION
SDL flag combination(SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE) causes crash.

![CleanShot 2024-06-23 at 13 55 52@2x](https://github.com/thorvg/thorvg/assets/11167117/912266c4-35a9-4af3-ac2c-7ffaf1649e14)
