### PR TITLE
Improve permissions handling in workflows

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build_x86_64:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build_x86_64:
     runs-on: macos-latest

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -45,6 +48,10 @@ jobs:
 
   unit_test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/memcheck_asan.sh
+++ b/.github/workflows/memcheck_asan.sh
@@ -27,10 +27,10 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
         OUTPUT+=$'\n```\n'
         OUTPUT+="$PAYLOAD_MEMCHECK"
         OUTPUT+=$'\n```\n' 
+
+        PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
+
+        curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
     fi
-
-    PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
-
-    curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
 fi
 

--- a/.github/workflows/memcheck_asan.sh
+++ b/.github/workflows/memcheck_asan.sh
@@ -28,6 +28,14 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
         OUTPUT+="$PAYLOAD_MEMCHECK"
         OUTPUT+=$'\n```\n' 
 
+        (
+            echo '<details><summary>ASAN output</sumary>'
+            echo
+            echo "$OUTPUT"
+            echo
+            echo '</details>'
+        ) >> "$GITHUB_STEP_SUMMARY"
+
         PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
 
         curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"

--- a/.github/workflows/memcheck_valgrind.sh
+++ b/.github/workflows/memcheck_valgrind.sh
@@ -26,10 +26,10 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
         OUTPUT+=$'\n```\n'
         OUTPUT+="$PAYLOAD_MEMCHECK"
         OUTPUT+=$'\n```\n' 
+
+        PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
+
+        curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
     fi
-
-    PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
-
-    curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
 fi
 

--- a/.github/workflows/memcheck_valgrind.sh
+++ b/.github/workflows/memcheck_valgrind.sh
@@ -27,6 +27,14 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
         OUTPUT+="$PAYLOAD_MEMCHECK"
         OUTPUT+=$'\n```\n' 
 
+        (
+            echo '<details><summary>Valgrind output</sumary>'
+            echo
+            echo "$OUTPUT"
+            echo
+            echo '</details>'
+        ) >> "$GITHUB_STEP_SUMMARY"
+
         PAYLOAD=$(echo '{}' | jq --arg body "$OUTPUT" '.body = $body')
 
         curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -159,6 +159,14 @@ jobs:
           export PATH=$PATH:~/.local/bin/
           python3 "${GITHUB_WORKSPACE}/.github/workflows/regression_check.py"
 
+          if [[ -f "fail_ci.txt" ]]; then
+            (
+              echo '```'
+              cat "fail_ci.txt"
+              echo '```'
+            ) >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Find Comment
         uses: peter-evans/find-comment@v3
         id: fc


### PR DESCRIPTION
My GitHub organizations are configured [not to include `write` permissions for workflows by default](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#configuring-the-default-github_token-permissions) (this is considered a best practice, but was set up as opt-in for existing orgs because it would otherwise break existing workflows). This means that the **valgrind**/**asan** test steps in the `build_ubuntu.yml` workflow triggered errors and weren't able to report.

As it happens, currently those two reporting things were trying to submit empty comments, which seems undesirable. So I'm proposing limiting them to only run when they have something to say.

Beyond that, best practices dictate that each workflow should specify only the permissions it needs. In this case, with the exception of the one job in `build_ubuntu.yml` and a commented out step in `regression.yml`, nothing seems to need any permission beyond `contents: read` (technically for public repositories, this isn't necessary, but it is handy to be able to make a private copy of a repository and run its CI when working on security vulnerabilities). The act of specifying any permissions triggers a restrictive envelop, so it's convenient to just use `contents: read`.

For the places that were trying to use comments, this PR adds code to expose the contents via [a job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary). There are a number of benefits to job summaries (especially larger content allowances and no required permissions), although they aren't as easily visible from GitHub PRs (you have to click an workflow run's details link and then click the summary tab on the left) -- I still hold out hope that they'll be made more visible as summaries tend to be much more digestible than detailed logs...