### PR TITLE
examples: fix crash

### DIFF
--- a/examples/Example.h
+++ b/examples/Example.h
@@ -227,6 +227,7 @@ struct Window
             }
 
             if (needResize) {
+                if (tickCnt == 0) draw();
                 resize();
                 needResize = false;
             }


### PR DESCRIPTION
If the initial window size does not fit on the screen, a resize event is triggered. This occurs at the very beginning after pushing to the canvas, at a stage when the buffer should not be accessed and changing the target is not possible. To prevent this situation, resizing is paused until rendering to the initial target is completed.