### PR TITLE
API: revise the APIs.

### DIFF
--- a/examples/Accessor.cpp
+++ b/examples/Accessor.cpp
@@ -44,7 +44,7 @@ struct UserExample : tvgexam::Example
         //This function will be called for every paint nodes of the picture tree.
         auto f = [](const tvg::Paint* paint) -> bool
         {
-            if (paint->identifier() == tvg::Shape::identifier()) {
+            if (paint->type() == tvg::Type::Shape) {
                 auto shape = (tvg::Shape*) paint;
                 //override color?
                 uint8_t r, g, b;

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -210,6 +210,28 @@ enum class CanvasEngine : uint8_t
 
 
 /**
+ * @brief Enumeration specifying the ThorVG class type value.
+ *
+ * ThorVG's drawing objects can return class type values, allowing you to identify the specific class of each object.
+ *
+ * @see Paint::type()
+ * @see Fill::type()
+ *
+ * @note Experimental API
+ */
+enum class Type : uint8_t
+{
+    Undefined = 0,         ///< Unkown class
+    Shape,                 ///< Shape class
+    Scene,                 ///< Scene class
+    Picture,               ///< Picture class
+    Text,                  ///< Text class
+    LinearGradient = 10,   ///< LinearGradient class
+    RadialGradient         ///< RadialGradient class
+};
+
+
+/**
  * @brief A data structure representing a point in two-dimensional space.
  */
 struct Point
@@ -407,13 +429,20 @@ public:
     BlendMethod blend() const noexcept;
 
     /**
-     * @brief Return the unique id value of the paint instance.
+     * @brief Returns the ID value of this class.
      *
-     * This method can be called for checking the current concrete instance type.
+     * This method can be used to check the current concrete instance type.
      *
-     * @return The type id of the Paint instance.
+     * @return The class type ID of the Paint instance.
+     *
+     * @since Experimental API
      */
-    uint32_t identifier() const noexcept;
+    virtual Type type() const noexcept = 0;
+
+    /**
+     * @see Paint::type()
+     */
+    TVG_DEPRECATED uint32_t identifier() const noexcept;
 
     _TVG_DECLARE_PRIVATE(Paint);
 };
@@ -506,13 +535,20 @@ public:
     Fill* duplicate() const noexcept;
 
     /**
-     * @brief Return the unique id value of the Fill instance.
+     * @brief Returns the ID value of this class.
      *
-     * This method can be called for checking the current concrete instance type.
+     * This method can be used to check the current concrete instance type.
      *
-     * @return The type id of the Fill instance.
+     * @return The class type ID of the Fill instance.
+     *
+     * @since Experimental API
      */
-    uint32_t identifier() const noexcept;
+    virtual Type type() const noexcept = 0;
+
+    /**
+     * @see Fill::type()
+     */
+    TVG_DEPRECATED uint32_t identifier() const noexcept;
 
     _TVG_DECLARE_PRIVATE(Fill);
 };
@@ -686,13 +722,20 @@ public:
     static std::unique_ptr<LinearGradient> gen() noexcept;
 
     /**
-     * @brief Return the unique id value of this class.
+     * @brief Returns the ID value of this class.
      *
-     * This method can be referred for identifying the LinearGradient class type.
+     * This method can be used to check the current concrete instance type.
      *
-     * @return The type id of the LinearGradient class.
+     * @return The class type ID of the LinearGradient instance.
+     *
+     * @since Experimental API
      */
-    static uint32_t identifier() noexcept;
+    Type type() const noexcept override;
+
+    /**
+     * @see LinearGradient::type()
+     */
+    TVG_DEPRECATED static uint32_t identifier() noexcept;
 
     _TVG_DECLARE_PRIVATE(LinearGradient);
 };
@@ -742,13 +785,20 @@ public:
     static std::unique_ptr<RadialGradient> gen() noexcept;
 
     /**
-     * @brief Return the unique id value of this class.
+     * @brief Returns the ID value of this class.
      *
-     * This method can be referred for identifying the RadialGradient class type.
+     * This method can be used to check the current concrete instance type.
      *
-     * @return The type id of the RadialGradient class.
+     * @return The class type ID of the LinearGradient instance.
+     *
+     * @since Experimental API
      */
-    static uint32_t identifier() noexcept;
+    Type type() const noexcept override;
+
+    /**
+     * @see RadialGradient::type()
+     */
+    TVG_DEPRECATED static uint32_t identifier() noexcept;
 
     _TVG_DECLARE_PRIVATE(RadialGradient);
 };
@@ -1155,13 +1205,20 @@ public:
     static std::unique_ptr<Shape> gen() noexcept;
 
     /**
-     * @brief Return the unique id value of this class.
+     * @brief Returns the ID value of this class.
      *
-     * This method can be referred for identifying the Shape class type.
+     * This method can be used to check the current concrete instance type.
      *
-     * @return The type id of the Shape class.
+     * @return The class type ID of the Shape instance.
+     *
+     * @since Experimental API
      */
-    static uint32_t identifier() noexcept;
+    Type type() const noexcept override;
+
+    /**
+     * @see Shape::type()
+     */
+    TVG_DEPRECATED static uint32_t identifier() noexcept;
 
     _TVG_DECLARE_PRIVATE(Shape);
 };
@@ -1302,13 +1359,20 @@ public:
     static std::unique_ptr<Picture> gen() noexcept;
 
     /**
-     * @brief Return the unique id value of this class.
+     * @brief Returns the ID value of this class.
      *
-     * This method can be referred for identifying the Picture class type.
+     * This method can be used to check the current concrete instance type.
      *
-     * @return The type id of the Picture class.
+     * @return The class type ID of the Picture instance.
+     *
+     * @since Experimental API
      */
-    static uint32_t identifier() noexcept;
+    Type type() const noexcept override;
+
+    /**
+     * @see Picture::type()
+     */
+    TVG_DEPRECATED static uint32_t identifier() noexcept;
 
     _TVG_DECLARE_ACCESSOR(Animation);
     _TVG_DECLARE_PRIVATE(Picture);
@@ -1379,13 +1443,20 @@ public:
     static std::unique_ptr<Scene> gen() noexcept;
 
     /**
-     * @brief Return the unique id value of this class.
+     * @brief Returns the ID value of this class.
      *
-     * This method can be referred for identifying the Scene class type.
+     * This method can be used to check the current concrete instance type.
      *
-     * @return The type id of the Scene class.
+     * @return The class type ID of the Scene instance.
+     *
+     * @since Experimental API
      */
