### PR TITLE
sw_engine: fix radial coefficients calculations

### DIFF
--- a/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/src/renderer/sw_engine/tvgSwFill.cpp
@@ -58,7 +58,7 @@ static void _calculateCoefficients(const SwFill* fill, uint32_t x, uint32_t y, f
     auto deltaDeltaRr = 2.0f * (radial->a11 * radial->a11 + radial->a21 * radial->a21) * radial->invA;
 
     det = b * b + (rr - radial->fr * radial->fr) * radial->invA;
-    deltaDet = 2.0f * b * deltaB + deltaB * deltaB + deltaRr + deltaDeltaRr;
+    deltaDet = 2.0f * b * deltaB + deltaB * deltaB + deltaRr + deltaDeltaRr * 0.5f;
     deltaDeltaDet = 2.0f * deltaB * deltaB + deltaDeltaRr;
 }
 


### PR DESCRIPTION
In the Taylor series expansion, there was a missing division by 2! in the term with the second derivative.

@Issue: https://github.com/thorvg/thorvg/issues/2530

sample:
```
<svg
  viewBox="0 0 100 100"
  xmlns="http://www.w3.org/2000/svg"
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <defs>
    <radialGradient id="myGradient" spreadMethod="reflect"
      gradientUnits="userSpaceOnUse"
      r="10" cx="50" cy="50">
      <stop offset="0.0" stop-color="#000000" />
      <stop offset="1.0" stop-color="#FFFFFF" />
    </radialGradient>
  </defs>

  <rect width="100" height="100" x="0" y="0" fill="url(#myGradient)" />
</svg>
```

before:
<img width="401" alt="Zrzut ekranu 2024-07-27 o 01 27 23" src="https://github.com/user-attachments/assets/19a5f70b-e45e-478d-a683-c32b4a08a3a8">

after:
<img width="401" alt="Zrzut ekranu 2024-07-27 o 01 27 06" src="https://github.com/user-attachments/assets/5bab0dd7-8439-4156-88c9-9b884c6a7ef4">
