### PR TITLE
lottie: handle edge case for rounded rect

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -472,11 +472,8 @@ void LottieBuilder::updateRect(LottieGroup* parent, LottieObject** child, float 
     auto roundness = rect->radius(frameNo, exps);
     if (ctx->roundness > roundness) roundness = ctx->roundness;
 
-    if (roundness > ROUNDNESS_EPSILON) {
-        if (roundness > size.x * 0.5f)  roundness = size.x * 0.5f;
-        if (roundness > size.y * 0.5f)  roundness = size.y * 0.5f;
-    }
-
+    if (roundness > ROUNDNESS_EPSILON) roundness = std::min(roundness, std::max(size.x, size.y) * 0.5f);
+    
     if (!ctx->repeaters.empty()) {
         auto shape = rect->pooling();
         shape->reset();


### PR DESCRIPTION
For rounded rectangles the roundness value should
be determined using to the formula:
r = max(min(size.x/2, r), min(size.y/2, r))
rather than the previous method:
r = min(size.x/2, size.y/2, r)

sample:
[roundedRect.json](https://github.com/user-attachments/files/16564597/roundedRect.json)

before:
<img width="350" alt="Zrzut ekranu 2024-08-9 o 18 45 44" src="https://github.com/user-attachments/assets/5be6f3d4-c8f0-402b-b878-7a51b22d8d5a">

after:
<img width="350" alt="Zrzut ekranu 2024-08-9 o 18 51 37" src="https://github.com/user-attachments/assets/99c824c9-c8ec-4514-b08b-e4098f560777">
