### PR TITLE
lottie: add support for image size

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1042,6 +1042,7 @@ static void _updateImage(LottieGroup* layer)
         TaskScheduler::async(true);
 
         PP(image->picture)->ref();
+        image->picture->size(image->width, image->height);
     }
 
     if (image->refCnt == 1) layer->scene->push(tvg::cast(image->picture));

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -458,6 +458,8 @@ struct LottieImage : LottieObject
     char* mimeType = nullptr;
     uint32_t size = 0;
     uint16_t refCnt = 0;   //refernce count
+    float width = 0.0f;
+    float height = 0.0f;
 
     ~LottieImage();
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -899,7 +899,7 @@ void LottieParser::parseObject(Array<LottieObject*>& parent)
 }
 
 
-LottieImage* LottieParser::parseImage(const char* data, const char* subPath, bool embedded)
+LottieImage* LottieParser::parseImage(const char* data, const char* subPath, bool embedded, float width, float height)
 {
     //Used for Image Asset
     auto image = new LottieImage;
@@ -922,6 +922,8 @@ LottieImage* LottieParser::parseImage(const char* data, const char* subPath, boo
         snprintf(image->path, len, "%s/%s%s", dirName, subPath, data);
     }
 
+    image->width = width;
+    image->height = height;
     image->prepare();
 
     return image;
@@ -938,6 +940,8 @@ LottieObject* LottieParser::parseAsset()
     //Used for Image Asset
     const char* data = nullptr;
     const char* subPath = nullptr;
+    float width = 0.0f;
+    float height = 0.0f;
     auto embedded = false;
 
     while (auto key = nextObjectKey()) {
@@ -952,10 +956,12 @@ LottieObject* LottieParser::parseAsset()
         else if (KEY_AS("layers")) obj = parseLayers();
         else if (KEY_AS("u")) subPath = getString();
         else if (KEY_AS("p")) data = getString();
+        else if (KEY_AS("w")) width = getFloat();
+        else if (KEY_AS("h")) height = getFloat();
         else if (KEY_AS("e")) embedded = getInt();
         else skip(key);
     }
-    if (data) obj = parseImage(data, subPath, embedded);
+    if (data) obj = parseImage(data, subPath, embedded, width, height);
     if (obj) obj->id = id;
     return obj;
 }

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -74,7 +74,7 @@ private:
 
     LottieObject* parseObject();
     LottieObject* parseAsset();
-    LottieImage* parseImage(const char* data, const char* subPath, bool embedded);
+    LottieImage* parseImage(const char* data, const char* subPath, bool embedded, float width, float height);
     LottieLayer* parseLayer();
     LottieObject* parseGroup();
     LottieRect* parseRect();


### PR DESCRIPTION
The width and height of the image must
be specified in the Lottie file and must
be taken into account during rendering.

solves 11493.json:

before:
<img width="500" alt="Zrzut ekranu 2024-07-8 o 13 29 30" src="https://github.com/thorvg/thorvg/assets/67589014/f92ecb5c-fa98-4861-bc5f-9b48589367a2">

after:
<img width="500" alt="Zrzut ekranu 2024-07-8 o 13 20 35" src="https://github.com/thorvg/thorvg/assets/67589014/d076907b-be0a-4d12-bd9d-eb3cd5c31613">

also solves 11636.json