### PR TITLE
wg_engine: light/dark mask mode support

### DIFF
--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -40,7 +40,7 @@ private:
     WGPUShaderModule shaderBlendSolid[14];
     WGPUShaderModule shaderBlendGradient[14];
     WGPUShaderModule shaderBlendImage[14];
-    WGPUShaderModule shaderCompose[10];
+    WGPUShaderModule shaderCompose[12];
     WGPUShaderModule shaderCopy;
 private:
     // graphics pipeline layouts
@@ -68,7 +68,7 @@ public:
     WGPUComputePipeline blendSolid[14];
     WGPUComputePipeline blendGradient[14];
     WGPUComputePipeline blendImage[14];
-    WGPUComputePipeline compose[10];
+    WGPUComputePipeline compose[12];
     WGPUComputePipeline copy;
 private:
     void releaseGraphicHandles(WgContext& context);

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -652,6 +652,14 @@ std::string cComposeEquation_DifferenceMask = WG_SHADER_SOURCE(
     Rc = Sc;
     Ra = Sa * (1.0 - Ma) + Ma * (1.0 - Sa);
 );
+std::string cComposeEquation_LightenMask = WG_SHADER_SOURCE(
+    Rc = Sc;
+    Ra = select(Ma, Sa, Sa > Ma);
+);
+std::string cComposeEquation_DarkenMask = WG_SHADER_SOURCE(
+    Rc = Sc;
+    Ra = select(Sa, Ma, Sa > Ma);
+);
 
 std::string cComposeFooter = WG_SHADER_SOURCE(
     textureStore(imageTgt, id.xy, vec4f(Rc, Ra));
@@ -668,8 +676,10 @@ std::string compose_AddMask        = cComposeHeader + cComposeEquation_AddMask  
 std::string compose_SubtractMask   = cComposeHeader + cComposeEquation_SubtractMask   + cComposeFooter;
 std::string compose_IntersectMask  = cComposeHeader + cComposeEquation_IntersectMask  + cComposeFooter;
 std::string compose_DifferenceMask = cComposeHeader + cComposeEquation_DifferenceMask + cComposeFooter;
+std::string compose_LightenMask    = cComposeHeader + cComposeEquation_LightenMask    + cComposeFooter;
+std::string compose_DarkenMask     = cComposeHeader + cComposeEquation_DarkenMask     + cComposeFooter;
 
-const char* cShaderSrc_Compose[10] {
+const char* cShaderSrc_Compose[12] {
     compose_None.c_str(),
     compose_ClipPath.c_str(),
     compose_AlphaMask.c_str(),
@@ -680,6 +690,8 @@ const char* cShaderSrc_Compose[10] {
     compose_SubtractMask.c_str(),
     compose_IntersectMask.c_str(),
     compose_DifferenceMask.c_str(),
+    compose_LightenMask.c_str(),
+    compose_DarkenMask.c_str()
 };
 
 const char* cShaderSrc_Copy = WG_SHADER_SOURCE(

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -36,7 +36,7 @@ extern const char* cShaderSrc_Blend_Solid[14];
 extern const char* cShaderSrc_Blend_Solid[14];
 extern const char* cShaderSrc_Blend_Gradient[14];
 extern const char* cShaderSrc_Blend_Image[14];
-extern const char* cShaderSrc_Compose[10];
+extern const char* cShaderSrc_Compose[12];
 extern const char* cShaderSrc_Copy;
 
 #endif // _TVG_WG_SHEDER_SRC_H_


### PR DESCRIPTION
[issues 2608: light/dark mask](#2608)

* CompositeMethod::LightMask
* CompositeMethod::DarkMask

darken.json
![image](https://github.com/user-attachments/assets/735399df-7729-4c74-bf6b-d241c1c5ceb1)

lighten.json
![image](https://github.com/user-attachments/assets/ad867e59-c4d5-4e68-8f9a-0515530d31d8)
