### PR TITLE
wg_engine: composition and blend optimization - PART 2

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -27,7 +27,8 @@
 #include "tvgWgRenderData.h"
 
 struct WgCompose: public Compositor {
-    BlendMethod blend;
+    BlendMethod blend{};
+    RenderRegion aabb{};
 };
 
 class WgCompositor {
@@ -51,8 +52,12 @@ private:
     WgRenderStorage storageInterm;
     WgRenderStorage storageClipPath;
     WgRenderStorage storageDstCopy;
+    // composition and blend geometries
+    WgMeshData meshData;
 
     static WgPipelineBlendType blendMethodToBlendType(BlendMethod blendMethod);
+
+    void composeRegion(WgContext& context, WgRenderStorage* src, WgRenderStorage* mask, CompositeMethod composeMethod, RenderRegion& rect);
 public:
     // render target dimensions
     uint32_t width{};
@@ -76,6 +81,7 @@ public:
     void composeShape(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask, CompositeMethod composeMethod);
     void composeStrokes(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask, CompositeMethod composeMethod);
     void composeImage(WgContext& context, WgRenderDataPicture* renderData, WgRenderStorage* mask, CompositeMethod composeMethod);
+    void composeScene(WgContext& context, WgRenderStorage* src, WgRenderStorage* mask, WgCompose* cmp);
 
     void drawClipPath(WgContext& context, WgRenderDataShape* renderData);
     void drawShape(WgContext& context, WgRenderDataShape* renderData, WgPipelineBlendType blendType);
@@ -84,7 +90,6 @@ public:
 
     void mergeMasks(WGPUCommandEncoder encoder, WgRenderStorage* mask0, WgRenderStorage* mask1);
     void blend(WGPUCommandEncoder encoder, WgRenderStorage* src, WgRenderStorage* dst, uint8_t opacity, BlendMethod blendMethod, WgRenderRasterType rasterType);
-    void compose(WGPUCommandEncoder encoder, WgRenderStorage* src, WgRenderStorage* mask, WgRenderStorage* dst, CompositeMethod composeMethod);
 };
 
 #endif // _TVG_WG_COMPOSITOR_H_

--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -59,7 +59,7 @@ public:
     inline void normalize() { float rlen = 1.0f / length(); x *= rlen; y *= rlen; }
     inline WgPoint normal() const { float rlen = 1.0f / length(); return { x * rlen, y * rlen }; }
     inline WgPoint lerp(const WgPoint& p, float t) const { return { x + (p.x - x) * t, y + (p.y - y) * t }; };
-    inline WgPoint trans(const Matrix& m) const { return { x * m.e11 + y * m.e12, x * m.e21 + y * m.e22 }; };
+    inline WgPoint trans(const Matrix& m) const { return { x * m.e11 + y * m.e12 + m.e13, x * m.e21 + y * m.e22 + m.e23 }; };
 };
 
 struct WgMath

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -35,12 +35,12 @@ private:
     WGPUShaderModule shaderRadial{};
     WGPUShaderModule shaderLinear{};
     WGPUShaderModule shaderImage{};
+    WGPUShaderModule shaderSceneComp{};
     // compute pipeline shaders
     WGPUShaderModule shaderMergeMasks;
     WGPUShaderModule shaderBlendSolid;
     WGPUShaderModule shaderBlendGradient;
     WGPUShaderModule shaderBlendImage;
-    WGPUShaderModule shaderCompose;
     WGPUShaderModule shaderCopy;
 private:
     // graphics pipeline layouts
@@ -48,10 +48,10 @@ private:
     WGPUPipelineLayout layoutSolid{};
     WGPUPipelineLayout layoutGradient{};
     WGPUPipelineLayout layoutImage{};
+    WGPUPipelineLayout layoutSceneComp{};
     // compute pipeline layouts
     WGPUPipelineLayout layoutMergeMasks{};
     WGPUPipelineLayout layoutBlend{};
