### PR TITLE
lottie: Improve 3d rotation

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -102,19 +102,21 @@ static void _updateLayer(LottieLayer* root, LottieLayer* layer, float frameNo, L
 static bool _buildComposition(LottieComposition* comp, LottieLayer* parent);
 static bool _draw(LottieGroup* parent, RenderContext* ctx);
 
-static void _rotateX(Matrix* m, float degree)
-{
-    if (degree == 0.0f) return;
-    auto radian = mathDeg2Rad(degree);
-    m->e22 *= cosf(radian);
-}
 
+static void _rotationXYZ(Matrix* m, float degreeX, float degreeY, float degreeZ) {
+    if (degreeX == 0.0f && degreeY == 0.0f && degreeZ == 0.0f) return;
 
-static void _rotateY(Matrix* m, float degree)
-{
-    if (degree == 0.0f) return;
-    auto radian = mathDeg2Rad(degree);
-    m->e11 *= cosf(radian);
+    auto radianX = mathDeg2Rad(degreeX);
+    auto radianY = mathDeg2Rad(degreeY);
+    auto radianZ = mathDeg2Rad(degreeZ);
+
+    auto cx = cosf(radianX), sx = sinf(radianX);
+    auto cy = cosf(radianY), sy = sinf(radianY);;
+    auto cz = cosf(radianZ), sz = sinf(radianZ);;
+    m->e11 = cy * cz;
+    m->e12 = -cy * sz;
+    m->e21 = sx * sy * cz + cx * sz;
+    m->e22 = -sx * sy * sz + cx * cz;
 }
 
 
@@ -183,12 +185,9 @@ static bool _updateTransform(LottieTransform* transform, float frameNo, bool aut
 
     auto angle = 0.0f;
     if (autoOrient) angle = transform->position.angle(frameNo);
-    _rotationZ(&matrix, transform->rotation(frameNo, exps) + angle);
+    if (transform->rotationEx) _rotationXYZ(&matrix, transform->rotationEx->x(frameNo, exps), transform->rotationEx->y(frameNo, exps), transform->rotation(frameNo, exps) + angle);
+    else _rotationZ(&matrix, transform->rotation(frameNo, exps) + angle);
 
-    if (transform->rotationEx) {
-        _rotateY(&matrix, transform->rotationEx->y(frameNo, exps));
-        _rotateX(&matrix, transform->rotationEx->x(frameNo, exps));
-    }
 
     auto skewAngle = transform->skewAngle(frameNo, exps);
     if (skewAngle != 0.0f) {

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -313,6 +313,7 @@ struct LottieTransform : LottieObject
     {
         LottieFloat x = 0.0f;
         LottieFloat y = 0.0f;
+        Matrix rotation3D;
     };
 
     ~LottieTransform()
@@ -565,6 +566,7 @@ struct LottieLayer : LottieGroup
     struct {
         float frameNo = -1.0f;
         Matrix matrix;
+        Matrix rotation3D;
         uint8_t opacity;
     } cache;
 


### PR DESCRIPTION
still needs some changes, but works
- contains #2549
- needs to be rebased
- do not store rotation3D from RotationEx


9691.json

main:
<img width="400" alt="rot3d_a_before" src="https://github.com/thorvg/thorvg/assets/67589014/be0c3379-738b-43a1-9abc-d318d20c461c">

this pr:
<img width="400" alt="rot3d_a_before" src="https://github.com/thorvg/thorvg/assets/67589014/8e273de7-3841-46db-bf27-49ae0ebb7af0">
