### PR TITLE
lottie: ensure a null terminator at the end of the copied data

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -186,9 +186,10 @@ bool LottieLoader::header()
 bool LottieLoader::open(const char* data, uint32_t size, const std::string& rpath, bool copy)
 {
     if (copy) {
-        content = (char*)malloc(size);
+        content = (char*)malloc(size + 1);
         if (!content) return false;
         memcpy((char*)content, data, size);
+        const_cast<char*>(content)[size] = '\0';
     } else content = data;
 
     this->size = size;


### PR DESCRIPTION
In certain cases, the user might want to set mapped memory directly. This update ensures that a null terminator is appended to the string data.

Co-Authored-By: Mira Grudzinska <mira@lottiefiles.com>

Issue: https://github.com/thorvg/thorvg/issues/2642