### PR TITLE
doc: removed useless information for easier maintainence

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -72,6 +72,10 @@ class Animation;
 
 /**
  * @brief Enumeration specifying the result from the APIs.
+ *
+ * All ThorVG APIs could potentially return one of the values in the list.
+ * Please note that some APIs may additionally specify the reasons that trigger their return values.
+ *
  */
 enum class Result
 {
@@ -278,8 +282,6 @@ public:
      * The rotational axis passes through the point on the object with zero coordinates.
      *
      * @param[in] degree The value of the angle in degrees.
-     *
-     * @retval Result::Success when succeed, Result::FailedAllocation otherwise.
      */
     Result rotate(float degree) noexcept;
 
@@ -287,8 +289,6 @@ public:
      * @brief Sets the scale value of the object.
      *
      * @param[in] factor The value of the scaling factor. The default value is 1.
-     *
-     * @retval Result::Success when succeed, Result::FailedAllocation otherwise.
      */
     Result scale(float factor) noexcept;
 
@@ -300,8 +300,6 @@ public:
      *
      * @param[in] x The value of the horizontal shift.
      * @param[in] y The value of the vertical shift.
-     *
-     * @retval Result::Success when succeed, Result::FailedAllocation otherwise.
      */
     Result translate(float x, float y) noexcept;
 
@@ -311,8 +309,6 @@ public:
      * The augmented matrix of the transformation is expected to be given.
      *
      * @param[in] m The 3x3 augmented matrix.
-     *
-     * @retval Result::Success when succeed, Result::FailedAllocation otherwise.
      */
     Result transform(const Matrix& m) noexcept;
 
@@ -333,8 +329,6 @@ public:
      *
      * @param[in] o The opacity value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque.
      *
-     * @retval Result::Success when succeed.
-     *
      * @note Setting the opacity with this API may require multiple render pass for composition. It is recommended to avoid changing the opacity if possible.
      * @note ClipPath won't use the opacity value. (see: enum class CompositeMethod::ClipPath)
      */
@@ -345,8 +339,6 @@ public:
      *
      * @param[in] target The paint of the target object.
      * @param[in] method The method used to composite the source object with the target.
-     *
-     * @retval Result::Success when succeed, Result::InvalidArguments otherwise.
      */
     Result composite(std::unique_ptr<Paint> target, CompositeMethod method) noexcept;
 
@@ -358,8 +350,6 @@ public:
      * The blending operation is determined by the chosen @p BlendMethod, which specifies how the colors or images are combined.
      *
      * @param[in] method The blending method to be set.
-     *
-     * @retval Result::Success when the blending method is successfully set.
      *
      * @note Experimental API
      */
@@ -375,8 +365,6 @@ public:
      * @param[out] w The width of the object.
      * @param[out] h The height of the object.
      * @param[in] transformed If @c true, the paint's transformations are taken into account, otherwise they aren't.
-     *
-     * @retval Result::Success when succeed, Result::InsufficientCondition otherwise.
      *
      * @note The bounding box doesn't indicate the actual drawing region. It's the smallest rectangle that encloses the object.
      */
@@ -464,8 +452,6 @@ public:
      *
      * @param[in] colorStops An array of ColorStop data structure.
      * @param[in] cnt The count of the @p colorStops array equal to the colors number used in the gradient.
-     *
-     * @retval Result::Success when succeed.
      */
     Result colorStops(const ColorStop* colorStops, uint32_t cnt) noexcept;
 
@@ -473,8 +459,6 @@ public:
      * @brief Sets the FillSpread value, which specifies how to fill the area outside the gradient bounds.
      *
      * @param[in] s The FillSpread value.
-     *
-     * @retval Result::Success when succeed.
      */
     Result spread(FillSpread s) noexcept;
 
@@ -484,8 +468,6 @@ public:
      * The augmented matrix of the transformation is expected to be given.
      *
      * @param[in] m The 3x3 augmented matrix.
-     *
-     * @retval Result::Success when succeed, Result::FailedAllocation otherwise.
      */
     Result transform(const Matrix& m) noexcept;
 
@@ -572,9 +554,7 @@ public:
      *
      * @param[in] paint A Paint object to be drawn.
      *
-     * @retval Result::Success When succeed.
      * @retval Result::MemoryCorruption In case a @c nullptr is passed as the argument.
-     * @retval Result::InsufficientCondition An internal error.
      *
      * @note The rendering order of the paints is the same as the order as they were pushed into the canvas. Consider sorting the paints before pushing them if you intend to use layering.
      * @see Canvas::paints()
@@ -592,8 +572,6 @@ public:
      * @param[in] paints If @c true, the memory occupied by paints is deallocated; otherwise, the paints will be retained on the canvas.
      * @param[in] buffer If @c true, the canvas target buffer is cleared with a zero value.
      *
-     * @retval Result::Success when succeed, Result::InsufficientCondition otherwise.
-     *
      * @see Canvas::push()
      * @see Canvas::paints()
      */
@@ -607,16 +585,12 @@ public:
      *
      * @param[in] paint A pointer to the Paint object or @c nullptr.
      *
-     * @retval Result::Success when succeed, Result::InsufficientCondition otherwise.
-     *
      * @note The Update behavior can be asynchronous if the assigned thread number is greater than zero.
      */
     virtual Result update(Paint* paint = nullptr) noexcept;
 
     /**
      * @brief Requests the canvas to draw the Paint objects.
-     *
-     * @retval Result::Success when succeed, Result::InsufficientCondition otherwise.
      *
      * @note Drawing can be asynchronous if the assigned thread number is greater than zero. To guarantee the drawing is done, call sync() afterwards.
      * @see Canvas::sync()
@@ -633,8 +607,6 @@ public:
      * @param[in] y The y-coordinate of the upper-left corner of the rectangle.
      * @param[in] w The width of the rectangle.
      * @param[in] h The height of the rectangle.
-     *
-     * @retval Result::Success when succeed, Result::InsufficientCondition otherwise.
      *
      * @see SwCanvas::target()
      * @see GlCanvas::target()
@@ -653,7 +625,6 @@ public:
      * The Canvas rendering can be performed asynchronously. To make sure that rendering is finished,
      * the sync() must be called after the draw() regardless of threading.
      *
-     * @retval Result::Success when succeed, Result::InsufficientCondition otherwise.
      * @see Canvas::draw()
      */
     virtual Result sync() noexcept;
@@ -687,8 +658,6 @@ public:
      * @param[in] x2 The horizontal coordinate of the second point used to determine the gradient bounds.
      * @param[in] y2 The vertical coordinate of the second point used to determine the gradient bounds.
      *
-     * @retval Result::Success when succeed.
-     *
      * @note In case the first and the second points are equal, an object filled with such a gradient fill is not rendered.
      */
     Result linear(float x1, float y1, float x2, float y2) noexcept;
@@ -704,8 +673,6 @@ public:
      * @param[out] y1 The vertical coordinate of the first point used to determine the gradient bounds.
      * @param[out] x2 The horizontal coordinate of the second point used to determine the gradient bounds.
      * @param[out] y2 The vertical coordinate of the second point used to determine the gradient bounds.
-     *
-     * @retval Result::Success when succeed.
      */
     Result linear(float* x1, float* y1, float* x2, float* y2) const noexcept;
 
@@ -749,7 +716,7 @@ public:
      * @param[in] cy The vertical coordinate of the center of the bounding circle.
      * @param[in] radius The radius of the bounding circle.
      *
-     * @retval Result::Success when succeed, Result::InvalidArguments in case the @p radius value is zero or less.
+     * @retval Result::InvalidArguments in case the @p radius value is zero or less.
      */
     Result radial(float cx, float cy, float radius) noexcept;
 
@@ -762,7 +729,6 @@ public:
      * @param[out] cy The vertical coordinate of the center of the bounding circle.
      * @param[out] radius The radius of the bounding circle.
      *
-     * @retval Result::Success when succeed.
      */
     Result radial(float* cx, float* cy, float* radius) const noexcept;
 
@@ -808,8 +774,6 @@ public:
      *
      * The transformation matrix, the color, the fill and the stroke properties are retained.
      *
-     * @retval Result::Success when succeed.
-     *
      * @note The memory, where the path data is stored, is not deallocated at this stage for caching effect.
      */
     Result reset() noexcept;
@@ -821,8 +785,6 @@ public:
      *
      * @param[in] x The horizontal coordinate of the initial point of the sub-path.
      * @param[in] y The vertical coordinate of the initial point of the sub-path.
-     *
-     * @retval Result::Success when succeed.
      */
     Result moveTo(float x, float y) noexcept;
 
@@ -833,8 +795,6 @@ public:
      *
      * @param[in] x The horizontal coordinate of the end-point of the line.
      * @param[in] y The vertical coordinate of the end-point of the line.
-     *
-     * @retval Result::Success when succeed.
      *
      * @note In case this is the first command in the path, it corresponds to the moveTo() call.
      */
@@ -853,8 +813,6 @@ public:
      * @param[in] x The horizontal coordinate of the end-point of the curve.
      * @param[in] y The vertical coordinate of the end-point of the curve.
      *
-     * @retval Result::Success when succeed.
-     *
      * @note In case this is the first command in the path, no data from the path are rendered.
      */
     Result cubicTo(float cx1, float cy1, float cx2, float cy2, float x, float y) noexcept;
@@ -863,8 +821,6 @@ public:
      * @brief Closes the current sub-path by drawing a line from the current point to the initial point of the sub-path.
      *
      * The value of the current point is set to the initial point of the closed sub-path.
-     *
-     * @retval Result::Success when succeed.
      *
      * @note In case the sub-path does not contain any points, this function has no effect.
      */
@@ -890,8 +846,6 @@ public:
      * @param[in] rx The x-axis radius of the ellipse defining the rounded corners of the rectangle.
      * @param[in] ry The y-axis radius of the ellipse defining the rounded corners of the rectangle.
      *
-     * @retval Result::Success when succeed.
-     *
      * @note For @p rx and @p ry greater than or equal to the half of @p w and the half of @p h, respectively, the shape become an ellipse.
      */
     Result appendRect(float x, float y, float w, float h, float rx = 0, float ry = 0) noexcept;
@@ -910,7 +864,6 @@ public:
      * @param[in] rx The x-axis radius of the ellipse.
      * @param[in] ry The y-axis radius of the ellipse.
      *
-     * @retval Result::Success when succeed.
      */
     Result appendCircle(float cx, float cy, float rx, float ry) noexcept;
 
@@ -926,8 +879,6 @@ public:
      * @param[in] startAngle The start angle of the arc given in degrees, measured counter-clockwise from the horizontal line.
      * @param[in] sweep The central angle of the arc given in degrees, measured counter-clockwise from @p startAngle.
      * @param[in] pie Specifies whether to draw radii from the arc's center to both of its end-point - drawn if @c true.
-     *
-     * @retval Result::Success when succeed.
      *
      * @note Setting @p sweep value greater than 360 degrees, is equivalent to calling appendCircle(cx, cy, radius, radius).
      */
@@ -945,8 +896,6 @@ public:
      * @param[in] pts The array of the two-dimensional points.
      * @param[in] ptsCnt The number of the points in the @p pts array.
      *
-     * @retval Result::Success when succeed, Result::InvalidArguments otherwise.
-     *
      * @note The interface is designed for optimal path setting if the caller has a completed path commands already.
      */
     Result appendPath(const PathCommand* cmds, uint32_t cmdCnt, const Point* pts, uint32_t ptsCnt) noexcept;
@@ -956,7 +905,6 @@ public:
      *
      * @param[in] width The width of the stroke. The default value is 0.
      *
-     * @retval Result::Success when succeed.
      */
     Result strokeWidth(float width) noexcept;
 
@@ -968,7 +916,6 @@ public:
      * @param[in] b The blue color channel value in the range [0 ~ 255]. The default value is 0.
      * @param[in] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque. The default value is 0.
      *
-     * @retval Result::Success when succeed.
      */
     Result strokeFill(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255) noexcept;
 
@@ -977,8 +924,7 @@ public:
      *
      * @param[in] f The gradient fill.
      *
-     * @retval Result::Success When succeed.
-     * @retval Result::MemoryCorruption In case a @c nullptr is passed as the argument or an error with accessing it.
+     * @retval Result::MemoryCorruption In case a @c nullptr is passed as the argument.
      */
     Result strokeFill(std::unique_ptr<Fill> f) noexcept;
 
@@ -989,8 +935,6 @@ public:
      * @param[in] cnt The length of the @p dashPattern array.
      * @param[in] offset The shift of the starting point within the repeating dash pattern from which the path's dashing begins.
      *
-     * @retval Result::Success When succeed.
-     * @retval Result::FailedAllocation An internal error with a memory allocation for an object to be dashed.
      * @retval Result::InvalidArguments In case @p dashPattern is @c nullptr and @p cnt > 0, @p cnt is zero, any of the dash pattern values is zero or less.
      *
      * @note To reset the stroke dash pattern, pass @c nullptr to @p dashPattern and zero to @p cnt.
@@ -1005,7 +949,6 @@ public:
      *
      * @param[in] cap The cap style value. The default value is @c StrokeCap::Square.
      *
-     * @retval Result::Success when succeed.
      */
     Result strokeCap(StrokeCap cap) noexcept;
 
@@ -1016,7 +959,6 @@ public:
      *
      * @param[in] join The join style value. The default value is @c StrokeJoin::Bevel.
      *
-     * @retval Result::Success when succeed.
      */
     Result strokeJoin(StrokeJoin join) noexcept;
 
@@ -1025,7 +967,7 @@ public:
      *
      * @param[in] miterlimit The miterlimit imposes a limit on the extent of the stroke join, when the @c StrokeJoin::Miter join style is set. The default value is 4.
      *
-     * @retval Result::Success when succeed or Result::InvalidArgument for @p miterlimit values less than zero.
+     * @retval Result::InvalidArgument for @p miterlimit values less than zero.
      * 
      * @since 0.11
      */
@@ -1041,8 +983,6 @@ public:
      * @param[in] simultaneous Determines how to trim multiple paths within a single shape. If set to @c true (default), trimming is applied simultaneously to all paths;
      * Otherwise, all paths are treated as a single entity with a combined length equal to the sum of their individual lengths and are trimmed as such.
      *
-     * @retval Result::Success when succeed.
-     *
      * @note Experimental API
      */
     Result strokeTrim(float begin, float end, bool simultaneous = true) noexcept;
@@ -1057,8 +997,6 @@ public:
      * @param[in] b The blue color channel value in the range [0 ~ 255]. The default value is 0.
      * @param[in] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque. The default value is 0.
      *
-     * @retval Result::Success when succeed.
-     *
      * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
      * @note ClipPath won't use the fill values. (see: enum class CompositeMethod::ClipPath)
      */
@@ -1071,8 +1009,6 @@ public:
      *
      * @param[in] f The unique pointer to the gradient fill.
      *
-     * @retval Result::Success when succeed, Result::MemoryCorruption otherwise.
-     *
      * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
      */
     Result fill(std::unique_ptr<Fill> f) noexcept;
@@ -1081,8 +1017,6 @@ public:
      * @brief Sets the fill rule for the Shape object.
      *
      * @param[in] r The fill rule value. The default value is @c FillRule::Winding.
-     *
-     * @retval Result::Success when succeed.
      */
     Result fill(FillRule r) noexcept;
 
@@ -1090,8 +1024,6 @@ public:
      * @brief Sets the rendering order of the stroke and the fill.
      *
      * @param[in] strokeFirst If @c true the stroke is rendered before the fill, otherwise the stroke is rendered as the second one (the default option).
-     *
-     * @retval Result::Success when succeed.
      *
      * @since 0.10
      */
@@ -1156,7 +1088,6 @@ public:
      * @param[out] b The blue color channel value in the range [0 ~ 255].
      * @param[out] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque.
      *
-     * @retval Result::Success when succeed, Result::InsufficientCondition otherwise.
      */
     Result strokeFill(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a = nullptr) const noexcept;
 
@@ -1257,10 +1188,8 @@ public:
      *
      * @param[in] path A path to the picture file.
      *
-     * @retval Result::Success When succeed.
      * @retval Result::InvalidArguments In case the @p path is invalid.
      * @retval Result::NonSupport When trying to load a file with an unknown extension.
-     * @retval Result::Unknown If an error occurs at a later stage.
      *
      * @note The Load behavior can be asynchronous if the assigned thread number is greater than zero.
      * @see Initializer::init()
@@ -1280,10 +1209,8 @@ public:
      * @param[in] rpath A resource directory path, if the @p data needs to access any external resources.
      * @param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
      *
-     * @retval Result::Success When succeed.
      * @retval Result::InvalidArguments In case no data are provided or the @p size is zero or less.
      * @retval Result::NonSupport When trying to load a file with an unknown extension.
-     * @retval Result::Unknown If an error occurs at a later stage.
      *
      * @warning: It's the user responsibility to release the @p data memory.
      *
@@ -1301,7 +1228,6 @@ public:
      * @param[in] w A new width of the image in pixels.
      * @param[in] h A new height of the image in pixels.
      *
-     * @retval Result::Success when succeed, Result::InsufficientCondition otherwise.
      */
     Result size(float w, float h) noexcept;
 
@@ -1311,7 +1237,6 @@ public:
      * @param[out] w The width of the image in pixels.
      * @param[out] h The height of the image in pixels.
      *
-     * @retval Result::Success when succeed.
      */
     Result size(float* w, float* h) const noexcept;
 
@@ -1327,9 +1252,6 @@ public:
      * @param[in] h The height of the image @p data in pixels.
      * @param[in] premultiplied If @c true, the given image data is alpha-premultiplied.
      * @param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
-     *
-     * @retval Result::Success When succeed, Result::InsufficientCondition otherwise.
-     * @retval Result::FailedAllocation An internal error possibly with memory allocation.
      *
      * @since 0.9
      */
@@ -1348,9 +1270,6 @@ public:
      *
      * @param[in] triangles An array of Polygons(triangles) that make up the mesh, or null to remove the mesh.
      * @param[in] triangleCnt The number of Polygons(triangles) provided, or 0 to remove the mesh.
-     *
-     * @retval Result::Success When succeed.
-     * @retval Result::Unknown If fails
      *
      * @note The Polygons are copied internally, so modifying them after calling Mesh::mesh has no affect.
      * @warning Please do not use it, this API is not official one. It could be modified in the next version.
@@ -1418,8 +1337,6 @@ public:
      *
      * @param[in] paint A Paint object to be drawn.
      *
-     * @retval Result::Success when succeed, Result::MemoryCorruption otherwise.
-     *
      * @note The rendering order of the paints is the same as the order as they were pushed. Consider sorting the paints before pushing them if you intend to use layering.
      * @see Scene::paints()
      * @see Scene::clear()
@@ -1445,8 +1362,6 @@ public:
      * Depending on the value of the @p free argument, the paints are freed or not.
      *
      * @param[in] free If @c true, the memory occupied by paints is deallocated, otherwise it is not.
-     *
-     * @retval Result::Success when succeed
      *
      * @warning If you don't free the paints they become dangled. They are supposed to be reused, otherwise you are responsible for their lives. Thus please use the @p free argument only when you know how it works, otherwise it's not recommended.
      *
@@ -1497,7 +1412,6 @@ public:
      * @param[in] style The style of the font. It can be used to set the font to 'italic'.
      *                  If not specified, the default style is used. Only 'italic' style is supported currently.
      *
-     * @retval Result::Success when the font properties are set successfully.
      * @retval Result::InsufficientCondition when the specified @p name cannot be found.
      *
      * @note Experimental API
@@ -1512,8 +1426,6 @@ public:
      *
      * @param[in] text The multi-byte text encoded with utf8 string to be rendered.
      *
-     * @retval Result::Success when succeed.
-     *
      * @note Experimental API
      */
     Result text(const char* text) noexcept;
@@ -1525,7 +1437,6 @@ public:
      * @param[in] g The green color channel value in the range [0 ~ 255]. The default value is 0.
      * @param[in] b The blue color channel value in the range [0 ~ 255]. The default value is 0.
      *
-     * @retval Result::Success when succeed.
      * @retval Result::InsufficientCondition when the font has not been set up prior to this operation.
      *
      * @see Text::font()
@@ -1541,7 +1452,6 @@ public:
      *
      * @param[in] f The unique pointer to the gradient fill.
      *
-     * @retval Result::Success when succeed, Result::MemoryCorruption otherwise.
      * @retval Result::InsufficientCondition when the font has not been set up prior to this operation.
      *
      * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
@@ -1560,10 +1470,8 @@ public:
      *
      * @param[in] path The path to the font file.
      *
-     * @retval Result::Success When succeed.
      * @retval Result::InvalidArguments In case the @p path is invalid.
      * @retval Result::NonSupport When trying to load a file with an unknown extension.
-     * @retval Result::Unknown If an error occurs at a later stage.
      *
      * @note Experimental API
      *
@@ -1584,10 +1492,8 @@ public:
      * @param[in] mimeType Mimetype or extension of font data. In case an empty string is provided the loader will be determined automatically.
      * @param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not (default).
      *
-     * @retval Result::Success When succeed.
      * @retval Result::InvalidArguments If no name is provided or if @p size is zero while @p data points to a valid memory location.
      * @retval Result::NonSupport When trying to load a file with an unsupported extension.
-     * @retval Result::Unknown If an error occurs at a later stage.
      * @retval Result::InsufficientCondition If attempting to unload the font data that has not been previously loaded.
      *
      * @warning: It's the user responsibility to release the @p data memory.
@@ -1607,7 +1513,6 @@ public:
      *
      * @param[in] path The file path of the loaded font.
      *
-     * @retval Result::Success Successfully unloads the font data.
      * @retval Result::InsufficientCondition Fails if the loader is not initialized.
      *
      * @note If the font data is currently in use, it will not be immediately unloaded.
@@ -1682,8 +1587,6 @@ public:
      * @param[in] h The height of the raster image.
      * @param[in] cs The value specifying the way the 32-bits colors should be read/written.
      *
-     * @retval Result::Success When succeed.
-     * @retval Result::MemoryCorruption When casting in the internal function implementation failed.
      * @retval Result::InvalidArguments In case no valid pointer is provided or the width, or the height or the stride is zero.
      * @retval Result::InsufficientCondition if the canvas is performing rendering. Please ensure the canvas is synced.
      * @retval Result::NonSupport In case the software engine is not supported.
@@ -1707,7 +1610,6 @@ public:
      *
      * @param[in] policy The method specifying the Memory Pool behavior. The default value is @c MempoolPolicy::Default.
      *
-     * @retval Result::Success When succeed.
      * @retval Result::InsufficientCondition If the canvas contains some paints already.
      * @retval Result::NonSupport In case the software engine is not supported.
      *
@@ -1754,8 +1656,6 @@ public:
      * @param[in] w The width (in pixels) of the raster image.
      * @param[in] h The height (in pixels) of the raster image.
      *
-     * @retval Result::Success When succeed.
-     * @retval Result::MemoryCorruption When casting in the internal function implementation failed.
      * @retval Result::InsufficientCondition if the canvas is performing rendering. Please ensure the canvas is synced.
      * @retval Result::NonSupport In case the gl engine is not supported.
      *
@@ -1844,10 +1744,7 @@ public:
      * @param[in] threads The number of additional threads. Zero indicates only the main thread is to be used.
      * @param[in] engine The engine types to initialize. This is relative to the Canvas types, in which it will be used. For multiple backends bitwise operation is allowed.
      *
-     * @retval Result::Success When succeed.
-     * @retval Result::FailedAllocation An internal error possibly with memory allocation.
      * @retval Result::NonSupport In case the engine type is not supported on the system.
-     * @retval Result::Unknown Others.
      *
      * @note The Initializer keeps track of the number of times it was called. Threads count is fixed at the first init() call.
      * @see Initializer::term()
@@ -1859,10 +1756,8 @@ public:
      *
      * @param[in] engine The engine types to terminate. This is relative to the Canvas types, in which it will be used. For multiple backends bitwise operation is allowed
      *
-     * @retval Result::Success When succeed.
      * @retval Result::InsufficientCondition In case there is nothing to be terminated.
      * @retval Result::NonSupport In case the engine type is not supported on the system.
-     * @retval Result::Unknown Others.
      *
      * @note Initializer does own reference counting for multiple calls.
      * @see Initializer::init()
@@ -1893,7 +1788,6 @@ public:
      *
      * @param[in] no The index of the animation frame to be displayed. The index should be less than the totalFrame().
      *
-     * @retval Result::Success Successfully set the frame.
      * @retval Result::InsufficientCondition if the given @p no is the same as the current frame value.
      * @retval Result::NonSupport The current Picture data does not support animations.
      *
@@ -1965,9 +1859,7 @@ public:
      * @param[in] begin segment start.
      * @param[in] end segment end.
      *
-     * @retval Result::Success When succeed.
      * @retval Result::InsufficientCondition In case the animation is not loaded.
-     * @retval Result::InvalidArguments When the given parameter is invalid.
      * @retval Result::NonSupport When it's not animatable.
      *
      * @note Range from 0.0~1.0
@@ -1983,9 +1875,7 @@ public:
      * @param[out] begin segment start.
      * @param[out] end segment end.
      *
-     * @retval Result::Success When succeed.
      * @retval Result::InsufficientCondition In case the animation is not loaded.
-     * @retval Result::InvalidArguments When the given parameter is invalid.
      * @retval Result::NonSupport When it's not animatable.
      *
      * @note Experimental API
@@ -2046,10 +1936,8 @@ public:
      * @param[in] path A path to the file, in which the paint data is to be saved.
      * @param[in] quality The encoded quality level. @c 0 is the minimum, @c 100 is the maximum value(recommended).
      *
-     * @retval Result::Success When succeed.
      * @retval Result::InsufficientCondition If currently saving other resources.
      * @retval Result::NonSupport When trying to save a file with an unknown extension or in an unsupported format.
-     * @retval Result::MemoryCorruption An internal error.
      * @retval Result::Unknown In case an empty paint is to be saved.
      *
      * @note Saving can be asynchronous if the assigned thread number is greater than zero. To guarantee the saving is done, call sync() afterwards.
@@ -2069,10 +1957,8 @@ public:
      * @param[in] quality The encoded quality level. @c 0 is the minimum, @c 100 is the maximum value(recommended).
      * @param[in] fps The desired frames per second (FPS). For example, to encode data at 60 FPS, pass 60. Pass 0 to keep the original frame data.
      *
-     * @retval Result::Success if the export succeeds.
      * @retval Result::InsufficientCondition if there are ongoing resource-saving operations.
      * @retval Result::NonSupport if an attempt is made to save the file with an unknown extension or in an unsupported format.
-     * @retval Result::MemoryCorruption in case of an internal error.
      * @retval Result::Unknown if attempting to save an empty paint.
      *
      * @note A higher frames per second (FPS) would result in a larger file size. It is recommended to use the default value.
@@ -2090,9 +1976,6 @@ public:
      * The behavior of the Saver works on a sync/async basis, depending on the threading setting of the Initializer.
      * Thus, if you wish to have a benefit of it, you must call sync() after the save() in the proper delayed time.
      * Otherwise, you can call sync() immediately.
-     *
-     * @retval Result::Success when succeed.
-     * @retval Result::InsufficientCondition otherwise.
      *
      * @note The asynchronous tasking is dependent on the Saver module implementation.
      * @see Saver::save()

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -115,6 +115,10 @@ typedef enum {
 
 /**
  * \brief Enumeration specifying the result from the APIs.
+ *
+ * All ThorVG APIs could potentially return one of the values in the list.
+ * Please note that some APIs may additionally specify the reasons that trigger their return values.
+ *
  */
 typedef enum {
     TVG_RESULT_SUCCESS = 0,            ///< The value returned in case of a correct request execution.
@@ -316,11 +320,8 @@ typedef struct
 * \param[in] threads The number of additional threads used to perform rendering. Zero indicates only the main thread is to be used.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
-* \retval TVG_RESULT_FAILED_ALLOCATION An internal error possibly with memory allocation.
 * \retval TVG_RESULT_INVALID_ARGUMENT Unknown engine type.
 * \retval TVG_RESULT_NOT_SUPPORTED Unsupported engine type.
-* \retval TVG_RESULT_UNKNOWN Other error.
 *
 * \note The Initializer keeps track of the number of times it was called. Threads count is fixed at the first init() call.
 * \see tvg_engine_term()
@@ -345,11 +346,9 @@ TVG_API Tvg_Result tvg_engine_init(Tvg_Engine engine_method, unsigned threads);
 *   - TVG_ENGINE_GL: OpenGL rasterizer (not supported yet)
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION Nothing to be terminated.
 * \retval TVG_RESULT_INVALID_ARGUMENT Unknown engine type.
 * \retval TVG_RESULT_NOT_SUPPORTED Unsupported engine type.
-* \retval TVG_RESULT_UNKNOWN An internal error.
 *
 * \see tvg_engine_init()
 * \see Tvg_Engine
@@ -449,8 +448,6 @@ TVG_API Tvg_Canvas* tvg_swcanvas_create(void);
 * - TVG_COLORSPACE_ARGB8888
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
-* \retval TVG_RESULT_MEMORY_CORRUPTION Casting in the internal function implementation failed.
 * \retval TVG_RESULT_INVALID_ARGUMENTS An invalid canvas or buffer pointer passed or one of the @p stride, @p w or @p h being zero.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
 * \retval TVG_RESULT_NOT_SUPPORTED The software engine is not supported.
@@ -476,7 +473,6 @@ TVG_API Tvg_Result tvg_swcanvas_set_target(Tvg_Canvas* canvas, uint32_t* buffer,
 * \param[in] policy The method specifying the Memory Pool behavior. The default value is @c TVG_MEMPOOL_POLICY_DEFAULT.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENTS An invalid canvas pointer passed.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION The canvas contains some paints already.
 * \retval TVG_RESULT_NOT_SUPPORTED The software engine is not supported.
@@ -547,7 +543,6 @@ TVG_API Tvg_Result tvg_swcanvas_set_mempool(Tvg_Canvas* canvas, Tvg_Mempool_Poli
 * \param[in] canvas The Tvg_Canvas object to be destroyed.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer to the Tvg_Canvas object is passed.
 *
 * \note If the paints from the canvas should not be released, the tvg_canvas_clear() with a @c free argument value set to @c false should be called.
@@ -568,7 +563,6 @@ TVG_API Tvg_Result tvg_canvas_destroy(Tvg_Canvas* canvas);
 * They are retained by the canvas until you call tvg_canvas_clear().
 *
 * \return Tvg_Result return values:
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION An internal error.
 *
@@ -604,9 +598,7 @@ TVG_API Tvg_Result tvg_canvas_push(Tvg_Canvas* canvas, Tvg_Paint* paint);
 * \param[in] n The number of objects for which the memory is to be reserved.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Canvas pointer.
-* \retval TVG_RESULT_FAILED_ALLOCATION An internal error with memory allocation.
 */
 TVG_DEPRECATED TVG_API Tvg_Result tvg_canvas_reserve(Tvg_Canvas* canvas, uint32_t n);
 
@@ -621,9 +613,7 @@ TVG_DEPRECATED TVG_API Tvg_Result tvg_canvas_reserve(Tvg_Canvas* canvas, uint32_
 * \param[in] buffer If @c true the canvas target buffer is cleared with a zero value.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Canvas pointer.
-* \retval TVG_RESULT_INSUFFICIENT_CONDITION An internal error.
 *
 * \see tvg_canvas_destroy()
 */
@@ -681,9 +671,7 @@ TVG_API Tvg_Result tvg_canvas_clear(Tvg_Canvas* canvas, bool paints, bool buffer
 * \param[in] canvas The Tvg_Canvas object to be updated.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Canvas pointer.
-* \retval TVG_RESULT_INSUFFICIENT_CONDITION An internal error.
 *
 * \see tvg_canvas_update_paint()
 */
@@ -700,7 +688,6 @@ TVG_API Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas);
 * \param[in] paint The Tvg_Paint object to be updated.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
 *
 * \see tvg_canvas_update()
@@ -716,9 +703,7 @@ TVG_API Tvg_Result tvg_canvas_update_paint(Tvg_Canvas* canvas, Tvg_Paint* paint)
 * \param[in] canvas The Tvg_Canvas object containing elements to be drawn.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Canvas pointer.
-* \retval TVG_RESULT_INSUFFICIENT_CONDITION An internal error.
 *
 * \note Drawing can be asynchronous based on the assigned thread number. To guarantee the drawing is done, call tvg_canvas_sync() afterwards.
 * \see tvg_canvas_sync()
@@ -734,9 +719,7 @@ TVG_API Tvg_Result tvg_canvas_draw(Tvg_Canvas* canvas);
 * \param[in] canvas The Tvg_Canvas object containing elements which were drawn.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Canvas pointer.
-* \retval TVG_RESULT_INSUFFICIENT_CONDITION An internal error.
 *
 * \see tvg_canvas_draw()
 */
@@ -756,8 +739,6 @@ TVG_API Tvg_Result tvg_canvas_sync(Tvg_Canvas* canvas);
 * \param[in] h The height of the rectangle.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
-* \retval TVG_RESULT_INSUFFICIENT_CONDITION An internal error.
 *
 * \warning It's not allowed to change the viewport during tvg_canvas_update() - tvg_canvas_sync() or tvg_canvas_push() - tvg_canvas_sync().
 *
@@ -803,7 +784,6 @@ TVG_API Tvg_Result tvg_canvas_set_viewport(Tvg_Canvas* canvas, int32_t x, int32_
 * \param[in] paint The Tvg_Paint object to be released.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \warning If this function is used, tvg_canvas_clear() with the @c free argument value set to @c false should be used in order to avoid unexpected behaviours.
@@ -820,9 +800,7 @@ TVG_API Tvg_Result tvg_paint_del(Tvg_Paint* paint);
 * \param[in] factor The value of the scaling factor. The default value is 1.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-* \retval TVG_RESULT_FAILED_ALLOCATION An internal error with memory allocation.
 */
 TVG_API Tvg_Result tvg_paint_scale(Tvg_Paint* paint, float factor);
 
@@ -837,9 +815,7 @@ TVG_API Tvg_Result tvg_paint_scale(Tvg_Paint* paint, float factor);
 * \param[in] degree The value of the rotation angle in degrees.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-* \retval TVG_RESULT_FAILED_ALLOCATION An internal error with memory allocation.
 */
 TVG_API Tvg_Result tvg_paint_rotate(Tvg_Paint* paint, float degree);
 
@@ -855,9 +831,7 @@ TVG_API Tvg_Result tvg_paint_rotate(Tvg_Paint* paint, float degree);
 * \param[in] y The value of the vertical shift.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-* \retval TVG_RESULT_FAILED_ALLOCATION An internal error with memory allocation.
 */
 TVG_API Tvg_Result tvg_paint_translate(Tvg_Paint* paint, float x, float y);
 
@@ -871,9 +845,7 @@ TVG_API Tvg_Result tvg_paint_translate(Tvg_Paint* paint, float x, float y);
 * \param[in] m The 3x3 augmented matrix.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr is passed as the argument.
-* \retval TVG_RESULT_FAILED_ALLOCATION An internal error with memory allocation.
 */
 TVG_API Tvg_Result tvg_paint_set_transform(Tvg_Paint* paint, const Tvg_Matrix* m);
 
@@ -887,7 +859,6 @@ TVG_API Tvg_Result tvg_paint_set_transform(Tvg_Paint* paint, const Tvg_Matrix* m
 * \param[out] m The 3x3 augmented matrix.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr is passed as the argument.
 */
 TVG_API Tvg_Result tvg_paint_get_transform(Tvg_Paint* paint, Tvg_Matrix* m);
@@ -900,7 +871,6 @@ TVG_API Tvg_Result tvg_paint_get_transform(Tvg_Paint* paint, Tvg_Matrix* m);
 * \param[in] opacity The opacity value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note Setting the opacity with this API may require multiple renderings using a composition. It is recommended to avoid changing the opacity if possible.
@@ -915,7 +885,6 @@ TVG_API Tvg_Result tvg_paint_set_opacity(Tvg_Paint* paint, uint8_t opacity);
 * \param[out] opacity The opacity value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
 */
 TVG_API Tvg_Result tvg_paint_get_opacity(const Tvg_Paint* paint, uint8_t* opacity);
@@ -944,9 +913,7 @@ TVG_API Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint);
 * \param[in] transformed If @c true, the transformation of the paint is taken into account, otherwise it isn't.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-* \retval TVG_RESULT_INSUFFICIENT_CONDITION Other errors.
 *
 * \note The bounding box doesn't indicate the actual drawing region. It's the smallest rectangle that encloses the object.
 */
@@ -961,7 +928,6 @@ TVG_API Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float*
 * \param[in] method The method used to composite the source object with the target.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid @p paint or @p target object or the @p method equal to TVG_COMPOSITE_METHOD_NONE.
 */
 TVG_API Tvg_Result tvg_paint_set_composite_method(Tvg_Paint* paint, Tvg_Paint* target, Tvg_Composite_Method method);
@@ -975,7 +941,6 @@ TVG_API Tvg_Result tvg_paint_set_composite_method(Tvg_Paint* paint, Tvg_Paint* t
 * \param[out] method The method used to composite the source object with the target.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr is passed as the argument.
 */
 TVG_API Tvg_Result tvg_paint_get_composite_method(const Tvg_Paint* paint, const Tvg_Paint** target, Tvg_Composite_Method* method);
@@ -988,7 +953,6 @@ TVG_API Tvg_Result tvg_paint_get_composite_method(const Tvg_Paint* paint, const 
 * \param[out] identifier The unique identifier of the paint instance type.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
 *
 * \since 0.9
@@ -1068,7 +1032,6 @@ TVG_API Tvg_Paint* tvg_shape_new(void);
 * \param[in] paint A Tvg_Paint pointer to the shape object.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note The memory, where the path data is stored, is not deallocated at this stage for caching effect.
@@ -1086,7 +1049,6 @@ TVG_API Tvg_Result tvg_shape_reset(Tvg_Paint* paint);
 * \param[in] y The vertical coordinate of the initial point of the sub-path.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
 TVG_API Tvg_Result tvg_shape_move_to(Tvg_Paint* paint, float x, float y);
@@ -1102,7 +1064,6 @@ TVG_API Tvg_Result tvg_shape_move_to(Tvg_Paint* paint, float x, float y);
 * \param[in] y The vertical coordinate of the end-point of the line.
 
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note In case this is the first command in the path, it corresponds to the tvg_shape_move_to() call.
@@ -1125,7 +1086,6 @@ TVG_API Tvg_Result tvg_shape_line_to(Tvg_Paint* paint, float x, float y);
 * \param[in] y The vertical coordinate of the endpoint of the curve.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note In case this is the first command in the path, no data from the path are rendered.
@@ -1141,7 +1101,6 @@ TVG_API Tvg_Result tvg_shape_cubic_to(Tvg_Paint* paint, float cx1, float cy1, fl
 * \param[in] paint A Tvg_Paint pointer to the shape object.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note In case the sub-path does not contain any points, this function has no effect.
@@ -1171,7 +1130,6 @@ TVG_API Tvg_Result tvg_shape_close(Tvg_Paint* paint);
 * \param[in] ry The y-axis radius of the ellipse defining the rounded corners of the rectangle.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 & \note For @p rx and @p ry greater than or equal to the half of @p w and the half of @p h, respectively, the shape become an ellipse.
@@ -1195,7 +1153,6 @@ TVG_API Tvg_Result tvg_shape_append_rect(Tvg_Paint* paint, float x, float y, flo
 * \param[in] ry The y-axis radius of the ellipse.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
 TVG_API Tvg_Result tvg_shape_append_circle(Tvg_Paint* paint, float cx, float cy, float rx, float ry);
@@ -1216,7 +1173,6 @@ TVG_API Tvg_Result tvg_shape_append_circle(Tvg_Paint* paint, float cx, float cy,
 * \param[in] pie Specifies whether to draw radii from the arc's center to both of its end-point - drawn if @c true.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note Setting @p sweep value greater than 360 degrees, is equivalent to calling tvg_shape_append_circle(paint, cx, cy, radius, radius).
@@ -1238,7 +1194,6 @@ TVG_API Tvg_Result tvg_shape_append_arc(Tvg_Paint* paint, float cx, float cy, fl
 * \param[in] ptsCnt The length of the @p pts array.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the argument or @p cmdCnt or @p ptsCnt equal to zero.
 */
 TVG_API Tvg_Result tvg_shape_append_path(Tvg_Paint* paint, const Tvg_Path_Command* cmds, uint32_t cmdCnt, const Tvg_Point* pts, uint32_t ptsCnt);
@@ -1264,7 +1219,6 @@ TVG_API Tvg_Result tvg_shape_append_path(Tvg_Paint* paint, const Tvg_Path_Comman
 * \param[out] cnt The length of the @p pts array.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the argument.
 */
 TVG_API Tvg_Result tvg_shape_get_path_coords(const Tvg_Paint* paint, const Tvg_Point** pts, uint32_t* cnt);
@@ -1290,7 +1244,6 @@ TVG_API Tvg_Result tvg_shape_get_path_coords(const Tvg_Paint* paint, const Tvg_P
 * \param[out] cnt The length of the @p cmds array.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the argument.
 */
 TVG_API Tvg_Result tvg_shape_get_path_commands(const Tvg_Paint* paint, const Tvg_Path_Command** cmds, uint32_t* cnt);
@@ -1303,7 +1256,6 @@ TVG_API Tvg_Result tvg_shape_get_path_commands(const Tvg_Paint* paint, const Tvg
 * \param[in] width The width of the stroke. The default value is 0.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
 TVG_API Tvg_Result tvg_shape_set_stroke_width(Tvg_Paint* paint, float width);
@@ -1316,7 +1268,6 @@ TVG_API Tvg_Result tvg_shape_set_stroke_width(Tvg_Paint* paint, float width);
 * \param[out] width The stroke width.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer passed as an argument.
 */
 TVG_API Tvg_Result tvg_shape_get_stroke_width(const Tvg_Paint* paint, float* width);
@@ -1332,7 +1283,6 @@ TVG_API Tvg_Result tvg_shape_get_stroke_width(const Tvg_Paint* paint, float* wid
 * \param[in] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note Either a solid color or a gradient fill is applied, depending on what was set as last.
@@ -1350,7 +1300,6 @@ TVG_API Tvg_Result tvg_shape_set_stroke_color(Tvg_Paint* paint, uint8_t r, uint8
 * \param[out] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION No stroke was set.
 */
@@ -1364,7 +1313,6 @@ TVG_API Tvg_Result tvg_shape_get_stroke_color(const Tvg_Paint* paint, uint8_t* r
 * \param[in] grad The linear gradient fill.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 * \retval TVG_RESULT_MEMORY_CORRUPTION An invalid Tvg_Gradient pointer or an error with accessing it.
 *
@@ -1380,7 +1328,6 @@ TVG_API Tvg_Result tvg_shape_set_stroke_linear_gradient(Tvg_Paint* paint, Tvg_Gr
 * \param[in] grad The radial gradient fill.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 * \retval TVG_RESULT_MEMORY_CORRUPTION An invalid Tvg_Gradient pointer or an error with accessing it.
 *
@@ -1398,7 +1345,6 @@ TVG_API Tvg_Result tvg_shape_set_stroke_radial_gradient(Tvg_Paint* paint, Tvg_Gr
 * \param[out] grad The gradient fill.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer passed as an argument.
 */
 TVG_API Tvg_Result tvg_shape_get_stroke_gradient(const Tvg_Paint* paint, Tvg_Gradient** grad);
@@ -1413,9 +1359,7 @@ TVG_API Tvg_Result tvg_shape_get_stroke_gradient(const Tvg_Paint* paint, Tvg_Gra
 * \param[in] offset The shift of the starting point within the repeating dash pattern from which the path's dashing begins.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer passed as an argument and @p cnt > 0, the given length of the array is less than two or any of the @p dashPattern values is zero or less.
-* \retval TVG_RESULT_FAILED_ALLOCATION An internal error with a memory allocation.
 *
 * \note To reset the stroke dash pattern, pass @c nullptr to @p dashPattern and zero to @p cnt.
 * \since 1.0
@@ -1434,7 +1378,6 @@ TVG_API Tvg_Result tvg_shape_set_stroke_dash(Tvg_Paint* paint, const float* dash
 * \param[out] offset The shift of the starting point within the repeating dash pattern.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer passed as an argument.
 * \since 1.0
 */
@@ -1450,7 +1393,6 @@ TVG_API Tvg_Result tvg_shape_get_stroke_dash(const Tvg_Paint* paint, const float
 * \param[in] cap The cap style value. The default value is @c TVG_STROKE_CAP_SQUARE.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
 TVG_API Tvg_Result tvg_shape_set_stroke_cap(Tvg_Paint* paint, Tvg_Stroke_Cap cap);
@@ -1463,7 +1405,6 @@ TVG_API Tvg_Result tvg_shape_set_stroke_cap(Tvg_Paint* paint, Tvg_Stroke_Cap cap
 * \param[out] cap The cap style value.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer passed as an argument.
 */
 TVG_API Tvg_Result tvg_shape_get_stroke_cap(const Tvg_Paint* paint, Tvg_Stroke_Cap* cap);
@@ -1476,7 +1417,6 @@ TVG_API Tvg_Result tvg_shape_get_stroke_cap(const Tvg_Paint* paint, Tvg_Stroke_C
 * \param[in] join The join style value. The default value is @c TVG_STROKE_JOIN_BEVEL.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
 TVG_API Tvg_Result tvg_shape_set_stroke_join(Tvg_Paint* paint, Tvg_Stroke_Join join);
@@ -1489,7 +1429,6 @@ TVG_API Tvg_Result tvg_shape_set_stroke_join(Tvg_Paint* paint, Tvg_Stroke_Join j
 * \param[out] join The join style value.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer passed as an argument.
 */
 TVG_API Tvg_Result tvg_shape_get_stroke_join(const Tvg_Paint* paint, Tvg_Stroke_Join* join);
@@ -1502,7 +1441,6 @@ TVG_API Tvg_Result tvg_shape_get_stroke_join(const Tvg_Paint* paint, Tvg_Stroke_
 * \param[in] miterlimit The miterlimit imposes a limit on the extent of the stroke join when the @c TVG_STROKE_JOIN_MITER join style is set. The default value is 4.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer or Unsupported @p miterlimit values (less than zero).
 *
 * \since 0.11
@@ -1517,7 +1455,6 @@ TVG_API Tvg_Result tvg_shape_set_stroke_miterlimit(Tvg_Paint* paint, float miter
 * \param[out] miterlimit The stroke miterlimit.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer passed as an argument.
 *
 * \since 0.11
@@ -1537,7 +1474,6 @@ TVG_API Tvg_Result tvg_shape_get_stroke_miterlimit(const Tvg_Paint* paint, float
 * Otherwise, all paths are treated as a single entity with a combined length equal to the sum of their individual lengths and are trimmed as such.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note Experimental API
@@ -1554,7 +1490,6 @@ TVG_API Tvg_Result tvg_shape_set_stroke_trim(Tvg_Paint* paint, float begin, floa
 * \param[out] simultaneous Determines how to trim multiple paths within a shape.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note Experimental API
@@ -1574,7 +1509,6 @@ TVG_API Tvg_Result tvg_shape_get_stroke_trim(Tvg_Paint* paint, float* begin, flo
 * \param[in] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque. The default value is 0.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \note Either a solid color or a gradient fill is applied, depending on what was set as last.
@@ -1593,7 +1527,6 @@ TVG_API Tvg_Result tvg_shape_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t
 * \param[out] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque. The default value is 0.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
 TVG_API Tvg_Result tvg_shape_get_fill_color(const Tvg_Paint* paint, uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a);
@@ -1606,7 +1539,6 @@ TVG_API Tvg_Result tvg_shape_get_fill_color(const Tvg_Paint* paint, uint8_t* r, 
 * \param[in] rule The fill rule value. The default value is @c TVG_FILL_RULE_WINDING.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
 TVG_API Tvg_Result tvg_shape_set_fill_rule(Tvg_Paint* paint, Tvg_Fill_Rule rule);
@@ -1619,7 +1551,6 @@ TVG_API Tvg_Result tvg_shape_set_fill_rule(Tvg_Paint* paint, Tvg_Fill_Rule rule)
 * \param[out] rule shape's fill rule
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer passed as an argument.
 */
 TVG_API Tvg_Result tvg_shape_get_fill_rule(const Tvg_Paint* paint, Tvg_Fill_Rule* rule);
@@ -1632,7 +1563,6 @@ TVG_API Tvg_Result tvg_shape_get_fill_rule(const Tvg_Paint* paint, Tvg_Fill_Rule
 * \param[in] strokeFirst If @c true the stroke is rendered before the fill, otherwise the stroke is rendered as the second one (the default option).
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 * \since 0.10
@@ -1663,7 +1593,6 @@ TVG_API Tvg_Result tvg_shape_set_paint_order(Tvg_Paint* paint, bool strokeFirst)
 * \param[in] grad The linear gradient fill.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 * \retval TVG_RESULT_MEMORY_CORRUPTION An invalid Tvg_Gradient pointer.
 *
@@ -1696,7 +1625,6 @@ TVG_API Tvg_Result tvg_shape_set_linear_gradient(Tvg_Paint* paint, Tvg_Gradient*
 * \param[in] grad The radial gradient fill.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 * \retval TVG_RESULT_MEMORY_CORRUPTION An invalid Tvg_Gradient pointer.
 *
@@ -1715,7 +1643,6 @@ TVG_API Tvg_Result tvg_shape_set_radial_gradient(Tvg_Paint* paint, Tvg_Gradient*
 * \param[out] grad The gradient fill.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer passed as an argument.
 */
 TVG_API Tvg_Result tvg_shape_get_gradient(const Tvg_Paint* paint, Tvg_Gradient** grad);
@@ -1796,7 +1723,6 @@ TVG_API Tvg_Gradient* tvg_radial_gradient_new(void);
 * @param[in] y2 The vertical coordinate of the second point used to determine the gradient bounds.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Gradient pointer.
 *
 * \note In case the first and the second points are equal, an object filled with such a gradient fill is not rendered.
@@ -1818,7 +1744,6 @@ TVG_API Tvg_Result tvg_linear_gradient_set(Tvg_Gradient* grad, float x1, float y
 * \param[out] y2 The vertical coordinate of the second point used to determine the gradient bounds.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Gradient pointer.
 */
 TVG_API Tvg_Result tvg_linear_gradient_get(Tvg_Gradient* grad, float* x1, float* y1, float* x2, float* y2);
@@ -1835,7 +1760,6 @@ TVG_API Tvg_Result tvg_linear_gradient_get(Tvg_Gradient* grad, float* x1, float*
 * \param[in] radius The radius of the bounding circle.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Gradient pointer or the @p radius value less than zero.
 */
 TVG_API Tvg_Result tvg_radial_gradient_set(Tvg_Gradient* grad, float cx, float cy, float radius);
@@ -1850,7 +1774,6 @@ TVG_API Tvg_Result tvg_radial_gradient_set(Tvg_Gradient* grad, float cx, float c
 * \param[out] radius The radius of the bounding circle.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Gradient pointer.
 */
 TVG_API Tvg_Result tvg_radial_gradient_get(Tvg_Gradient* grad, float* cx, float* cy, float* radius);
@@ -1864,7 +1787,6 @@ TVG_API Tvg_Result tvg_radial_gradient_get(Tvg_Gradient* grad, float* cx, float*
 * \param[in] cnt The size of the @p color_stop array equal to the colors number used in the gradient.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Gradient pointer.
 */
 TVG_API Tvg_Result tvg_gradient_set_color_stops(Tvg_Gradient* grad, const Tvg_Color_Stop* color_stop, uint32_t cnt);
@@ -1880,7 +1802,6 @@ TVG_API Tvg_Result tvg_gradient_set_color_stops(Tvg_Gradient* grad, const Tvg_Co
 * \param[out] cnt The size of the @p color_stop array equal to the colors number used in the gradient.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the argument.
 */
 TVG_API Tvg_Result tvg_gradient_get_color_stops(const Tvg_Gradient* grad, const Tvg_Color_Stop** color_stop, uint32_t* cnt);
@@ -1893,7 +1814,6 @@ TVG_API Tvg_Result tvg_gradient_get_color_stops(const Tvg_Gradient* grad, const 
 * \param[in] spread The FillSpread value.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Gradient pointer.
 */
 TVG_API Tvg_Result tvg_gradient_set_spread(Tvg_Gradient* grad, const Tvg_Stroke_Fill spread);
@@ -1906,7 +1826,6 @@ TVG_API Tvg_Result tvg_gradient_set_spread(Tvg_Gradient* grad, const Tvg_Stroke_
 * \param[out] spread The FillSpread value.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the argument.
 */
 TVG_API Tvg_Result tvg_gradient_get_spread(const Tvg_Gradient* grad, Tvg_Stroke_Fill* spread);
@@ -1921,9 +1840,7 @@ TVG_API Tvg_Result tvg_gradient_get_spread(const Tvg_Gradient* grad, Tvg_Stroke_
 * \param[in] m The 3x3 augmented matrix.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr is passed as the argument.
-* \retval TVG_RESULT_FAILED_ALLOCATION An internal error with a memory allocation.
 */
 TVG_API Tvg_Result tvg_gradient_set_transform(Tvg_Gradient* grad, const Tvg_Matrix* m);
 
@@ -1937,7 +1854,6 @@ TVG_API Tvg_Result tvg_gradient_set_transform(Tvg_Gradient* grad, const Tvg_Matr
 * \param[out] m The 3x3 augmented matrix.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr is passed as the argument.
 */
 TVG_API Tvg_Result tvg_gradient_get_transform(const Tvg_Gradient* grad, Tvg_Matrix* m);
@@ -1949,7 +1865,6 @@ TVG_API Tvg_Result tvg_gradient_get_transform(const Tvg_Gradient* grad, Tvg_Matr
 * \param[out] identifier The unique identifier of the gradient instance type.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
 *
 * \since 0.9
@@ -1975,7 +1890,6 @@ TVG_API Tvg_Gradient* tvg_gradient_duplicate(Tvg_Gradient* grad);
 * \param[in] grad The gradient object to be deleted.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Gradient pointer.
 */
 TVG_API Tvg_Result tvg_gradient_del(Tvg_Gradient* grad);
@@ -2015,10 +1929,8 @@ TVG_API Tvg_Paint* tvg_picture_new(void);
 * \param[in] path The absolute path to the image file.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer or an empty @p path.
 * \retval TVG_RESULT_NOT_SUPPORTED A file with an unknown extension.
-* \retval TVG_RESULT_UNKNOWN An error at a later stage.
 */
 TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path);
 
@@ -2038,10 +1950,8 @@ TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path);
 * \param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer or no data are provided or the @p width or @p height value is zero or less.
 * \retval TVG_RESULT_FAILED_ALLOCATION A problem with memory allocation occurs.
-* \retval TVG_RESULT_INSUFFICIENT_CONDITION An error occurs at a later stage.
 *
 * \since 0.9
 */
@@ -2063,10 +1973,8 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32
 * \param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument or the @p size is zero or less.
 * \retval TVG_RESULT_NOT_SUPPORTED A file with an unknown extension.
-* \retval TVG_RESULT_UNKNOWN An error at a later stage.
 *
 * \warning: It's the user responsibility to release the @p data memory if the @p copy is @c true.
 */
@@ -2084,9 +1992,7 @@ TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uin
 * \param[in] h A new height of the image in pixels.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-* \retval TVG_RESULT_INSUFFICIENT_CONDITION An internal error.
 */
 TVG_API Tvg_Result tvg_picture_set_size(Tvg_Paint* paint, float w, float h);
 
@@ -2099,7 +2005,6 @@ TVG_API Tvg_Result tvg_picture_set_size(Tvg_Paint* paint, float w, float h);
 * \param[out] h A height of the image in pixels.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
 TVG_API Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, float* h);
@@ -2141,7 +2046,6 @@ TVG_API Tvg_Paint* tvg_scene_new(void);
 * \param[in] size The number of objects for which the memory is to be reserved.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_FAILED_ALLOCATION An internal error with a memory allocation.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
@@ -2159,9 +2063,7 @@ TVG_DEPRECATED TVG_API Tvg_Result tvg_scene_reserve(Tvg_Paint* scene, uint32_t s
 * \param[in] paint A graphical object to be drawn.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the argument.
-* \retval TVG_RESULT_MEMORY_CORRUPTION An internal error.
 *
 * \note The rendering order of the paints is the same as the order as they were pushed. Consider sorting the paints before pushing them if you intend to use layering.
 */
@@ -2178,7 +2080,6 @@ TVG_API Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint);
 * \param[in] free If @c true the memory occupied by paints is deallocated, otherwise it is not.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Canvas pointer.
 *
 * \warning Please use the @p free argument only when you know how it works, otherwise it's not recommended.
@@ -2223,7 +2124,6 @@ TVG_API Tvg_Paint* tvg_text_new(void);
 * \param[in] style The style of the font. If empty, the default style is used. Currently only 'italic' style is supported.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A \c nullptr passed as the \p paint argument.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION  The specified \p name cannot be found.
 *
@@ -2242,7 +2142,6 @@ TVG_API Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name, float s
 * \param[in] text The multi-byte text encoded with utf8 string to be rendered.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A \c nullptr passed as the \p paint argument.
 *
 * \note Experimental API
@@ -2259,7 +2158,6 @@ TVG_API Tvg_Result tvg_text_set_text(Tvg_Paint* paint, const char* text);
 * \param[in] b The blue color channel value in the range [0 ~ 255]. The default value is 0.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A \c nullptr passed as the \p paint argument.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION The font has not been set up prior to this operation.
 *
@@ -2278,7 +2176,6 @@ TVG_API Tvg_Result tvg_text_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t 
 * \param[in] grad The linear gradient fill
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A \c nullptr passed as the \p paint argument.
 * \retval TVG_RESULT_MEMORY_CORRUPTION An invalid Tvg_Gradient pointer.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION The font has not been set up prior to this operation.
@@ -2298,7 +2195,6 @@ TVG_API Tvg_Result tvg_text_set_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* 
 * \param[in] grad The radial gradient fill
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A \c nullptr passed as the \p paint argument.
 * \retval TVG_RESULT_MEMORY_CORRUPTION An invalid Tvg_Gradient pointer.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION The font has not been set up prior to this operation.
@@ -2321,10 +2217,8 @@ TVG_API Tvg_Result tvg_text_set_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* 
 * \param[in] path The path to the font file.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid \p path passed as an argument.
 * \retval TVG_RESULT_NOT_SUPPORTED When trying to load a file with an unknown extension.
-* \retval TVG_RESULT_UNKNOWN An error occurs at a later stage.
 *
 * \note Experimental API
 *
@@ -2347,11 +2241,9 @@ TVG_API Tvg_Result tvg_font_load(const char* path);
 * \param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not (default).
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT If no name is provided or if \p size is zero while \p data points to a valid memory location.
 * \retval TVG_RESULT_NOT_SUPPORTED When trying to load a file with an unknown extension.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION When trying to unload the font data that has not been previously loaded.
-* \retval TVG_RESULT_UNKNOWN An error occurs at a later stage.
 *
 * \warning: It's the user responsibility to release the \p data memory.
 *
@@ -2369,7 +2261,6 @@ TVG_API Tvg_Result tvg_font_load_data(const char* name, const char* data, uint32
 * \param[in] path The path to the loaded font file.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION The loader is not initialized.
 *
 * \note If the font data is currently in use, it will not be immediately unloaded.
@@ -2417,11 +2308,9 @@ TVG_API Tvg_Saver* tvg_saver_new(void);
 * \param[in] quality The encoded quality level. @c 0 is the minimum, @c 100 is the maximum value(recommended).
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the argument.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION Currently saving other resources.
 * \retval TVG_RESULT_NOT_SUPPORTED Trying to save a file with an unknown extension or in an unsupported format.
-* \retval TVG_RESULT_MEMORY_CORRUPTION An internal error.
 * \retval TVG_RESULT_UNKNOWN An empty paint is to be saved.
 *
 * \note Saving can be asynchronous if the assigned thread number is greater than zero. To guarantee the saving is done, call tvg_saver_sync() afterwards.
@@ -2440,7 +2329,6 @@ TVG_API Tvg_Result tvg_saver_save(Tvg_Saver* saver, Tvg_Paint* paint, const char
 * \param[in] saver The Tvg_Saver object connected with the saving task.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the argument.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION No saving task is running.
 *
@@ -2456,7 +2344,6 @@ TVG_API Tvg_Result tvg_saver_sync(Tvg_Saver* saver);
 * \param[in] saver The Tvg_Saver object to be deleted.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Saver pointer.
 */
 TVG_API Tvg_Result tvg_saver_del(Tvg_Saver* saver);
@@ -2495,7 +2382,6 @@ TVG_API Tvg_Animation* tvg_animation_new(void);
 * \param[in] no The index of the animation frame to be displayed. The index should be less than the tvg_animatio_total_frame().
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Animation pointer.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION if the given @p no is the same as the current frame value.
 * \retval TVG_RESULT_NOT_SUPPORTED The picture data does not support animations.
@@ -2535,7 +2421,6 @@ TVG_API Tvg_Paint* tvg_animation_get_picture(Tvg_Animation* animation);
 * \param[in] no The current frame number of the animation, between 0 and totalFrame() - 1.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Animation pointer or @p no
 *
 * \see tvg_animation_get_total_frame()
@@ -2553,7 +2438,6 @@ TVG_API Tvg_Result tvg_animation_get_frame(Tvg_Animation* animation, float* no);
 * \param[in] cnt The total number of frames in the animation.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Animation pointer or @p cnt.
 *
 * \note Frame numbering starts from 0.
@@ -2571,7 +2455,6 @@ TVG_API Tvg_Result tvg_animation_get_total_frame(Tvg_Animation* animation, float
 * \param[in] duration The duration of the animation in seconds.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Animation pointer or @p duration.
 *
 * \note If the Picture is not properly configured, this function will return 0.
@@ -2589,7 +2472,6 @@ TVG_API Tvg_Result tvg_animation_get_duration(Tvg_Animation* animation, float* d
 * \param[in] end segment end.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION In case the animation is not loaded.
 * \retval TVG_RESULT_INVALID_ARGUMENT When the given parameters are out of range.
 *
@@ -2608,7 +2490,6 @@ TVG_API Tvg_Result tvg_animation_set_segment(Tvg_Animation* animation, float beg
 * \param[out] end segment end.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION In case the animation is not loaded.
 * \retval TVG_RESULT_INVALID_ARGUMENT When the given parameters are @c nullptr.
 *
@@ -2623,7 +2504,6 @@ TVG_API Tvg_Result tvg_animation_get_segment(Tvg_Animation* animation, float* be
 * \param[in] animation The Tvg_Animation object to be deleted.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Animation pointer.
 *
 * \since 0.13
@@ -2663,7 +2543,6 @@ TVG_API Tvg_Animation* tvg_lottie_animation_new(void);
 * \param[in] slot The Lottie slot data in json, or @c nullptr to reset.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION In case the animation is not loaded.
 * \retval TVG_RESULT_INVALID_ARGUMENT When the given @p slot is invalid
 * \retval TVG_RESULT_NOT_SUPPORTED The Lottie Animation is not supported.
@@ -2680,7 +2559,6 @@ TVG_API Tvg_Result tvg_lottie_animation_override(Tvg_Animation* animation, const
 * \param[in] marker The name of the segment marker.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION In case the animation is not loaded.
 * \retval TVG_RESULT_INVALID_ARGUMENT When the given @p marker is invalid.
 * \retval TVG_RESULT_NOT_SUPPORTED The Lottie Animation is not supported.
@@ -2697,7 +2575,6 @@ TVG_API Tvg_Result tvg_lottie_animation_set_marker(Tvg_Animation* animation, con
 * \param[out] cnt The count value of the merkers.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
 *
 * \note Experimental API
@@ -2713,7 +2590,6 @@ TVG_API Tvg_Result tvg_lottie_animation_get_markers_cnt(Tvg_Animation* animation
 * \param[out] name The name of marker when succeed.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_SUCCESS Succeed.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case @c nullptr is passed as the argument or @c idx is out of range.
 *
 * \note Experimental API


### PR DESCRIPTION
That basic information is addressed in the Results section.
We can only add information that pertains to a specific scenario.