### PR TITLE
renderer: support `shape-rendering="crispEdges"` for aliased shapes

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -160,6 +160,14 @@ enum class FillRule : uint8_t
     EvenOdd      ///< A line from the point to a location outside the shape is drawn and its intersections with the path segments of the shape are counted. If the number of intersections is an odd number, the point is inside the shape.
 };
 
+/**
+ * @brief Enumeration specifying whether the shapes are anti-aliased or not.
+ */
+enum class ShapeRendering : uint8_t
+{
+    AntiAliased = 0, ///< The shape has anti-aliasing applied to it.
+    CrispEdges      ///< The shape has crisp edges, no anti-aliasing applied to it.
+};
 
 /**
  * @brief Enumeration indicating the method used in the mask of two objects - the target and the source.
@@ -1179,6 +1187,17 @@ public:
     Result fill(FillRule r) noexcept;
 
     /**
+     * @brief Sets the shape rendering method style for the lines of the Shape object.
+     *
+     * The shape rendering method determines whether the lines are anti-aliased or not.
+     *
+     * @param[in] sr The shape rendering method value. The default value is @c ShapeRendering::AntiAliased.
+     *
+     * @retval Result::Success when succeed.
+     */
+    Result shapeRendering(ShapeRendering sr) noexcept;
+
+    /**
      * @brief Sets the rendering order of the stroke and the fill.
      *
      * @param[in] strokeFirst If @c true the stroke is rendered before the fill, otherwise the stroke is rendered as the second one (the default option).
@@ -1228,6 +1247,13 @@ public:
      * @return The fill rule value of the shape.
      */
     FillRule fillRule() const noexcept;
+
+    /**
+     * @brief Gets the shape rendering method value.
+     *
+     * @return The shape rendering method value of the shape.
+     */
+    ShapeRendering shapeRendering() const noexcept;
 
     /**
      * @brief Gets the stroke width.

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -323,6 +323,23 @@ static constexpr struct
 _PARSE_TAG(FillRule, fillRule, FillRule, fillRuleTags, FillRule::NonZero)
 
 
+/* parse the shape rendering method used during stroking a path.
+ * Value:   auto | optimizeSpeed |  crispEdges | geometricPrecision
+ * Initial:    auto
+ * https://www.w3.org/TR/SVG/painting.html
+ */
+static constexpr struct
+{
+    ShapeRendering shapeRendering;
+    const char* tag;
+} shapeRenderingTags[] = {
+    { ShapeRendering::CrispEdges, "crispEdges" }
+};
+
+
+_PARSE_TAG(ShapeRendering, shapeRendering, ShapeRendering, shapeRenderingTags, ShapeRendering::AntiAliased)
+
+
 /* parse the dash pattern used during stroking a path.
  * Value:   none | <dasharray> | inherit
  * Initial:    none
@@ -1016,6 +1033,12 @@ static void _handleStrokeDashOffsetAttr(SvgLoaderData* loader, SvgNode* node, co
     node->style->stroke.dash.offset = _toFloat(loader->svgParse, value, SvgParserLengthType::Horizontal);
 }
 
+static void _handleShapeRenderingAttr(SvgLoaderData* loader, SvgNode* node, const char* value)
+{
+    node->style->stroke.flags = (node->style->stroke.flags | SvgStrokeFlags::AntiAliasing);
+    node->style->stroke.antiAlias = _toShapeRendering(value);
+}
+
 static void _handleStrokeWidthAttr(SvgLoaderData* loader, SvgNode* node, const char* value)
 {
     node->style->stroke.flags = (node->style->stroke.flags | SvgStrokeFlags::Width);
@@ -1185,6 +1208,7 @@ static constexpr struct
     STYLE_DEF(stroke-opacity, StrokeOpacity, SvgStyleFlags::StrokeOpacity),
     STYLE_DEF(stroke-dasharray, StrokeDashArray, SvgStyleFlags::StrokeDashArray),
     STYLE_DEF(stroke-dashoffset, StrokeDashOffset, SvgStyleFlags::StrokeDashOffset),
+    STYLE_DEF(shape-rendering, ShapeRendering, SvgStyleFlags::ShapeRendering),
     STYLE_DEF(transform, Transform, SvgStyleFlags::Transform),
     STYLE_DEF(clip-path, ClipPath, SvgStyleFlags::ClipPath),
     STYLE_DEF(mask, Mask, SvgStyleFlags::Mask),
@@ -1488,6 +1512,8 @@ static SvgNode* _createNode(SvgNode* parent, SvgNodeType type)
     node->style->stroke.join = StrokeJoin::Miter;
     node->style->stroke.miterlimit = 4.0f;
     node->style->stroke.scale = 1.0;
+    node->style->stroke.antiAlias = ShapeRendering::AntiAliased;
+
     node->style->paintOrder = _toPaintOrder("fill stroke");
     node->style->display = true;
     node->parent = parent;

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -124,7 +124,8 @@ enum class SvgStrokeFlags
     Join = 0x40,
     Dash = 0x80,
     Miterlimit = 0x100,
-    DashOffset = 0x200
+    DashOffset = 0x200,
+    AntiAliasing = 0x400,
 };
 
 constexpr bool operator &(SvgStrokeFlags a, SvgStrokeFlags b)
@@ -165,7 +166,8 @@ enum class SvgStyleFlags
     PaintOrder = 0x10000,
     StrokeMiterlimit = 0x20000,
     StrokeDashOffset = 0x40000,
-    Filter = 0x80000
+    Filter = 0x80000,
+    ShapeRendering = 0x100000
 };
 
 constexpr bool operator &(SvgStyleFlags a, SvgStyleFlags b)
@@ -491,6 +493,7 @@ struct SvgStyleStroke
     StrokeJoin join;
     float miterlimit;
     SvgDash dash;
+    ShapeRendering antiAlias;
 };
 
 struct SvgFilter

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -420,6 +420,7 @@ static Paint* _applyProperty(SvgLoaderData& loaderData, SvgNode* node, Shape* vg
     vg->strokeCap(style->stroke.cap);
     vg->strokeJoin(style->stroke.join);
     vg->strokeMiterlimit(style->stroke.miterlimit);
+    vg->shapeRendering(style->stroke.antiAlias);
     vg->strokeDash(style->stroke.dash.array.data, style->stroke.dash.array.count, style->stroke.dash.offset);
 
     //If stroke property is nullptr then do nothing

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -85,6 +85,7 @@ struct SwShapeTask : SwTask
        Additionally, the stroke style should not be dashed. */
     bool antialiasing(float strokeWidth)
     {
+        if (rshape->stroke && rshape->stroke->antiAlias == ShapeRendering::CrispEdges) return false;
         return strokeWidth < 2.0f || rshape->stroke->dash.count > 0 || rshape->stroke->strokeFirst || rshape->trimpath() || rshape->stroke->color.a < 255;
     }
 

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -533,7 +533,7 @@ bool shapeGenStrokeRle(SwShape* shape, const RenderShape* rshape, const Matrix& 
         goto clear;
     }
 