-    WGPUPipelineLayout layoutCompose{};
     WGPUPipelineLayout layoutCopy{};
 public:
     // graphics pipeline
@@ -63,13 +63,13 @@ public:
     WGPURenderPipeline radial[3]{};
     WGPURenderPipeline linear[3]{};
     WGPURenderPipeline image[3]{};
+    WGPURenderPipeline sceneComp[12];
     WGPURenderPipeline clipPath{};
     // compute pipeline
     WGPUComputePipeline mergeMasks;
     WGPUComputePipeline blendSolid[14];
     WGPUComputePipeline blendGradient[14];
     WGPUComputePipeline blendImage[14];
-    WGPUComputePipeline compose[12];
     WGPUComputePipeline copy;
 private:
     void releaseGraphicHandles(WgContext& context);
@@ -79,7 +79,8 @@ private:
     WGPUPipelineLayout createPipelineLayout(WGPUDevice device, const WGPUBindGroupLayout* bindGroupLayouts, const uint32_t bindGroupLayoutsCount);
     WGPURenderPipeline createRenderPipeline(
         WGPUDevice device, const char* pipelineLabel,
-        const WGPUShaderModule shaderModule, const WGPUPipelineLayout pipelineLayout,
+        const WGPUShaderModule shaderModule, const char* vsEntryPoint, const char* fsEntryPoint,
+        const WGPUPipelineLayout pipelineLayout,
         const WGPUVertexBufferLayout *vertexBufferLayouts, const uint32_t vertexBufferLayoutsCount,
         const WGPUColorWriteMaskFlags writeMask,
         const WGPUCompareFunction stencilFunctionFrnt, const WGPUStencilOperation stencilOperationFrnt,

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -306,6 +306,18 @@ void WgRenderDataShape::updateBBox(WgPoint pmin, WgPoint pmax)
 }
 
 
+void WgRenderDataShape::updateAABB(const Matrix& rt) {
+    WgPoint p0 = WgPoint(pMin.x, pMin.y).trans(rt);
+    WgPoint p1 = WgPoint(pMax.x, pMin.y).trans(rt);
+    WgPoint p2 = WgPoint(pMin.x, pMax.y).trans(rt);
+    WgPoint p3 = WgPoint(pMax.x, pMax.y).trans(rt);
+    aabb.x = std::min({p0.x, p1.x, p2.x, p3.x});
+    aabb.y = std::min({p0.y, p1.y, p2.y, p3.y});
+    aabb.w = std::max({p0.x, p1.x, p2.x, p3.x}) - aabb.x;
+    aabb.h = std::max({p0.y, p1.y, p2.y, p3.y}) - aabb.y;
+}
+
+
 void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rshape, const Matrix& rt)
 {
     releaseMeshes(context);
@@ -368,6 +380,7 @@ void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rsha
     for (uint32_t i = 0; i < polylines.count; i++)
         delete polylines[i];
     // update shapes bbox
+    updateAABB(rt);
     meshDataBBox.update(context, pMin, pMax);
 }
 
@@ -443,6 +456,7 @@ void WgRenderDataShape::updateStrokes(WgContext& context, const WgPolyline* poly
             geometryData.positions.getBBox(pmin, pmax);
             meshGroupStrokes.append(context, &geometryData);
             meshGroupStrokesBBox.append(context, pmin, pmax);
+            updateBBox(pmin, pmax);
         }
     }
 }

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -97,6 +97,7 @@ struct WgRenderDataPaint
     WGPUBuffer bufferBlendSettings{};
     WGPUBindGroup bindGroupPaint{};
     RenderRegion viewport{};
+    RenderRegion aabb{};
     float opacity{};
     Array<WgRenderDataPaint*> clips;
 
@@ -123,6 +124,7 @@ struct WgRenderDataShape: public WgRenderDataPaint
     FillRule fillRule{};
 
     void updateBBox(WgPoint pmin, WgPoint pmax);
