### PR TITLE
common: add missing consts & fix arg name

### DIFF
--- a/src/common/tvgArray.h
+++ b/src/common/tvgArray.h
@@ -59,7 +59,7 @@ struct Array
         data[count++] = element;
     }
 
-    void push(Array<T>& rhs)
+    void push(const Array<T>& rhs)
     {
         if (rhs.count == 0) return;
         grow(rhs.count);

--- a/src/common/tvgInlist.h
+++ b/src/common/tvgInlist.h
@@ -100,7 +100,7 @@ struct Inlist
         if (element == tail) tail = element->prev;
     }
 
-    bool empty()
+    bool empty() const
     {
         return head ? false : true;
     }

--- a/src/common/tvgMath.cpp
+++ b/src/common/tvgMath.cpp
@@ -273,27 +273,27 @@ float Bezier::lengthApprox() const
 }
 
 
-void Bezier::split(float at, Bezier& left)
+void Bezier::split(float t, Bezier& left)
 {
     left.start = start;
 
-    left.ctrl1.x = start.x + at * (ctrl1.x - start.x);
-    left.ctrl1.y = start.y + at * (ctrl1.y - start.y);
+    left.ctrl1.x = start.x + t * (ctrl1.x - start.x);
+    left.ctrl1.y = start.y + t * (ctrl1.y - start.y);
 
-    left.ctrl2.x = ctrl1.x + at * (ctrl2.x - ctrl1.x); //temporary holding spot
-    left.ctrl2.y = ctrl1.y + at * (ctrl2.y - ctrl1.y); //temporary holding spot
+    left.ctrl2.x = ctrl1.x + t * (ctrl2.x - ctrl1.x); //temporary holding spot
+    left.ctrl2.y = ctrl1.y + t * (ctrl2.y - ctrl1.y); //temporary holding spot
 
-    ctrl2.x = ctrl2.x + at * (end.x - ctrl2.x);
-    ctrl2.y = ctrl2.y + at * (end.y - ctrl2.y);
+    ctrl2.x = ctrl2.x + t * (end.x - ctrl2.x);
+    ctrl2.y = ctrl2.y + t * (end.y - ctrl2.y);
 
-    ctrl1.x = left.ctrl2.x + at * (ctrl2.x - left.ctrl2.x);
-    ctrl1.y = left.ctrl2.y + at * (ctrl2.y - left.ctrl2.y);
+    ctrl1.x = left.ctrl2.x + t * (ctrl2.x - left.ctrl2.x);
+    ctrl1.y = left.ctrl2.y + t * (ctrl2.y - left.ctrl2.y);
 
-    left.ctrl2.x = left.ctrl1.x + at * (left.ctrl2.x - left.ctrl1.x);
-    left.ctrl2.y = left.ctrl1.y + at * (left.ctrl2.y - left.ctrl1.y);
+    left.ctrl2.x = left.ctrl1.x + t * (left.ctrl2.x - left.ctrl1.x);
+    left.ctrl2.y = left.ctrl1.y + t * (left.ctrl2.y - left.ctrl1.y);
 
-    left.end.x = start.x = left.ctrl2.x + at * (ctrl1.x - left.ctrl2.x);
-    left.end.y = start.y = left.ctrl2.y + at * (ctrl1.y - left.ctrl2.y);
+    left.end.x = start.x = left.ctrl2.x + t * (ctrl1.x - left.ctrl2.x);
+    left.end.y = start.y = left.ctrl2.y + t * (ctrl1.y - left.ctrl2.y);
 }
 
 

--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -264,7 +264,7 @@ struct Bezier
     Point ctrl2;
     Point end;
 
-    void split(float at, Bezier& left);
+    void split(float t, Bezier& left);
     void split(Bezier& left, Bezier& right) const;
     void split(float at, Bezier& left, Bezier& right) const;
     float length() const;


### PR DESCRIPTION
common: add missing consts
    
    Adding const was necessary to allow calling
    the functions on constant objects.


common: fix arg name
    
    For Bezier curves, we typically use 't' as a parameter
    within the 0-1 range, while 'at' is used for the parameter
    scaled by the curve's length. In one of the functions,
    an incorrect name was used, which could be confusing.
    No logical changes.
