### PR TITLE
wg_engine: Introduce ClipPath composition support

### DIFF
--- a/src/renderer/wg_engine/tvgWgBindGroups.cpp
+++ b/src/renderer/wg_engine/tvgWgBindGroups.cpp
@@ -36,11 +36,15 @@ WGPUBindGroupLayout WgBindGroupTexture::layout = nullptr;
 WGPUBindGroupLayout WgBindGroupTextureStorageRgba::layout = nullptr;
 WGPUBindGroupLayout WgBindGroupTextureStorageBgra::layout = nullptr;
 WGPUBindGroupLayout WgBindGroupTextureSampled::layout = nullptr;
+WGPUBindGroupLayout WgBindGroupTexMaskCompose::layout = nullptr;
 WGPUBindGroupLayout WgBindGroupTexComposeBlend::layout = nullptr;
 WGPUBindGroupLayout WgBindGroupOpacity::layout = nullptr;
 WGPUBindGroupLayout WgBindGroupBlendMethod::layout = nullptr;
 WGPUBindGroupLayout WgBindGroupCompositeMethod::layout = nullptr;
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupCanvas
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupCanvas::getLayout(WGPUDevice device)
 {
@@ -78,6 +82,9 @@ void WgBindGroupCanvas::release()
     releaseBuffer(uBufferViewMat);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupPaint
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupPaint::getLayout(WGPUDevice device)
 {
@@ -123,6 +130,9 @@ void WgBindGroupPaint::release()
     releaseBuffer(uBufferModelMat);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupSolidColor
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupSolidColor::getLayout(WGPUDevice device)
 {
@@ -163,6 +173,9 @@ void WgBindGroupSolidColor::release()
     releaseBuffer(uBufferSolidColor);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupLinearGradient
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupLinearGradient::getLayout(WGPUDevice device)
 {
@@ -203,6 +216,9 @@ void WgBindGroupLinearGradient::release()
     releaseBuffer(uBufferLinearGradient);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupRadialGradient
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupRadialGradient::getLayout(WGPUDevice device)
 {
@@ -243,6 +259,9 @@ void WgBindGroupRadialGradient::release()
     releaseBindGroup(mBindGroup);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupPicture
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupPicture::getLayout(WGPUDevice device)
 {
@@ -280,6 +299,9 @@ void WgBindGroupPicture::release()
     releaseBindGroup(mBindGroup);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupTexture
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupTexture::getLayout(WGPUDevice device)
 {
@@ -315,6 +337,9 @@ void WgBindGroupTexture::release()
     releaseBindGroup(mBindGroup);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupTextureStorageRgba
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupTextureStorageRgba::getLayout(WGPUDevice device)
 {
@@ -350,6 +375,9 @@ void WgBindGroupTextureStorageRgba::release()
     releaseBindGroup(mBindGroup);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupTextureStorageBgra
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupTextureStorageBgra::getLayout(WGPUDevice device)
 {
@@ -385,6 +413,9 @@ void WgBindGroupTextureStorageBgra::release()
     releaseBindGroup(mBindGroup);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupTextureSampled
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupTextureSampled::getLayout(WGPUDevice device)
 {
@@ -422,6 +453,9 @@ void WgBindGroupTextureSampled::release()
     releaseBindGroup(mBindGroup);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupTexComposeBlend
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupTexComposeBlend::getLayout(WGPUDevice device)
 {
@@ -461,7 +495,49 @@ void WgBindGroupTexComposeBlend::release()
     releaseBindGroup(mBindGroup);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupTexMaskCompose
+///////////////////////////////////////////////////////////////////////////////
 
+WGPUBindGroupLayout WgBindGroupTexMaskCompose::getLayout(WGPUDevice device)
+{
+    if (layout) return layout;
+    const WGPUBindGroupLayoutEntry bindGroupLayoutEntries[] {
+        makeBindGroupLayoutEntryStorage(0, WGPUStorageTextureAccess_ReadOnly, WGPUTextureFormat_RGBA8Unorm),
+        makeBindGroupLayoutEntryStorage(1, WGPUStorageTextureAccess_ReadWrite, WGPUTextureFormat_RGBA8Unorm)
+    };
+    layout = createBindGroupLayout(device, bindGroupLayoutEntries, 2);
+    assert(layout);
+    return layout;
+}
+
+
+void WgBindGroupTexMaskCompose::releaseLayout()
+{
+    releaseBindGroupLayout(layout);
+}
+
+
+void WgBindGroupTexMaskCompose::initialize(WGPUDevice device, WGPUQueue queue, WGPUTextureView uTexMsk0, WGPUTextureView uTexMsk1)
+{
+    release();
+    const WGPUBindGroupEntry bindGroupEntries[] {
+        makeBindGroupEntryTextureView(0, uTexMsk0),
+        makeBindGroupEntryTextureView(1, uTexMsk1),
+    };
+    mBindGroup = createBindGroup(device, getLayout(device), bindGroupEntries, 2);
+    assert(mBindGroup);
+}
+
+
+void WgBindGroupTexMaskCompose::release()
+{
+    releaseBindGroup(mBindGroup);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupOpacity
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupOpacity::getLayout(WGPUDevice device)
 {
@@ -500,6 +576,9 @@ void WgBindGroupOpacity::release()
     releaseBindGroup(mBindGroup);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupBlendMethod
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupBlendMethod::getLayout(WGPUDevice device)
 {
@@ -538,6 +617,9 @@ void WgBindGroupBlendMethod::release()
     releaseBindGroup(mBindGroup);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// WgBindGroupCompositeMethod
+///////////////////////////////////////////////////////////////////////////////
 
 WGPUBindGroupLayout WgBindGroupCompositeMethod::getLayout(WGPUDevice device)
 {

--- a/src/renderer/wg_engine/tvgWgBindGroups.h
+++ b/src/renderer/wg_engine/tvgWgBindGroups.h
@@ -170,6 +170,20 @@ struct WgBindGroupTexComposeBlend : public WgBindGroup
 };
 
 
+// @group(0)
+struct WgBindGroupTexMaskCompose : public WgBindGroup
+{
+    static WGPUBindGroupLayout layout;
+    static WGPUBindGroupLayout getLayout(WGPUDevice device);
+    static void releaseLayout();
+
+    void initialize(WGPUDevice device, WGPUQueue queue,
+                    WGPUTextureView uTexMsk0,
+                    WGPUTextureView uTexMsk1);
+    void release();
+};
+
+
 // @group(1 or 2)
 struct WgBindGroupOpacity : public WgBindGroup
 {

--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -49,7 +49,7 @@ void WgPipelineFillShapeWinding::initialize(WGPUDevice device)
     WGPUCompareFunction stencilFunctionBack = WGPUCompareFunction_Always;
     WGPUStencilOperation stencilOperationBack = WGPUStencilOperation_DecrementWrap;
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderSource = cShaderSource_PipelineFill;
     auto shaderLabel = "The shader fill";
     auto pipelineLabel = "The render pipeline fill shape winding";
@@ -83,7 +83,7 @@ void WgPipelineFillShapeEvenOdd::initialize(WGPUDevice device)
     WGPUCompareFunction stencilFunctionBack = WGPUCompareFunction_Always;
     WGPUStencilOperation stencilOperationBack = WGPUStencilOperation_Invert;
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderSource = cShaderSource_PipelineFill;
     auto shaderLabel = "The shader fill";
     auto pipelineLabel = "The render pipeline fill shape Even Odd";
@@ -115,13 +115,45 @@ void WgPipelineFillStroke::initialize(WGPUDevice device)
     WGPUCompareFunction stencilFunction = WGPUCompareFunction_Always;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Replace;
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderSource = cShaderSource_PipelineFill;
     auto shaderLabel = "The shader fill";
     auto pipelineLabel = "The render pipeline fill stroke";
 
     // allocate all pipeline handles
     allocate(device, WgPipelineBlendType::SrcOver, WGPUColorWriteMask_None,
+             vertexBufferLayouts, ARRAY_ELEMENTS_COUNT(vertexBufferLayouts),
+             bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
+             stencilFunction, stencilOperation, stencilFunction, stencilOperation,
+             shaderSource, shaderLabel, pipelineLabel);
+}
+
+
+void WgPipelineClipMask::initialize(WGPUDevice device)
+{
+    // vertex and buffers settings
+    WGPUVertexAttribute vertexAttributesPos = { WGPUVertexFormat_Float32x2, sizeof(float) * 0, 0 };
+    WGPUVertexBufferLayout vertexBufferLayouts[] = {
+        makeVertexBufferLayout(&vertexAttributesPos, 1, sizeof(float) * 2)
+    };
+
+    // bind groups
+    WGPUBindGroupLayout bindGroupLayouts[] = {
+        WgBindGroupCanvas::getLayout(device),
+        WgBindGroupPaint::getLayout(device)
+    };
+
+    // stencil function
+    WGPUCompareFunction stencilFunction = WGPUCompareFunction_NotEqual;
+    WGPUStencilOperation stencilOperation = WGPUStencilOperation_Zero;
+
+    // shader source and labels
+    auto shaderSource = cShaderSource_PipelineFill;
+    auto shaderLabel = "The shader fill";
+    auto pipelineLabel = "The render pipeline clip mask";
+
+    // allocate all pipeline handles
+    allocate(device, WgPipelineBlendType::SrcOver, WGPUColorWriteMask_All,
              vertexBufferLayouts, ARRAY_ELEMENTS_COUNT(vertexBufferLayouts),
              bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
              stencilFunction, stencilOperation, stencilFunction, stencilOperation,
@@ -148,7 +180,7 @@ void WgPipelineSolid::initialize(WGPUDevice device, WgPipelineBlendType blendTyp
     WGPUCompareFunction stencilFunction = WGPUCompareFunction_NotEqual;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Zero;
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderSource = cShaderSource_PipelineSolid;
     auto shaderLabel = "The shader solid color";
     auto pipelineLabel = "The render pipeline solid color";
@@ -181,7 +213,7 @@ void WgPipelineLinear::initialize(WGPUDevice device, WgPipelineBlendType blendTy
     WGPUCompareFunction stencilFunction = WGPUCompareFunction_NotEqual;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Zero;
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderSource = cShaderSource_PipelineLinear;
     auto shaderLabel = "The shader linear gradient";
     auto pipelineLabel = "The render pipeline linear gradient";
@@ -214,7 +246,7 @@ void WgPipelineRadial::initialize(WGPUDevice device, WgPipelineBlendType blendTy
     WGPUCompareFunction stencilFunction = WGPUCompareFunction_NotEqual;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Zero;
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderSource = cShaderSource_PipelineRadial;
     auto shaderLabel = "The shader radial gradient";
     auto pipelineLabel = "The render pipeline radial gradient";
@@ -249,7 +281,7 @@ void WgPipelineImage::initialize(WGPUDevice device, WgPipelineBlendType blendTyp
     WGPUCompareFunction stencilFunction = WGPUCompareFunction_Always;
     WGPUStencilOperation stencilOperation = WGPUStencilOperation_Zero;
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderSource = cShaderSource_PipelineImage;
     auto shaderLabel = "The shader image";
     auto pipelineLabel = "The render pipeline image";
@@ -273,7 +305,7 @@ void WgPipelineClear::initialize(WGPUDevice device)
         WgBindGroupTextureStorageRgba::getLayout(device)
     };
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderSource = cShaderSource_PipelineComputeClear;
     auto shaderLabel = "The compute shader clear";
     auto pipelineLabel = "The compute pipeline clear";
@@ -295,7 +327,7 @@ void WgPipelineBlend::initialize(WGPUDevice device, const char *shaderSource)
         WgBindGroupOpacity::getLayout(device)
     };
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderLabel = "The compute shader blend";
     auto pipelineLabel = "The compute pipeline blend";
 
@@ -306,7 +338,46 @@ void WgPipelineBlend::initialize(WGPUDevice device, const char *shaderSource)
 }
 
 
-void WgPipelineComposeBlend::initialize(WGPUDevice device)
+void WgPipelineBlendMask::initialize(WGPUDevice device, const char *shaderSource)
+{
+    // bind groups and layouts
+    WGPUBindGroupLayout bindGroupLayouts[] = {
+        WgBindGroupTexComposeBlend::getLayout(device),
+        WgBindGroupBlendMethod::getLayout(device),
+        WgBindGroupOpacity::getLayout(device)
+    };
+
+    // shader source and labels
+    auto shaderLabel = "The compute shader blend mask";
+    auto pipelineLabel = "The compute pipeline blend mask";
+
+    // allocate all pipeline handles
+    allocate(device,
+             bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
+             shaderSource, shaderLabel, pipelineLabel);
+}
+
+
+void WgPipelineMaskCompose::initialize(WGPUDevice device)
+{
+    // bind groups and layouts
+    WGPUBindGroupLayout bindGroupLayouts[] = {
+        WgBindGroupTexMaskCompose::getLayout(device),
+    };
+
+    // shader source and labels
+    auto shaderSource = cShaderSource_PipelineComputeMaskCompose;
+    auto shaderLabel = "The compute shader mask compose";
+    auto pipelineLabel = "The compute pipeline mask compose";
+
+    // allocate all pipeline handles
+    allocate(device,
+             bindGroupLayouts, ARRAY_ELEMENTS_COUNT(bindGroupLayouts),
+             shaderSource, shaderLabel, pipelineLabel);
+}
+
+
+void WgPipelineCompose::initialize(WGPUDevice device)
 {
     // bind groups and layouts
     WGPUBindGroupLayout bindGroupLayouts[] = {
@@ -316,8 +387,8 @@ void WgPipelineComposeBlend::initialize(WGPUDevice device)
         WgBindGroupOpacity::getLayout(device)
     };
 
-    // sheder source and labels
-    auto shaderSource = cShaderSource_PipelineComputeComposeBlend;
+    // shader source and labels
+    auto shaderSource = cShaderSource_PipelineComputeCompose;
     auto shaderLabel = "The compute shader compose blend";
     auto pipelineLabel = "The compute pipeline compose blend";
 
@@ -336,7 +407,7 @@ void WgPipelineAntiAliasing::initialize(WGPUDevice device)
         WgBindGroupTextureStorageBgra::getLayout(device)
     };
 
-    // sheder source and labels
+    // shader source and labels
     auto shaderSource = cShaderSource_PipelineComputeAntiAlias;
     auto shaderLabel = "The compute shader anti-aliasing";
     auto pipelineLabel = "The compute pipeline anti-aliasing";
@@ -357,6 +428,7 @@ void WgPipelines::initialize(WgContext& context)
     fillShapeWinding.initialize(context.device);
     fillShapeEvenOdd.initialize(context.device);
     fillStroke.initialize(context.device);
+    clipMask.initialize(context.device);
     for (uint8_t type = (uint8_t)WgPipelineBlendType::SrcOver; type <= (uint8_t)WgPipelineBlendType::Custom; type++) {
         solid[type].initialize(context.device, (WgPipelineBlendType)type);
         linear[type].initialize(context.device, (WgPipelineBlendType)type);
@@ -368,7 +440,11 @@ void WgPipelines::initialize(WgContext& context)
     computeBlendSolid.initialize(context.device, cShaderSource_PipelineComputeBlendSolid);
     computeBlendGradient.initialize(context.device, cShaderSource_PipelineComputeBlendGradient);
     computeBlendImage.initialize(context.device, cShaderSource_PipelineComputeBlendImage);
-    computeComposeBlend.initialize(context.device);
+    computeBlendSolidMask.initialize(context.device, cShaderSource_PipelineComputeBlendSolidMask);
+    computeBlendGradientMask.initialize(context.device, cShaderSource_PipelineComputeBlendGradientMask);
+    computeBlendImageMask.initialize(context.device, cShaderSource_PipelineComputeBlendImageMask);
+    computeMaskCompose.initialize(context.device);
+    computeCompose.initialize(context.device);
     computeAntiAliasing.initialize(context.device);
     // store pipelines to context
     context.pipelines = this;
@@ -377,7 +453,8 @@ void WgPipelines::initialize(WgContext& context)
 
 void WgPipelines::release()
 {
-    WgBindGroupTexComposeBlend::layout = nullptr;
+    WgBindGroupTexMaskCompose::releaseLayout();
+    WgBindGroupTexComposeBlend::releaseLayout();
     WgBindGroupTextureSampled::releaseLayout();
     WgBindGroupTextureStorageBgra::releaseLayout();
     WgBindGroupTextureStorageRgba::releaseLayout();
@@ -391,7 +468,11 @@ void WgPipelines::release()
     WgBindGroupCanvas::releaseLayout();
     // compute pipelines
     computeAntiAliasing.release();
-    computeComposeBlend.release();
+    computeCompose.release();
+    computeMaskCompose.release();
+    computeBlendImageMask.release();
+    computeBlendGradientMask.release();
+    computeBlendSolidMask.release();
     computeBlendImage.release();
     computeBlendGradient.release();
     computeBlendSolid.release();
@@ -403,6 +484,7 @@ void WgPipelines::release()
         linear[type].release();
         solid[type].release();
     }
+    clipMask.release();
     fillStroke.release();
     fillShapeEvenOdd.release();
     fillShapeWinding.release();

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -62,6 +62,17 @@ struct WgPipelineFillStroke: public WgRenderPipeline
     }
 };
 
+struct WgPipelineClipMask: public WgRenderPipeline
+{
+    void initialize(WGPUDevice device) override;
+    void use(WGPURenderPassEncoder encoder, WgBindGroupCanvas& groupCanvas,WgBindGroupPaint& groupPaint)
+    {
+        set(encoder);
+        groupCanvas.set(encoder, 0);
+        groupPaint.set(encoder, 1);
+    }
+};
+
 struct WgPipelineSolid: public WgRenderPipeline
 {
     void initialize(WGPUDevice device) override {}
@@ -144,7 +155,32 @@ struct WgPipelineBlend: public WgComputePipeline
 };
 
 
-struct WgPipelineComposeBlend: public WgComputePipeline
+struct WgPipelineBlendMask: public WgComputePipeline
+{
+    void initialize(WGPUDevice device) override { assert(false); };
+    void initialize(WGPUDevice device, const char *shaderSource);
+    void use(WGPUComputePassEncoder encoder, WgBindGroupTexComposeBlend& groupTexs, WgBindGroupBlendMethod& blendMethod, WgBindGroupOpacity& groupOpacity)
+    {
+        set(encoder);
+        groupTexs.set(encoder, 0);
+        blendMethod.set(encoder, 1);
+        groupOpacity.set(encoder, 2);
+    }
+};
+
+
+struct WgPipelineMaskCompose: public WgComputePipeline
+{
+    void initialize(WGPUDevice device) override;
+    void use(WGPUComputePassEncoder encoder, WgBindGroupTexMaskCompose& groupTexs)
+    {
+        set(encoder);
+        groupTexs.set(encoder, 0);
+    }
+};
+
+
+struct WgPipelineCompose: public WgComputePipeline
 {
     void initialize(WGPUDevice device) override;
     void use(WGPUComputePassEncoder encoder, WgBindGroupTexComposeBlend& groupTexs, WgBindGroupCompositeMethod& groupComposeMethod, WgBindGroupBlendMethod& groupBlendMethod, WgBindGroupOpacity& groupOpacity)
@@ -180,6 +216,7 @@ struct WgPipelines
     WgPipelineFillShapeEvenOdd fillShapeEvenOdd;
     WgPipelineFillStroke fillStroke;
     // fill pipelines
+    WgPipelineClipMask clipMask;
     WgPipelineSolid solid[3];
     WgPipelineLinear linear[3];
     WgPipelineRadial radial[3];
@@ -189,7 +226,11 @@ struct WgPipelines
     WgPipelineBlend computeBlendSolid;
     WgPipelineBlend computeBlendGradient;
     WgPipelineBlend computeBlendImage;
-    WgPipelineComposeBlend computeComposeBlend;
+    WgPipelineBlendMask computeBlendSolidMask;
+    WgPipelineBlendMask computeBlendGradientMask;
+    WgPipelineBlendMask computeBlendImageMask;
+    WgPipelineMaskCompose computeMaskCompose;
+    WgPipelineCompose computeCompose;
     WgPipelineAntiAliasing computeAntiAliasing;
 
     void initialize(WgContext& context);

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -262,7 +262,16 @@ void WgRenderSettings::release(WgContext& context)
 void WgRenderDataPaint::release(WgContext& context)
 {
     bindGroupPaint.release();
+    clips.clear();
 };
+
+
+void WgRenderDataPaint::updateClips(tvg::Array<tvg::RenderData> &clips) {
+    this->clips.clear();
+    for (uint32_t i = 0; i < clips.count; i++)
+        if (clips[i])
+            this->clips.push((WgRenderDataPaint*)clips[i]);
+}
 
 //***********************************************************************
 // WgRenderDataShape
@@ -371,6 +380,7 @@ void WgRenderDataShape::releaseMeshes(WgContext &context)
     meshGroupShapes.release(context);
     pMin = {FLT_MAX, FLT_MAX};
     pMax = {0.0f, 0.0f};
+    clips.clear();
 }
 
 
@@ -407,6 +417,7 @@ void WgRenderDataShapePool::free(WgContext& context, WgRenderDataShape* dataShap
     dataShape->meshGroupShapesBBox.release(context);
     dataShape->meshGroupStrokes.release(context);
     dataShape->meshGroupStrokesBBox.release(context);
+    dataShape->clips.clear();
     mPool.push(dataShape);
 }
 

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -88,10 +88,13 @@ struct WgRenderDataPaint
     WgBindGroupPaint bindGroupPaint{};
     RenderRegion viewport{};
     float opacity{};
+    Array<WgRenderDataPaint*> clips;
 
     virtual ~WgRenderDataPaint() {};
     virtual void release(WgContext& context);
     virtual Type type() { return Type::Undefined; };
+
+    void updateClips(tvg::Array<tvg::RenderData> &clips);
 };
 
 struct WgRenderDataShape: public WgRenderDataPaint

--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -52,10 +52,29 @@ public:
 
     void renderShape(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
     void renderPicture(WgContext& context, WgRenderDataPicture* renderData, WgPipelineBlendType blendType);
+    void renderClipPath(WgContext& context, WgRenderDataPaint* renderData);
 
     void clear(WGPUCommandEncoder commandEncoder);
-    void blend(WGPUCommandEncoder commandEncoder, WgRenderStorage* targetSrc, WgPipelineBlend* pipeline, WgBindGroupBlendMethod* blendMethod, WgBindGroupOpacity* opacity);
-    void composeBlend(
+    void blend(
+        WgContext& context,
+        WGPUCommandEncoder commandEncoder,
+        WgPipelineBlend* pipeline,
+        WgRenderStorage* targetSrc,
+        WgBindGroupBlendMethod* blendMethod,
+        WgBindGroupOpacity* opacity);
+    void blendMask(
+        WgContext& context,
+        WGPUCommandEncoder commandEncoder,
+        WgPipelineBlendMask* pipeline,
+        WgRenderStorage* texMsk,
+        WgRenderStorage* texSrc,
+        WgBindGroupBlendMethod* blendMethod,
+        WgBindGroupOpacity* opacity);
+    void maskCompose(
+        WgContext& context,
+        WGPUCommandEncoder commandEncoder,
+        WgRenderStorage* texMsk0);
+    void compose(
         WgContext& context,
         WGPUCommandEncoder commandEncoder,
         WgRenderStorage* texMsk,
@@ -67,6 +86,9 @@ public:
 private:
     void drawShape(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
     void drawStroke(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
+
+    void drawShapeClipPath(WgContext& context, WgRenderDataShape* renderData);
+    void drawPictureClipPath(WgContext& context, WgRenderDataPicture* renderData);
 
     void dispatchWorkgroups(WGPUComputePassEncoder computePassEncoder);
 

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -62,12 +62,14 @@ private:
     void initialize();
     void release();
     void clearDisposes();
+    void renderClipPath(Array<WgRenderDataPaint*>& clips);
 
-    WGPUCommandEncoder mCommandEncoder{};    // render handles
-    WgRenderStorage mRenderStorageInterm;    // intermidiate buffer to render
-    WgRenderStorage mRenderStorageRoot;    // root render storage
-    WgRenderStorage mRenderStorageScreen;    // storage with data after antializing
-    WgRenderStoragePool mRenderStoragePool;    // pool to hold render tree storages
+    WGPUCommandEncoder mCommandEncoder{};
+    WgRenderStorage mRenderStorageInterm; // intermidiate buffer to render
+    WgRenderStorage mRenderStorageMask;   // buffer to render mask 
+    WgRenderStorage mRenderStorageRoot;   // root render storage
+    WgRenderStorage mRenderStorageScreen; // storage with data after antializing
+    WgRenderStoragePool mRenderStoragePool; // pool to hold render tree storages
     WgBindGroupOpacityPool mOpacityPool;    // opacity, blend methods and composite methods pool
     WgBindGroupBlendMethodPool mBlendMethodPool;
     WgBindGroupCompositeMethodPool mCompositeMethodPool;

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -45,7 +45,11 @@ extern const char* cShaderSource_PipelineComputeClear;
 extern const char* cShaderSource_PipelineComputeBlendSolid;
 extern const char* cShaderSource_PipelineComputeBlendGradient;
 extern const char* cShaderSource_PipelineComputeBlendImage;
-extern const char* cShaderSource_PipelineComputeComposeBlend;
+extern const char* cShaderSource_PipelineComputeBlendSolidMask;
+extern const char* cShaderSource_PipelineComputeBlendGradientMask;
+extern const char* cShaderSource_PipelineComputeBlendImageMask;
+extern const char* cShaderSource_PipelineComputeMaskCompose;
+extern const char* cShaderSource_PipelineComputeCompose;
 extern const char* cShaderSource_PipelineComputeAntiAlias;
 
 #endif // _TVG_WG_SHADER_SRC_H_


### PR DESCRIPTION
[issues 1479: ClipPath](#1479)

Introduce ClipPath composition support.
Clip path composition is an only composition type who doesn't ignore blend method. 
Clip path is a combination of composition approach and blend approach using compute shader.

![image](https://github.com/user-attachments/assets/5b74e6ca-c303-41e9-b5d1-c781fdaf8806)
