### PR TITLE
Lighten/Darken Masking Enhancement

### DIFF
--- a/examples/MaskingMethods.cpp
+++ b/examples/MaskingMethods.cpp
@@ -109,6 +109,38 @@ struct UserExample : tvgexam::Example
             mask4->composite(std::move(diff), tvg::CompositeMethod::DifferenceMask);
             shape4->composite(std::move(mask4), tvg::CompositeMethod::AlphaMask);
             canvas->push(std::move(shape4));
+
+            //Shape + Shape Mask Lighten
+            auto shape5 = tvg::Shape::gen();
+            shape5->appendCircle(1125, 100, 150, 150);
+            shape5->fill(255, 255, 255);
+
+            auto mask5 = tvg::Shape::gen();
+            mask5->appendCircle(1125, 100, 50, 50);
+            mask5->fill(255, 255, 255, 200);
+
+            auto light = tvg::Shape::gen();
+            light->appendCircle(1150, 100, 50, 50);
+            light->fill(255, 255, 255);
+            mask5->composite(std::move(light), tvg::CompositeMethod::LightenMask);
+            shape5->composite(std::move(mask5), tvg::CompositeMethod::AlphaMask);
+            canvas->push(std::move(shape5));
+
+            //Shape + Shape Mask Darken
+            auto shape6 = tvg::Shape::gen();
+            shape6->appendCircle(1375, 100, 150, 150);
+            shape6->fill(255, 255, 255);
+
+            auto mask6 = tvg::Shape::gen();
+            mask6->appendCircle(1375, 100, 50, 50);
+            mask6->fill(255, 255, 255, 200);
+
+            auto dark = tvg::Shape::gen();
+            dark->appendCircle(1400, 100, 50, 50);
+            dark->fill(255, 255, 255);
+            mask6->composite(std::move(dark), tvg::CompositeMethod::DarkenMask);
+            shape6->composite(std::move(mask6), tvg::CompositeMethod::AlphaMask);
+            canvas->push(std::move(shape6));
         }
         {
             //Shape + Shape Mask Add
@@ -174,6 +206,38 @@ struct UserExample : tvgexam::Example
             mask4->composite(std::move(diff), tvg::CompositeMethod::DifferenceMask);
             shape4->composite(std::move(mask4), tvg::CompositeMethod::InvAlphaMask);
             canvas->push(std::move(shape4));
+
+            //Shape + Shape Mask Lighten
+            auto shape5 = tvg::Shape::gen();
+            shape5->appendCircle(1125, 300, 100, 100);
+            shape5->fill(255, 255, 255);
+
+            auto mask5 = tvg::Shape::gen();
+            mask5->appendCircle(1125, 300, 50, 50);
+            mask5->fill(255, 255, 255, 200);
+
+            auto light = tvg::Shape::gen();
+            light->appendCircle(1150, 300, 50, 50);
+            light->fill(255, 255, 255);
+            mask5->composite(std::move(light), tvg::CompositeMethod::LightenMask);
+            shape5->composite(std::move(mask5), tvg::CompositeMethod::InvAlphaMask);
+            canvas->push(std::move(shape5));
+
+            //Shape + Shape Mask Darken
+            auto shape6 = tvg::Shape::gen();
+            shape6->appendCircle(1375, 300, 100, 100);
+            shape6->fill(255, 255, 255);
+
+            auto mask6 = tvg::Shape::gen();
+            mask6->appendCircle(1375, 300, 50, 50);
+            mask6->fill(255, 255, 255, 200);
+
+            auto dark = tvg::Shape::gen();
+            dark->appendCircle(1400, 300, 50, 50);
+            dark->fill(255, 255, 255);
+            mask6->composite(std::move(dark), tvg::CompositeMethod::DarkenMask);
+            shape6->composite(std::move(mask6), tvg::CompositeMethod::InvAlphaMask);
+            canvas->push(std::move(shape6));
         }
         {
             //Rect + Rect Mask Add
@@ -239,8 +303,39 @@ struct UserExample : tvgexam::Example
             mask4->composite(std::move(diff), tvg::CompositeMethod::DifferenceMask);
             shape4->composite(std::move(mask4), tvg::CompositeMethod::AlphaMask);
             canvas->push(std::move(shape4));
-        }
 
