### PR TITLE
wg_engine: fix blend methods support

### DIFF
--- a/src/renderer/wg_engine/tvgWgBindGroups.cpp
+++ b/src/renderer/wg_engine/tvgWgBindGroups.cpp
@@ -643,11 +643,11 @@ WgBindGroupBlendMethod* WgBindGroupBlendMethodPool::allocate(WgContext& context,
 void WgBindGroupCompositeMethodPool::initialize(WgContext& context)
 {
     release(context);
-    for (uint8_t composeMethods = (uint8_t)CompositeMethod::None;
-         composeMethods <= (uint8_t)CompositeMethod::DifferenceMask;
-         composeMethods++) {
-        mPool[composeMethods] = new WgBindGroupCompositeMethod;
-        mPool[composeMethods]->initialize(context.device, context.queue, (CompositeMethod)composeMethods);
+    for (uint8_t composeMethdos = (uint8_t)CompositeMethod::None;
+         composeMethdos <= (uint8_t)CompositeMethod::DifferenceMask;
+         composeMethdos++) {
+        mPool[composeMethdos] = new WgBindGroupCompositeMethod;
+        mPool[composeMethdos]->initialize(context.device, context.queue, (CompositeMethod)composeMethdos);
     }
 }
 

--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -52,12 +52,12 @@ void WgContext::initialize(WGPUInstance instance, WGPUSurface surface)
     wgpuInstanceRequestAdapter(instance, &requestAdapterOptions, onAdapterRequestEnded, &adapter);
     assert(adapter);
 
-    // adapter enumerate features
+    // adapter enumerate fueatures
     size_t featuresCount = wgpuAdapterEnumerateFeatures(adapter, featureNames);
     wgpuAdapterGetProperties(adapter, &adapterProperties);
     wgpuAdapterGetLimits(adapter, &supportedLimits);
 
-    // request device
+    // reguest device
     WGPUDeviceDescriptor deviceDesc{};
     deviceDesc.nextInChain = nullptr;
     deviceDesc.label = "The device";
@@ -596,40 +596,23 @@ void WgRenderPipeline::set(WGPURenderPassEncoder renderPassEncoder)
 WGPUBlendState WgRenderPipeline::makeBlendState(WgPipelineBlendType blendType)
 {
     WGPUBlendState blendState{};
-    // src
-    if (blendType == WgPipelineBlendType::Src) {
+    // srcover
+    if (blendType == WgPipelineBlendType::SrcOver) {
         blendState.color.operation = WGPUBlendOperation_Add;
         blendState.color.srcFactor = WGPUBlendFactor_One;
         blendState.color.dstFactor = WGPUBlendFactor_Zero;
-    } else // normal
-    if (blendType == WgPipelineBlendType::Normal) {
+    // normal
+    } else if (blendType == WgPipelineBlendType::Normal) {
         blendState.color.operation = WGPUBlendOperation_Add;
-        blendState.color.srcFactor = WGPUBlendFactor_SrcAlpha;
+        blendState.color.srcFactor = WGPUBlendFactor_One;
         blendState.color.dstFactor = WGPUBlendFactor_OneMinusSrcAlpha;
-    } else // add
-    if (blendType == WgPipelineBlendType::Add) {
+    // custom
+    } else if (blendType == WgPipelineBlendType::Custom) {
         blendState.color.operation = WGPUBlendOperation_Add;
         blendState.color.srcFactor = WGPUBlendFactor_One;
-        blendState.color.dstFactor = WGPUBlendFactor_One;
-    } else // mult
-    if (blendType == WgPipelineBlendType::Mult) {
-        blendState.color.operation = WGPUBlendOperation_Add;
-        blendState.color.srcFactor = WGPUBlendFactor_Dst;
         blendState.color.dstFactor = WGPUBlendFactor_Zero;
-    } else // min
-    if (blendType == WgPipelineBlendType::Min) {
-        blendState.color.operation = WGPUBlendOperation_Min;
-        blendState.color.srcFactor = WGPUBlendFactor_One;
-        blendState.color.dstFactor = WGPUBlendFactor_One;
-    } else // max
-    if (blendType == WgPipelineBlendType::Max) {
-        blendState.color.operation = WGPUBlendOperation_Max;
-        blendState.color.srcFactor = WGPUBlendFactor_One;
-        blendState.color.dstFactor = WGPUBlendFactor_One;
     }
-    blendState.alpha.operation = WGPUBlendOperation_Add;
-    blendState.alpha.srcFactor = WGPUBlendFactor_SrcAlpha;
-    blendState.alpha.dstFactor = WGPUBlendFactor_Zero;
+    blendState.alpha = blendState.color;
     return blendState;
 }
 

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -36,12 +36,9 @@ struct WgCompositor: public Compositor {
 };
 
 enum class WgPipelineBlendType {
-    Src = 0, // S
-    Normal,  // (Sa * S) + (255 - Sa) * D
-    Add,     // (S + D)
-    Mult,    // (S * D)
-    Min,     // min(S, D)
-    Max      // max(S, D)
+    SrcOver = 0,
+    Normal,
+    Custom
 };
 
 struct WgPipelines;

--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -55,7 +55,7 @@ void WgPipelineFillShapeWinding::initialize(WGPUDevice device)
     auto pipelineLabel = "The render pipeline fill shape winding";
 
     // allocate all pipeline handles
-    allocate(device, WgPipelineBlendType::Add, WGPUColorWriteMask_None,
+    allocate(device, WgPipelineBlendType::SrcOver, WGPUColorWriteMask_None,
              vertexBufferLayouts, ARRAY_ELEMENTS_COUNT(vertexBufferLayouts),
              bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
              stencilFunctionFront, stencilOperationFront, stencilFunctionBack, stencilOperationBack,
@@ -78,9 +78,9 @@ void WgPipelineFillShapeEvenOdd::initialize(WGPUDevice device)
     };
 
     // stencil function
-    WGPUCompareFunction stencilFunctionFront = WGPUCompareFunction_Always;
+    WGPUCompareFunction stencilFuncionFront = WGPUCompareFunction_Always;
     WGPUStencilOperation stencilOperationFront = WGPUStencilOperation_Invert;
-    WGPUCompareFunction stencilFunctionBack = WGPUCompareFunction_Always;
+    WGPUCompareFunction stencilFuncionBack = WGPUCompareFunction_Always;
     WGPUStencilOperation stencilOperationBack = WGPUStencilOperation_Invert;
 
     // sheder source and labels
@@ -89,10 +89,10 @@ void WgPipelineFillShapeEvenOdd::initialize(WGPUDevice device)
     auto pipelineLabel = "The render pipeline fill shape Even Odd";
 
     // allocate all pipeline handles
-    allocate(device, WgPipelineBlendType::Add, WGPUColorWriteMask_None,
+    allocate(device, WgPipelineBlendType::SrcOver, WGPUColorWriteMask_None,
              vertexBufferLayouts, ARRAY_ELEMENTS_COUNT(vertexBufferLayouts),
              bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
-             stencilFunctionFront, stencilOperationFront, stencilFunctionBack, stencilOperationBack,
+             stencilFuncionFront, stencilOperationFront, stencilFuncionBack, stencilOperationBack,
              shaderSource, shaderLabel, pipelineLabel);
 }
 
@@ -112,7 +112,7 @@ void WgPipelineFillStroke::initialize(WGPUDevice device)
     };
 
     // stencil function
-    WGPUCompareFunction stencilFunction = WGPUCompareFunction_Always;
+    WGPUCompareFunction stencilFuncion = WGPUCompareFunction_Always;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Replace;
 
     // sheder source and labels
@@ -121,10 +121,10 @@ void WgPipelineFillStroke::initialize(WGPUDevice device)
     auto pipelineLabel = "The render pipeline fill stroke";
 
     // allocate all pipeline handles
-    allocate(device, WgPipelineBlendType::Add, WGPUColorWriteMask_None,
+    allocate(device, WgPipelineBlendType::SrcOver, WGPUColorWriteMask_None,
              vertexBufferLayouts, ARRAY_ELEMENTS_COUNT(vertexBufferLayouts),
              bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
-             stencilFunction, stencilOperation, stencilFunction, stencilOperation,
+             stencilFuncion, stencilOperation, stencilFuncion, stencilOperation,
              shaderSource, shaderLabel, pipelineLabel);
 }
 
@@ -145,7 +145,7 @@ void WgPipelineSolid::initialize(WGPUDevice device, WgPipelineBlendType blendTyp
     };
 
     // stencil function
-    WGPUCompareFunction stencilFunction = WGPUCompareFunction_NotEqual;
+    WGPUCompareFunction stencilFuncion = WGPUCompareFunction_NotEqual;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Zero;
 
     // sheder source and labels
@@ -157,7 +157,7 @@ void WgPipelineSolid::initialize(WGPUDevice device, WgPipelineBlendType blendTyp
     allocate(device, blendType, WGPUColorWriteMask_All,
              vertexBufferLayouts, ARRAY_ELEMENTS_COUNT(vertexBufferLayouts),
              bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
-             stencilFunction, stencilOperation, stencilFunction, stencilOperation,
+             stencilFuncion, stencilOperation, stencilFuncion, stencilOperation,
              shaderSource, shaderLabel, pipelineLabel);
 }
 
@@ -178,7 +178,7 @@ void WgPipelineLinear::initialize(WGPUDevice device, WgPipelineBlendType blendTy
     };
 
     // stencil function
-    WGPUCompareFunction stencilFunction = WGPUCompareFunction_NotEqual;
+    WGPUCompareFunction stencilFuncion = WGPUCompareFunction_NotEqual;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Zero;
 
     // sheder source and labels
@@ -190,7 +190,7 @@ void WgPipelineLinear::initialize(WGPUDevice device, WgPipelineBlendType blendTy
     allocate(device, blendType, WGPUColorWriteMask_All,
              vertexBufferLayouts, ARRAY_ELEMENTS_COUNT(vertexBufferLayouts),
              bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
-             stencilFunction, stencilOperation, stencilFunction, stencilOperation,
+             stencilFuncion, stencilOperation, stencilFuncion, stencilOperation,
              shaderSource, shaderLabel, pipelineLabel);
 }
 
@@ -211,7 +211,7 @@ void WgPipelineRadial::initialize(WGPUDevice device, WgPipelineBlendType blendTy
     };
 
     // stencil function
-    WGPUCompareFunction stencilFunction = WGPUCompareFunction_NotEqual;
+    WGPUCompareFunction stencilFuncion = WGPUCompareFunction_NotEqual;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Zero;
 
     // sheder source and labels
@@ -223,7 +223,7 @@ void WgPipelineRadial::initialize(WGPUDevice device, WgPipelineBlendType blendTy
     allocate(device, blendType, WGPUColorWriteMask_All,
              vertexBufferLayouts, ARRAY_ELEMENTS_COUNT(vertexBufferLayouts),
              bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
-             stencilFunction, stencilOperation, stencilFunction, stencilOperation,
+             stencilFuncion, stencilOperation, stencilFuncion, stencilOperation,
              shaderSource, shaderLabel, pipelineLabel);
 }
 
@@ -246,7 +246,7 @@ void WgPipelineImage::initialize(WGPUDevice device, WgPipelineBlendType blendTyp
     };
 
     // stencil function
-    WGPUCompareFunction stencilFunction = WGPUCompareFunction_Always;
+    WGPUCompareFunction stencilFuncion = WGPUCompareFunction_Always;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Zero;
 
     // sheder source and labels
@@ -258,7 +258,7 @@ void WgPipelineImage::initialize(WGPUDevice device, WgPipelineBlendType blendTyp
     allocate(device, blendType, WGPUColorWriteMask_All,
              vertexBufferLayouts, ARRAY_ELEMENTS_COUNT(vertexBufferLayouts),
              bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
-             stencilFunction, stencilOperation, stencilFunction, stencilOperation,
+             stencilFuncion, stencilOperation, stencilFuncion, stencilOperation,
              shaderSource, shaderLabel, pipelineLabel);
 }
 
@@ -285,17 +285,17 @@ void WgPipelineClear::initialize(WGPUDevice device)
 }
 
 
-void WgPipelineBlend::initialize(WGPUDevice device)
+void WgPipelineBlend::initialize(WGPUDevice device, const char *shaderSource)
 {
     // bind groups and layouts
     WGPUBindGroupLayout bindGroupLayouts[] = {
         WgBindGroupTextureStorageRgba::getLayout(device),
         WgBindGroupTextureStorageRgba::getLayout(device),
-        WgBindGroupBlendMethod::getLayout(device)
+        WgBindGroupBlendMethod::getLayout(device),
+        WgBindGroupOpacity::getLayout(device)
     };
 
     // sheder source and labels
-    auto shaderSource = cShaderSource_PipelineComputeBlend;
     auto shaderLabel = "The compute shader blend";
     auto pipelineLabel = "The compute pipeline blend";
 
@@ -379,7 +379,7 @@ void WgPipelines::initialize(WgContext& context)
     fillShapeWinding.initialize(context.device);
     fillShapeEvenOdd.initialize(context.device);
     fillStroke.initialize(context.device);
-    for (uint8_t type = (uint8_t)WgPipelineBlendType::Src; type <= (uint8_t)WgPipelineBlendType::Max; type++) {
+    for (uint8_t type = (uint8_t)WgPipelineBlendType::SrcOver; type <= (uint8_t)WgPipelineBlendType::Custom; type++) {
         solid[type].initialize(context.device, (WgPipelineBlendType)type);
         linear[type].initialize(context.device, (WgPipelineBlendType)type);
         radial[type].initialize(context.device, (WgPipelineBlendType)type);
@@ -387,7 +387,9 @@ void WgPipelines::initialize(WgContext& context)
     }
     // compute pipelines
     computeClear.initialize(context.device);
-    computeBlend.initialize(context.device);
+    computeBlendSolid.initialize(context.device, cShaderSource_PipelineComputeBlendSolid);
+    computeBlendGradient.initialize(context.device, cShaderSource_PipelineComputeBlendGradient);
+    computeBlendImage.initialize(context.device, cShaderSource_PipelineComputeBlendImage);
     computeCompose.initialize(context.device);
     computeComposeBlend.initialize(context.device);
     computeAntiAliasing.initialize(context.device);
@@ -414,10 +416,12 @@ void WgPipelines::release()
     computeAntiAliasing.release();
     computeComposeBlend.release();
     computeCompose.release();
-    computeBlend.release();
+    computeBlendImage.release();
+    computeBlendGradient.release();
+    computeBlendSolid.release();
     computeClear.release();
     // fill pipelines
-    for (uint8_t type = (uint8_t)WgPipelineBlendType::Src; type <= (uint8_t)WgPipelineBlendType::Max; type++) {
+    for (uint8_t type = (uint8_t)WgPipelineBlendType::SrcOver; type <= (uint8_t)WgPipelineBlendType::Custom; type++) {
         image[type].release();
         radial[type].release();
         linear[type].release();
@@ -434,10 +438,6 @@ bool WgPipelines::isBlendMethodSupportsHW(BlendMethod blendMethod)
     switch (blendMethod) {
         case BlendMethod::SrcOver:
         case BlendMethod::Normal:
-        case BlendMethod::Add:
-        case BlendMethod::Multiply:
-        case BlendMethod::Darken:
-        case BlendMethod::Lighten:
             return true;
         default: return false;
     };
@@ -447,12 +447,8 @@ bool WgPipelines::isBlendMethodSupportsHW(BlendMethod blendMethod)
 WgPipelineBlendType WgPipelines::blendMethodToBlendType(BlendMethod blendMethod)
 {
     switch (blendMethod) {
-        case BlendMethod::SrcOver: return WgPipelineBlendType::Src;
+        case BlendMethod::SrcOver: return WgPipelineBlendType::SrcOver;
         case BlendMethod::Normal: return WgPipelineBlendType::Normal;
-        case BlendMethod::Add: return WgPipelineBlendType::Add;
-        case BlendMethod::Multiply: return WgPipelineBlendType::Mult;
-        case BlendMethod::Darken: return WgPipelineBlendType::Min;
-        case BlendMethod::Lighten: return WgPipelineBlendType::Max;
-        default: return WgPipelineBlendType::Src;
+        default: return WgPipelineBlendType::Custom;
     };
 }

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -103,7 +103,7 @@ struct WgPipelineRadial: public WgRenderPipeline
 
 struct WgPipelineImage: public WgRenderPipeline
 {
-    void initialize(WGPUDevice device) override {}
+    void initialize(WGPUDevice device) override { assert(false); };
     void initialize(WGPUDevice device, WgPipelineBlendType blendType);
     void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas, WgBindGroupPaint& groupPaint, WgBindGroupPicture& groupPicture)
     {
@@ -131,13 +131,15 @@ struct WgPipelineClear: public WgComputePipeline
 
 struct WgPipelineBlend: public WgComputePipeline
 {
-    void initialize(WGPUDevice device) override;
-    void use(WGPUComputePassEncoder encoder, WgBindGroupTextureStorageRgba& groupTexSrc, WgBindGroupTextureStorageRgba& groupTexDst, WgBindGroupBlendMethod& blendMethod)
+    void initialize(WGPUDevice device) override { assert(false); };
+    void initialize(WGPUDevice device, const char *shaderSource);
+    void use(WGPUComputePassEncoder encoder, WgBindGroupTextureStorageRgba& groupTexSrc, WgBindGroupTextureStorageRgba& groupTexDst, WgBindGroupBlendMethod& blendMethod, WgBindGroupOpacity& groupOpacity)
     {
         set(encoder);
         groupTexSrc.set(encoder, 0);
         groupTexDst.set(encoder, 1);
         blendMethod.set(encoder, 2);
+        groupOpacity.set(encoder, 3);
     }
 };
 
@@ -192,13 +194,15 @@ struct WgPipelines
     WgPipelineFillShapeEvenOdd fillShapeEvenOdd;
     WgPipelineFillStroke fillStroke;
     // fill pipelines
-    WgPipelineSolid solid[6];
-    WgPipelineLinear linear[6];
-    WgPipelineRadial radial[6];
-    WgPipelineImage image[6];
+    WgPipelineSolid solid[3];
+    WgPipelineLinear linear[3];
+    WgPipelineRadial radial[3];
+    WgPipelineImage image[3];
     // compute pipelines
     WgPipelineClear computeClear;
-    WgPipelineBlend computeBlend;
+    WgPipelineBlend computeBlendSolid;
+    WgPipelineBlend computeBlendGradient;
+    WgPipelineBlend computeBlendImage;
     WgPipelineCompose computeCompose;
     WgPipelineComposeBlend computeComposeBlend;
     WgPipelineAntiAliasing computeAntiAliasing;

--- a/src/renderer/wg_engine/tvgWgRenderTarget.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.cpp
@@ -173,15 +173,15 @@ void WgRenderStorage::clear(WGPUCommandEncoder commandEncoder)
 }
 
 
-void WgRenderStorage::blend(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc, WgBindGroupBlendMethod* blendMethod)
-{
+void WgRenderStorage::blend(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc, WgPipelineBlend* pipeline, WgBindGroupBlendMethod* blendMethod, WgBindGroupOpacity* opacity) {
     assert(commandEncoder);
     assert(targetSrc);
+    assert(pipeline);
     WGPUComputePassEncoder computePassEncoder = beginComputePass(commandEncoder);
-    mPipelines->computeBlend.use(computePassEncoder, targetSrc->bindGroupTexStorageRgba, bindGroupTexStorageRgba, *blendMethod);
+    pipeline->use(computePassEncoder, targetSrc->bindGroupTexStorageRgba, bindGroupTexStorageRgba, *blendMethod, *opacity);
     dispatchWorkgroups(computePassEncoder);
     endComputePass(computePassEncoder);
-};
+}
 
 
 void WgRenderStorage::compose(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetMsk, WgBindGroupCompositeMethod* composeMethod, WgBindGroupOpacity* opacity)

--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -53,7 +53,7 @@ public:
     void renderPicture(WgContext& context, WgRenderDataPicture* renderData, WgPipelineBlendType blendType);
 
     void clear(WGPUCommandEncoder commandEncoder);
-    void blend(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc, WgBindGroupBlendMethod* blendMethod);
+    void blend(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc, WgPipelineBlend* pipeline, WgBindGroupBlendMethod* blendMethod, WgBindGroupOpacity* opacity);
     void compose(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetMsk, WgBindGroupCompositeMethod* composeMethod, WgBindGroupOpacity* opacity);
     void composeBlend(
         WgContext& context,

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -63,13 +63,19 @@ public:
 private:
     // render handles
     WGPUCommandEncoder mCommandEncoder{};
-    WgRenderStorage mRenderTarget;
+    // intermidiate buffer to render
+    WgRenderStorage mRenderStorageInterm;
+    // root render storage
     WgRenderStorage mRenderStorageRoot;
+    // storage with data after antializing
     WgRenderStorage mRenderStorageScreen;
+    // pool to hold render tree storages
     WgRenderStoragePool mRenderStoragePool;
+    // opacity, blend methods and composite methods pool
     WgBindGroupOpacityPool mOpacityPool;
     WgBindGroupBlendMethodPool mBlendMethodPool;
     WgBindGroupCompositeMethodPool mCompositeMethodPool;
+    // render data shpes pool
     WgRenderDataShapePool mRenderDataShapePool;
 
     // render tree stacks
@@ -80,6 +86,7 @@ private:
     WgContext mContext;
     WgPipelines mPipelines;
     Surface mTargetSurface;
+    // current blend method
     BlendMethod mBlendMethod{};
 };
 

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -23,11 +23,13 @@
 #include "tvgWgShaderSrc.h"
 #include <string>
 
+#define WG_SHADER_SOURCE(...) #__VA_ARGS__
+
 //************************************************************************
 // shader pipeline fill
 //************************************************************************
 
-const char* cShaderSource_PipelineFill = R"(
+const char* cShaderSource_PipelineFill = WG_SHADER_SOURCE(
 // vertex input
 struct VertexInput {
     @location(0) position: vec2f
@@ -54,20 +56,20 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 fn fs_main(in: VertexOutput) -> void {
     // nothing to draw, just stencil value
 }
-)";
+);
 
 //************************************************************************
 // shader pipeline solid
 //************************************************************************
 
-const char* cShaderSource_PipelineSolid = R"(
+const char* cShaderSource_PipelineSolid = WG_SHADER_SOURCE(
 // vertex input
 struct VertexInput {
     @location(0) position: vec2f
 };
 
-// BlendSettings
-struct BlendSettings {
+// BlendSettigs
+struct BlendSettigs {
     format  : u32, // ColorSpace
     dummy0  : f32,
     dummy1  : f32,
@@ -82,7 +84,7 @@ struct VertexOutput {
 // uniforms
 @group(0) @binding(0) var<uniform> uViewMat      : mat4x4f;
 @group(1) @binding(0) var<uniform> uModelMat     : mat4x4f;
-@group(1) @binding(1) var<uniform> uBlendSettings : BlendSettings;
+@group(1) @binding(1) var<uniform> uBlendSettigs : BlendSettigs;
 @group(2) @binding(0) var<uniform> uSolidColor   : vec4f;
 
 @vertex
@@ -101,22 +103,23 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     // get color
     color = uSolidColor;
 
-    return vec4f(color.rgb, color.a * uBlendSettings.opacity);
+    let alpha: f32 = color.a * uBlendSettigs.opacity;
+    return vec4f(color.rgb * alpha, alpha);
 }
-)";
+);
 
 //************************************************************************
 // shader pipeline linear
 //************************************************************************
 
-const char* cShaderSource_PipelineLinear = R"(
+const char* cShaderSource_PipelineLinear = WG_SHADER_SOURCE(
 // vertex input
 struct VertexInput {
     @location(0) position: vec2f
 };
 
-// BlendSettings
-struct BlendSettings {
+// BlendSettigs
+struct BlendSettigs {
     format  : u32, // ColorSpace
     dummy0  : f32,
     dummy1  : f32,
@@ -146,7 +149,7 @@ struct VertexOutput {
 // uniforms
 @group(0) @binding(0) var<uniform> uViewMat        : mat4x4f;
 @group(1) @binding(0) var<uniform> uModelMat       : mat4x4f;
-@group(1) @binding(1) var<uniform> uBlendSettings   : BlendSettings;
+@group(1) @binding(1) var<uniform> uBlendSettigs   : BlendSettigs;
 @group(2) @binding(0) var<uniform> uLinearGradient : LinearGradient;
 
 @vertex
@@ -170,7 +173,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     let ba: vec2f = ed - st;
 
     // get interpolation factor
-    var t: f32 = abs(dot(pos - st, ba) / dot(ba, ba));
+    var t: f32 = dot(pos - st, ba) / dot(ba, ba);
 
     // fill spread
     switch uLinearGradient.spread {
@@ -203,22 +206,23 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
         }
     }
 
-    return vec4f(color.rgb, color.a * uBlendSettings.opacity);
+    let alpha: f32 = color.a * uBlendSettigs.opacity;
+    return vec4f(color.rgb * alpha, alpha);
 }
-)";
+);
 
 //************************************************************************
 // shader pipeline radial
 //************************************************************************
 
-const char* cShaderSource_PipelineRadial = R"(
+const char* cShaderSource_PipelineRadial = WG_SHADER_SOURCE(
 // vertex input
 struct VertexInput {
     @location(0) position: vec2f
 };
 
-// BlendSettings
-struct BlendSettings {
+// BlendSettigs
+struct BlendSettigs {
     format  : u32, // ColorSpace
     dummy0  : f32,
     dummy1  : f32,
@@ -248,7 +252,7 @@ struct VertexOutput {
 // uniforms
 @group(0) @binding(0) var<uniform> uViewMat        : mat4x4f;
 @group(1) @binding(0) var<uniform> uModelMat       : mat4x4f;
-@group(1) @binding(1) var<uniform> uBlendSettings   : BlendSettings;
+@group(1) @binding(1) var<uniform> uBlendSettigs   : BlendSettigs;
 @group(2) @binding(0) var<uniform> uRadialGradient : RadialGradient;
 
 @vertex
@@ -299,23 +303,24 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
         }
     }
 
-    return vec4f(color.rgb, color.a * uBlendSettings.opacity);
+    let alpha: f32 = color.a * uBlendSettigs.opacity;
+    return vec4f(color.rgb * alpha, alpha);
 }
-)";
+);
 
 //************************************************************************
 // cShaderSource_PipelineImage
 //************************************************************************
 
-const char* cShaderSource_PipelineImage = R"(
+const char* cShaderSource_PipelineImage = WG_SHADER_SOURCE(
 // vertex input
 struct VertexInput {
     @location(0) position: vec2f,
     @location(1) texCoord: vec2f
 };
 
-// BlendSettings
-struct BlendSettings {
+// BlendSettigs
+struct BlendSettigs {
     format  : u32, // ColorSpace
     dummy0  : f32,
     dummy1  : f32,
@@ -330,7 +335,7 @@ struct VertexOutput {
 
 @group(0) @binding(0) var<uniform> uViewMat      : mat4x4f;
 @group(1) @binding(0) var<uniform> uModelMat     : mat4x4f;
-@group(1) @binding(1) var<uniform> uBlendSettings : BlendSettings;
+@group(1) @binding(1) var<uniform> uBlendSettigs : BlendSettigs;
 @group(2) @binding(0) var uSampler               : sampler;
 @group(2) @binding(1) var uTextureView           : texture_2d<f32>;
 
@@ -347,79 +352,150 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     var color: vec4f = textureSample(uTextureView, uSampler, in.texCoord.xy);
     var result: vec4f = color;
-    var format: u32 = uBlendSettings.format;
+    var format: u32 = uBlendSettigs.format;
     if (format == 1u) { /* FMT_ARGB8888 */
         result = color.bgra;
     } else if (format == 2u) { /* FMT_ABGR8888S */
-        result = vec4(color.rgb * color.a, color.a);
+        result = color.rgba;
     } else if (format == 3u) { /* FMT_ARGB8888S */
-        result = vec4(color.bgr * color.a, color.a);
+        result = color.bgra;
     }
-    return vec4f(result.rgb, result.a * uBlendSettings.opacity);
+    return result * uBlendSettigs.opacity;
 };
-)";
+);
 
 //************************************************************************
 // cShaderSource_PipelineComputeBlend
 //************************************************************************
 
-// pipeline shader modules clear
-const char* cShaderSource_PipelineComputeClear = R"(
-@group(0) @binding(0) var imageDst : texture_storage_2d<rgba8unorm, read_write>;
-
-@compute @workgroup_size(8, 8)
-fn cs_main( @builtin(global_invocation_id) id: vec3u) {
-    textureStore(imageDst, id.xy, vec4f(0.0, 0.0, 0.0, 0.0));
-}
-)";
-
-
-// pipeline shader modules blend
-const char* cShaderSource_PipelineComputeBlend = R"(
+const std::string strBlendShaderHeader = WG_SHADER_SOURCE(
 @group(0) @binding(0) var imageSrc : texture_storage_2d<rgba8unorm, read_write>;
 @group(1) @binding(0) var imageDst : texture_storage_2d<rgba8unorm, read_write>;
 @group(2) @binding(0) var<uniform> blendMethod : u32;
+@group(3) @binding(0) var<uniform> opacity : f32;
 
 @compute @workgroup_size(8, 8)
 fn cs_main( @builtin(global_invocation_id) id: vec3u) {
     let texSize = textureDimensions(imageSrc);
     if ((id.x >= texSize.x) || (id.y >= texSize.y)) { return; };
 
-    let srcColor = textureLoad(imageSrc, id.xy);
-    if (srcColor.a == 0.0) { return; };
-    let dstColor = textureLoad(imageDst, id.xy);
+    let colorSrc= textureLoad(imageSrc, id.xy);
+    if (colorSrc.a == 0.0) { return; }
+    let colorDst = textureLoad(imageDst, id.xy);
 
-    let Sa: f32  = srcColor.a;
-    let Da: f32  = dstColor.a;
-    let S: vec3f = srcColor.xyz;
-    let D: vec3f = dstColor.xyz;
-    let One: vec3f = vec3(1.0);
+    var One: vec3f = vec3(1.0);
+    var So: f32    = opacity;
+    var Sc: vec3f  = colorSrc.rgb;
+    var Sa: f32    = colorSrc.a;
+    var Dc: vec3f  = colorDst.rgb;
+    var Da: f32    = colorDst.a;
+    var Rc: vec3f  = colorDst.rgb;
+    var Ra: f32    = 1.0;
+);
 
-    var color: vec3f = vec3f(0.0, 0.0, 0.0);
+const std::string strBlendShaderPreConditionsGradient = WG_SHADER_SOURCE(
+    Sc = Sc + Dc.rgb * (1.0 - Sa);
+    Sa = Sa + Da     * (1.0 - Sa);
+);
+
+const std::string strBlendShaderPreConditionsImage = WG_SHADER_SOURCE(
+    Sc = Sc * So;
+    Sa = Sa * So;
+);
+
+const std::string strBlendShaderBlendMethod = WG_SHADER_SOURCE(
     switch blendMethod {
-        /* Normal     */ case 0u:  { color = (Sa * S) + (1.0 - Sa) * D; }
-        /* Add        */ case 1u:  { color = (S + D); }
-        /* Screen     */ case 2u:  { color = (S + D) - (S * D); }
-        /* Multiply   */ case 3u:  { color = (S * D); }
-        /* Overlay    */ case 4u:  { color = (Sa * Da) - 2 * (Da - S) * (Sa - D); }
-        /* Difference */ case 5u:  { color = abs(S - D); }
-        /* Exclusion  */ case 6u:  { color = S + D - (2 * S * D); }
-        /* SrcOver    */ case 7u:  { color = S; }
-        /* Darken     */ case 8u:  { color = min(S, D); }
-        /* Lighten    */ case 9u:  { color = max(S, D); }
-        /* ColorDodge */ case 10u: { color = D / (One - S); }
-        /* ColorBurn  */ case 11u: { color = One - (One - D) / S; }
-        /* HardLight  */ case 12u: { color = (Sa * Da) - 2.0 * (Da - S) * (Sa - D); }
-        /* SoftLight  */ case 13u: { color = (One - 2 * S) * (D * D) + (2 * S * D); }
-        default:  { color = (Sa * S) + (1.0 - Sa) * D; }
+        /* Normal     */ case 0u:  {
+            Rc = Sc + Dc * (1.0 - Sa);
+            Ra = Sa + Da * (1.0 - Sa);
+        }
+        /* Add        */ case 1u:  { Rc = Sc + Dc; }
+        /* Screen     */ case 2u:  { Rc = Sc + Dc - Sc * Dc; }
+        /* Multiply   */ case 3u:  { Rc = Sc * Dc; }
+        /* Overlay    */ case 4u:  { 
+            Rc.r = select(1.0 - min(1.0, 2 * (1 - Sc.r) * (1 - Dc.r)), min(1.0, 2 * Sc.r * Dc.r), (Dc.r < 0.5));
+            Rc.g = select(1.0 - min(1.0, 2 * (1 - Sc.g) * (1 - Dc.g)), min(1.0, 2 * Sc.g * Dc.g), (Dc.g < 0.5));
+            Rc.b = select(1.0 - min(1.0, 2 * (1 - Sc.b) * (1 - Dc.b)), min(1.0, 2 * Sc.b * Dc.b), (Dc.b < 0.5));
+        }
+        /* Difference */ case 5u:  { Rc = abs(Dc - Sc); }
+        /* Exclusion  */ case 6u:  { Rc = min(One, Sc + Dc - min(One, 2 * Sc * Dc)); }
+        /* SrcOver    */ case 7u:  { Rc = Sc; Ra = Sa; }
+        /* Darken     */ case 8u:  { Rc = min(Sc, Dc); }
+        /* Lighten    */ case 9u:  { Rc = max(Sc, Dc); }
+        /* ColorDodge */ case 10u: {
+            Rc.r = select(Dc.r, (Dc.r * 255.0 / (255.0 - Sc.r * 255.0))/255.0, (1.0 - Sc.r > 0.0));
+            Rc.g = select(Dc.g, (Dc.g * 255.0 / (255.0 - Sc.g * 255.0))/255.0, (1.0 - Sc.g > 0.0));
+            Rc.b = select(Dc.b, (Dc.b * 255.0 / (255.0 - Sc.b * 255.0))/255.0, (1.0 - Sc.b > 0.0));
+        }
+        /* ColorBurn  */ case 11u: {
+            Rc.r = select(1.0 - Dc.r, (255.0 - (255.0 - Dc.r * 255.0) / (Sc.r * 255.0)) / 255.0, (Sc.r > 0.0));
+            Rc.g = select(1.0 - Dc.g, (255.0 - (255.0 - Dc.g * 255.0) / (Sc.g * 255.0)) / 255.0, (Sc.g > 0.0));
+            Rc.b = select(1.0 - Dc.b, (255.0 - (255.0 - Dc.b * 255.0) / (Sc.b * 255.0)) / 255.0, (Sc.b > 0.0));
+        }
+        /* HardLight  */ case 12u: {
+            Rc.r = select(1.0 - min(1.0, 2 * (1 - Sc.r) * (1 - Dc.r)), min(1.0, 2 * Sc.r * Dc.r), (Sc.r < 0.5));
+            Rc.g = select(1.0 - min(1.0, 2 * (1 - Sc.g) * (1 - Dc.g)), min(1.0, 2 * Sc.g * Dc.g), (Sc.g < 0.5));
+            Rc.b = select(1.0 - min(1.0, 2 * (1 - Sc.b) * (1 - Dc.b)), min(1.0, 2 * Sc.b * Dc.b), (Sc.b < 0.5));
+        }
+        /* SoftLight  */ case 13u: { Rc = min(One, (One - 2 * Sc) * Dc * Dc + 2.0 * Sc * Dc); }
+        default:  { 
+            Rc = Sc + Dc * (1.0 - Sa);
+            Ra = Sa + Da * (1.0 - Sa);
+        }
     }
+);
 
-    textureStore(imageDst, id.xy, vec4f(color, Sa));
+const std::string strBlendShaderPostConditionsGradient = WG_SHADER_SOURCE(
+    // nothing
+);
+
+const std::string strBlendShaderPostConditionsImage = WG_SHADER_SOURCE(
+    Rc = select(mix(Dc, Rc, Sa), Rc, blendMethod == 0);
+    Ra = select(mix(Da, Ra, Sa), Ra, blendMethod == 0);
+);
+
+const std::string strBlendShaderFooter = WG_SHADER_SOURCE(
+    textureStore(imageDst, id.xy, vec4(Rc, Ra));
 }
-)";
+);
+
+// pipeline shader modules blend solid
+const std::string strComputeBlendSolid =
+    strBlendShaderHeader + 
+    strBlendShaderBlendMethod + 
+    strBlendShaderFooter;
+const char* cShaderSource_PipelineComputeBlendSolid = strComputeBlendSolid.c_str();
+
+// pipeline shader modules blend gradient
+const std::string strComputeBlendGradient =
+    strBlendShaderHeader + 
+    strBlendShaderPreConditionsGradient + 
+    strBlendShaderBlendMethod + 
+    strBlendShaderPostConditionsGradient + 
+    strBlendShaderFooter;
+const char* cShaderSource_PipelineComputeBlendGradient = strComputeBlendGradient.c_str();
+
+// pipeline shader modules blend image
+const std::string strComputeBlendImage =
+    strBlendShaderHeader + 
+    strBlendShaderPreConditionsImage + 
+    strBlendShaderBlendMethod + 
+    strBlendShaderPostConditionsImage + 
+    strBlendShaderFooter;
+const char* cShaderSource_PipelineComputeBlendImage = strComputeBlendImage.c_str();
+
+// pipeline shader modules clear
+const char* cShaderSource_PipelineComputeClear = WG_SHADER_SOURCE(
+@group(0) @binding(0) var imageDst : texture_storage_2d<rgba8unorm, read_write>;
+
+@compute @workgroup_size(8, 8)
+fn cs_main( @builtin(global_invocation_id) id: vec3u) {
+    textureStore(imageDst, id.xy, vec4f(0.0, 0.0, 0.0, 0.0));
+}
+);
 
 // pipeline shader modules compose
-const char* cShaderSource_PipelineComputeCompose = R"(
+const char* cShaderSource_PipelineComputeCompose = WG_SHADER_SOURCE(
 @group(0) @binding(0) var imageSrc : texture_storage_2d<rgba8unorm, read_write>;
 @group(1) @binding(0) var imageMsk : texture_storage_2d<rgba8unorm, read_write>;
 @group(2) @binding(0) var<uniform> composeMethod : u32;
@@ -451,10 +527,10 @@ fn cs_main( @builtin(global_invocation_id) id: vec3u) {
 
     textureStore(imageSrc, id.xy, vec4f(color, alpha * opacity));
 }
-)";
+);
 
 // pipeline shader modules compose blend
-const char* cShaderSource_PipelineComputeComposeBlend = R"(
+const char* cShaderSource_PipelineComputeComposeBlend = WG_SHADER_SOURCE(
 @group(0) @binding(0) var imageSrc : texture_storage_2d<rgba8unorm, read>;
 @group(0) @binding(1) var imageMsk : texture_storage_2d<rgba8unorm, read>;
 @group(0) @binding(2) var imageDst : texture_storage_2d<rgba8unorm, read_write>;
@@ -472,30 +548,33 @@ fn cs_main( @builtin(global_invocation_id) id: vec3u) {
     if ((length(colorSrc) == 0.0) || (length(colorMsk) == 0.0)) { return; };
     let colorDst = textureLoad(imageDst, id.xy);
 
-    var color: vec3f = colorSrc.xyz;
+    var result: vec3f = colorSrc.xyz;
     var alpha: f32   = colorMsk.a;
     let luma: f32    = dot(colorMsk.xyz, vec3f(0.299, 0.587, 0.114));
     switch composeMethod {
-        /* None           */ case 0u: { color = colorSrc.xyz; }
+        /* None           */ case 0u: { result = colorSrc.xyz; }
         /* ClipPath       */ case 1u: { if (colorMsk.a == 0) { alpha = 0.0; }; }
-        /* AlphaMask      */ case 2u: { color = colorSrc.xyz; alpha = colorSrc.a * colorMsk.a; }
-        /* InvAlphaMask   */ case 3u: { color = colorSrc.xyz; alpha = colorSrc.a * (1.0 - colorMsk.a); }
-        /* LumaMask       */ case 4u: { color = colorSrc.xyz; alpha = colorSrc.a * luma; }
-        /* InvLumaMask    */ case 5u: { color = colorSrc.xyz; alpha = colorSrc.a * (1.0 - luma); }
-        /* AddMask        */ case 6u: { color = colorSrc.xyz * colorSrc.a + colorMsk.xyz * (1.0 - colorSrc.a); }
-        /* SubtractMask   */ case 7u: { color = colorSrc.xyz * colorSrc.a - colorMsk.xyz * (1.0 - colorSrc.a); }
-        /* IntersectMask  */ case 8u: { color = colorSrc.xyz * min(colorSrc.a, colorMsk.a); }
-        /* DifferenceMask */ case 9u: { color = abs(colorMsk.xyz - colorSrc.xyz * (1.0 - colorMsk.a)); }
-        default: { color = colorSrc.xyz; }
+        /* AlphaMask      */ case 2u: { result = colorSrc.xyz; alpha = colorSrc.a * colorMsk.a; }
+        /* InvAlphaMask   */ case 3u: { result = colorSrc.xyz; alpha = colorSrc.a * (1.0 - colorMsk.a); }
+        /* LumaMask       */ case 4u: { result = colorSrc.xyz; alpha = colorSrc.a * luma; }
+        /* InvLumaMask    */ case 5u: { result = colorSrc.xyz; alpha = colorSrc.a * (1.0 - luma); }
+        /* AddMask        */ case 6u: { result = colorSrc.xyz * colorSrc.a + colorMsk.xyz * (1.0 - colorSrc.a); }
+        /* SubtractMask   */ case 7u: { result = colorSrc.xyz * colorSrc.a - colorMsk.xyz * (1.0 - colorSrc.a); }
+        /* IntersectMask  */ case 8u: { result = colorSrc.xyz * min(colorSrc.a, colorMsk.a); }
+        /* DifferenceMask */ case 9u: { result = abs(colorMsk.xyz - colorSrc.xyz * (1.0 - colorMsk.a)); }
+        default: { result = colorSrc.xyz; }
     }
 
-    let S: vec3f = color.xyz;
-    let D: vec3f = colorDst.xyz;
+    let So: f32  = opacity;
     let Sa: f32  = alpha;
     let Da: f32  = colorDst.a;
-    let One: vec3f = vec3(1.0);
+    let S: vec4f = vec4(result, alpha);
+    let D: vec4f = colorDst;
+    let One: vec4f = vec4(1.0);
+
+    var color: vec4f = vec4f(0.0, 0.0, 0.0, 0.0);
     switch blendMethod {
-        /* Normal     */ case 0u:  { color = (Sa * S) + (1.0 - Sa) * D; }
+        /* Normal     */ case 0u:  { color = (S * So) + (1.0 - Sa * So) * D; }
         /* Add        */ case 1u:  { color = (S + D); }
         /* Screen     */ case 2u:  { color = (S + D) - (S * D); }
         /* Multiply   */ case 3u:  { color = (S * D); }
@@ -509,15 +588,15 @@ fn cs_main( @builtin(global_invocation_id) id: vec3u) {
         /* ColorBurn  */ case 11u: { color = One - (One - D) / S; }
         /* HardLight  */ case 12u: { color = (Sa * Da) - 2.0 * (Da - S) * (Sa - D); }
         /* SoftLight  */ case 13u: { color = (One - 2 * S) * (D * D) + (2 * S * D); }
-        default:  { color = (Sa * S) + (1.0 - Sa) * D; }
+        default:  { color = (S * So) + (1.0 - Sa * So) * D; }
     }
 
-    textureStore(imageDst, id.xy, vec4f(color, Sa));
+    textureStore(imageDst, id.xy, color);
 }
-)";
+);
 
 // pipeline shader modules anti-aliasing
-const char* cShaderSource_PipelineComputeAntiAlias = R"(
+const char* cShaderSource_PipelineComputeAntiAlias = WG_SHADER_SOURCE(
 @group(0) @binding(0) var imageSrc : texture_storage_2d<rgba8unorm, read_write>;
 @group(1) @binding(0) var imageDst : texture_storage_2d<bgra8unorm, write>;
 
@@ -537,4 +616,4 @@ fn cs_main( @builtin(global_invocation_id) id: vec3u) {
 
     textureStore(imageDst, id.xy, color / f32(samples * samples));
 }
-)";
+);

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -42,7 +42,9 @@ extern const char* cShaderSource_PipelineImage;
 
 // pipeline shader modules clear, compose and blend
 extern const char* cShaderSource_PipelineComputeClear;
-extern const char* cShaderSource_PipelineComputeBlend;
+extern const char* cShaderSource_PipelineComputeBlendSolid;
+extern const char* cShaderSource_PipelineComputeBlendGradient;
+extern const char* cShaderSource_PipelineComputeBlendImage;
 extern const char* cShaderSource_PipelineComputeCompose;
 extern const char* cShaderSource_PipelineComputeComposeBlend;
 extern const char* cShaderSource_PipelineComputeAntiAlias;


### PR DESCRIPTION
See Blending, SceneBlending, Opacity examples

Full review of blending support.
Support Solid color, Gradient fill and Image blending workflows

See [Blend Mechanics](https://github.com/thorvg/thorvg/wiki/WebGPU-Raster-Engine-Development#blendcomposition-mechanics)

sw/before/after
![image](https://github.com/thorvg/thorvg/assets/7770034/13dffb90-1bd9-4b39-8596-18fb52401f42)
