### PR TITLE
sw_engine: fix linear grad issue

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -134,7 +134,6 @@ struct SwFill
 {
     struct SwLinear {
         float dx, dy;
-        float len;
         float offset;
     };
 

--- a/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/src/renderer/sw_engine/tvgSwFill.cpp
@@ -212,12 +212,12 @@ bool _prepareLinear(SwFill* fill, const LinearGradient* linear, const Matrix* tr
 
     fill->linear.dx = x2 - x1;
     fill->linear.dy = y2 - y1;
-    fill->linear.len = fill->linear.dx * fill->linear.dx + fill->linear.dy * fill->linear.dy;
+    auto len = fill->linear.dx * fill->linear.dx + fill->linear.dy * fill->linear.dy;
 
-    if (fill->linear.len < FLOAT_EPSILON) return true;
+    if (len < FLOAT_EPSILON) return true;
 
-    fill->linear.dx /= fill->linear.len;
-    fill->linear.dy /= fill->linear.len;
+    fill->linear.dx /= len;
+    fill->linear.dy /= len;
     fill->linear.offset = -fill->linear.dx * x1 - fill->linear.dy * y1;
 
     auto gradTransform = linear->transform();
@@ -239,8 +239,6 @@ bool _prepareLinear(SwFill* fill, const LinearGradient* linear, const Matrix* tr
         auto dx = fill->linear.dx;
         fill->linear.dx = dx * invTransform.e11 + fill->linear.dy * invTransform.e21;
         fill->linear.dy = dx * invTransform.e12 + fill->linear.dy * invTransform.e22;
-
-        fill->linear.len = fill->linear.dx * fill->linear.dx + fill->linear.dy * fill->linear.dy;
     }
 
     return true;

--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -1590,8 +1590,6 @@ static bool _rasterSolidGradientRect(SwSurface* surface, const SwBBox& region, c
 
 static bool _rasterLinearGradientRect(SwSurface* surface, const SwBBox& region, const SwFill* fill)
 {
-    if (fill->linear.len < FLOAT_EPSILON) return false;
-
     if (_compositing(surface)) {
         if (_matting(surface)) return _rasterGradientMattedRect<FillLinear>(surface, region, fill);
         else return _rasterGradientMaskedRect<FillLinear>(surface, region, fill);


### PR DESCRIPTION
The restriction of the 'length' of a linear gradient
to values greater than FLT_EPSILON was causing rendering
issues in cases where it was a valid gradient with well
defined dx and dy values.

@issue: https://github.com/thorvg/thorvg/issues/2582