### PR TITLE
Revert "renderer/canvas: Check refresh before draw"

### DIFF
--- a/src/renderer/tvgCanvas.h
+++ b/src/renderer/tvgCanvas.h
@@ -114,7 +114,6 @@ struct Canvas::Impl
 
     Result draw()
     {
-        if (refresh) update(nullptr, false);
         if (status == Status::Drawing || paints.empty() || !renderer->preRender()) return Result::InsufficientCondition;
 
         bool rendered = false;


### PR DESCRIPTION
This reverts commit 60212747b54c73e97ab93a15bfc5ff9362408c02.

this triggered duplicated updates,
it came up with many thread sanitizer problems.

issue: https://github.com/thorvg/thorvg/issues/2462