### PR TITLE
wasm: Support WebGPU Binding

### DIFF
--- a/cross/wasm_webgpu.txt
+++ b/cross/wasm_webgpu.txt
@@ -1,0 +1,21 @@
+[binaries]
+cpp = 'EMSDK:upstream/emscripten/em++.py'
+ar = 'EMSDK:upstream/emscripten/emar.py'
+strip = '-strip'
+
+[properties]
+root = 'EMSDK:upstream/emscripten/system'
+shared_lib_suffix = 'js'
+static_lib_suffix = 'js'
+shared_module_suffix = 'js'
+exe_suffix = 'js'
+
+[built-in options]
+cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
+cpp_link_args = ['-lembind', '-sMODULARIZE=1', '-sUSE_WEBGPU=1', '-sASYNCIFY=1', '-sFORCE_FILESYSTEM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sSINGLE_FILE=1']
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'

--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -23,6 +23,9 @@
 #include <thorvg.h>
 #include <emscripten/bind.h>
 #include "tvgPicture.h"
+#ifdef THORVG_WG_RASTER_SUPPORT
+    #include <webgpu/webgpu.h>
+#endif
 
 using namespace emscripten;
 using namespace std;
@@ -36,6 +39,10 @@ public:
     ~TvgLottieAnimation()
     {
         free(buffer);
+        #ifdef THORVG_WG_RASTER_SUPPORT
+            wgpuSurfaceRelease(surface);
+            wgpuInstanceRelease(instance);
+        #endif
         Initializer::term();
     }
 
@@ -74,7 +81,7 @@ public:
     }
 
     // Render methods
-    bool load(string data, string mimetype, int width, int height, string rpath = "")
+    bool load(string data, string mimetype, int width, int height, string selector = "", string rpath = "")
     {
         errorMsg = NoError;
 
@@ -85,8 +92,20 @@ public:
             return false;
         }
 
-        //back up for saving
-        this->data = data;
+        this->data = data; //back up for saving
+
+        #ifdef THORVG_WG_RASTER_SUPPORT
+            this->selector = selector;
+            instance = wgpuCreateInstance(nullptr);
+            // surface
+            WGPUSurfaceDescriptorFromCanvasHTMLSelector canvasDesc{};
+            canvasDesc.chain.next = nullptr;
+            canvasDesc.chain.sType = WGPUSType_SurfaceDescriptorFromCanvasHTMLSelector;
+            canvasDesc.selector = this->selector.c_str();
+            WGPUSurfaceDescriptor surfaceDesc{};
+            surfaceDesc.nextInChain = &canvasDesc.chain;
+            surface = wgpuInstanceCreateSurface(instance, &surfaceDesc);
+        #endif
 
         canvas->clear(true);
 
@@ -184,9 +203,14 @@ public:
         this->width = width;
         this->height = height;
 
-        free(buffer);
-        buffer = (uint8_t*)malloc(width * height * sizeof(uint32_t));
-        canvas->target((uint32_t *)buffer, width, width, height, SwCanvas::ABGR8888S);
+        #ifdef THORVG_WG_RASTER_SUPPORT
+            static_cast<WgCanvas*>(canvas.get())->target(this->instance, this->surface, width, height);
+        #else
+            free(buffer);
+            buffer = (uint8_t*)malloc(width * height * sizeof(uint32_t));
+            static_cast<SwCanvas*>(canvas.get())->target((uint32_t *)buffer, width, width, height, SwCanvas::ABGR8888S);
+        #endif
+
 
         float scale;
         float shiftX = 0.0f, shiftY = 0.0f;
@@ -312,13 +336,22 @@ private:
     explicit TvgLottieAnimation()
     {
         errorMsg = NoError;
+        auto engine = CanvasEngine::Sw;
+        #ifdef THORVG_WG_RASTER_SUPPORT
+            engine = CanvasEngine::Wg;
+        #endif
 
-        if (Initializer::init(0) != Result::Success) {
+
+        if (Initializer::init(0, engine) != Result::Success) {
             errorMsg = "init() fail";
             return;
         }
 
-        canvas = SwCanvas::gen();
+        #ifdef THORVG_WG_RASTER_SUPPORT
+            canvas = WgCanvas::gen();
+        #else
+            canvas = SwCanvas::gen();
+        #endif
         if (!canvas) errorMsg = "Invalid canvas";
 
         animation = Animation::gen();
@@ -327,7 +360,7 @@ private:
 
 private:
     string                 errorMsg;
-    unique_ptr<SwCanvas>   canvas = nullptr;
+    unique_ptr<Canvas>   canvas = nullptr;
     unique_ptr<Animation>  animation = nullptr;
     string                 data;
     uint8_t*               buffer = nullptr;
@@ -335,6 +368,12 @@ private:
     uint32_t               height = 0;
     float                  psize[2];         //picture size
     bool                   updated = false;
+
+    #ifdef THORVG_WG_RASTER_SUPPORT
+    WGPUInstance instance{};
+    WGPUSurface surface{};
+    string selector;
+    #endif
 };
 
 EMSCRIPTEN_BINDINGS(thorvg_bindings)

--- a/src/renderer/wg_engine/meson.build
+++ b/src/renderer/wg_engine/meson.build
@@ -19,7 +19,10 @@ source_file = [
     'tvgWgShaderTypes.cpp'
 ]
 
-wgpu_dep = dependency('wgpu_native')
+wgpu_dep = []
+if not get_option('bindings').contains('wasm_beta')
+    wgpu_dep = dependency('wgpu_native')
+endif
 
 engine_dep += [declare_dependency(
     dependencies        : wgpu_dep,

--- a/wasm_webgpu_build.sh
+++ b/wasm_webgpu_build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#https://github.com/thorvg/thorvg/wiki/WebGPU-Raster-Engine-Development
+
+if [ ! -d "./build_wasm" ]; then
+    sed "s|EMSDK:|$1|g" ./cross/wasm_webgpu.txt > /tmp/.wasm_cross.txt
+    meson -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="wg_beta" --cross-file /tmp/.wasm_cross.txt build_wasm
+fi
+
+ninja -C build_wasm/
+ls -lrt build_wasm/src/bindings/wasm/thorvg-wasm.*


### PR DESCRIPTION
Added build script & binding for WebGPU.

This is compatible for lottie-player in thorvg.web, doesn't affect to SW Renderer WASM.

Developers can choose one of ways for building ThorVG WASM.

```sh
# Enter ThorVG directory
cd ./thorvg

# If build_wasm exists, remove it
rm -rf ./build_wasm

# (Option 1) Build ThorVG for SW Renderer
./wasm_build.sh {absolute path}/emsdk/

# (Option 2) Build ThorVG for WebGPU capability [NEW]
./wasm_webgpu_build.sh {absolute path}/emsdk/
```