### PR TITLE
wg_engine: fix cubic generation artifacts (GradientStroke example)

### DIFF
--- a/src/renderer/wg_engine/tvgWgGeometry.cpp
+++ b/src/renderer/wg_engine/tvgWgGeometry.cpp
@@ -93,9 +93,7 @@ void WgPolyline::appendCubic(WgPoint p1, WgPoint p2, WgPoint p3, size_t nsegs)
     WgPoint p0 = pts.count > 0 ? pts.last() : WgPoint(0.0f, 0.0f);
     nsegs = nsegs == 0 ? 1 : nsegs;
     float dt = 1.0f / (float)nsegs;
-    float t = 0.0f;
-    for (size_t i = 1; i <= nsegs; i++) {
-        t += dt;
+    for (auto t = 0.0f; t <= 1.0f; t += dt) {
         // get cubic spline interpolation coefficients
         float t0 = 1.0f * (1.0f - t) * (1.0f - t) * (1.0f - t);
         float t1 = 3.0f * (1.0f - t) * (1.0f - t) * t;


### PR DESCRIPTION
[GradientStroke](https://github.com/thorvg/thorvg/issues/2435) example

More accurate coefitient computation

Before:
![image](https://github.com/user-attachments/assets/f69b3328-6fe8-46f6-adc5-8006e0674ce1)

After:
![image](https://github.com/user-attachments/assets/589a7e1f-57a0-40eb-ab78-cf1413485468)
