### PR TITLE
examples: fix sdl2 headers include path

### DIFF
--- a/examples/Example.h
+++ b/examples/Example.h
@@ -27,8 +27,8 @@
 #include <iostream>
 #include <thread>
 #include <thorvg.h>
-#include <SDL.h>
-#include <SDL_syswm.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_syswm.h>
 #ifdef _WIN32
     #include <windows.h>
     #ifndef PATH_MAX


### PR DESCRIPTION
Fix SDL2 headers include path to use them in more standard way and release IDE warnings
Tested on linux and macos