### PR TITLE
common: increase precision for bezier calculations

### DIFF
--- a/src/common/tvgMath.cpp
+++ b/src/common/tvgMath.cpp
@@ -79,7 +79,7 @@ float _bezAt(const Bezier& bz, float at, float length, LengthFunc lineLengthFunc
         Bezier left;
         right.split(t, left);
         length = _bezLength(left, lineLengthFunc);
-        if (fabsf(length - at) < BEZIER_EPSILON || fabsf(smallest - biggest) < BEZIER_EPSILON) {
+        if (fabsf(length - at) < BEZIER_EPSILON || fabsf(smallest - biggest) < 1e-3f) {
             break;
         }
         if (length < at) {


### PR DESCRIPTION
The epsilon value currently used for the precision of Beziers calculations is sufficient for comparing curve lengths. However, for the parameter t, which ranges from 0 to 1, an accuracy of 1% can introduce errors.
The solution is to increase the precision for the t parameter while keeping the rest of the calculations at the previously used epsilon value.

@Issue: https://github.com/thorvg/thorvg/issues/2619