### PR TITLE
wg_engine: fix safe disposing of render data in MT environment

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -88,6 +88,13 @@ private:
     Surface mTargetSurface;
     // current blend method
     BlendMethod mBlendMethod{};
+
+    // disposed resources, they should be released on synced call.
+    struct {
+        Array<RenderData> renderDatas{};
+        Key key;
+    } mDisposed;
+    void clearDisposes();
 };
 
 #endif /* _TVG_WG_RENDERER_H_ */


### PR DESCRIPTION
Store desposed object in MT-safe list and then despose objects in sync stage