### PR TITLE
infra: switch the optimization option to level 3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('thorvg',
         'cpp',
-        default_options : ['buildtype=debugoptimized', 'b_sanitize=none', 'werror=false', 'optimization=s', 'cpp_std=c++14', 'strip=true'],
+        default_options : ['buildtype=debugoptimized', 'b_sanitize=none', 'werror=false', 'optimization=3', 'cpp_std=c++14', 'strip=true'],
         version : '0.14.99',
         license : 'MIT')
 


### PR DESCRIPTION
In case of modern systems, size is not a big problem, so we turn the optimization option to default
for better performance.

FPS: ~20% enhanced
Size: ~25% increased

Note that this doesn't affect to the web player.