### PR TITLE
gl_engine: fix memory leak when rendering image

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -951,7 +951,10 @@ bool GlRenderer::renderImage(void* data)
     auto task = new GlRenderTask(mPrograms[RT_Image].get());
     task->setDrawDepth(drawDepth);
 
-    if (!sdata->geometry->draw(task, mGpuBuffer.get(), RenderUpdateFlag::Image)) return true;
+    if (!sdata->geometry->draw(task, mGpuBuffer.get(), RenderUpdateFlag::Image)) {
+        delete task;
+        return true;
+    }
 
     // matrix buffer
     {


### PR DESCRIPTION
Fix memory leak when nothing need to be draw in renderImage
issue: #2522 