### PR TITLE
sw_engine: fix masked translucent rect

### DIFF
--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -383,7 +383,8 @@ static bool _rasterMattedRect(SwSurface* surface, const SwBBox& region, uint8_t 
             auto dst = &buffer[y * surface->stride];
             auto cmp = &cbuffer[y * surface->compositor->image.stride * csize];
             for (uint32_t x = 0; x < w; ++x, ++dst, cmp += csize) {
-                *dst = INTERPOLATE(color, *dst, alpha(cmp));
+                auto tmp = ALPHA_BLEND(color, alpha(cmp));
+                *dst = tmp + ALPHA_BLEND(*dst, IA(tmp));
             }
         }
     //8bits grayscale


### PR DESCRIPTION
```
        auto bg = tvg::Shape::gen();
        bg->appendRect(0, 0, 400, 400);
        bg->fill(255, 255, 255);
        canvas->push(std::move(bg));
        
        auto shape = tvg::Shape::gen();
        shape->appendRect(0, 0, 400, 400);
        shape->fill(0, 0, 255, 100);
        
        auto mask = tvg::Shape::gen();
        mask->appendCircle(200, 200, 125, 125);
        mask->fill(255, 255, 255);
        
        shape->composite(std::move(mask), tvg::CompositeMethod::AlphaMask);
        canvas->push(std::move(shape));
```

before:
<img width="360" alt="Zrzut ekranu 2024-07-9 o 15 24 10" src="https://github.com/thorvg/thorvg/assets/67589014/066fee35-ff9b-493a-beae-c121e2f56fb9">

after:
<img width="382" alt="Zrzut ekranu 2024-07-9 o 15 23 56" src="https://github.com/thorvg/thorvg/assets/67589014/1fd5e3b9-e4b5-4844-812a-1b4e989263b5">

