### PR TITLE
gl_engine: Fix memory leak caused by no deleted GlRenderTask

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -263,6 +263,12 @@ void GlDrawBlitTask::run()
 GlClipTask::GlClipTask(GlRenderTask* clip, GlRenderTask* mask)
  :GlRenderTask(nullptr), mClipTask(clip), mMaskTask(mask) {}
 
+GlClipTask::~GlClipTask()
+{
+    delete mClipTask;
+    delete mMaskTask;
+}
+
 void GlClipTask::run()
 {
     GL_CHECK(glEnable(GL_STENCIL_TEST));

--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -171,7 +171,7 @@ class GlClipTask : public GlRenderTask
 {
 public:
     GlClipTask(GlRenderTask* clip, GlRenderTask* mask);
-    ~GlClipTask() override = default;
+    ~GlClipTask() override;
 
     void run() override;
 

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -566,7 +566,10 @@ void GlRenderer::drawPrimitive(GlShape& sdata, uint8_t r, uint8_t g, uint8_t b, 
     auto task = new GlRenderTask(mPrograms[RT_Color].get());
     task->setDrawDepth(depth);
 
-    if (!sdata.geometry->draw(task, mGpuBuffer.get(), flag)) return;
+    if (!sdata.geometry->draw(task, mGpuBuffer.get(), flag)) {
+        delete task;
+        return;
+    }
 
     GlRenderTask* stencilTask = nullptr;
 


### PR DESCRIPTION
This PR Fix memory leak cuased ClipTask and empty render task

#2461 