### PR TITLE
Renderer: rectified a missing image update flag

### DIFF
--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -96,7 +96,9 @@ struct Shape::Impl
     }
 
     RenderData update(RenderMethod* renderer, const RenderTransform* transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper)
-    {     
+    {
+        if (static_cast<RenderUpdateFlag>(pFlag | flag) == RenderUpdateFlag::None) return rd;
+
         if ((needComp = needComposition(opacity))) {
             /* Overriding opacity value. If this scene is half-translucent,
                It must do intermediate composition with that opacity value. */ 


### PR DESCRIPTION
The flag could be missed when the image is copied with a surface.