### PR TITLE
gl_engine: --deprecated warnings on macOS

### DIFF
--- a/src/renderer/gl_engine/meson.build
+++ b/src/renderer/gl_engine/meson.build
@@ -25,6 +25,7 @@ source_file = [
 
 if host_machine.system() == 'darwin'
     gl_dep = declare_dependency(link_args: ['-framework', 'OpenGL'])
+    compiler_flags += ['-Wno-deprecated']     #for deprecated opengl
 else
     #find a opengl library with fallbacks
     gl_dep = dependency('GL', required: false)


### PR DESCRIPTION
macOS has officially deprecated OpenGL.
shutdown the warnings to avoid be side-tracked.