### PR TITLE
sw_engine: fix aa

### DIFF
--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -86,7 +86,7 @@ struct SwShapeTask : SwTask
        Additionally, the stroke style should not be dashed. */
     bool antialiasing(float strokeWidth)
     {
-        return strokeWidth < 2.0f || rshape->stroke->dashCnt > 0 || rshape->stroke->strokeFirst || rshape->strokeTrim();
+        return strokeWidth < 2.0f || rshape->stroke->dashCnt > 0 || rshape->stroke->strokeFirst || rshape->strokeTrim() || rshape->stroke->color[3] < 255;;
     }
 
     float validStrokeWidth()

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -296,6 +296,7 @@ struct Shape::Impl
         if (!rs.stroke) rs.stroke = new RenderStroke();
         if (rs.stroke->fill && rs.stroke->fill != p) delete(rs.stroke->fill);
         rs.stroke->fill = p;
+        rs.stroke->color[3] = 0;
 
         flag |= RenderUpdateFlag::Stroke;
         flag |= RenderUpdateFlag::GradientStroke;


### PR DESCRIPTION
For shapes with a stroke that has opacity, anti-aliasing should be applied to a fill.
The use of a transparent gradient stroke will also be handled correctly.

before:
<img width="744" alt="Zrzut ekranu 2024-07-2 o 16 29 58" src="https://github.com/thorvg/thorvg/assets/67589014/c8e6c6ef-6fe4-43ee-af29-83a35c633b75">

after:
<img width="747" alt="Zrzut ekranu 2024-07-2 o 16 30 16" src="https://github.com/thorvg/thorvg/assets/67589014/b949c58d-74a0-4232-8f00-faee853ce42b">

sample:
```
        auto shape = tvg::Shape::gen();
        shape->appendRect(100, 100, 600, 600, 250, 250);
        shape->fill(0, 255, 0);
        shape->strokeWidth(100);
        shape->strokeFill(255, 255, 255, 100);
        canvas->push(std::move(shape));
```