### PR TITLE
lottie: fix crash caught by asan

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1028,7 +1028,7 @@ static void _updatePrecomp(LottieLayer* precomp, float frameNo, LottieExpression
     }
 
     //TODO: remove the intermediate scene....
-    if (precomp->scene->composite(nullptr) != tvg::CompositeMethod::None) {
+    if (precomp->scene->composite(nullptr) != CompositeMethod::None) {
         auto cscene = Scene::gen().release();
         cscene->push(cast(precomp->scene));
         precomp->scene = cscene;
@@ -1037,7 +1037,7 @@ static void _updatePrecomp(LottieLayer* precomp, float frameNo, LottieExpression
     //clip the layer viewport
     if (!precomp->clipper) {
         precomp->clipper = Shape::gen().release();
-        precomp->clipper->appendRect(0, 0, static_cast<float>(precomp->w), static_cast<float>(precomp->h));
+        precomp->clipper->appendRect(0.0f, 0.0f, precomp->w, precomp->h);
         PP(precomp->clipper)->ref();
         precomp->scene->composite(cast(precomp->clipper), CompositeMethod::ClipPath);
     }

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1039,9 +1039,9 @@ static void _updatePrecomp(LottieLayer* precomp, float frameNo, LottieExpression
         precomp->clipper = Shape::gen().release();
         precomp->clipper->appendRect(0, 0, static_cast<float>(precomp->w), static_cast<float>(precomp->h));
         PP(precomp->clipper)->ref();
+        precomp->scene->composite(cast(precomp->clipper), CompositeMethod::ClipPath);
     }
     precomp->clipper->transform(precomp->cache.matrix);
-    precomp->scene->composite(cast(precomp->clipper), CompositeMethod::ClipPath);
 }
 
 


### PR DESCRIPTION
Address sanitizer detected a bug introduced
in https://github.com/thorvg/thorvg/commit/d95ec723354d532598b9a7192d959a35c2eeecb0, causing a crash during precomposition update. Fixed.

Crash observed on game_finished.json 