### PR TITLE
renderer/animation: rectified the segment value exception

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1957,7 +1957,7 @@ public:
      * @retval Result::InsufficientCondition In case the animation is not loaded.
      * @retval Result::NonSupport When it's not animatable.
      *
-     * @note Range from 0.0~1.0
+     * @note Animation allows a range from 0.0 to 1.0. @p end should not be higher than @p begin.
      * @note If a marker has been specified, its range will be disregarded.
      * @see LottieAnimation::segment(const char* marker)
      * @note Experimental API

--- a/src/renderer/tvgAnimation.cpp
+++ b/src/renderer/tvgAnimation.cpp
@@ -95,7 +95,7 @@ float Animation::duration() const noexcept
 
 Result Animation::segment(float begin, float end) noexcept
 {
-    if (begin < 0.0 || end > 1.0 || begin >= end) return Result::InvalidArguments;
+    if (begin < 0.0 || end > 1.0 || begin > end) return Result::InvalidArguments;
 
     auto loader = pImpl->picture->pImpl->loader;
     if (!loader) return Result::InsufficientCondition;


### PR DESCRIPTION
A zero-range segment can be useful for a stopped motion. There is no need to prohibit these values.