### PR TITLE
Revert `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` workaround

### DIFF
--- a/src/common/tvgLock.h
+++ b/src/common/tvgLock.h
@@ -25,8 +25,6 @@
 
 #ifdef THORVG_THREAD_SUPPORT
 
-#define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
-
 #include <mutex>
 #include "tvgTaskScheduler.h"
 

--- a/src/renderer/tvgTaskScheduler.h
+++ b/src/renderer/tvgTaskScheduler.h
@@ -23,8 +23,6 @@
 #ifndef _TVG_TASK_SCHEDULER_H_
 #define _TVG_TASK_SCHEDULER_H_
 
-#define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
-
 #include <mutex>
 #include <condition_variable>
 


### PR DESCRIPTION
This reverts #2385, which was merged on 2024-06-10 as a workaround for broken GitHub Actions runner images (see https://github.com/actions/runner-images/issues/10004). GitHub Actions was fixed a few days later, so the workaround is no longer necessary, and should be reverted to avoid problems with the upcoming release of VS 2022 17.12.

This workaround macro `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` should have been defined on the command line (i.e. somewhere in thorvg's `meson.build`). Defining workaround macros in source files is fragile, because library headers could be dragged in before the workaround macros are defined, and upcoming changes to MSVC's STL will reveal this problem and emit compiler errors. (I work on MSVC's STL, and this was found by our [vcpkg](https://github.com/microsoft/vcpkg) team, which is building thorvg with the latest development version of MSVC's STL, finding this issue in advance.)

Technical details: https://github.com/microsoft/STL/pull/4720 (which will ship in VS 2022 17.12 Preview 1 very soon) changed the STL to declare its internal function `_Mtx_init_in_situ` in its internal header `<xthreads.h>` for use in `<mutex>` only when it's needed, i.e. when `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` is defined. This will be broken if user code attempts to define `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` in a source file, and does so "in the middle" after some STL headers have already been included (and have dragged in `<xthreads.h>` indirectly) but before `<mutex>` has been included. That's what's happening in thorvg. Although `tvgLock.h` and `tvgTaskScheduler.h` were defining the workaround macro at the beginning of their files, they aren't necessarily included at the very beginning of every translation unit that uses them.

Because the GitHub Actions runners have been fixed, simply reverting the workaround is best, instead of moving it to `meson.build`.