### PR TITLE
Introduced Paint::clip() API

### DIFF
--- a/examples/Clipping.cpp
+++ b/examples/Clipping.cpp
@@ -70,7 +70,7 @@ struct UserExample : tvgexam::Example
         clipStar->appendCircle(200, 230, 110, 110);
         clipStar->translate(10, 10);
 
-        star1->composite(std::move(clipStar), tvg::CompositeMethod::ClipPath);
+        star1->clip(std::move(clipStar));
 
         auto star2 = tvg::Shape::gen();
         compose(star2.get());
@@ -91,7 +91,7 @@ struct UserExample : tvgexam::Example
         scene->push(std::move(star2));
 
         //Clipping scene to shape
-        scene->composite(std::move(clip), tvg::CompositeMethod::ClipPath);
+        scene->clip(std::move(clip));
 
         canvas->push(std::move(scene));
 
@@ -118,7 +118,7 @@ struct UserExample : tvgexam::Example
         clipRect->translate(20, 20);
 
         //Clipping scene to rect(shape)
-        star3->composite(std::move(clipRect), tvg::CompositeMethod::ClipPath);
+        star3->clip(std::move(clipRect));
 
         canvas->push(std::move(star3));
 
@@ -136,7 +136,7 @@ struct UserExample : tvgexam::Example
         clipPath->translate(20, 20);
 
         //Clipping picture to path
-        picture->composite(std::move(clipPath), tvg::CompositeMethod::ClipPath);
+        picture->clip(std::move(clipPath));
 
         canvas->push(std::move(picture));
 
@@ -150,7 +150,7 @@ struct UserExample : tvgexam::Example
         clipShape->appendRect(600, 420, 100, 100);
 
         //Clipping shape1 to clipShape
-        shape1->composite(std::move(clipShape), tvg::CompositeMethod::ClipPath);
+        shape1->clip(std::move(clipShape));
 
         canvas->push(std::move(shape1));
 

--- a/examples/PictureRaw.cpp
+++ b/examples/PictureRaw.cpp
@@ -62,7 +62,7 @@ struct UserExample : tvgexam::Example
         auto circle = tvg::Shape::gen();
         circle->appendCircle(350, 350, 200, 200);
 
-        picture2->composite(std::move(circle), tvg::CompositeMethod::ClipPath);
+        picture2->clip(std::move(circle));
 
         canvas->push(std::move(picture2));
 

--- a/examples/TvgSaver.cpp
+++ b/examples/TvgSaver.cpp
@@ -38,7 +38,7 @@ unique_ptr<tvg::Paint> tvgClippedImage(uint32_t * data, int width, int height)
     auto imageClip = tvg::Shape::gen();
     imageClip->appendCircle(400, 200, 80, 180);
     imageClip->translate(200, 0);
