### PR TITLE
common: fix trimming

### DIFF
--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -159,7 +159,7 @@ struct RenderStroke
         begin = trim.begin;
         end = trim.end;
 
-        if (fabsf(end - begin) > 1.0f) {
+        if (fabsf(end - begin) >= 1.0f) {
             begin = 0.0f;
             end = 1.0f;
             return false;
@@ -224,7 +224,7 @@ struct RenderShape
     {
         if (!stroke) return false;
         if (stroke->trim.begin == 0.0f && stroke->trim.end == 1.0f) return false;
-        if (fabsf(stroke->trim.end - stroke->trim.begin) > 1.0f) return false;
+        if (fabsf(stroke->trim.end - stroke->trim.begin) >= 1.0f) return false;
         return true;
     }
 


### PR DESCRIPTION
By mistake > was used instead of >=.
The issue was observed for trim when
the trim length was exactly zero.

should be done in https://github.com/thorvg/thorvg/pull/2596 but somehow was lost