### PR TITLE
lottie: ++optimization with object culling

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -268,7 +268,7 @@ static void _updateGroup(LottieGroup* parent, LottieObject** child, float frameN
 {
     auto group = static_cast<LottieGroup*>(*child);
 
-    if (group->children.empty()) return;
+    if (!group->visible) return;
 
     //Prepare render data
     group->scene = parent->scene;
@@ -1028,6 +1028,7 @@ static void _updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderCon
                 }
                 default: break;
             }
+            if (ctx->propagator->opacity() == 0) break;
         }
         delete(ctx);
     }
@@ -1053,7 +1054,7 @@ static void _updatePrecomp(LottieLayer* precomp, float frameNo, LottieExpression
     }
 
     //clip the layer viewport
-    auto clipper = precomp->pooling();
+    auto clipper = precomp->pooling(true);
     clipper->transform(precomp->cache.matrix);
     precomp->scene->composite(cast(clipper), CompositeMethod::ClipPath);
 }
@@ -1061,7 +1062,7 @@ static void _updatePrecomp(LottieLayer* precomp, float frameNo, LottieExpression
 
 static void _updateSolid(LottieLayer* layer)
 {
-    auto solidFill = layer->pooling();
+    auto solidFill = layer->pooling(true);
     solidFill->opacity(layer->cache.opacity);
     layer->scene->push(cast(solidFill));
 }

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -277,7 +277,10 @@ struct LottieShape : LottieObject, LottieRenderPooler<tvg::Shape>
         return true;
     }
 
-    void prepare(LottieObject::Type type);
+    void prepare(LottieObject::Type type)
+    {
+        LottieObject::type = type;
+    }
 };
 
 
@@ -533,6 +536,8 @@ struct LottieRepeater : LottieObject
 
 struct LottieGroup : LottieObject
 {
+    LottieGroup();
+
     virtual ~LottieGroup()
     {
         for (auto p = children.begin(); p < children.end(); ++p) delete(*p);
@@ -558,10 +563,11 @@ struct LottieGroup : LottieObject
     Scene* scene = nullptr;
     Array<LottieObject*> children;
 
-    bool reqFragment = false;   //requirement to fragment the render context
-    bool buildDone = false;     //completed in building the composition.
-    bool allowMerge = true;     //if this group is consisted of simple (transformed) shapes.
-    bool trimpath = false;      //this group has a trimpath.
+    bool reqFragment : 1;   //requirement to fragment the render context
+    bool buildDone : 1;     //completed in building the composition.
+    bool trimpath : 1;      //this group has a trimpath.
+    bool visible : 1;       //this group has visible contents.
+    bool allowMerge : 1;    //if this group is consisted of simple (transformed) shapes.
 };
 
 


### PR DESCRIPTION
More precisely, culling the render objects by
determining if the group has no renderable objects.

Additionally, check opacity to quickly return
in the rendering process.