### PR TITLE
examples: fix crash after resize

### DIFF
--- a/examples/AnimateMasking.cpp
+++ b/examples/AnimateMasking.cpp
@@ -72,7 +72,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/Animation.cpp
+++ b/examples/Animation.cpp
@@ -67,14 +67,14 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 
         auto progress = tvgexam::progress(elapsed, animation->duration());
 
         //Update animation frame only when it's changed
-        if (animation->frame(animation->totalFrame() * progress) == tvg::Result(0)) {
+        if (animation->frame(animation->totalFrame() * progress) == tvg::Result(0) || force) {
             canvas->update();
             return true;
         }

--- a/examples/CustomTransform.cpp
+++ b/examples/CustomTransform.cpp
@@ -30,10 +30,10 @@ struct UserExample : tvgexam::Example
 {
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, 0, false);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/DirectUpdate.cpp
+++ b/examples/DirectUpdate.cpp
@@ -62,7 +62,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 
@@ -78,9 +78,14 @@ struct UserExample : tvgexam::Example
             pShape->strokeFill(0, 0, 255);
             pShape->strokeWidth(30 * progress);
 
-            //Update shape for drawing (this may work asynchronously)
-            canvas->update(pShape);
+            if (force) canvas->update();
+            else canvas->update(pShape); //Update shape for drawing (this may work asynchronously)
 
+            return true;
+        }
+
+        if (force) {
+            canvas->update();
             return true;
         }
 

--- a/examples/Example.h
+++ b/examples/Example.h
@@ -64,7 +64,14 @@ bool verify(tvg::Result result);
 struct Example
 {
     virtual bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) = 0;
-    virtual bool update(tvg::Canvas* canvas, uint32_t elapsed) { return false; }
+    virtual bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force)
+    {
+        if (force) {
+            canvas->update();
+            return true;
+        }
+        return false;
+    }
     virtual void populate(const char* path) {}
     virtual ~Example() {}
 
@@ -237,16 +244,10 @@ struct Window
                 }
             }
 
-            if (needResize) {
-                resize();
-                needResize = false;
-            }
+            if (needResize) resize();
 
-            if (tickCnt > 0) {
-                if (example->update(canvas, elapsed)) {
-                    needDraw = true;
-                }
-            }
+            needDraw = example->update(canvas, elapsed, needResize);
+            needResize = false;
 
             if (needDraw) {
                 if (draw()) refresh();

--- a/examples/GradientTransform.cpp
+++ b/examples/GradientTransform.cpp
@@ -30,10 +30,10 @@ struct UserExample : tvgexam::Example
 {
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, 0, false);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/ImageScaleDown.cpp
+++ b/examples/ImageScaleDown.cpp
@@ -45,7 +45,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/ImageScaleUp.cpp
+++ b/examples/ImageScaleUp.cpp
@@ -46,7 +46,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/Lottie.cpp
+++ b/examples/Lottie.cpp
@@ -75,7 +75,7 @@ struct UserExample : tvgexam::Example
         counter++;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/LottieExtension.cpp
+++ b/examples/LottieExtension.cpp
@@ -54,7 +54,7 @@ struct UserExample : tvgexam::Example
         picture->translate((counter % NUM_PER_ROW) * size + shiftX, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + shiftY);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/Performance.cpp
+++ b/examples/Performance.cpp
@@ -54,7 +54,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/Retaining.cpp
+++ b/examples/Retaining.cpp
@@ -72,7 +72,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 
@@ -84,9 +84,16 @@ struct UserExample : tvgexam::Example
             list.pop_front();
             list.push_back(paint);
             last = elapsed;
+            canvas->update();
+            return true;
         }
 
-        return true;
+        if (force) {
+            canvas->update();
+            return true;
+        }
+
+        return false;
     }
 };
 

--- a/examples/SceneTransform.cpp
+++ b/examples/SceneTransform.cpp
@@ -30,10 +30,10 @@ struct UserExample : tvgexam::Example
 {
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, 0, false);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/Transform.cpp
+++ b/examples/Transform.cpp
@@ -30,10 +30,10 @@ struct UserExample : tvgexam::Example
 {
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, 0, false);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/Update.cpp
+++ b/examples/Update.cpp
@@ -41,7 +41,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 

--- a/examples/Viewport.cpp
+++ b/examples/Viewport.cpp
@@ -55,7 +55,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, bool force) override
     {
         if (!canvas) return false;
 


### PR DESCRIPTION
Changing target (resizing) should enforce canvas update.