### PR TITLE
renderer: rectified the bounds() behavior

### DIFF
--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -402,7 +402,7 @@ Matrix Paint::transform() noexcept
 
 Result Paint::bounds(float* x, float* y, float* w, float* h, bool transformed) const noexcept
 {
-    if (pImpl->bounds(x, y, w, h, transformed, true, true)) return Result::Success;
+    if (pImpl->bounds(x, y, w, h, transformed, true, transformed)) return Result::Success;
     return Result::InsufficientCondition;
 }
 

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -148,7 +148,7 @@ struct Text::Impl
     bool bounds(float* x, float* y, float* w, float* h, TVG_UNUSED bool stroking)
     {
         if (!load() || !paint) return false;
-        paint->bounds(x, y, w, h, true);
+        PP(paint)->bounds(x, y, w, h, true, true, false);
         return true;
     }
 


### PR DESCRIPTION
Text fill is broken by 43c87b4eb5cef0fbaa3a4ab8084790b5b5c19735