### PR TITLE
common: fix bezAngleAt function

### DIFF
--- a/src/common/tvgLines.cpp
+++ b/src/common/tvgLines.cpp
@@ -238,7 +238,7 @@ float bezAngleAt(const Bezier& bz, float t)
     pt.x *= 3;
     pt.y *= 3;
 
-    return mathRad2Deg(atan2(pt.x, pt.y));
+    return mathRad2Deg(atan2(pt.y, pt.x));
 }
 
 


### PR DESCRIPTION
In the function calculating the tangent to a cubic bezier at a given t, the atan was calculated using dx over dy, instead of dy over dx. The error was visible during the animation using auto-orient = true.

 file | before | after|
-----|--|------|
5949.json |<img width="300" alt="Zrzut ekranu 2024-07-9 o 01 04 19" src="https://github.com/thorvg/thorvg/assets/67589014/bbfcb620-aa68-4389-b0d7-28cd29de9f86">|<img width="300" alt="Zrzut ekranu 2024-07-9 o 01 04 35" src="https://github.com/thorvg/thorvg/assets/67589014/9b2a6f68-2614-436f-a1a7-5710586f8dcf">|
16787.json|<img width="300" alt="Zrzut ekranu 2024-07-9 o 01 16 34" src="https://github.com/thorvg/thorvg/assets/67589014/8038510b-ab0d-40de-88ac-4ddea3a10892">|<img width="300" alt="Zrzut ekranu 2024-07-8 o 20 14 39" src="https://github.com/thorvg/thorvg/assets/67589014/d1bc814c-5956-4f1b-9155-5058b7e06b3a">|
16625.json|<img width="300" alt="Zrzut ekranu 2024-07-9 o 01 20 11" src="https://github.com/thorvg/thorvg/assets/67589014/54b212fc-4d33-4672-85ef-6974a65ca282">|<img width="300" alt="Zrzut ekranu 2024-07-8 o 20 13 00" src="https://github.com/thorvg/thorvg/assets/67589014/32bb15b7-6a47-4f5c-a30e-11c549ac35f2">|
10335.json|<img width="300" alt="Zrzut ekranu 2024-07-9 o 01 22 08" src="https://github.com/thorvg/thorvg/assets/67589014/795e26ce-dfe4-47f4-b3a3-487742076b89">|<img width="300" alt="Zrzut ekranu 2024-07-8 o 20 09 06" src="https://github.com/thorvg/thorvg/assets/67589014/9cc534ad-2e34-47ea-a760-f6011194c29f">|