### PR TITLE
renderer: Rectified the paint transforms.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -304,6 +304,9 @@ public:
      * The rotational axis passes through the point on the object with zero coordinates.
      *
      * @param[in] degree The value of the angle in degrees.
+     *
+     * @retval Result::InsufficientCondition in case a custom transform is applied.
+     * @see Paint::transform()
      */
     Result rotate(float degree) noexcept;
 
@@ -311,6 +314,9 @@ public:
      * @brief Sets the scale value of the object.
      *
      * @param[in] factor The value of the scaling factor. The default value is 1.
+     *
+     * @retval Result::InsufficientCondition in case a custom transform is applied.
+     * @see Paint::transform()
      */
     Result scale(float factor) noexcept;
 
@@ -322,6 +328,9 @@ public:
      *
      * @param[in] x The value of the horizontal shift.
      * @param[in] y The value of the vertical shift.
+     *
+     * @retval Result::InsufficientCondition in case a custom transform is applied.
+     * @see Paint::transform()
      */
     Result translate(float x, float y) noexcept;
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -822,6 +822,9 @@ TVG_API Tvg_Result tvg_paint_del(Tvg_Paint* paint);
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
+* \retval TVG_RESULT_INSUFFICIENT_CONDITION in case a custom transform is applied.
+*
+* \see tvg_paint_set_transform()
 */
 TVG_API Tvg_Result tvg_paint_scale(Tvg_Paint* paint, float factor);
 
@@ -837,6 +840,9 @@ TVG_API Tvg_Result tvg_paint_scale(Tvg_Paint* paint, float factor);
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
+* \retval TVG_RESULT_INSUFFICIENT_CONDITION in case a custom transform is applied.
+*
+* \see tvg_paint_set_transform()
 */
 TVG_API Tvg_Result tvg_paint_rotate(Tvg_Paint* paint, float degree);
 
@@ -853,6 +859,9 @@ TVG_API Tvg_Result tvg_paint_rotate(Tvg_Paint* paint, float degree);
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
+* \retval TVG_RESULT_INSUFFICIENT_CONDITION in case a custom transform is applied.
+*
+* \see tvg_paint_set_transform()
 */
 TVG_API Tvg_Result tvg_paint_translate(Tvg_Paint* paint, float x, float y);
 

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -86,7 +86,6 @@ namespace tvg
             if (!rTransform) {
                 if (mathIdentity(&m)) return true;
                 rTransform = new RenderTransform();
-                if (!rTransform) return false;
             }
             rTransform->override(m);
             renderFlag |= RenderUpdateFlag::Transform;
@@ -97,7 +96,7 @@ namespace tvg
         Matrix* transform()
         {
             if (rTransform) {
-                rTransform->update();
+                if (renderFlag & RenderUpdateFlag::Transform) rTransform->update();
                 return &rTransform->m;
             }
             return nullptr;

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -43,13 +43,18 @@ void RenderTransform::update()
 {
     if (overriding) return;
 
-    mathIdentity(&m);
+    m.e11 = 1.0f;
+    m.e12 = 0.0f;
+
+    m.e21 = 0.0f;
+    m.e22 = 1.0f;
+
+    m.e31 = 0.0f;
+    m.e32 = 0.0f;
+    m.e33 = 1.0f;
 
     mathScale(&m, scale, scale);
-
     mathRotate(&m, degree);
-
-    mathTranslate(&m, x, y);
 }
 
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -110,9 +110,7 @@ struct RenderRegion
 
 struct RenderTransform
 {
-    Matrix m;             //3x3 Matrix Elements
-    float x = 0.0f;
-    float y = 0.0f;
+    Matrix m;
     float degree = 0.0f;  //rotation degree
     float scale = 1.0f;   //scale factor
     bool overriding = false;  //user transform?
@@ -120,7 +118,11 @@ struct RenderTransform
     void update();
     void override(const Matrix& m);
 
-    RenderTransform() {}
+    RenderTransform()
+    {
+        m.e13 = m.e23 = 0.0f;
+    }
+
     RenderTransform(const RenderTransform* lhs, const RenderTransform* rhs);
 };
 

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -59,11 +59,12 @@ TEST_CASE("Custom Transformation", "[tvgPaint]")
     REQUIRE(m2.e32 == Approx(m3.e32).margin(0.000001));
     REQUIRE(m2.e33 == Approx(m3.e33).margin(0.000001));
 
-    //Verify Transform is not modified
-    REQUIRE(shape->translate(155.0f, -155.0f) == Result::Success);
-    REQUIRE(shape->scale(4.7f) == Result::Success);
-    REQUIRE(shape->rotate(45.0f) == Result::Success);
+    //It's not allowed if the custom transform is applied.
+    REQUIRE(shape->translate(155.0f, -155.0f) == Result::InsufficientCondition);
+    REQUIRE(shape->scale(4.7f) == Result::InsufficientCondition);
+    REQUIRE(shape->rotate(45.0f) == Result::InsufficientCondition);
 
+    //Verify Transform is not modified
     auto m4 = shape->transform();
     REQUIRE(m2.e11 == Approx(m4.e11).margin(0.000001));
     REQUIRE(m2.e12 == Approx(m4.e12).margin(0.000001));


### PR DESCRIPTION
This corrects the return value to Result::InsufficientCondition when a custom transform is applied.

Additionally, unnecessary x and y member fields have been removed.