### PR TITLE
build: Override dependency for use as subproject

### DIFF
--- a/inc/meson.build
+++ b/inc/meson.build
@@ -1,3 +1,5 @@
 header_files = ['thorvg.h']
 
+thorvg_inc = include_directories('.')
+
 install_headers(header_files)

--- a/src/meson.build
+++ b/src/meson.build
@@ -62,6 +62,12 @@ thorvg_lib = library(
     override_options       : override_options
 )
 
+thorvg_dep = declare_dependency(
+  include_directories: thorvg_inc,
+  link_with: thorvg_lib,
+)
+meson.override_dependency('thorvg', thorvg_dep)
+
 pkg_mod = import('pkgconfig')
 
 pkg_mod.generate(


### PR DESCRIPTION
A pkgconfig file is already provided, which enables using `thorvg` once it is installed. However, this file is not, and cannot be, available at setup time if using `thorvg` as a subproject.

In such cases, Meson provides the `override_dependency` mechanism for a subproject to tell its parent how to use it. 

This would be necessary for #1723, for example.