### PR TITLE
hotfix

### DIFF
--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -842,7 +842,7 @@ static bool _scaledRleImage(SwSurface* surface, const SwImage* image, const Matr
     Matrix itransform;
 
     if (transform) {
-        if (!inverse(transform, &itransform)) return false;
+        if (!inverse(transform, &itransform)) return true;
     } else identity(&itransform);
 
     if (_compositing(surface)) {
@@ -1202,7 +1202,7 @@ static bool _scaledImage(SwSurface* surface, const SwImage* image, const Matrix*
     Matrix itransform;
 
     if (transform) {
-        if (!inverse(transform, &itransform)) return false;
+        if (!inverse(transform, &itransform)) return true;
     } else identity(&itransform);
 
     if (_compositing(surface)) {

--- a/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -1092,7 +1092,7 @@ static bool _rasterTexmapPolygon(SwSurface* surface, const SwImage* image, const
     }
 
     //Exceptions: No dedicated drawing area?
-    if ((!image->rle && !region) || (image->rle && image->rle->size == 0)) return false;
+    if ((!image->rle && !region) || (image->rle && image->rle->size == 0)) return true;
 
    /* Prepare vertices.
       shift XY coordinates to match the sub-pixeling technique. */


### PR DESCRIPTION
Return the raster image as a success unless
it fails due to any problematic condition.

The changed cases are just invisible condition
of the images.