+            //Rect + Rect Mask Lighten
+            auto shape5 = tvg::Shape::gen();
+            shape5->appendRect(1125, 450, 150, 150);
+            shape5->fill(255, 255, 255);
+
+            auto mask5 = tvg::Shape::gen();
+            mask5->appendRect(1125, 500, 100, 100);
+            mask5->fill(255, 255, 255, 200);
+
+            auto light = tvg::Shape::gen();
+            light->appendRect(1175, 450, 100, 100);
+            light->fill(255, 255, 255);
+            mask5->composite(std::move(light), tvg::CompositeMethod::LightenMask);
+            shape5->composite(std::move(mask5), tvg::CompositeMethod::AlphaMask);
+            canvas->push(std::move(shape5));
+
+            //Rect + Rect Mask Darken
+            auto shape6 = tvg::Shape::gen();
+            shape6->appendRect(1375, 450, 150, 150);
+            shape6->fill(255, 255, 255);
+
+            auto mask6 = tvg::Shape::gen();
+            mask6->appendRect(1375, 500, 100, 100);
+            mask6->fill(255, 255, 255, 200);
+
+            auto dark = tvg::Shape::gen();
+            dark->appendRect(1400, 450, 100, 100);
+            dark->fill(255, 255, 255);
+            mask6->composite(std::move(dark), tvg::CompositeMethod::DarkenMask);
+            shape6->composite(std::move(mask6), tvg::CompositeMethod::AlphaMask);
+            canvas->push(std::move(shape6));
+        }
         {
             //Transformed Image + Shape Mask Add
             auto image = tvg::Picture::gen();
@@ -313,6 +408,42 @@ struct UserExample : tvgexam::Example
             mask4->composite(std::move(diff), tvg::CompositeMethod::DifferenceMask);
             image4->composite(std::move(mask4), tvg::CompositeMethod::AlphaMask);
             canvas->push(std::move(image4));
+
+            //Transformed Image + Shape Mask Lighten
+            auto image5 = tvg::Picture::gen();
+            if (!tvgexam::verify(image5->load(data, 200, 300, true, true))) return false;
+            image5->translate(1150, 650);
+            image5->scale(0.5f);
+            image5->rotate(45);
+
+            auto mask5 = tvg::Shape::gen();
+            mask5->appendCircle(1125, 700, 50, 50);
+            mask5->fill(255, 255, 255, 200);
+
+            auto light = tvg::Shape::gen();
+            light->appendCircle(1150, 750, 50, 50);
+            light->fill(255, 255, 255);
+            mask5->composite(std::move(light), tvg::CompositeMethod::LightenMask);
+            image5->composite(std::move(mask5), tvg::CompositeMethod::AlphaMask);
+            canvas->push(std::move(image5));
+
+            //Transformed Image + Shape Mask Darken
+            auto image6 = tvg::Picture::gen();
+            if (!tvgexam::verify(image6->load(data, 200, 300, true, true))) return false;
+            image6->translate(1400, 650);
+            image6->scale(0.5f);
+            image6->rotate(45);
+
+            auto mask6 = tvg::Shape::gen();
+            mask6->appendCircle(1375, 700, 50, 50);
+            mask6->fill(255, 255, 255, 200);
+
+            auto dark = tvg::Shape::gen();
+            dark->appendCircle(1400, 750, 50, 50);
+            dark->fill(255, 255, 255);
+            mask6->composite(std::move(dark), tvg::CompositeMethod::DarkenMask);
+            image6->composite(std::move(mask6), tvg::CompositeMethod::AlphaMask);
+            canvas->push(std::move(image6));
         }
         {
             //Transformed Image + Shape Mask Add
@@ -386,10 +517,44 @@ struct UserExample : tvgexam::Example
             mask4->composite(std::move(diff), tvg::CompositeMethod::DifferenceMask);
             image4->composite(std::move(mask4), tvg::CompositeMethod::InvAlphaMask);
             canvas->push(std::move(image4));
+
+            //Transformed Image + Shape Mask Lighten
+            auto image5 = tvg::Picture::gen();
+            if (!tvgexam::verify(image5->load(data, 200, 300, true, true))) return false;
+            image5->translate(1150, 850);
+            image5->scale(0.5f);
+            image5->rotate(45);
+
+            auto mask5 = tvg::Shape::gen();
+            mask5->appendCircle(1125, 900, 50, 50);
+            mask5->fill(255, 255, 255, 200);
+
+            auto light = tvg::Shape::gen();
+            light->appendCircle(1150, 950, 50, 50);
+            light->fill(255, 255, 255);
+            mask5->composite(std::move(light), tvg::CompositeMethod::LightenMask);
+            image5->composite(std::move(mask5), tvg::CompositeMethod::InvAlphaMask);
+            canvas->push(std::move(image5));
+
+            //Transformed Image + Shape Mask Darken
+            auto image6 = tvg::Picture::gen();
+            if (!tvgexam::verify(image6->load(data, 200, 300, true, true))) return false;
+            image6->translate(1400, 850);
+            image6->scale(0.5f);
+            image6->rotate(45);
+
+            auto mask6 = tvg::Shape::gen();
+            mask6->appendCircle(1375, 900, 50, 50);
+            mask6->fill(255, 255, 255, 200);
+
+            auto dark = tvg::Shape::gen();
+            dark->appendCircle(1400, 950, 50, 50);
+            dark->fill(255, 255, 255);
+            mask6->composite(std::move(dark), tvg::CompositeMethod::DarkenMask);
+            image6->composite(std::move(mask6), tvg::CompositeMethod::InvAlphaMask);
+            canvas->push(std::move(image6));
         }
-
         free(data);
-
         return true;
     }
 };
