### PR TITLE
renderer: Ensure `const` equality operators

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.h
+++ b/src/renderer/gl_engine/tvgGlGeometry.h
@@ -108,14 +108,14 @@ public:
         return *this;
     }
 
-    bool operator== (const GlPoint& rhs)
+    bool operator== (const GlPoint& rhs) const
     {
         if (&rhs == this) return true;
         if (rhs.x == this->x && rhs.y == this->y) return true;
         return false;
     }
 
-    bool operator!= (const GlPoint& rhs)
+    bool operator!= (const GlPoint& rhs) const
     {
         if (&rhs == this) return true;
         if (rhs.x != this->x || rhs.y != this->y) return true;

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -101,7 +101,7 @@ struct RenderRegion
     void intersect(const RenderRegion& rhs);
     void add(const RenderRegion& rhs);
 
-    bool operator==(const RenderRegion& rhs)
+    bool operator==(const RenderRegion& rhs) const
     {
         if (x == rhs.x && y == rhs.y && w == rhs.w && h == rhs.h) return true;
         return false;


### PR DESCRIPTION
A minor syntactic adjustment to two instances of `operator==` and one instance of `operator!=`, both to the end of ensuring these locally-scoped functions are properly identified as `const`. In the majority of cases, this shouldn't have any impact; however, this change makes these operators play nice in `c++20` contexts.