-    shape->strokeRle = rleRender(shape->strokeRle, strokeOutline, renderRegion, true);
+    shape->strokeRle = rleRender(shape->strokeRle, strokeOutline, renderRegion, rshape->stroke->antiAlias != ShapeRendering::CrispEdges);
 
 clear:
     if (dashStroking) mpoolRetDashOutline(mpool, tid);

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -139,6 +139,7 @@ struct RenderStroke
     RenderTrimPath trim;
     StrokeCap cap = StrokeCap::Square;
     StrokeJoin join = StrokeJoin::Bevel;
+    ShapeRendering antiAlias = ShapeRendering::AntiAliased;
     bool strokeFirst = false;
 
     void operator=(const RenderStroke& rhs)

--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -249,3 +249,14 @@ FillRule Shape::fillRule() const noexcept
 {
     return SHAPE(this)->rs.rule;
 }
+
+Result Shape::shapeRendering(ShapeRendering rs) noexcept
+{
+    SHAPE(this)->rs.stroke->antiAlias = rs;
+    return Result::Success;
+}
+
+ShapeRendering Shape::shapeRendering() const noexcept
+{
+    return SHAPE(this)->rs.stroke->antiAlias;
+}


### PR DESCRIPTION
Implements #1869 for the software renderer. If the `shape-rendering="crispEdges"` attribute is used in the SVG, the software renderer does not use anti-aliasing for the shape's lines. The rest of the `shape-rendering` values just default to anti-aliasing, I'm not sure how else to handle them. I tested it with svg2png and Godot and it seems to be working as intended.

Tested using the following svg file:

```svg
<svg width="460" height="200">
  <rect width="140" height="30" x="10" y="10" rx="20" ry="20" style="fill:rgb(0,0,255)" />
  <rect width="140" height="30" x="160" y="10" rx="20" ry="20" style="fill:rgb(0,0,255);stroke-width:1;stroke:red" />
  <rect width="140" height="30" x="310" y="10" rx="20" ry="20" shape-rendering="crispEdges" style="fill:rgb(0,0,255);stroke-width:1;stroke:red" />
  <rect width="140" height="30" x="10" y="60" rx="20" ry="20" fill="none" style="stroke-width:1;stroke:red" />
  <rect width="140" height="30" x="160" y="60" rx="20" ry="20" fill="none" shape-rendering="crispEdges" style="stroke-width:1;stroke:red" />
  <ellipse cx="210" cy="110" rx="170" ry="15" shape-rendering="crispEdges" style="fill:lime" />
  <ellipse cx="210" cy="160" rx="200" ry="30" style="fill:purple" />
  <polyline points="20,20 40,25 60,40 80,120 120,140 200,180"
    style="fill:none;stroke:white;stroke-width:3" shape-rendering="crispEdges" />
  <polyline points="60,20 80,25 100,40 120,120 160,140 240,180"
    style="fill:none;stroke:white;stroke-width:3" />
  <path d="M 10 10 C 20 20, 40 20, 50 10" stroke="black" shape-rendering="crispEdges" fill="transparent"/>
</svg>
```

Result png:
![Result png](https://github.com/thorvg/thorvg/assets/35376950/b6e28aa3-fa25-48eb-a76e-b3290445247f)

This is the first time I'm contributing to ThorVG, hopefully I did everything right. 😅
