### PR TITLE
wg_engine: force texture data writing on GPU side

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -209,6 +209,7 @@ void WgImageData::update(WgContext& context, Surface* surface)
     writeSize.height = surface->h;
     writeSize.depthOrArrayLayers = 1;
     wgpuQueueWriteTexture(context.queue, &imageCopyTexture, surface->data, 4 * surface->w * surface->h, &textureDataLayout, &writeSize);
+    wgpuQueueSubmit(context.queue, 0, nullptr);
 };
 
 


### PR DESCRIPTION
Texture must be fully uploaded into GPU memory before we can use or destroy it. This change force texture data to update.
See PicturePng, PictureJpg examples for texture usage