### PR TITLE
svg: resolve compiler warnings.

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -710,15 +710,16 @@ static bool _toColor(const char* str, uint8_t* r, uint8_t* g, uint8_t* b, char**
         return true;
     } else if (len >= 10 && (str[0] == 'h' || str[0] == 'H') && (str[1] == 's' || str[1] == 'S') && (str[2] == 'l' || str[2] == 'L') && str[3] == '(' && str[len - 1] == ')') {
         float th, ts, tb;
-        const char *content, *hue, *saturation, *brightness;
-        content = str + 4;
-        content = _skipSpace(content, nullptr);
+        const char* content = _skipSpace(str + 4, nullptr);
+        const char* hue = nullptr;
         if (_parseNumber(&content, &hue, &th) && hue) {
+            const char* saturation = nullptr;
             th = float(uint32_t(th) % 360);
             hue = _skipSpace(hue, nullptr);
             hue = (char*)_skipComma(hue);
             hue = _skipSpace(hue, nullptr);
             if (_parseNumber(&hue, &saturation, &ts) && saturation && *saturation == '%') {
+                const char* brightness = nullptr;
                 ts /= 100.0f;
                 saturation = _skipSpace(saturation + 1, nullptr);
                 saturation = (char*)_skipComma(saturation);


### PR DESCRIPTION
../src/loaders/svg/tvgSvgLoader.cpp: In function ‘bool _toColor(const char*, uint8_t*, uint8_t*, uint8_t*, char**)’: ../src/loaders/svg/tvgSvgLoader.cpp:108:17: warning: ‘hue’ may be used uninitialized [-Wmaybe-uninitialized]
  108 |     const char* _end = end ? *end : nullptr;
      |                 ^~~~
../src/loaders/svg/tvgSvgLoader.cpp:713:31: note: ‘hue’ was declared here
  713 |         const char *content, *hue, *saturation, *brightness;
      |                               ^~~
../src/loaders/svg/tvgSvgLoader.cpp:108:17: warning: ‘saturation’ may be used uninitialized [-Wmaybe-uninitialized]
  108 |     const char* _end = end ? *end : nullptr;
      |                 ^~~~
../src/loaders/svg/tvgSvgLoader.cpp:713:37: note: ‘saturation’ was declared here
  713 |         const char *content, *hue, *saturation, *brightness;
      |                                     ^~~~~~~~~~
../src/loaders/svg/tvgSvgLoader.cpp:108:17: warning: ‘brightness’ may be used uninitialized [-Wmaybe-uninitialized]
  108 |     const char* _end = end ? *end : nullptr;
      |                 ^~~~
../src/loaders/svg/tvgSvgLoader.cpp:713:50: note: ‘brightness’ was declared here
  713 |         const char *content, *hue, *saturation, *brightness;
      |                                                  ^~~~~~~~~~