### PR TITLE
example: clear buffer properly.

### DIFF
--- a/examples/DirectUpdate.cpp
+++ b/examples/DirectUpdate.cpp
@@ -66,6 +66,9 @@ struct UserExample : tvgexam::Example
     {
         if (!canvas) return false;
 
+        //clear buffer and redraw!
+        if (!tvgexam::verify(canvas->clear(false))) return false;
+
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 
         //Reset Shape


### PR DESCRIPTION
The update might affect areas outside of the
default window. Update the sample to handle window resizing.