### PR TITLE
wg_engine: fix fill spread artifacts

### DIFF
--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -200,7 +200,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     for (var i = 0i; i < last; i++) {
         let strt = uLinearGradient.stopPoints[i/4][i%4];
         let stop = uLinearGradient.stopPoints[(i+1)/4][(i+1)%4];
-        if ((t > strt) && (t < stop)) {
+        if ((t >= strt) && (t < stop)) {
             let step: f32 = (t - strt) / (stop - strt);
             color = mix(uLinearGradient.stopColors[i], uLinearGradient.stopColors[i+1], step);
         }
@@ -297,7 +297,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     for (var i = 0i; i < last; i++) {
         let strt = uRadialGradient.stopPoints[i/4][i%4];
         let stop = uRadialGradient.stopPoints[(i+1)/4][(i+1)%4];
-        if ((t > strt) && (t < stop)) {
+        if ((t >= strt) && (t < stop)) {
             let step: f32 = (t - strt) / (stop - strt);
             color = mix(uRadialGradient.stopColors[i], uRadialGradient.stopColors[i+1], step);
         }


### PR DESCRIPTION
[Fill spread](https://github.com/thorvg/thorvg/issues/2435) example

Fixed range selector edged cases
before:
![image](https://github.com/user-attachments/assets/1308feab-d929-44e3-8d25-dce1aa8355b1)

after:
![image](https://github.com/user-attachments/assets/d83437a9-dc95-492a-a7d8-39e36f0d7ed1)