-    static uint32_t identifier() noexcept;
+    Type type() const noexcept override;
+
+    /**
+     * @see Scene::type()
+     */
+    TVG_DEPRECATED static uint32_t identifier() noexcept;
 
     _TVG_DECLARE_PRIVATE(Scene);
 };
@@ -1534,13 +1605,15 @@ public:
     static std::unique_ptr<Text> gen() noexcept;
 
     /**
-     * @brief Return the unique id value of this class.
+     * @brief Returns the ID value of this class.
      *
-     * This method can be referred for identifying the Text class type.
+     * This method can be used to check the current concrete instance type.
      *
-     * @return The type id of the Text class.
+     * @return The class type ID of the Text instance.
+     *
+     * @since Experimental API
      */
-    static uint32_t identifier() noexcept;
+    Type type() const noexcept override;
 
     _TVG_DECLARE_PRIVATE(Text);
 };

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -171,11 +171,8 @@ typedef enum {
 
 
 /**
- * \brief Enumeration indicating the ThorVG class type.
- *
- * \ingroup ThorVGCapi_Paint
- *
- * \since 0.9
+ * \see Tvg_Type
+ * \deprecated
  */
 typedef enum {
     TVG_IDENTIFIER_UNDEF = 0,   ///< Undefined type.
@@ -186,6 +183,29 @@ typedef enum {
     TVG_IDENTIFIER_RADIAL_GRAD, ///< A radial gradient type.
     TVG_IDENTIFIER_TEXT         ///< A text type paint.
 } Tvg_Identifier;
+
+
+/**
+ * \brief Enumeration indicating the ThorVG object type value.
+ *
+ * ThorVG's drawing objects can return object type values, allowing you to identify the specific type of each object.
+ *
+ * \ingroup ThorVGCapi_Paint
+ *
+ * \see tvg_paint_get_type()
+ * \see tvg_gradient_get_type()
+ *
+ * \note Experimental API
+ */
+typedef enum {
+    TVG_TYPE_UNDEF = 0,        ///< Undefined type.
+    TVG_TYPE_SHAPE,            ///< A shape type paint.
+    TVG_TYPE_SCENE,            ///< A scene type paint.
+    TVG_TYPE_PICTURE,          ///< A picture type paint.
+    TVG_TYPE_TEXT,             ///< A text type paint.
+    TVG_TYPE_LINEAR_GRAD = 10, ///< A linear gradient type.
+    TVG_TYPE_RADIAL_GRAD       ///< A radial gradient type.
+} Tvg_Type;
 
 
 /**
@@ -948,17 +968,23 @@ TVG_API Tvg_Result tvg_paint_get_composite_method(const Tvg_Paint* paint, const 
 
 
 /**
-* \brief Gets the unique id value of the paint instance indicating the instance type.
+* \brief Gets the unique value of the paint instance indicating the instance type.
 *
-* \param[in] paint The Tvg_Paint object of which to get the identifier value.
-* \param[out] identifier The unique identifier of the paint instance type.
+* \param[in] paint The Tvg_Paint object of which to get the type value.
+* \param[out] type The unique type of the paint instance type.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
 *
-* \since 0.9
+* \note Experimental API
 */
-TVG_API Tvg_Result tvg_paint_get_identifier(const Tvg_Paint* paint, Tvg_Identifier* identifier);
+TVG_API Tvg_Result tvg_paint_get_type(const Tvg_Paint* paint, Tvg_Type* type);
+
+
+/**
+* \see tvg_paint_get_type()
+*/
+TVG_DEPRECATED TVG_API Tvg_Result tvg_paint_get_identifier(const Tvg_Paint* paint, Tvg_Identifier* identifier);
 
 
 /**
@@ -968,7 +994,7 @@ TVG_API Tvg_Result tvg_paint_get_identifier(const Tvg_Paint* paint, Tvg_Identifi
  * its process involves the combination of colors or images from the source paint object with the destination (the lower layer image) using blending operations.
  * The blending operation is determined by the chosen @p BlendMethod, which specifies how the colors or images are combined.
  *
- * \param[in] paint The Tvg_Paint object of which to get the identifier value.
+ * \param[in] paint The Tvg_Paint object of which to set the blend method.
  * \param[in] method The blending method to be set.
  *
  * \return Tvg_Result enumeration.
@@ -986,7 +1012,7 @@ TVG_API Tvg_Result tvg_paint_set_blend_method(const Tvg_Paint* paint, Tvg_Blend_
  * its process involves the combination of colors or images from the source paint object with the destination (the lower layer image) using blending operations.
  * The blending operation is determined by the chosen @p BlendMethod, which specifies how the colors or images are combined.
  *
- * \param[in] paint The Tvg_Paint object of which to get the identifier value.
+ * \param[in] paint The Tvg_Paint object of which to get the blend method.
  * \param[out] method The blending method of the paint.
  *
  * \return Tvg_Result enumeration.
@@ -1860,17 +1886,23 @@ TVG_API Tvg_Result tvg_gradient_set_transform(Tvg_Gradient* grad, const Tvg_Matr
 TVG_API Tvg_Result tvg_gradient_get_transform(const Tvg_Gradient* grad, Tvg_Matrix* m);
 
 /**
-* \brief Gets the unique id value of the gradient instance indicating the instance type.
+* \brief Gets the unique value of the gradient instance indicating the instance type.
 *
-* \param[in] grad The Tvg_Gradient object of which to get the identifier value.
-* \param[out] identifier The unique identifier of the gradient instance type.
+* \param[in] grad The Tvg_Gradient object of which to get the type value.
+* \param[out] type The unique type of the gradient instance type.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
 *
-* \since 0.9
+* \note Experimental API
 */
-TVG_API Tvg_Result tvg_gradient_get_identifier(const Tvg_Gradient* grad, Tvg_Identifier* identifier);
+TVG_API Tvg_Result tvg_gradient_get_type(const Tvg_Gradient* grad, Tvg_Type* type);
+
+
+/**
+* \see tvg_gradient_get_type()
+*/
+TVG_DEPRECATED TVG_API Tvg_Result tvg_gradient_get_identifier(const Tvg_Gradient* grad, Tvg_Identifier* identifier);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -246,11 +246,17 @@ TVG_API Tvg_Result tvg_paint_get_blend_method(const Tvg_Paint* paint, Tvg_Blend_
 }
 
 
-TVG_API Tvg_Result tvg_paint_get_identifier(const Tvg_Paint* paint, Tvg_Identifier* identifier)
+TVG_API Tvg_Result tvg_paint_get_type(const Tvg_Paint* paint, Tvg_Type* type)
 {
-    if (!paint || !identifier) return TVG_RESULT_INVALID_ARGUMENT;
-    *identifier = static_cast<Tvg_Identifier>(reinterpret_cast<const Paint*>(paint)->identifier());
+    if (!paint || !type) return TVG_RESULT_INVALID_ARGUMENT;
+    *type = static_cast<Tvg_Type>(reinterpret_cast<const Paint*>(paint)->type());
     return TVG_RESULT_SUCCESS;
+}
+
+
+TVG_DEPRECATED TVG_API Tvg_Result tvg_paint_get_identifier(const Tvg_Paint* paint, Tvg_Identifier* identifier)
+{
+    return tvg_paint_get_type(paint, (Tvg_Type*) identifier);
 }
 
 /************************************************************************/
@@ -674,11 +680,17 @@ TVG_API Tvg_Result tvg_gradient_get_transform(const Tvg_Gradient* grad, Tvg_Matr
 }
 
 
-TVG_API Tvg_Result tvg_gradient_get_identifier(const Tvg_Gradient* grad, Tvg_Identifier* identifier)
+TVG_API Tvg_Result tvg_gradient_get_type(const Tvg_Gradient* grad, Tvg_Type* type)
 {
-    if (!grad || !identifier) return TVG_RESULT_INVALID_ARGUMENT;
-    *identifier = static_cast<Tvg_Identifier>(reinterpret_cast<const Fill*>(grad)->identifier());
+    if (!grad || !type) return TVG_RESULT_INVALID_ARGUMENT;
+    *type = static_cast<Tvg_Type>(reinterpret_cast<const Fill*>(grad)->type());
     return TVG_RESULT_SUCCESS;
+}
+
+
+TVG_DEPRECATED TVG_API Tvg_Result tvg_gradient_get_identifier(const Tvg_Gradient* grad, Tvg_Identifier* identifier)
+{
+    return tvg_gradient_get_type(grad, (Tvg_Type*) identifier);
 }
 
 /************************************************************************/

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -215,9 +215,9 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
 
     GlRenderTask* task = nullptr;
 
-    if (fill->identifier() == TVG_CLASS_ID_LINEAR) {
+    if (fill->type() == Type::LinearGradient) {
         task = new GlRenderTask(mPrograms[RT_LinGradient].get());
-    } else if (fill->identifier() == TVG_CLASS_ID_RADIAL) {
+    } else if (fill->type() == Type::RadialGradient) {
         task = new GlRenderTask(mPrograms[RT_RadGradient].get());
     } else {
         return;
@@ -318,7 +318,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
         GlBindingResource gradientBinding{};
         uint32_t loc = task->getProgram()->getUniformBlockIndex("GradientInfo");
 
-        if (fill->identifier() == TVG_CLASS_ID_LINEAR) {
+        if (fill->type() == Type::LinearGradient) {
             auto linearFill = static_cast<const LinearGradient*>(fill);
 
             GlLinearGradientBlock gradientBlock;

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -557,11 +557,11 @@ SwOutline* mpoolReqDashOutline(SwMpool* mpool, unsigned idx);
 void mpoolRetDashOutline(SwMpool* mpool, unsigned idx);
 
 bool rasterCompositor(SwSurface* surface);
-bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id);
+bool rasterGradientShape(SwSurface* surface, SwShape* shape, Type type);
 bool rasterShape(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 bool rasterImage(SwSurface* surface, SwImage* image, const RenderMesh* mesh, const Matrix* transform, const SwBBox& bbox, uint8_t opacity);
 bool rasterStroke(SwSurface* surface, SwShape* shape, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id);
+bool rasterGradientStroke(SwSurface* surface, SwShape* shape, Type type);
 bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
 void rasterPixel32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len);
 void rasterGrayscale8(uint8_t *dst, uint8_t val, uint32_t offset, int32_t len);

--- a/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/src/renderer/sw_engine/tvgSwFill.cpp
@@ -66,7 +66,7 @@ static void _calculateCoefficients(const SwFill* fill, uint32_t x, uint32_t y, f
 static uint32_t _estimateAAMargin(const Fill* fdata)
 {
     constexpr float marginScalingFactor = 800.0f;
-    if (fdata->identifier() == TVG_CLASS_ID_RADIAL) {
+    if (fdata->type() == Type::RadialGradient) {
         auto radius = P(static_cast<const RadialGradient*>(fdata))->r;
         return mathZero(radius) ? 0 : static_cast<uint32_t>(marginScalingFactor / radius);
     }
@@ -826,9 +826,9 @@ bool fillGenColorTable(SwFill* fill, const Fill* fdata, const Matrix* transform,
         if (!_updateColorTable(fill, fdata, surface, opacity)) return false;
     }
 
-    if (fdata->identifier() == TVG_CLASS_ID_LINEAR) {
+    if (fdata->type() == Type::LinearGradient) {
         return _prepareLinear(fill, static_cast<const LinearGradient*>(fdata), transform);
-    } else if (fdata->identifier() == TVG_CLASS_ID_RADIAL) {
+    } else if (fdata->type() == Type::RadialGradient) {
         return _prepareRadial(fill, static_cast<const RadialGradient*>(fdata), transform);
     }
 

--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -1901,27 +1901,27 @@ void rasterPremultiply(Surface* surface)
 }
 
 
-bool rasterGradientShape(SwSurface* surface, SwShape* shape, unsigned id)
+bool rasterGradientShape(SwSurface* surface, SwShape* shape, Type type)
 {
     if (!shape->fill) return false;
 
     if (shape->fastTrack) {
-        if (id == TVG_CLASS_ID_LINEAR) return _rasterLinearGradientRect(surface, shape->bbox, shape->fill);
-        else if (id == TVG_CLASS_ID_RADIAL)return _rasterRadialGradientRect(surface, shape->bbox, shape->fill);
+        if (type == Type::LinearGradient) return _rasterLinearGradientRect(surface, shape->bbox, shape->fill);
+        else if (type == Type::RadialGradient)return _rasterRadialGradientRect(surface, shape->bbox, shape->fill);
     } else {
-        if (id == TVG_CLASS_ID_LINEAR) return _rasterLinearGradientRle(surface, shape->rle, shape->fill);
-        else if (id == TVG_CLASS_ID_RADIAL) return _rasterRadialGradientRle(surface, shape->rle, shape->fill);
+        if (type == Type::LinearGradient) return _rasterLinearGradientRle(surface, shape->rle, shape->fill);
+        else if (type == Type::RadialGradient) return _rasterRadialGradientRle(surface, shape->rle, shape->fill);
     }
     return false;
 }
 
 
-bool rasterGradientStroke(SwSurface* surface, SwShape* shape, unsigned id)
+bool rasterGradientStroke(SwSurface* surface, SwShape* shape, Type type)
 {
     if (!shape->stroke || !shape->stroke->fill || !shape->strokeRle) return false;
 
-    if (id == TVG_CLASS_ID_LINEAR) return _rasterLinearGradientRle(surface, shape->strokeRle, shape->stroke->fill);
-    else if (id == TVG_CLASS_ID_RADIAL) return _rasterRadialGradientRle(surface, shape->strokeRle, shape->stroke->fill);
+    if (type == Type::LinearGradient) return _rasterLinearGradientRle(surface, shape->strokeRle, shape->stroke->fill);
+    else if (type == Type::RadialGradient) return _rasterRadialGradientRle(surface, shape->strokeRle, shape->stroke->fill);
 
     return false;
 }

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -336,7 +336,7 @@ static void _renderFill(SwShapeTask* task, SwSurface* surface, uint8_t opacity)
 {
     uint8_t r, g, b, a;
     if (auto fill = task->rshape->fill) {
-        rasterGradientShape(surface, &task->shape, fill->identifier());
+        rasterGradientShape(surface, &task->shape, fill->type());
     } else {
         task->rshape->fillColor(&r, &g, &b, &a);
         a = MULTIPLY(opacity, a);
@@ -348,7 +348,7 @@ static void _renderStroke(SwShapeTask* task, SwSurface* surface, uint8_t opacity
 {
     uint8_t r, g, b, a;
     if (auto strokeFill = task->rshape->strokeFill()) {
-        rasterGradientStroke(surface, &task->shape, strokeFill->identifier());
+        rasterGradientStroke(surface, &task->shape, strokeFill->type());
     } else {
         if (task->rshape->strokeFill(&r, &g, &b, &a)) {
             a = MULTIPLY(opacity, a);

--- a/src/renderer/tvgCommon.h
+++ b/src/renderer/tvgCommon.h
@@ -54,15 +54,6 @@ using namespace tvg;
     #define strdup _strdup
 #endif
 
-//TVG class identifier values
-#define TVG_CLASS_ID_UNDEFINED 0
-#define TVG_CLASS_ID_SHAPE     1
-#define TVG_CLASS_ID_SCENE     2
-#define TVG_CLASS_ID_PICTURE   3
-#define TVG_CLASS_ID_LINEAR    4
-#define TVG_CLASS_ID_RADIAL    5
-#define TVG_CLASS_ID_TEXT      6
-
 enum class FileType { Png = 0, Jpg, Webp, Tvg, Svg, Lottie, Ttf, Raw, Gif, Unknown };
 
 using Size = Point;

--- a/src/renderer/tvgFill.cpp
+++ b/src/renderer/tvgFill.cpp
@@ -155,15 +155,14 @@ Fill* Fill::duplicate() const noexcept
 }
 
 
-uint32_t Fill::identifier() const noexcept
+TVG_DEPRECATED uint32_t Fill::identifier() const noexcept
 {
-    return pImpl->id;
+    return (uint32_t) type();
 }
 
 
 RadialGradient::RadialGradient():pImpl(new Impl())
 {
-    Fill::pImpl->id = TVG_CLASS_ID_RADIAL;
     Fill::pImpl->method(new FillDup<RadialGradient::Impl>(pImpl));
 }
 
@@ -196,15 +195,20 @@ unique_ptr<RadialGradient> RadialGradient::gen() noexcept
 }
 
 
-uint32_t RadialGradient::identifier() noexcept
+TVG_DEPRECATED uint32_t RadialGradient::identifier() noexcept
 {
-    return TVG_CLASS_ID_RADIAL;
+    return (uint32_t) Type::RadialGradient;
+}
+
+
+Type RadialGradient::type() const noexcept
+{
+    return Type::RadialGradient;
 }
 
 
 LinearGradient::LinearGradient():pImpl(new Impl())
 {
-    Fill::pImpl->id = TVG_CLASS_ID_LINEAR;
     Fill::pImpl->method(new FillDup<LinearGradient::Impl>(pImpl));
 }
 
@@ -243,8 +247,13 @@ unique_ptr<LinearGradient> LinearGradient::gen() noexcept
 }
 
 
-uint32_t LinearGradient::identifier() noexcept
+TVG_DEPRECATED uint32_t LinearGradient::identifier() noexcept
 {
-    return TVG_CLASS_ID_LINEAR;
+    return (uint32_t) Type::LinearGradient;
 }
 
+
+Type LinearGradient::type() const noexcept
+{
+    return Type::LinearGradient;
+}

--- a/src/renderer/tvgFill.h
+++ b/src/renderer/tvgFill.h
@@ -55,7 +55,6 @@ struct Fill::Impl
     uint32_t cnt = 0;
     FillSpread spread;
     DuplicateMethod<Fill>* dup = nullptr;
-    uint8_t id;
 
     ~Impl()
     {

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -32,11 +32,11 @@
 /************************************************************************/
 
 #define PAINT_METHOD(ret, METHOD) \
-    switch (id) { \
-        case TVG_CLASS_ID_SHAPE: ret = P((Shape*)paint)->METHOD; break; \
-        case TVG_CLASS_ID_SCENE: ret = P((Scene*)paint)->METHOD; break; \
-        case TVG_CLASS_ID_PICTURE: ret = P((Picture*)paint)->METHOD; break; \
-        case TVG_CLASS_ID_TEXT: ret = P((Text*)paint)->METHOD; break; \
+    switch (paint->type()) { \
+        case Type::Shape: ret = P((Shape*)paint)->METHOD; break; \
+        case Type::Scene: ret = P((Scene*)paint)->METHOD; break; \
+        case Type::Picture: ret = P((Picture*)paint)->METHOD; break; \
+        case Type::Text: ret = P((Text*)paint)->METHOD; break; \
         default: ret = {}; \
     }
 
@@ -282,7 +282,7 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const RenderTransform* pT
         /* If the transformation has no rotational factors and the ClipPath/Alpha(InvAlpha)Masking involves a simple rectangle,
            we can optimize by using the viewport instead of the regular ClipPath/AlphaMasking sequence for improved performance. */
         auto tryFastTrack = false;
-        if (target->identifier() == TVG_CLASS_ID_SHAPE) {
+        if (target->type() == Type::Shape) {
             if (method == CompositeMethod::ClipPath) tryFastTrack = true;
             else {
                 auto shape = static_cast<Shape*>(target);
@@ -474,9 +474,9 @@ uint8_t Paint::opacity() const noexcept
 }
 
 
-uint32_t Paint::identifier() const noexcept
+TVG_DEPRECATED uint32_t Paint::identifier() const noexcept
 {
-    return pImpl->id;
+    return (uint32_t) type();
 }
 
 

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -54,7 +54,6 @@ namespace tvg
         BlendMethod blendMethod = BlendMethod::Normal;   //uint8_t
         uint8_t renderFlag = RenderUpdateFlag::None;
         uint8_t ctxFlag = ContextFlag::Invalid;
-        uint8_t id;
         uint8_t opacity = 255;
         uint8_t refCnt = 0;                              //reference count
 

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -147,7 +147,6 @@ Result Picture::Impl::load(ImageLoader* loader)
 
 Picture::Picture() : pImpl(new Impl(this))
 {
-    Paint::pImpl->id = TVG_CLASS_ID_PICTURE;
 }
 
 
@@ -163,9 +162,15 @@ unique_ptr<Picture> Picture::gen() noexcept
 }
 
 
-uint32_t Picture::identifier() noexcept
+TVG_DEPRECATED uint32_t Picture::identifier() noexcept
 {
-    return TVG_CLASS_ID_PICTURE;
+    return (uint32_t) Type::Picture;
+}
+
+
+Type Picture::type() const noexcept
+{
+    return Type::Picture;
 }
 
 

--- a/src/renderer/tvgScene.cpp
+++ b/src/renderer/tvgScene.cpp
@@ -28,7 +28,6 @@
 
 Scene::Scene() : pImpl(new Impl(this))
 {
-    Paint::pImpl->id = TVG_CLASS_ID_SCENE;
 }
 
 
@@ -44,9 +43,15 @@ unique_ptr<Scene> Scene::gen() noexcept
 }
 
 
-uint32_t Scene::identifier() noexcept
+TVG_DEPRECATED uint32_t Scene::identifier() noexcept
 {
-    return TVG_CLASS_ID_SCENE;
+    return (uint32_t) Type::Scene;
+}
+
+
+Type Scene::type() const noexcept
+{
+    return Type::Scene;
 }
 
 

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -96,7 +96,7 @@ struct Scene::Impl
         //If scene has several children or only scene, it may require composition.
         //OPTIMIZE: the bitmap type of the picture would not need the composition.
         //OPTIMIZE: a single paint of a scene would not need the composition.
-        if (paints.size() == 1 && paints.front()->identifier() == TVG_CLASS_ID_SHAPE) return false;
+        if (paints.size() == 1 && paints.front()->type() == Type::Shape) return false;
 
         return true;
     }

--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -34,7 +34,6 @@
 
 Shape :: Shape() : pImpl(new Impl(this))
 {
-    Paint::pImpl->id = TVG_CLASS_ID_SHAPE;
 }
 
 
@@ -52,7 +51,13 @@ unique_ptr<Shape> Shape::gen() noexcept
 
 uint32_t Shape::identifier() noexcept
 {
-    return TVG_CLASS_ID_SHAPE;
+    return (uint32_t) Type::Shape;
+}
+
+
+Type Shape::type() const noexcept
+{
+    return Type::Shape;
 }
 
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -78,7 +78,7 @@ struct Shape::Impl
         auto method = shape->composite(&target);
         if (!target || method == CompositeMethod::ClipPath) return false;
         if (target->pImpl->opacity == 255 || target->pImpl->opacity == 0) {
-            if (target->identifier() == TVG_CLASS_ID_SHAPE) {
+            if (target->type() == Type::Shape) {
                 auto shape = static_cast<const Shape*>(target);
                 if (!shape->fill()) {
                     uint8_t r, g, b, a;

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -37,7 +37,6 @@
 
 Text::Text() : pImpl(new Impl)
 {
-    Paint::pImpl->id = TVG_CLASS_ID_TEXT;
 }
 
 
@@ -118,7 +117,7 @@ unique_ptr<Text> Text::gen() noexcept
 }
 
 
-uint32_t Text::identifier() noexcept
+Type Text::type() const noexcept
 {
-    return TVG_CLASS_ID_TEXT;
+    return Type::Text;
 }

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -128,7 +128,7 @@ struct Text::Impl
         if (P(paint)->flag & RenderUpdateFlag::Gradient) {
             auto fill = P(paint)->rs.fill;
             auto scale = 1.0f / loader->scale;
-            if (fill->identifier() == TVG_CLASS_ID_LINEAR) {
+            if (fill->type() == Type::LinearGradient) {
                 P(static_cast<LinearGradient*>(fill))->x1 *= scale;
                 P(static_cast<LinearGradient*>(fill))->y1 *= scale;
                 P(static_cast<LinearGradient*>(fill))->x2 *= scale;

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -229,11 +229,11 @@ void WgRenderSettings::update(WgContext& context, const Fill* fill, const uint8_
     // setup fill properties
     if ((flags & (RenderUpdateFlag::Gradient)) && fill) {
         // setup linear fill properties
-        if (fill->identifier() == TVG_CLASS_ID_LINEAR) {
+        if (fill->type() == Type::LinearGradient) {
             WgShaderTypeLinearGradient linearGradient((LinearGradient*)fill);
             bindGroupLinear.initialize(context.device, context.queue, linearGradient);
             fillType = WgRenderSettingsType::Linear;
-        } else if (fill->identifier() == TVG_CLASS_ID_RADIAL) {
+        } else if (fill->type() == Type::RadialGradient) {
             WgShaderTypeRadialGradient radialGradient((RadialGradient*)fill);
             bindGroupRadial.initialize(context.device, context.queue, radialGradient);
             fillType = WgRenderSettingsType::Radial;

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -90,7 +90,7 @@ struct WgRenderDataPaint
 
     virtual ~WgRenderDataPaint() {};
     virtual void release(WgContext& context);
-    virtual uint32_t identifier() { return TVG_CLASS_ID_UNDEFINED; };
+    virtual Type type() { return Type::Undefined; };
 };
 
 struct WgRenderDataShape: public WgRenderDataPaint
@@ -112,7 +112,7 @@ struct WgRenderDataShape: public WgRenderDataPaint
     void updateMeshes(WgContext& context, const WgPolyline* polyline, const RenderStroke* rstroke);
     void releaseMeshes(WgContext& context);
     void release(WgContext& context) override;
-    uint32_t identifier() override { return TVG_CLASS_ID_SHAPE; };
+    Type type() override { return Type::Shape; };
 };
 
 class WgRenderDataShapePool {
@@ -133,5 +133,5 @@ struct WgRenderDataPicture: public WgRenderDataPaint
 
     void update(WgContext& context);
     void release(WgContext& context) override;
-    uint32_t identifier() override { return TVG_CLASS_ID_PICTURE; };
+    Type type() override { return Type::Picture; };
 };

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -225,7 +225,7 @@ void WgRenderer::dispose(RenderData data)
 {
     auto renderData = (WgRenderDataPaint*)data;
     if (renderData) {
-        if (renderData->identifier() == TVG_CLASS_ID_SHAPE)
+        if (renderData->type() == Type::Shape)
             mRenderDataShapePool.free(mContext, (WgRenderDataShape*)renderData);
         else
             renderData->release(mContext);

--- a/test/capi/capiAnimation.cpp
+++ b/test/capi/capiAnimation.cpp
@@ -34,9 +34,9 @@ TEST_CASE("Animation Basic", "[capiAnimation]")
     Tvg_Paint* picture = tvg_animation_get_picture(animation);
     REQUIRE(picture);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(picture, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_PICTURE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(picture, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_PICTURE);
 
     //Negative cases
     REQUIRE(tvg_animation_set_frame(animation, 0) == TVG_RESULT_INSUFFICIENT_CONDITION);
@@ -72,9 +72,9 @@ TEST_CASE("Animation Lottie", "[capiAnimation]")
     Tvg_Paint* picture = tvg_animation_get_picture(animation);
     REQUIRE(picture);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(picture, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_PICTURE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(picture, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_PICTURE);
 
     REQUIRE(tvg_picture_load(picture, TEST_DIR"/invalid.json") == TVG_RESULT_INVALID_ARGUMENT);
     REQUIRE(tvg_picture_load(picture, TEST_DIR"/test.json") == TVG_RESULT_SUCCESS);
@@ -107,9 +107,9 @@ TEST_CASE("Animation Segment", "[capiAnimation]")
     Tvg_Paint* picture = tvg_animation_get_picture(animation);
     REQUIRE(picture);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(picture, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_PICTURE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(picture, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_PICTURE);
 
     float begin, end;
 

--- a/test/capi/capiLinearGradient.cpp
+++ b/test/capi/capiLinearGradient.cpp
@@ -29,10 +29,10 @@ TEST_CASE("Linear Gradient Basic Create", "[capiLinearGradient]")
     Tvg_Gradient *gradient = tvg_linear_gradient_new();
     REQUIRE(gradient);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_gradient_get_identifier(gradient, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_LINEAR_GRAD);
-    REQUIRE(id != TVG_IDENTIFIER_RADIAL_GRAD);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_gradient_get_type(gradient, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_LINEAR_GRAD);
+    REQUIRE(type != TVG_TYPE_RADIAL_GRAD);
 
     REQUIRE(tvg_gradient_del(gradient) == TVG_RESULT_SUCCESS);
 }
@@ -144,7 +144,7 @@ TEST_CASE("Linear Gradient duplicate", "[capiLinearGradient]")
     REQUIRE(tvg_paint_del(shape) == TVG_RESULT_SUCCESS);
 }
 
-TEST_CASE("Linear Gradient identifier", "[capiLinearGradient]")
+TEST_CASE("Linear Gradient type", "[capiLinearGradient]")
 {
     Tvg_Gradient* grad = tvg_linear_gradient_new();
     REQUIRE(grad);
@@ -152,14 +152,14 @@ TEST_CASE("Linear Gradient identifier", "[capiLinearGradient]")
     Tvg_Gradient* grad_copy = tvg_gradient_duplicate(grad);
     REQUIRE(grad_copy);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    Tvg_Identifier id_copy = TVG_IDENTIFIER_UNDEF;
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    Tvg_Type type2 = TVG_TYPE_UNDEF;
 
-    REQUIRE(tvg_gradient_get_identifier(nullptr, &id) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_gradient_get_identifier(grad, nullptr) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_gradient_get_identifier(grad, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(tvg_gradient_get_identifier(grad_copy, &id_copy) == TVG_RESULT_SUCCESS);
-    REQUIRE(id_copy == id);
+    REQUIRE(tvg_gradient_get_type(nullptr, &type) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_gradient_get_type(grad, nullptr) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_gradient_get_type(grad, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_gradient_get_type(grad_copy, &type2) == TVG_RESULT_SUCCESS);
+    REQUIRE(type2 == type);
 
     REQUIRE(tvg_gradient_del(grad_copy) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_gradient_del(grad) == TVG_RESULT_SUCCESS);

--- a/test/capi/capiLottie.cpp
+++ b/test/capi/capiLottie.cpp
@@ -37,9 +37,9 @@ TEST_CASE("Lottie Slot", "[capiLottie]")
     Tvg_Paint* picture = tvg_animation_get_picture(animation);
     REQUIRE(picture);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(picture, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_PICTURE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(picture, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_PICTURE);
 
     const char* slotJson = R"({"gradient_fill":{"p":{"a":0,"k":[0,0.1,0.1,0.2,1,1,0.1,0.2,0.1,1]}}})";
 
@@ -79,9 +79,9 @@ TEST_CASE("Lottie Slot 2", "[capiLottie]")
     Tvg_Paint* picture = tvg_animation_get_picture(animation);
     REQUIRE(picture);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(picture, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_PICTURE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(picture, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_PICTURE);
 
     const char* slotJson = R"({"lottie-icon-outline":{"p":{"a":0,"k":[1,1,0]}},"lottie-icon-solid":{"p":{"a":0,"k":[0,0,1]}}})";
 
@@ -112,9 +112,9 @@ TEST_CASE("Lottie Marker", "[capiLottie]")
     Tvg_Paint* picture = tvg_animation_get_picture(animation);
     REQUIRE(picture);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(picture, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_PICTURE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(picture, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_PICTURE);
 
     //Set marker before loaded
     REQUIRE(tvg_lottie_animation_set_marker(animation, "sectionC") == TVG_RESULT_INSUFFICIENT_CONDITION);

--- a/test/capi/capiPaint.cpp
+++ b/test/capi/capiPaint.cpp
@@ -216,14 +216,14 @@ TEST_CASE("Paint Identifier", "[capiPaint]")
     Tvg_Paint* paint_copy = tvg_paint_duplicate(paint);
     REQUIRE(paint_copy);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    Tvg_Identifier id_copy = TVG_IDENTIFIER_UNDEF;
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    Tvg_Type type2 = TVG_TYPE_UNDEF;
 
-    REQUIRE(tvg_paint_get_identifier(nullptr, &id) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_paint_get_identifier(paint, nullptr) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_paint_get_identifier(paint, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(tvg_paint_get_identifier(paint_copy, &id_copy) == TVG_RESULT_SUCCESS);
-    REQUIRE(id_copy == id);
+    REQUIRE(tvg_paint_get_type(nullptr, &type) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_paint_get_type(paint, nullptr) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_paint_get_type(paint, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_paint_get_type(paint_copy, &type2) == TVG_RESULT_SUCCESS);
+    REQUIRE(type2 == type);
 
     REQUIRE(tvg_paint_del(paint_copy) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_paint_del(paint) == TVG_RESULT_SUCCESS);

--- a/test/capi/capiPicture.cpp
+++ b/test/capi/capiPicture.cpp
@@ -31,11 +31,11 @@ TEST_CASE("Load Raw file in Picture", "[capiPicture]")
     Tvg_Paint* picture = tvg_picture_new();
     REQUIRE(picture);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(picture, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_PICTURE);
-    REQUIRE(id != TVG_IDENTIFIER_SHAPE);
-    REQUIRE(id != TVG_IDENTIFIER_SCENE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(picture, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_PICTURE);
+    REQUIRE(type != TVG_TYPE_SHAPE);
+    REQUIRE(type != TVG_TYPE_SCENE);
 
     //Load Raw Data
     FILE* fp = fopen(TEST_DIR"/rawimage_200x300.raw", "r");

--- a/test/capi/capiRadialGradient.cpp
+++ b/test/capi/capiRadialGradient.cpp
@@ -29,10 +29,10 @@ TEST_CASE("Basic Create", "[capiRadialGradient]")
     Tvg_Gradient *gradient = tvg_radial_gradient_new();
     REQUIRE(gradient);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_gradient_get_identifier(gradient, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_RADIAL_GRAD);
-    REQUIRE(id != TVG_IDENTIFIER_LINEAR_GRAD);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_gradient_get_type(gradient, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_RADIAL_GRAD);
+    REQUIRE(type != TVG_TYPE_LINEAR_GRAD);
 
     REQUIRE(tvg_gradient_del(gradient) == TVG_RESULT_SUCCESS);
 }

--- a/test/capi/capiScene.cpp
+++ b/test/capi/capiScene.cpp
@@ -29,11 +29,11 @@ TEST_CASE("Create a Scene", "[capiScene]")
     Tvg_Paint* scene = tvg_scene_new();
     REQUIRE(scene);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(scene, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_SCENE);
-    REQUIRE(id != TVG_IDENTIFIER_PICTURE);
-    REQUIRE(id != TVG_IDENTIFIER_SHAPE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(scene, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_SCENE);
+    REQUIRE(type != TVG_TYPE_PICTURE);
+    REQUIRE(type != TVG_TYPE_SHAPE);
 
     REQUIRE(tvg_paint_del(scene) == TVG_RESULT_SUCCESS);
 }

--- a/test/capi/capiShape.cpp
+++ b/test/capi/capiShape.cpp
@@ -29,11 +29,11 @@ TEST_CASE("Multiple shapes", "[capiShapes]")
     Tvg_Paint* paint = tvg_shape_new();
     REQUIRE(paint);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(paint, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_SHAPE);
-    REQUIRE(id != TVG_IDENTIFIER_SCENE);
-    REQUIRE(id != TVG_IDENTIFIER_PICTURE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(paint, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_SHAPE);
+    REQUIRE(type != TVG_TYPE_SCENE);
+    REQUIRE(type != TVG_TYPE_PICTURE);
 
     REQUIRE(tvg_shape_append_rect(paint, 0, 0, 100, 100, 0, 0) == TVG_RESULT_SUCCESS);
     REQUIRE(tvg_shape_append_rect(paint, 0, 0, 100, 100, 50, 50) == TVG_RESULT_SUCCESS);

--- a/test/capi/capiText.cpp
+++ b/test/capi/capiText.cpp
@@ -33,12 +33,9 @@ TEST_CASE("Create text", "[capiText]")
     Tvg_Paint* text = tvg_text_new();
     REQUIRE(text);
 
-    Tvg_Identifier id = TVG_IDENTIFIER_UNDEF;
-    REQUIRE(tvg_paint_get_identifier(text, &id) == TVG_RESULT_SUCCESS);
-    REQUIRE(id == TVG_IDENTIFIER_TEXT);
-    REQUIRE(id != TVG_IDENTIFIER_SHAPE);
-    REQUIRE(id != TVG_IDENTIFIER_SCENE);
-    REQUIRE(id != TVG_IDENTIFIER_PICTURE);
+    Tvg_Type type = TVG_TYPE_UNDEF;
+    REQUIRE(tvg_paint_get_type(text, &type) == TVG_RESULT_SUCCESS);
+    REQUIRE(type == TVG_TYPE_TEXT);
 
     REQUIRE(tvg_paint_del(text) == TVG_RESULT_SUCCESS);
 }

--- a/test/testAccessor.cpp
+++ b/test/testAccessor.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Set", "[tvgAccessor]")
     //Case 2
     auto f = [](const tvg::Paint* paint) -> bool
     {
-        if (paint->identifier() == tvg::Shape::identifier()) {
+        if (paint->type() == Type::Shape) {
             auto shape = (tvg::Shape*) paint;
             uint8_t r, g, b;
             shape->fillColor(&r, &g, &b);

--- a/test/testAnimation.cpp
+++ b/test/testAnimation.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Animation Basic", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
+    REQUIRE(picture->type() == Type::Picture);
 
     //Negative cases
     REQUIRE(animation->frame(0.0f) == Result::InsufficientCondition);
@@ -55,7 +55,6 @@ TEST_CASE("Animation Frames Counting", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test.json") == Result::Success);
 
@@ -93,7 +92,6 @@ TEST_CASE("Animation Lottie", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/invalid.json") == Result::InvalidArguments);
     REQUIRE(picture->load(TEST_DIR"/test.json") == Result::Success);
@@ -114,7 +112,6 @@ TEST_CASE("Animation Lottie2", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test2.json") == Result::Success);
 
@@ -131,7 +128,6 @@ TEST_CASE("Animation Lottie3", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test3.json") == Result::Success);
     
@@ -146,7 +142,6 @@ TEST_CASE("Animation Lottie4", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test4.json") == Result::Success);
 
@@ -161,7 +156,6 @@ TEST_CASE("Animation Lottie5", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test5.json") == Result::Success);
     
@@ -176,7 +170,6 @@ TEST_CASE("Animation Lottie6", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test6.json") == Result::Success);
 
@@ -191,7 +184,6 @@ TEST_CASE("Animation Lottie7", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test7.json") == Result::Success);
 
@@ -206,7 +198,6 @@ TEST_CASE("Animation Lottie8", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test8.json") == Result::Success);
 
@@ -221,7 +212,6 @@ TEST_CASE("Animation Lottie9", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     REQUIRE(picture->load(TEST_DIR"/test9.json") == Result::Success);
 
@@ -236,7 +226,6 @@ TEST_CASE("Animation Lottie10", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
     
     REQUIRE(picture->load(TEST_DIR"/test10.json") == Result::Success);
 
@@ -251,7 +240,6 @@ TEST_CASE("Animation Segment", "[tvgAnimation]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     float begin, end;
 

--- a/test/testFill.cpp
+++ b/test/testFill.cpp
@@ -33,14 +33,12 @@ TEST_CASE("Filling Creation", "[tvgFill]")
     auto linear = LinearGradient::gen();
     REQUIRE(linear);
 
-    REQUIRE(linear->identifier() == LinearGradient::identifier());
-    REQUIRE(linear->identifier() != RadialGradient::identifier());
-
+    REQUIRE(linear->type() == Type::LinearGradient);
+    
     auto radial = RadialGradient::gen();
     REQUIRE(radial);
 
-    REQUIRE(radial->identifier() == RadialGradient::identifier());
-    REQUIRE(radial->identifier() != LinearGradient::identifier());
+    REQUIRE(radial->type() == Type::RadialGradient);
 }
 
 TEST_CASE("Common Filling", "[tvgFill]")

--- a/test/testLottie.cpp
+++ b/test/testLottie.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Lottie Slot", "[tvgLottie]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
+    REQUIRE(picture->type() == Type::Picture);
 
     const char* slotJson = R"({"gradient_fill":{"p":{"a":0,"k":[0,0.1,0.1,0.2,1,1,0.1,0.2,0.1,1]}}})";
 
@@ -78,7 +78,6 @@ TEST_CASE("Lottie Slot 2", "[tvgLottie]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     const char* slotJson = R"({"lottie-icon-outline":{"p":{"a":0,"k":[1,1,0]}},"lottie-icon-solid":{"p":{"a":0,"k":[0,0,1]}}})";
 
@@ -105,7 +104,6 @@ TEST_CASE("Lottie Marker", "[tvgLottie]")
     REQUIRE(animation);
 
     auto picture = animation->picture();
-    REQUIRE(picture->identifier() == Picture::identifier());
 
     //Set marker name before loaded
     REQUIRE(animation->segment("sectionC") == Result::InsufficientCondition);

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -35,9 +35,7 @@ TEST_CASE("Picture Creation", "[tvgPicture]")
     auto picture = Picture::gen();
     REQUIRE(picture);
 
-    REQUIRE(picture->identifier() == Picture::identifier());
-    REQUIRE(picture->identifier() != Shape::identifier());
-    REQUIRE(picture->identifier() != Scene::identifier());
+    REQUIRE(picture->type() == Type::Picture);
 }
 
 TEST_CASE("Load RAW Data", "[tvgPicture]")

--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -31,9 +31,7 @@ TEST_CASE("Scene Creation", "[tvgScene]")
     auto scene = Scene::gen();
     REQUIRE(scene);
 
-    REQUIRE(scene->identifier() == Scene::identifier());
-    REQUIRE(scene->identifier() != Shape::identifier());
-    REQUIRE(scene->identifier() != Picture::identifier());
+    REQUIRE(scene->type() == Type::Scene);
 }
 
 TEST_CASE("Pushing Paints Into Scene", "[tvgScene]")

--- a/test/testShape.cpp
+++ b/test/testShape.cpp
@@ -31,9 +31,7 @@ TEST_CASE("Shape Creation", "[tvgShape]")
     auto shape = Shape::gen();
     REQUIRE(shape);
 
-    REQUIRE(shape->identifier() == Shape::identifier());
-    REQUIRE(shape->identifier() != Picture::identifier());
-    REQUIRE(shape->identifier() != Scene::identifier());
+    REQUIRE(shape->type() == Type::Shape);
 }
 
 TEST_CASE("Appending Commands", "[tvgShape]")

--- a/test/testText.cpp
+++ b/test/testText.cpp
@@ -36,10 +36,7 @@ TEST_CASE("Text Creation", "[tvgText]")
     auto text = Text::gen();
     REQUIRE(text);
 
-    REQUIRE(text->identifier() == Text::identifier());
-    REQUIRE(text->identifier() != Shape::identifier());
-    REQUIRE(text->identifier() != Scene::identifier());
-    REQUIRE(text->identifier() != Picture::identifier());
+    REQUIRE(text->type() == Type::Text);
 }
 
 TEST_CASE("Load TTF Data from a file", "[tvgText]")


### PR DESCRIPTION
deprecate the `identifier()` APIs by replacing them with `type()`.

ThorVG is going to introduce an instance `id()`,
and this could be confused with the `identifier()` methods.

with this new type() method can reduce the memory size by removing unncessary type data.

New Experimental C APIs:
- enum Tvg_Type
- Tvg_Result tvg_paint_get_type(const Tvg_Paint* paint, Tvg_Type* type)
- Tvg_Result tvg_gradient_get_type(const Tvg_Gradient* grad, Tvg_Type* type)

New Experimental C++ APIs:
- Type Paint::type() const
- Type Fill::type() const
- Type LinearGradient::type() const
- Type RadialGradient::type() const
- Type Shape::type() const
- Type Scene::type() const
- Type Picture::type() const
- Type Text::type() const

Deprecated C APIs:
- enum Tvg_Identifier
- Tvg_Result tvg_paint_get_identifier(const Tvg_Paint* paint, Tvg_Identifier* identifier)
- Tvg_Result tvg_gradient_get_identifier(const Tvg_Gradient* grad, Tvg_Identifier* identifier)

Deprecated C++ APIs:
- enum class Type
- uint32_t Paint::identifier() const
- uint32_t Fill::identifier() const
- static uint32_t Picture::identifier()
- static uint32_t Scene::identifier()
- static uint32_t Shape::identifier()
- static uint32_t LinearGradient:identifier()
- static uint32_T RadialGradient::identfier()

Removed Experimental APIs:
- static uint32_t Text::identifier()

issue: https://github.com/thorvg/thorvg/issues/1372