### PR TITLE
ttf_loader: Basic support for composite glyphs loading

### DIFF
--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -289,7 +289,7 @@ bool TtfLoader::read()
         auto rglyph = reader.glyph(code[idx], gmetrics);
         if (rglyph != INVALID_GLYPH) {
             if (lglyph != INVALID_GLYPH) reader.kerning(lglyph, rglyph, kerning);
-            if (!reader.convert(shape, gmetrics, offset, kerning)) break;
+            if (!reader.convert(shape, gmetrics, offset, kerning, 1U)) break;
         }
         offset.x += (gmetrics.advanceWidth + kerning.x);
         lglyph = rglyph;

--- a/src/loaders/ttf/tvgTtfReader.h
+++ b/src/loaders/ttf/tvgTtfReader.h
@@ -64,7 +64,7 @@ public:
     bool header();
     uint32_t glyph(uint32_t codepoint, TtfGlyphMetrics& gmetrics);
     void kerning(uint32_t lglyph, uint32_t rglyph, Point& out);
-    bool convert(Shape* shape, TtfGlyphMetrics& gmetrics, const Point& offset, const Point& kerning);
+    bool convert(Shape* shape, TtfGlyphMetrics& gmetrics, const Point& offset, const Point& kerning, uint16_t componentDepth);
 
 private:
     //table offsets
@@ -73,6 +73,7 @@ private:
     uint32_t loca = 0;
     uint32_t glyf = 0;
     uint32_t kern = 0;
+    uint32_t maxp = 0;
 
     uint32_t cmap_12_13(uint32_t table, uint32_t codepoint, int which) const;
     uint32_t cmap_4(uint32_t table, uint32_t codepoint) const;
@@ -81,6 +82,8 @@ private:
     uint32_t table(const char* tag);
     uint32_t outlineOffset(uint32_t glyph);
     uint32_t glyph(uint32_t codepoint);
+    bool glyphMetrics(uint32_t glyphIndex, TtfGlyphMetrics& gmetrics);
+    bool convertComposite(Shape* shape, TtfGlyphMetrics& gmetrics, const Point& offset, const Point& kerning, uint16_t componentDepth);
     bool genPath(uint8_t* flags, uint16_t basePoint, uint16_t count);
     bool genSimpleOutline(Shape* shape, uint32_t outline, uint32_t cntrsCnt);
     bool points(uint32_t outline, uint8_t* flags, Point* pts, uint32_t ptsCnt, const Point& offset);

--- a/test/testText.cpp
+++ b/test/testText.cpp
@@ -138,7 +138,7 @@ TEST_CASE("Text Basic", "[tvgText]")
     Initializer::term();
 }
 
-TEST_CASE("Text with composite glyfs", "[tvgText]")
+TEST_CASE("Text with composite glyphs", "[tvgText]")
 {
     Initializer::init(0);
 

--- a/test/testText.cpp
+++ b/test/testText.cpp
@@ -138,4 +138,25 @@ TEST_CASE("Text Basic", "[tvgText]")
     Initializer::term();
 }
 
+TEST_CASE("Text with composite glyfs", "[tvgText]")
+{
+    Initializer::init(0);
+
+    auto canvas = SwCanvas::gen();
+
+    auto text = Text::gen();
+    REQUIRE(text);
+
+    REQUIRE(Text::load(TEST_DIR"/Arial.ttf") == tvg::Result::Success);
+    REQUIRE(text->font("Arial", 80) == tvg::Result::Success);
+
+    REQUIRE(text->text("\xc5\xbb\x6f\xc5\x82\xc4\x85\x64\xc5\xba \xc8\xab") == tvg::Result::Success);
+
+    REQUIRE(text->fill(255, 255, 255) == tvg::Result::Success);
+
+    REQUIRE(canvas->push(std::move(text)) == Result::Success);
+
+    Initializer::term();
+}
+
 #endif


### PR DESCRIPTION
Adds the ability to load some composite glyphs and prevents an error when a composite glyph is used.

Implementation based on ttf glyf table documentation: https://learn.microsoft.com/en-us/typography/opentype/spec/glyf

There are still some missing features like scaling, parent glyph point based positioning etc. I think this is a topic for future work. Howerever, it looks like implemented features are enough for utf-8 latin subset in major fonts.

solves issue: #2599