### PR TITLE
wg_engine: fix line joins

### DIFF
--- a/src/renderer/wg_engine/tvgWgGeometry.cpp
+++ b/src/renderer/wg_engine/tvgWgGeometry.cpp
@@ -57,6 +57,7 @@ WgPolyline::WgPolyline()
     constexpr uint32_t nPoints = 360;
     pts.reserve(nPoints);
     dist.reserve(nPoints);
+    closed = false;
 }
 
 
@@ -149,12 +150,7 @@ void WgPolyline::trim(WgPolyline* polyline, float trimBegin, float trimEnd) cons
 void WgPolyline::close()
 {
     if (pts.count > 0) appendPoint(pts[0]);
-}
-
-
-bool WgPolyline::isClosed() const
-{
-    return (pts.count >= 2) && (mathZero(pts[0].dist2(pts.last())));
+    closed = true;
 }
 
 
@@ -166,6 +162,7 @@ void WgPolyline::clear()
     // clear points and distances
     pts.clear();
     dist.clear();
+    closed = false;
 }
 
 
@@ -406,7 +403,7 @@ void WgGeometryData::appendStroke(const WgPolyline* polyline, const RenderStroke
             );
         }
     } else if (polyline->pts.count > 2) {  // multi-lined sub-path
-        if (polyline->isClosed()) {
+        if (polyline->closed) {
             WgPoint v0 = polyline->pts[polyline->pts.count - 2];
             WgPoint v1 = polyline->pts[0];
             WgPoint v2 = polyline->pts[1];

--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -84,6 +84,7 @@ struct WgPolyline
     uint32_t imaxy{};
     // total polyline length
     float len{};
+    bool closed{};
 
     WgPolyline();
 
@@ -95,7 +96,6 @@ struct WgPolyline
     void close();
     void clear();
 
-    bool isClosed() const;
     void getBBox(WgPoint& pmin, WgPoint& pmax) const;
 };
 


### PR DESCRIPTION
Shapes were incorrectly closed in certain cases -
the decision to close a shape or not should be based on path commands rather than the number of points and their distances from each other.

before:
<img width="300" alt="Zrzut ekranu 2024-06-24 o 00 27 56" src="https://github.com/thorvg/thorvg/assets/67589014/f80d1fcb-d8b9-46a3-a386-a7491c30ba67">

after - expected result is that the second triangle is not closed:
<img width="300" alt="Zrzut ekranu 2024-06-24 o 00 34 57" src="https://github.com/thorvg/thorvg/assets/67589014/06f264ed-7599-4904-95a4-3c05c083626e">

sample:
```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500" >
    <path d="M 20 20 h 300 l -150 200 l -150 -200 Z" stroke="blue" stroke-width="30" fill="none" stroke-linejoin="round" opacity="0.5"/>
    <path d="M 20 270 h 300 l -150 200 l -150 -200" stroke="red" stroke-width="30" fill="none" stroke-linejoin="round" opacity="0.5"/>
</svg>
```