@@ -401,5 +566,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv, 1024, 1024);
+    return tvgexam::main(new UserExample, argc, argv, 1500, 1024);
 }

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -165,7 +165,9 @@ enum class CompositeMethod : uint8_t
     AddMask,            ///< Combines the target and source objects pixels using target alpha. (T * TA) + (S * (255 - TA)) (Experimental API)
     SubtractMask,       ///< Subtracts the source color from the target color while considering their respective target alpha. (T * TA) - (S * (255 - TA)) (Experimental API)
     IntersectMask,      ///< Computes the result by taking the minimum value between the target alpha and the source alpha and multiplies it with the target color. (T * min(TA, SA)) (Experimental API)
-    DifferenceMask      ///< Calculates the absolute difference between the target color and the source color multiplied by the complement of the target alpha. abs(T - S * (255 - TA)) (Experimental API)
+    DifferenceMask,     ///< Calculates the absolute difference between the target color and the source color multiplied by the complement of the target alpha. abs(T - S * (255 - TA)) (Experimental API)
+    LightenMask,        ///< Where multiple masks intersect, the highest transparency value is used. (Experimental API)
+    DarkenMask          ///< Where multiple masks intersect, the lowest transparency value is used. (Experimental API)
 };
 
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -71,14 +71,8 @@ CompositeMethod LottieParser::getMaskMethod(bool inversed)
         case 's': return CompositeMethod::SubtractMask;
         case 'i': return CompositeMethod::IntersectMask;
         case 'f': return CompositeMethod::DifferenceMask;
-        case 'l': {
-            TVGLOG("LOTTIE", "Mask Lighten is not supported");
-            return CompositeMethod::None;
-        }
-        case 'd': {
-            TVGLOG("LOTTIE", "Mask Darken is not supported");
-            return CompositeMethod::None;
-        }
+        case 'l': return CompositeMethod::LightenMask;
+        case 'd': return CompositeMethod::DarkenMask;
         default: return CompositeMethod::None;
     }
 }

--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -194,10 +194,21 @@ static inline uint8_t _opMaskDifference(uint8_t s, uint8_t d, uint8_t a)
 }
 
 
+static inline uint8_t _opMaskLighten(uint8_t s, uint8_t d, uint8_t a)
+{
+    return (s > d) ? s : d;
+}
+
+
+static inline uint8_t _opMaskDarken(uint8_t s, uint8_t d, uint8_t a)
+{
+    return (s < d) ? s : d;
+}
+
+
 static inline bool _direct(CompositeMethod method)
 {
-    //subtract & Intersect allows the direct composition
-    if (method == CompositeMethod::SubtractMask || method == CompositeMethod::IntersectMask) return true;
+    if (method == CompositeMethod::SubtractMask || method == CompositeMethod::IntersectMask || method == CompositeMethod::DarkenMask) return true;
     return false;
 }
 
@@ -209,6 +220,8 @@ static inline SwMask _getMaskOp(CompositeMethod method)
         case CompositeMethod::SubtractMask: return _opMaskSubtract;
         case CompositeMethod::DifferenceMask: return _opMaskDifference;
         case CompositeMethod::IntersectMask: return _opMaskIntersect;
+        case CompositeMethod::LightenMask: return _opMaskLighten;
+        case CompositeMethod::DarkenMask: return _opMaskDarken;
         default: return nullptr;
     }
 }

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -321,6 +321,8 @@ static inline bool MASK_REGION_MERGING(CompositeMethod method)
         //these might expand the rendering region
         case CompositeMethod::AddMask:
         case CompositeMethod::DifferenceMask:
+        case CompositeMethod::LightenMask:
+        case CompositeMethod::DarkenMask:
             return true;
         default:
             TVGERR("RENDERER", "Unsupported Composite Method! = %d", (int)method);
@@ -354,6 +356,8 @@ static inline ColorSpace COMPOSITE_TO_COLORSPACE(RenderMethod* renderer, Composi
         case CompositeMethod::DifferenceMask:
         case CompositeMethod::SubtractMask:
         case CompositeMethod::IntersectMask:
+        case CompositeMethod::LightenMask:
+        case CompositeMethod::DarkenMask:
             return ColorSpace::Grayscale8;
         //TODO: Optimize Luma/InvLuma colorspace to Grayscale8
         case CompositeMethod::LumaMask:


### PR DESCRIPTION
This is only introduced for software rasterizer.
issue: https://github.com/thorvg/thorvg/issues/2608

- examples/MaskingMethods
![maskingmethod](https://github.com/user-attachments/assets/151079fb-7f8d-4012-89d7-566f39a71df1)

- Lottie Lighten
![light](https://github.com/user-attachments/assets/9f3cae49-8b1a-4c1c-9673-32cf1d091d02)
[lighten.json](https://github.com/user-attachments/files/16510008/lighten.json)

- Lottie Darken
![darken](https://github.com/user-attachments/assets/510fbe1e-50c3-495a-84e4-2ae0f97b5713)
[darken.json](https://github.com/user-attachments/files/16510009/darken.json)

