### PR TITLE
gl_engine: support simple hairline stroke rendering

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.h
+++ b/src/renderer/gl_engine/tvgGlGeometry.h
@@ -27,6 +27,7 @@
 #include "tvgGlCommon.h"
 #include "tvgMath.h"
 
+#define MIN_GL_STROKE_WIDTH 0.5f
 
 #define MVP_MATRIX() \
     float mvp[4*4] = { \

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -581,6 +581,14 @@ void GlRenderer::drawPrimitive(GlShape& sdata, uint8_t r, uint8_t g, uint8_t b, 
 
     a = MULTIPLY(a, sdata.opacity);
 
+    if (flag & RenderUpdateFlag::Stroke) {
+        float strokeWidth = sdata.rshape->strokeWidth();
+        if (strokeWidth < MIN_GL_STROKE_WIDTH) {
+            float alpha = strokeWidth / MIN_GL_STROKE_WIDTH;
+            a = MULTIPLY(a, static_cast<uint8_t>(alpha * 255));
+        }
+    }
+
     // matrix buffer
     {
         auto matrix = sdata.geometry->getTransformMatrix();
@@ -710,6 +718,15 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
         });
     }
 
+    float alpha = 1.0f;
+
+    if (flag & RenderUpdateFlag::GradientStroke) {
+        float strokeWidth = sdata.rshape->strokeWidth();
+        if (strokeWidth < MIN_GL_STROKE_WIDTH) {
+            alpha = strokeWidth / MIN_GL_STROKE_WIDTH;
+        }
+    }
+
     // gradient block
     {
         GlBindingResource gradientBinding{};
@@ -730,7 +747,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
                 gradientBlock.stopColors[i * 4 + 0] = stops[i].r / 255.f;
                 gradientBlock.stopColors[i * 4 + 1] = stops[i].g / 255.f;
                 gradientBlock.stopColors[i * 4 + 2] = stops[i].b / 255.f;
-                gradientBlock.stopColors[i * 4 + 3] = stops[i].a / 255.f;
+                gradientBlock.stopColors[i * 4 + 3] = stops[i].a / 255.f * alpha;
                 nStops++;
             }
             gradientBlock.nStops[0] = nStops * 1.f;
@@ -766,7 +783,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
                 gradientBlock.stopColors[i * 4 + 0] = stops[i].r / 255.f;
                 gradientBlock.stopColors[i * 4 + 1] = stops[i].g / 255.f;
                 gradientBlock.stopColors[i * 4 + 2] = stops[i].b / 255.f;
-                gradientBlock.stopColors[i * 4 + 3] = stops[i].a / 255.f;
+                gradientBlock.stopColors[i * 4 + 3] = stops[i].a / 255.f * alpha;
                 nStops++;
             }
             gradientBlock.nStops[0] = nStops * 1.f;

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -148,7 +148,7 @@ private:
     Array<float>* mResGlPoints;
     Array<uint32_t>* mResIndices;
     Matrix mMatrix;
-    float mStrokeWidth = 1.f;
+    float mStrokeWidth = MIN_GL_STROKE_WIDTH;
     float mMiterLimit = 4.f;
     StrokeCap mStrokeCap = StrokeCap::Square;
     StrokeJoin mStrokeJoin = StrokeJoin::Bevel;


### PR DESCRIPTION
This PR can improve the hairline rendering : #2509 


<img width="1015" alt="截屏2024-07-03 21 35 48" src="https://github.com/thorvg/thorvg/assets/26308154/d6968a19-6e0b-4410-9ec6-1697ba580ea3">