-    image->composite(std::move(imageClip), tvg::CompositeMethod::ClipPath);
+    image->clip(std::move(imageClip));
 
     return image;
 }

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -22,7 +22,7 @@ source_file = [
     'AnimateMasking.cpp',
     'Animation.cpp',
     'Blending.cpp',
-    'ClipPath.cpp',
+    'Clipping.cpp',
     'CustomTransform.cpp',
     'DataLoad.cpp',
     'DirectUpdate.cpp',

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -157,7 +157,7 @@ enum class FillRule : uint8_t
 enum class CompositeMethod : uint8_t
 {
     None = 0,           ///< No composition is applied.
-    ClipPath,           ///< The intersection of the source and the target is determined and only the resulting pixels from the source are rendered. Note that ClipPath only supports the Shape type.
+    ClipPath,           ///< The intersection of the source and the target is determined and only the resulting pixels from the source are rendered. Note that ClipPath only supports the Shape type. @deprecated Use Paint::clip() instead.
     AlphaMask,          ///< Alpha Masking using the compositing target's pixels as an alpha value.
     InvAlphaMask,       ///< Alpha Masking using the complement to the compositing target's pixels as an alpha value.
     LumaMask,           ///< Alpha Masking using the grayscale (0.2125R + 0.7154G + 0.0721*B) of the compositing target's pixels. @since 0.9
@@ -339,7 +339,6 @@ public:
      * @param[in] o The opacity value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque.
      *
      * @note Setting the opacity with this API may require multiple render pass for composition. It is recommended to avoid changing the opacity if possible.
-     * @note ClipPath won't use the opacity value. (see: enum class CompositeMethod::ClipPath)
      */
     Result opacity(uint8_t o) noexcept;
 
@@ -350,6 +349,20 @@ public:
      * @param[in] method The method used to composite the source object with the target.
      */
     Result composite(std::unique_ptr<Paint> target, CompositeMethod method) noexcept;
+
+    /**
+     * @brief Clip the drawing region of the paint object.
+     *
+     * This function restricts the drawing area of the paint object to the specified shape's paths.
+     *
+     * @param[in] clipper The shape object as the clipper.
+     *
+     * @retval Result::NonSupport If the @p clipper type is not Shape.
+     *
+     * @note @p clipper only supports the Shape type.
+     * @note Experimental API
+     */
+    Result clip(std::unique_ptr<Paint> clipper) noexcept;
 
     /**
      * @brief Sets the blending method for the paint object.
@@ -1050,7 +1063,6 @@ public:
      * @param[in] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque. The default value is 0.
      *
      * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
-     * @note ClipPath won't use the fill values. (see: enum class CompositeMethod::ClipPath)
      */
     Result fill(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255) noexcept;
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -138,7 +138,7 @@ typedef enum {
  */
 typedef enum {
     TVG_COMPOSITE_METHOD_NONE = 0,           ///< No composition is applied.
-    TVG_COMPOSITE_METHOD_CLIP_PATH,          ///< The intersection of the source and the target is determined and only the resulting pixels from the source are rendered. Note that ClipPath only supports the Shape type.
+    TVG_COMPOSITE_METHOD_CLIP_PATH,          ///< The intersection of the source and the target is determined and only the resulting pixels from the source are rendered. Note that ClipPath only supports the Shape type. @deprecated Use Paint::clip() instead.
     TVG_COMPOSITE_METHOD_ALPHA_MASK,         ///< The pixels of the source and the target are alpha blended. As a result, only the part of the source, which intersects with the target is visible.
     TVG_COMPOSITE_METHOD_INVERSE_ALPHA_MASK, ///< The pixels of the source and the complement to the target's pixels are alpha blended. As a result, only the part of the source which is not covered by the target is visible.
     TVG_COMPOSITE_METHOD_LUMA_MASK,          ///< The source pixels are converted to grayscale (luma value) and alpha blended with the target. As a result, only the part of the source which intersects with the target is visible. \since 0.9
@@ -992,6 +992,23 @@ TVG_API Tvg_Result tvg_paint_set_composite_method(Tvg_Paint* paint, Tvg_Paint* t
 * \retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr is passed as the argument.
 */
 TVG_API Tvg_Result tvg_paint_get_composite_method(const Tvg_Paint* paint, const Tvg_Paint** target, Tvg_Composite_Method* method);
+
+
+/*!
+* \brief Clip the drawing region of the paint object.
+*
+* This function restricts the drawing area of the paint object to the specified shape's paths.
+*
+* \param[in] paint The target object of the clipping.
+* \param[in] clipper The shape object as the clipper.
+*
+* \return Tvg_Result enumeration.
+* \retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
+* \retval TVG_RESULT_NOT_SUPPORTED If the @p clipper type is not Shape.
+*
+* \note Experimental API
+*/
+TVG_API Tvg_Result tvg_paint_set_clip(Tvg_Paint* paint, Tvg_Paint* clipper);
 
 
 /**

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -260,6 +260,13 @@ TVG_API Tvg_Result tvg_paint_get_type(const Tvg_Paint* paint, Tvg_Type* type)
 }
 
 
+TVG_API Tvg_Result tvg_paint_set_clip(Tvg_Paint* paint, Tvg_Paint* clipper)
+{
+   if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+   return (Tvg_Result) reinterpret_cast<Paint*>(paint)->clip(unique_ptr<Paint>((Paint*)(clipper)));
+}
+
+
 TVG_DEPRECATED TVG_API Tvg_Result tvg_paint_get_identifier(const Tvg_Paint* paint, Tvg_Identifier* identifier)
 {
     return tvg_paint_get_type(paint, (Tvg_Type*) identifier);

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -961,17 +961,10 @@ void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp,
         if (!child->matteSrc) updateLayer(comp, precomp->scene, child, frameNo);
     }
 
-    //TODO: remove the intermediate scene....
-    if (precomp->scene->composite(nullptr) != CompositeMethod::None) {
-        auto cscene = Scene::gen().release();
-        cscene->push(cast(precomp->scene));
-        precomp->scene = cscene;
-    }
-
     //clip the layer viewport
     auto clipper = precomp->statical.pooling(true);
     clipper->transform(precomp->cache.matrix);
-    precomp->scene->composite(cast(clipper), CompositeMethod::ClipPath);
+    precomp->scene->clip(cast(clipper));
 }
 
 
@@ -1396,5 +1389,5 @@ void LottieBuilder::build(LottieComposition* comp)
     //viewport clip
     auto clip = Shape::gen();
     clip->appendRect(0, 0, comp->w, comp->h);
-    comp->root->scene->composite(std::move(clip), CompositeMethod::ClipPath);
+    comp->root->scene->clip(std::move(clip));
 }

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -272,8 +272,7 @@ static void _applyComposition(SvgLoaderData& loaderData, Paint* paint, const Svg
             if (valid) {
                 Matrix finalTransform = _compositionTransform(paint, node, compNode, SvgNodeType::ClipPath);
                 comp->transform(finalTransform);
-
-                paint->composite(std::move(comp), CompositeMethod::ClipPath);
+                paint->clip(std::move(comp));
             }
 
             node->style->clipPath.applying = false;
@@ -714,7 +713,6 @@ static Matrix _calculateAspectRatioMatrix(AspectRatioAlign align, AspectRatioMee
 
 static unique_ptr<Scene> _useBuildHelper(SvgLoaderData& loaderData, const SvgNode* node, const Box& vBox, const string& svgPath, int depth, bool* isMaskWhite)
 {
-    unique_ptr<Scene> finalScene;
     auto scene = _sceneBuildHelper(loaderData, node, vBox, svgPath, false, depth + 1, isMaskWhite);
 
     // mUseTransform = mUseTransform * mTranslate
@@ -751,9 +749,7 @@ static unique_ptr<Scene> _useBuildHelper(SvgLoaderData& loaderData, const SvgNod
         mSceneTransform = mUseTransform * mSceneTransform;
         scene->transform(mSceneTransform);
 
-        if (node->node.use.symbol->node.symbol.overflowVisible) {
-            finalScene = std::move(scene);
-        } else {
+        if (!node->node.use.symbol->node.symbol.overflowVisible) {
             auto viewBoxClip = Shape::gen();
             viewBoxClip->appendRect(0, 0, width, height, 0, 0);
 
@@ -764,21 +760,13 @@ static unique_ptr<Scene> _useBuildHelper(SvgLoaderData& loaderData, const SvgNod
             }
             viewBoxClip->transform(mClipTransform);
 
-            auto compositeLayer = Scene::gen();
-            compositeLayer->composite(std::move(viewBoxClip), CompositeMethod::ClipPath);
-            compositeLayer->push(std::move(scene));
-
-            auto root = Scene::gen();
-            root->push(std::move(compositeLayer));
-
-            finalScene = std::move(root);
+            scene->clip(std::move(viewBoxClip));
         }
     } else {
         scene->transform(mUseTransform);
-        finalScene = std::move(scene);
     }
 
-    return finalScene;
+    return scene;
 }
 
 
@@ -937,7 +925,7 @@ Scene* svgSceneBuild(SvgLoaderData& loaderData, Box vBox, float w, float h, Aspe
     viewBoxClip->appendRect(0, 0, w, h);
 
     auto compositeLayer = Scene::gen();
-    compositeLayer->composite(std::move(viewBoxClip), CompositeMethod::ClipPath);
+    compositeLayer->clip(std::move(viewBoxClip));
     compositeLayer->push(std::move(docNode));
 
     auto root = Scene::gen();

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -542,8 +542,8 @@ SwRle* rleRender(const SwBBox* bbox);
 void rleFree(SwRle* rle);
 void rleReset(SwRle* rle);
 void rleMerge(SwRle* rle, SwRle* clip1, SwRle* clip2);
-void rleClipPath(SwRle* rle, const SwRle* clip);
-void rleClipRect(SwRle* rle, const SwBBox* clip);
+void rleClip(SwRle* rle, const SwRle* clip);
+void rleClip(SwRle* rle, const SwBBox* clip);
 
 SwMpool* mpoolInit(uint32_t threads);
 bool mpoolTerm(SwMpool* mpool);

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -66,8 +66,6 @@ struct SwTask : Task
 
     virtual void dispose() = 0;
     virtual bool clip(SwRle* target) = 0;
-    virtual SwRle* rle() = 0;
-
     virtual ~SwTask() {}
 };
 
@@ -102,19 +100,11 @@ struct SwShapeTask : SwTask
 
     bool clip(SwRle* target) override
     {
-        if (shape.fastTrack) rleClipRect(target, &bbox);
-        else if (shape.rle) rleClipPath(target, shape.rle);
+        if (shape.fastTrack) rleClip(target, &bbox);
+        else if (shape.rle) rleClip(target, shape.rle);
         else return false;
 
         return true;
-    }
-
-    SwRle* rle() override
-    {
-        if (!shape.rle && shape.fastTrack) {
-            shape.rle = rleRender(&shape.bbox);
-        }
-        return shape.rle;
     }
 
     void run(unsigned tid) override
@@ -207,12 +197,6 @@ struct SwImageTask : SwTask
     {
         TVGERR("SW_ENGINE", "Image is used as ClipPath?");
         return true;
-    }
-
-    SwRle* rle() override
-    {
-        TVGERR("SW_ENGINE", "Image is used as Scene ClipPath?");
-        return nullptr;
     }
 
     void run(unsigned tid) override

--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -990,7 +990,7 @@ void rleFree(SwRle* rle)
 }
 
 
-void rleClipPath(SwRle *rle, const SwRle *clip)
+void rleClip(SwRle *rle, const SwRle *clip)
 {
     if (rle->size == 0 || clip->size == 0) return;
     auto spanCnt = rle->size > clip->size ? rle->size : clip->size;
@@ -999,11 +999,11 @@ void rleClipPath(SwRle *rle, const SwRle *clip)
 
     _replaceClipSpan(rle, spans, spansEnd - spans);
 
-    TVGLOG("SW_ENGINE", "Using ClipPath!");
+    TVGLOG("SW_ENGINE", "Using Path Clipping!");
 }
 
 
-void rleClipRect(SwRle *rle, const SwBBox* clip)
+void rleClip(SwRle *rle, const SwBBox* clip)
 {
     if (rle->size == 0) return;
     auto spans = static_cast<SwSpan*>(malloc(sizeof(SwSpan) * (rle->size)));
@@ -1011,5 +1011,5 @@ void rleClipRect(SwRle *rle, const SwBBox* clip)
 
     _replaceClipSpan(rle, spans, spansEnd - spans);
 
-    TVGLOG("SW_ENGINE", "Using ClipRect!");
+    TVGLOG("SW_ENGINE", "Using Box Clipping!");
 }

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -164,6 +164,7 @@ Paint* Paint::Impl::duplicate(Paint* ret)
     ret->pImpl->opacity = opacity;
 
     if (compData) ret->pImpl->composite(ret, compData->target->duplicate(), compData->method);
+    if (clipper) ret->pImpl->clip(clipper->duplicate());
 
     return ret;
 }
@@ -209,9 +210,7 @@ bool Paint::Impl::render(RenderMethod* renderer)
 
     Compositor* cmp = nullptr;
 
-    /* Note: only ClipPath is processed in update() step.
-        Create a composition image. */
-    if (compData && compData->method != CompositeMethod::ClipPath && !(compData->target->pImpl->ctxFlag & ContextFlag::FastTrack)) {
+    if (compData && !(compData->target->pImpl->ctxFlag & ContextFlag::FastTrack)) {
         RenderRegion region;
         PAINT_METHOD(region, bounds(renderer));
 
@@ -248,43 +247,47 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
     RenderData trd = nullptr;                 //composite target render data
     RenderRegion viewport;
     Result compFastTrack = Result::InsufficientCondition;
-    bool childClipper = false;
 
     if (compData) {
         auto target = compData->target;
         auto method = compData->method;
         P(target)->ctxFlag &= ~ContextFlag::FastTrack;   //reset
 
-        /* If the transformation has no rotational factors and the ClipPath/Alpha(InvAlpha)Masking involves a simple rectangle,
-           we can optimize by using the viewport instead of the regular ClipPath/AlphaMasking sequence for improved performance. */
-        auto tryFastTrack = false;
+        /* If the transformation has no rotational factors and the Alpha(InvAlpha)Masking involves a simple rectangle,
+           we can optimize by using the viewport instead of the regular AlphaMasking sequence for improved performance. */
         if (target->type() == Type::Shape) {
-            if (method == CompositeMethod::ClipPath) tryFastTrack = true;
-            else {
-                auto shape = static_cast<Shape*>(target);
-                uint8_t a;
-                shape->fillColor(nullptr, nullptr, nullptr, &a);
-                //no gradient fill & no compositions of the composition target.
-                if (!shape->fill() && !(PP(shape)->compData)) {
-                    if (method == CompositeMethod::AlphaMask && a == 255 && PP(shape)->opacity == 255) tryFastTrack = true;
-                    else if (method == CompositeMethod::InvAlphaMask && (a == 0 || PP(shape)->opacity == 0)) tryFastTrack = true;
-                }
-            }
-            if (tryFastTrack) {
-                viewport = renderer->viewport();
-                if ((compFastTrack = _compFastTrack(renderer, target, pm, viewport)) == Result::Success) {
-                    P(target)->ctxFlag |= ContextFlag::FastTrack;
+            auto shape = static_cast<Shape*>(target);
+            uint8_t a;
+            shape->fillColor(nullptr, nullptr, nullptr, &a);
+            //no gradient fill & no compositions of the composition target.
+            if (!shape->fill() && !(PP(shape)->compData)) {
+                if ((method == CompositeMethod::AlphaMask && a == 255 && PP(shape)->opacity == 255) || (method == CompositeMethod::InvAlphaMask && (a == 0 || PP(shape)->opacity == 0))) {
+                    viewport = renderer->viewport();
+                    if ((compFastTrack = _compFastTrack(renderer, target, pm, viewport)) == Result::Success) {
+                        P(target)->ctxFlag |= ContextFlag::FastTrack;
+                    }
                 }
             }
         }
         if (compFastTrack == Result::InsufficientCondition) {
-            childClipper = compData->method == CompositeMethod::ClipPath ? true : false;
-            trd = P(target)->update(renderer, pm, clips, 255, pFlag, childClipper);
-            if (childClipper) clips.push(trd);
+            trd = P(target)->update(renderer, pm, clips, 255, pFlag, false);
         }
     }
 
-    /* 2. Main Update */
+    /* 2. Clipping */
+    if (this->clipper) {
+        P(this->clipper)->ctxFlag &= ~ContextFlag::FastTrack;   //reset
+        viewport = renderer->viewport();
+        if ((compFastTrack = _compFastTrack(renderer, this->clipper, pm, viewport)) == Result::Success) {
+            P(this->clipper)->ctxFlag |= ContextFlag::FastTrack;
+        }
+        if (compFastTrack == Result::InsufficientCondition) {
+            trd = P(this->clipper)->update(renderer, pm, clips, 255, pFlag, true);
+            clips.push(trd);
+        }
+    }
+
+    /* 3. Main Update */
     auto newFlag = static_cast<RenderUpdateFlag>(pFlag | renderFlag);
     renderFlag = RenderUpdateFlag::None;
     opacity = MULTIPLY(opacity, this->opacity);
@@ -294,9 +297,9 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
     tr.cm = pm * tr.m;
     PAINT_METHOD(rd, update(renderer, tr.cm, clips, opacity, newFlag, clipper));
 
-    /* 3. Composition Post Processing */
+    /* 4. Composition Post Processing */
     if (compFastTrack == Result::Success) renderer->viewport(viewport);
-    else if (childClipper) clips.pop();
+    else if (this->clipper) clips.pop();
 
     return rd;
 }
@@ -351,6 +354,11 @@ bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transforme
 
 void Paint::Impl::reset()
 {
+    if (clipper) {
+        delete(clipper);
+        clipper = nullptr;
+    }
+
     if (compData) {
         if (P(compData->target)->unref() == 0) delete(compData->target);
         free(compData);
@@ -431,15 +439,27 @@ Paint* Paint::duplicate() const noexcept
 }
 
 
-Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) noexcept
+Result Paint::clip(std::unique_ptr<Paint> clipper) noexcept
 {
-    if (method == CompositeMethod::ClipPath && target && target->type() != Type::Shape) {
-        TVGERR("RENDERER", "ClipPath only allows the Shape!");
+    auto p = clipper.release();
+
+    if (p && p->type() != Type::Shape) {
+        TVGERR("RENDERER", "Clipping only supports the Shape!");
         return Result::NonSupport;
     }
+    pImpl->clip(p);
+    return Result::Success;
+}
+
+
+Result Paint::composite(std::unique_ptr<Paint> target, CompositeMethod method) noexcept
+{
+    //TODO: remove. Keep this for the backward compatibility
+    if (method == CompositeMethod::ClipPath) return clip(std::move(target));
 
     auto p = target.release();
     if (pImpl->composite(this, p, method)) return Result::Success;
+
     delete(p);
     return Result::InvalidArguments;
 }
@@ -451,6 +471,11 @@ CompositeMethod Paint::composite(const Paint** target) const noexcept
         if (target) *target = pImpl->compData->target;
         return pImpl->compData->method;
     } else {
+        //TODO: remove. Keep this for the backward compatibility
+        if (pImpl->clipper) {
+            if (target) *target = pImpl->clipper;
+            return CompositeMethod::ClipPath;
+        }
         if (target) *target = nullptr;
         return CompositeMethod::None;
     }

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -49,6 +49,7 @@ namespace tvg
     {
         Paint* paint = nullptr;
         Composite* compData = nullptr;
+        Paint* clipper = nullptr;
         RenderMethod* renderer = nullptr;
         struct {
             Matrix m;                 //input matrix
@@ -88,6 +89,7 @@ namespace tvg
                 if (P(compData->target)->unref() == 0) delete(compData->target);
                 free(compData);
             }
+            if (clipper && P(clipper)->unref() == 0) delete(clipper);
             if (renderer && (renderer->unref() == 0)) delete(renderer);
         }
 
@@ -118,6 +120,20 @@ namespace tvg
             if (renderFlag & RenderUpdateFlag::Transform) tr.update();
             if (origin) return tr.cm;
             return tr.m;
+        }
+
+        void clip(Paint* clipper)
+        {
+            if (this->clipper) {
+                P(this->clipper)->unref();
+                if (this->clipper != clipper && P(this->clipper)->refCnt == 0) {
+                    delete(this->clipper);
+                }
+            }
+            this->clipper = clipper;
+            if (!clipper) return;
+
+            P(clipper)->ref();
         }
 
         bool composite(Paint* source, Paint* target, CompositeMethod method)

--- a/test/capi/capiPaint.cpp
+++ b/test/capi/capiPaint.cpp
@@ -237,7 +237,7 @@ TEST_CASE("Paint Identifier", "[capiPaint]")
     REQUIRE(tvg_paint_del(paint) == TVG_RESULT_SUCCESS);
 }
 
-TEST_CASE("Paint Clip Path Composite Method", "[capiPaint]")
+TEST_CASE("Paint Clipping", "[capiPaint]")
 {
     Tvg_Paint* paint = tvg_shape_new();
     REQUIRE(paint);
@@ -245,21 +245,13 @@ TEST_CASE("Paint Clip Path Composite Method", "[capiPaint]")
     Tvg_Paint* target = tvg_shape_new();
     REQUIRE(target);
 
-    REQUIRE(tvg_paint_set_composite_method(paint, NULL, TVG_COMPOSITE_METHOD_NONE) == TVG_RESULT_SUCCESS);
-    REQUIRE(tvg_paint_set_composite_method(paint, target, TVG_COMPOSITE_METHOD_NONE) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_paint_set_composite_method(paint, NULL, TVG_COMPOSITE_METHOD_CLIP_PATH) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_paint_set_clip(paint, NULL) == TVG_RESULT_SUCCESS);
 
     Tvg_Paint* target2 = tvg_shape_new();
     REQUIRE(target2);
-    REQUIRE(tvg_paint_set_composite_method(paint, target2, TVG_COMPOSITE_METHOD_CLIP_PATH) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_paint_set_clip(paint, target2) == TVG_RESULT_SUCCESS);
 
-    const Tvg_Paint* target3 = nullptr;
-    Tvg_Composite_Method method = TVG_COMPOSITE_METHOD_NONE;
-    REQUIRE(tvg_paint_get_composite_method(paint, NULL, &method) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_paint_get_composite_method(paint, &target3, NULL) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_paint_get_composite_method(paint, &target3, &method) == TVG_RESULT_SUCCESS);
-    REQUIRE(method == TVG_COMPOSITE_METHOD_CLIP_PATH);
-    REQUIRE(target2 == target3);
+    REQUIRE(tvg_paint_set_clip(paint, NULL) == TVG_RESULT_SUCCESS);
 
     REQUIRE(tvg_paint_del(paint) == TVG_RESULT_SUCCESS);
 }

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -180,7 +180,7 @@ TEST_CASE("Duplication", "[tvgPaint]")
 
     auto comp = Shape::gen();
     REQUIRE(comp);
-    REQUIRE(shape->composite(std::move(comp), CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(shape->clip(std::move(comp)) == Result::Success);
 
     //Duplication
     auto dup = tvg::cast<Shape>(shape->duplicate());
@@ -199,8 +199,6 @@ TEST_CASE("Duplication", "[tvgPaint]")
     REQUIRE(m.e31 == Approx(0.0f).margin(0.000001));
     REQUIRE(m.e32 == Approx(0.0f).margin(0.000001));
     REQUIRE(m.e33 == Approx(1.0f).margin(0.000001));
-
-    REQUIRE(dup->composite(nullptr) == CompositeMethod::ClipPath);
 }
 
 TEST_CASE("Composition", "[tvgPaint]")
@@ -212,23 +210,19 @@ TEST_CASE("Composition", "[tvgPaint]")
     REQUIRE(shape->composite(nullptr) == CompositeMethod::None);
 
     auto comp = Shape::gen();
-    REQUIRE(shape->composite(nullptr, CompositeMethod::ClipPath) == Result::InvalidArguments);
     REQUIRE(shape->composite(std::move(comp), CompositeMethod::None) == Result::InvalidArguments);
 
-    //ClipPath
+    //Clipping
     comp = Shape::gen();
     auto pComp = comp.get();
-    REQUIRE(shape->composite(std::move(comp), CompositeMethod::ClipPath) == Result::Success);
-
-    const Paint* pComp2 = nullptr;
-    REQUIRE(shape->composite(&pComp2) == CompositeMethod::ClipPath);
-    REQUIRE(pComp == pComp2);
+    REQUIRE(shape->clip(std::move(comp)) == Result::Success);
 
     //AlphaMask
     comp = Shape::gen();
     pComp = comp.get();
     REQUIRE(shape->composite(std::move(comp), CompositeMethod::AlphaMask) == Result::Success);
 
+    const Paint* pComp2 = nullptr;
     REQUIRE(shape->composite(&pComp2) == CompositeMethod::AlphaMask);
     REQUIRE(pComp == pComp2);
 

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -157,7 +157,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(basicPicture2->composite(std::move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
 
-    REQUIRE(basicPicture3->composite(std::move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture3->clip(std::move(rectMask3)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
 
     REQUIRE(basicPicture4->composite(std::move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
@@ -167,10 +167,10 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->composite(std::move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture6->clip(std::move(rleMask)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
 
-    REQUIRE(basicPicture7->composite(std::move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture7->clip(std::move(rleMask7)) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
 
@@ -223,7 +223,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(basicPicture2->composite(std::move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
 
-    REQUIRE(basicPicture3->composite(std::move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture3->clip(std::move(rectMask3)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
 
     REQUIRE(basicPicture4->composite(std::move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
@@ -233,10 +233,10 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->composite(std::move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture6->clip(std::move(rleMask)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
 
-    REQUIRE(basicPicture7->composite(std::move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture7->clip(std::move(rleMask7)) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
 
@@ -287,7 +287,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(basicPicture2->composite(std::move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
 
-    REQUIRE(basicPicture3->composite(std::move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture3->clip(std::move(rectMask3)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
 
     REQUIRE(basicPicture4->composite(std::move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
@@ -297,10 +297,10 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->composite(std::move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture6->clip(std::move(rleMask)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
 
-    REQUIRE(basicPicture7->composite(std::move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture7->clip(std::move(rleMask7)) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
 
@@ -351,7 +351,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(basicPicture2->composite(std::move(rectMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
 
-    REQUIRE(basicPicture3->composite(std::move(rectMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture3->clip(std::move(rectMask3)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
 
     REQUIRE(basicPicture4->composite(std::move(rectMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
@@ -361,10 +361,10 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->composite(std::move(rleMask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture6->clip(std::move(rleMask)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
 
-    REQUIRE(basicPicture7->composite(std::move(rleMask7), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicPicture7->clip(std::move(rleMask7)) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
     REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
 
@@ -420,7 +420,7 @@ TEST_CASE("Rect Draw", "[tvgSwEngine]")
     REQUIRE(basicShape2->composite(std::move(basicMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
     REQUIRE(canvas->push(std::move(basicShape2)) == Result::Success);
 
-    REQUIRE(basicShape3->composite(std::move(basicMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicShape3->clip(std::move(basicMask3)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicShape3)) == Result::Success);
 
     REQUIRE(basicShape4->composite(std::move(basicMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
@@ -478,7 +478,7 @@ TEST_CASE("RLE Draw", "[tvgSwEngine]")
     REQUIRE(basicShape2->composite(std::move(basicMask2), tvg::CompositeMethod::InvAlphaMask) == Result::Success);
     REQUIRE(canvas->push(std::move(basicShape2)) == Result::Success);
 
-    REQUIRE(basicShape3->composite(std::move(basicMask3), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(basicShape3->clip(std::move(basicMask3)) == Result::Success);
     REQUIRE(canvas->push(std::move(basicShape3)) == Result::Success);
 
     REQUIRE(basicShape4->composite(std::move(basicMask4), tvg::CompositeMethod::LumaMask) == Result::Success);
@@ -770,7 +770,7 @@ TEST_CASE("Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(Initializer::term() == Result::Success);
 }
 
-TEST_CASE("Filling ClipPath", "[tvgSwEngine]")
+TEST_CASE("Filling Clipping", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
@@ -798,10 +798,10 @@ TEST_CASE("Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(linearFill->linear(0.0f, 0.0f, 100.0f, 120.0f) == Result::Success);
     REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
 
-    //Mask
-    auto mask = tvg::Shape::gen();
-    REQUIRE(mask);
-    REQUIRE(mask->appendCircle(50, 50, 50, 50) == Result::Success);
+    //Clipper
+    auto clipper = tvg::Shape::gen();
+    REQUIRE(clipper);
+    REQUIRE(clipper->appendCircle(50, 50, 50, 50) == Result::Success);
 
     //Filled Shapes
     auto shape3 = tvg::Shape::gen();
@@ -819,7 +819,7 @@ TEST_CASE("Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(scene);
     REQUIRE(scene->push(std::move(shape3)) == Result::Success);
     REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(scene->clip(std::move(clipper)) == Result::Success);
     REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
@@ -1163,7 +1163,7 @@ TEST_CASE("RLE Filling InvLumaMask", "[tvgSwEngine]")
     REQUIRE(Initializer::term() == Result::Success);
 }
 
-TEST_CASE("RLE Filling ClipPath", "[tvgSwEngine]")
+TEST_CASE("RLE Filling Clipping", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
@@ -1192,9 +1192,9 @@ TEST_CASE("RLE Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(radialFill->radial(50.0f, 50.0f, 50.0f) == Result::Success);
 
     //Mask
-    auto mask = tvg::Shape::gen();
-    REQUIRE(mask);
-    REQUIRE(mask->appendCircle(50, 50, 50, 50) == Result::Success);
+    auto clipper = tvg::Shape::gen();
+    REQUIRE(clipper);
+    REQUIRE(clipper->appendCircle(50, 50, 50, 50) == Result::Success);
 
     //Filled Shapes
     auto shape3 = tvg::Shape::gen();
@@ -1212,7 +1212,7 @@ TEST_CASE("RLE Filling ClipPath", "[tvgSwEngine]")
     REQUIRE(scene);
     REQUIRE(scene->push(std::move(shape3)) == Result::Success);
     REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->composite(std::move(mask), tvg::CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(scene->clip(std::move(clipper)) == Result::Success);
     REQUIRE(canvas->push(std::move(scene)) == Result::Success);
 
     //Draw
@@ -1300,7 +1300,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     REQUIRE(picture);
     REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture->blend(BlendMethod::Lighten) == Result::Success);
-    REQUIRE(picture->composite(std::move(clipper), CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(picture->clip(std::move(clipper)) == Result::Success);
     REQUIRE(canvas->push(std::move(picture)) == Result::Success);
 
     //scaled images
@@ -1321,7 +1321,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     REQUIRE(picture3->load(data, 200, 300, true, false) == Result::Success);
     REQUIRE(picture3->scale(2) == Result::Success);
     REQUIRE(picture3->blend(BlendMethod::Lighten) == Result::Success);
-    REQUIRE(picture3->composite(std::move(clipper2), CompositeMethod::ClipPath) == Result::Success);
+    REQUIRE(picture3->clip(std::move(clipper2)) == Result::Success);
     REQUIRE(canvas->push(std::move(picture3)) == Result::Success);
 
     //normal image


### PR DESCRIPTION
Separate clip function from the Composite() clipping and composition can be used together.

This helps avoid the introduction of nested scenes  when composition and clipping overlap.

Deprecated:
```
enum class CompositeMethod::ClipPath
enum Tvg_Composite_Method::TVG_COMPOSITE_METHOD_CLIP_PATH
```

Experimental API:
```
- Result Paint::clip(std::unique_ptr<Paint> clipper)
- Tvg_Result tvg_paint_set_clip(Tvg_Paint* paint, Tvg_Paint* clipper)
```

Issue: https://github.com/thorvg/thorvg/issues/1496