### PR TITLE
lottie: prioritization of roundness in rectangles

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -470,9 +470,11 @@ void LottieBuilder::updateRect(LottieGroup* parent, LottieObject** child, float 
     auto position = rect->position(frameNo, exps);
     auto size = rect->size(frameNo, exps);
     auto roundness = rect->radius(frameNo, exps);
-    if (ctx->roundness > roundness) roundness = ctx->roundness;
-
-    if (roundness > ROUNDNESS_EPSILON) roundness = std::min(roundness, std::max(size.x, size.y) * 0.5f);
+    if (roundness == 0.0f)  {
+        if (ctx->roundness > ROUNDNESS_EPSILON) roundness = std::min(ctx->roundness, std::max(size.x, size.y) * 0.5f);
+    } else {
+        roundness = std::min({roundness, size.x * 0.5f, size.y * 0.5f});
+    }
     
     if (!ctx->repeaters.empty()) {
         auto shape = rect->pooling();


### PR DESCRIPTION
Added prioritization of rectangle roundness over
rounded corners, in line with AE results.

<img width="400" alt="Zrzut ekranu 2024-08-12 o 23 27 09" src="https://github.com/user-attachments/assets/c08afe2f-b530-401d-8744-528191713f90">


[rectRound0_RCornerS.json](https://github.com/user-attachments/files/16592171/rectRound0_RCornerS.json)
[rectRound1_RCornerS.json](https://github.com/user-attachments/files/16592172/rectRound1_RCornerS.json)
[rectRoundS_RCorner0.json](https://github.com/user-attachments/files/16592173/rectRoundS_RCorner0.json)
[rectRoundS_RCorner1.json](https://github.com/user-attachments/files/16592174/rectRoundS_RCorner1.json)
