### PR TITLE
sw_engine: ++skip radial gradient filling.

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -155,6 +155,7 @@ struct SwFill
     FillSpread spread;
 
     bool translucent;
+    bool invalid;
 };
 
 struct SwStrokeBorder

--- a/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/src/renderer/sw_engine/tvgSwFill.cpp
@@ -256,7 +256,12 @@ bool _prepareRadial(SwFill* fill, const RadialGradient* radial, const Matrix* tr
     auto fy = P(radial)->fy;
     auto fr = P(radial)->fr;
 
-    if (r < FLOAT_EPSILON) return true;
+    fill->invalid = false;
+
+    if (r < FLOAT_EPSILON) {
+        fill->invalid = true;
+        return true;
+    }
 
     fill->radial.dr = r - fr;
     fill->radial.dx = cx - fx;

--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -1607,6 +1607,8 @@ static bool _rasterLinearGradientRect(SwSurface* surface, const SwBBox& region, 
 
 static bool _rasterRadialGradientRect(SwSurface* surface, const SwBBox& region, const SwFill* fill)
 {
+    if (fill->invalid) return false;
+
     if (_compositing(surface)) {
         if (_matting(surface)) return _rasterGradientMattedRect<FillRadial>(surface, region, fill);
         else return _rasterGradientMaskedRect<FillRadial>(surface, region, fill);


### PR DESCRIPTION
Do not rendering if the filling has an invalid condition.