### PR TITLE
gl_engine: Fix compose render not correct after canvas resize

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -63,28 +63,17 @@ bool GlRenderer::target(int32_t id, uint32_t w, uint32_t h)
     surface.w = w;
     surface.h = h;
 
-    mTargetViewport.x = 0;
-    mTargetViewport.y = 0;
-    mTargetViewport.w = surface.w;
-    mTargetViewport.h = surface.h;
-
     mTargetFboId = static_cast<GLint>(id);
-
-    //TODO: It's not allow to draw onto the main surface. Need to confirm the policy.
-    if (mTargetFboId == 0) {
-        GL_CHECK(glGetIntegerv(GL_FRAMEBUFFER_BINDING, &mTargetFboId));
-
-        GLint dims[4] = {0};
-
-        GL_CHECK(glGetIntegerv(GL_VIEWPORT, dims));
-        // If targeting on the main framebuffer ,the actual size may by adjusted by the window system.
-        // In case the size is different from logical size, query and set the actual viewport here
-        mTargetViewport.w = dims[2];
-        mTargetViewport.h = dims[3];
-    }
 
     mRootTarget = make_unique<GlRenderTarget>(surface.w, surface.h);
     mRootTarget->init(mTargetFboId);
+
+    mRenderPassStack.clear();
+    mComposeStack.clear();
+
+    for (uint32_t i = 0; i < mComposePool.count; i++) delete mComposePool[i];
+
+    mComposePool.clear();
 
     return true;
 }
@@ -109,7 +98,7 @@ bool GlRenderer::sync()
     prepareBlitTask(task);
 
     task->mClearBuffer = mClearBuffer;
-    task->setTargetViewport(mTargetViewport);
+    task->setTargetViewport(RenderRegion{0, 0, static_cast<int32_t>(surface.w), static_cast<int32_t>(surface.h)});
 
     mGpuBuffer->flushToGPU();
     mGpuBuffer->bind();

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -98,7 +98,6 @@ private:
     Surface surface;
     GLint mTargetFboId = 0;
     RenderRegion mViewport;
-    RenderRegion mTargetViewport;
     //TODO: remove all unique_ptr / replace the vector with tvg::Array
     unique_ptr<GlStageBuffer> mGpuBuffer;
     vector<std::unique_ptr<GlProgram>> mPrograms;


### PR DESCRIPTION
This PR Fix some rendering error after Example window resize.

When canvas size changed, need to clear cached GLRenderTarget and GLCompose.
