### PR TITLE
common: fix trimming

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1037,7 +1037,7 @@ public:
     /**
      * @brief Sets the trim of the stroke along the defined path segment, allowing control over which part of the stroke is visible.
      *
-     * The values of the arguments @p begin, @p end, and @p offset are in the range of 0.0 to 1.0, representing the beginning of the path and the end, respectively.
+     * If the values of the arguments @p begin and @p end exceed the 0-1 range, they are wrapped around in a manner similar to angle wrapping, effectively treating the range as circular.
      *
      * @param[in] begin Specifies the start of the segment to display along the path.
      * @param[in] end Specifies the end of the segment to display along the path.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1516,7 +1516,7 @@ TVG_API Tvg_Result tvg_shape_get_stroke_miterlimit(const Tvg_Paint* paint, float
 /*!
 * \brief Sets the trim of the stroke along the defined path segment, allowing control over which part of the stroke is visible.
 *
-* The values of the arguments @p begin, @p end, and @p offset are in the range of 0.0 to 1.0, representing the beginning of the path and the end, respectively.
+* If the values of the arguments @p begin and @p end exceed the 0-1 range, they are wrapped around in a manner similar to angle wrapping, effectively treating the range as circular.
 *
 * \param[in] paint A Tvg_Paint pointer to the shape object.
 * \param[in] begin Specifies the start of the segment to display along the path.

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -23,6 +23,7 @@
 #ifndef _TVG_RENDER_H_
 #define _TVG_RENDER_H_
 
+#include <math.h>
 #include "tvgCommon.h"
 #include "tvgArray.h"
 #include "tvgLock.h"
@@ -153,6 +154,32 @@ struct RenderStroke
         trim = rhs.trim;
     }
 
+    bool strokeTrim(float& begin, float& end) const
+    {
+        begin = trim.begin;
+        end = trim.end;
+
+        if (fabsf(end - begin) > 1.0f) {
+            begin = 0.0f;
+            end = 1.0f;
+            return false;
+        }
+
+        auto loop = true;
+
+        if (begin > 1.0f && end > 1.0f) loop = false;
+        if (begin < 0.0f && end < 0.0f) loop = false;
+        if (begin >= 0.0f && begin <= 1.0f && end >= 0.0f  && end <= 1.0f) loop = false;
+
+        if (begin > 1.0f) begin -= 1.0f;
+        if (begin < 0.0f) begin += 1.0f;
+        if (end > 1.0f) end -= 1.0f;
+        if (end < 0.0f) end += 1.0f;
+
+        if ((loop && begin < end) || (!loop && begin > end)) std::swap(begin, end);
+        return true;
+    }
+
     ~RenderStroke()
     {
         free(dashPattern);
@@ -197,7 +224,7 @@ struct RenderShape
     {
         if (!stroke) return false;
         if (stroke->trim.begin == 0.0f && stroke->trim.end == 1.0f) return false;
-        if (stroke->trim.begin == 1.0f && stroke->trim.end == 0.0f) return false;
+        if (fabsf(stroke->trim.end - stroke->trim.begin) > 1.0f) return false;
         return true;
     }
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -217,23 +217,6 @@ struct Shape::Impl
         if (tvg::equal(rs.stroke->trim.begin, begin) && tvg::equal(rs.stroke->trim.end, end) &&
             rs.stroke->trim.simultaneous == simultaneous) return;
 
-        auto loop = true;
-
-        if (begin > 1.0f && end > 1.0f) loop = false;
-        if (begin < 0.0f && end < 0.0f) loop = false;
-        if (begin >= 0.0f && begin <= 1.0f && end >= 0.0f  && end <= 1.0f) loop = false;
-
-        if (begin > 1.0f) begin -= 1.0f;
-        if (begin < 0.0f) begin += 1.0f;
-        if (end > 1.0f) end -= 1.0f;
-        if (end < 0.0f) end += 1.0f;
-
-        if ((loop && begin < end) || (!loop && begin > end)) {
-            auto tmp = begin;
-            begin = end;
-            end = tmp;
-        }
-
         rs.stroke->trim.begin = begin;
         rs.stroke->trim.end = end;
         rs.stroke->trim.simultaneous = simultaneous;


### PR DESCRIPTION
For pairs of start/end values like -0.5 and 0.5
(also -0.4 and 0.6, etc), the entire stroke should be drawn, but instead, nothing is drawn.


```
        auto shape1 = tvg::Shape::gen();
        shape1->appendCircle(245, 125, 50, 120);
        shape1->appendCircle(245, 365, 50, 120);
        shape1->appendCircle(125, 245, 120, 50);
        shape1->appendCircle(365, 245, 120, 50);
        shape1->fill(0, 50, 155, 100);
        shape1->strokeFill(0, 0, 255);
        shape1->strokeJoin(tvg::StrokeJoin::Round);
        shape1->strokeCap(tvg::StrokeCap::Round);
        shape1->strokeWidth(12);
        shape1->strokeTrim(-0.4f, 0.6f, false);

        auto shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
        shape2->translate(300, 300);
        shape2->fill(0, 155, 50, 100);
        shape2->strokeFill(0, 255, 0);
        shape2->strokeTrim(-0.4f, 0.6f, true);

        canvas->push(std::move(shape1));
        canvas->push(std::move(shape2));
```

before:
<img width="783" alt="Zrzut ekranu 2024-07-25 o 19 54 01" src="https://github.com/user-attachments/assets/1d086744-2586-438b-bad8-9ab8818cbef8">

after:
<img width="778" alt="Zrzut ekranu 2024-07-25 o 19 52 37" src="https://github.com/user-attachments/assets/b3fafc67-95ca-4f68-8eaa-183e7c417ae9">