+    void updateAABB(const Matrix& rt);
     void updateMeshes(WgContext& context, const RenderShape& rshape, const Matrix& rt);
     void updateShapes(WgContext& context, const WgPolyline* polyline);
     void updateStrokesList(WgContext& context, Array<WgPolyline*> polylines, const RenderStroke* rstroke, float totalLen, float trimBegin, float trimEnd);

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -200,8 +200,12 @@ void WgRenderer::dispose(RenderData data) {
 }
 
 
-RenderRegion WgRenderer::region(TVG_UNUSED RenderData data)
+RenderRegion WgRenderer::region(RenderData data)
 {
+    auto renderData = (WgRenderDataPaint*)data;
+    if (renderData->type() == Type::Shape) {
+        return renderData->aabb;
+    }
     return { 0, 0, (int32_t)mTargetSurface.w, (int32_t)mTargetSurface.h };
 }
 
@@ -317,6 +321,7 @@ bool WgRenderer::target(WGPUInstance instance, WGPUSurface surface, uint32_t w, 
 Compositor* WgRenderer::target(TVG_UNUSED const RenderRegion& region, TVG_UNUSED ColorSpace cs)
 {
     mCompositorStack.push(new WgCompose);
+    mCompositorStack.last()->aabb = region;
     return mCompositorStack.last();
 }
 
@@ -355,6 +360,8 @@ bool WgRenderer::endComposite(Compositor* cmp)
         mCompositor.blend(mCommandEncoder, src, dst, comp->opacity, comp->blend, WgRenderRasterType::Image);
         // back render targets to the pool
         mRenderStoragePool.free(mContext, src);
+        // begin previous render pass
+        mCompositor.beginRenderPass(mCommandEncoder, mRenderStorageStack.last(), false);
     } else { // finish composition
         // get source, mask and destination render storages
         WgRenderStorage* src = mRenderStorageStack.last();
@@ -362,14 +369,14 @@ bool WgRenderer::endComposite(Compositor* cmp)
         WgRenderStorage* msk = mRenderStorageStack.last();
         mRenderStorageStack.pop();
         WgRenderStorage* dst = mRenderStorageStack.last();
+        // begin previous render pass
+        mCompositor.beginRenderPass(mCommandEncoder, dst, false);
         // apply composition
-        mCompositor.compose(mCommandEncoder, src, msk, dst,comp->method);
+        mCompositor.composeScene(mContext, src, msk, comp);
         // back render targets to the pool
         mRenderStoragePool.free(mContext, src);
         mRenderStoragePool.free(mContext, msk);
     }
-    // begin previous render pass
-    mCompositor.beginRenderPass(mCommandEncoder, mRenderStorageStack.last(), false);
 
     // delete current compositor settings
     delete mCompositorStack.last();

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -29,6 +29,7 @@ extern const char* cShaderSrc_Solid;
 extern const char* cShaderSrc_Linear;
 extern const char* cShaderSrc_Radial;
 extern const char* cShaderSrc_Image;
+extern const char* cShaderSrc_Scene_Comp;
 
 // compute shader sources: blend, compose and merge path
 extern const char* cShaderSrc_MergeMasks;
@@ -36,7 +37,6 @@ extern const char* cShaderSrc_BlendHeader_Solid;
 extern const char* cShaderSrc_BlendHeader_Gradient;
 extern const char* cShaderSrc_BlendHeader_Image;
 extern const char* cShaderSrc_Blend_Funcs;
-extern const char* cShaderSrc_Compose;
 extern const char* cShaderSrc_Copy;
 
 #endif // _TVG_WG_SHEDER_SRC_H_


### PR DESCRIPTION
wg_engine: aabb based masking optimization

* used fragment shaders for mask applience instead of compute shaders
* less render targets swithing
* aabb based mask application. Masks computes only on the area with shapes, but not full screen
* shape aabb based on transformed shape bbox

Ready for direct mask application (part 3)

Samples to verify:
* Masking
* MaskingMethods