### PR TITLE
build: Remove redundant comparisons

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,4 +1,4 @@
-if (lib_type == 'static')
+if lib_type == 'static'
     compiler_flags += ['-DTVG_STATIC']
 endif
 
@@ -8,7 +8,7 @@ endif
 
 examples_dep = [dependency('sdl2')]
 
-if (get_option('engines').contains('wg_beta'))
+if get_option('engines').contains('wg_beta')
     examples_dep += dependency('wgpu_native')
     if host_machine.system() == 'darwin'
         add_languages('objcpp')
@@ -93,7 +93,7 @@ foreach current_file : source_file
 endforeach
 
 
-if get_option('bindings').contains('capi') == true
+if get_option('bindings').contains('capi')
     capi_source_file = [
         'Capi.cpp'
     ]

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@ add_project_arguments('-DEXAMPLE_DIR="@0@/examples/resources"'.format(src_dir),
 config_h.set_quoted('THORVG_VERSION_STRING', meson.project_version())
 
 #Multi-Tasking
-if get_option('threads') == true
+if get_option('threads')
   config_h.set10('THORVG_THREAD_SUPPORT', true)
 endif
 
@@ -100,7 +100,7 @@ endif
 #Vectorization
 simd_type = 'none'
 
-if get_option('simd') == true
+if get_option('simd')
   if host_machine.cpu_family().startswith('x86')
     config_h.set10('THORVG_AVX_VECTOR_SUPPORT', true)
     simd_type = 'avx'
@@ -114,16 +114,16 @@ if get_option('simd') == true
 endif
 
 #Bindings
-if get_option('bindings').contains('capi') == true
+if get_option('bindings').contains('capi')
     config_h.set10('THORVG_CAPI_BINDING_SUPPORT', true)
 endif
 
-if get_option('bindings').contains('wasm_beta') == true
+if get_option('bindings').contains('wasm_beta')
     config_h.set10('THORVG_WASM_BINDING_SUPPORT', true)
 endif
 
 #Log
-if get_option('log') == true
+if get_option('log')
     config_h.set10('THORVG_LOG_ENABLED', true)
 endif
 
@@ -151,11 +151,11 @@ subdir('inc')
 subdir('src')
 subdir('tools')
 
-if get_option('examples') == true
+if get_option('examples')
     subdir('examples')
 endif
 
-if get_option('tests') == true
+if get_option('tests')
    subdir('test')
 endif
 

--- a/src/bindings/meson.build
+++ b/src/bindings/meson.build
@@ -1,7 +1,7 @@
-if get_option('bindings').contains('capi') == true
+if get_option('bindings').contains('capi')
     subdir('capi')
 endif
 
-if get_option('bindings').contains('wasm_beta') == true
+if get_option('bindings').contains('wasm_beta')
     subdir('wasm')
 endif

--- a/src/bindings/wasm/meson.build
+++ b/src/bindings/wasm/meson.build
@@ -1,4 +1,4 @@
-if (cc.get_id() == 'emscripten')
+if cc.get_id() == 'emscripten'
     source_file = files('tvgWasmLottieAnimation.cpp')
     thorvg_wasm_dep = declare_dependency(include_directories
                                          : include_directories('.'), sources

--- a/src/loaders/meson.build
+++ b/src/loaders/meson.build
@@ -17,7 +17,7 @@ if lottie_loader
 endif
 
 if png_loader
-    if get_option('static') == true
+    if get_option('static')
         subdir('png')
     else
         subdir('external_png')
@@ -28,7 +28,7 @@ if png_loader
 endif
 
 if jpg_loader
-    if get_option('static') == true
+    if get_option('static')
         subdir('jpg')
     else
         subdir('external_jpg')
@@ -39,7 +39,7 @@ if jpg_loader
 endif
 
 if webp_loader
-    if get_option('static') == true
+    if get_option('static')
         subdir('webp')
     else
         subdir('external_webp')

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,14 +3,14 @@ override_options = []
 
 lib_type = get_option('default_library')
 
-if (lib_type == 'shared')
+if lib_type == 'shared'
     compiler_flags += ['-DTVG_EXPORT', '-DTVG_BUILD']
 else
     compiler_flags += ['-DTVG_STATIC']
 endif
 
 cc = meson.get_compiler('cpp')
-if (cc.get_id() == 'clang-cl')
+if cc.get_id() == 'clang-cl'
     if simd_type == 'avx'
         compiler_flags += ['/clang:-mavx']
     endif
@@ -44,7 +44,7 @@ subdir('savers')
 
 thorvg_lib_dep = [common_dep, utils_dep, loader_dep, saver_dep]
 
-if get_option('threads') == true and host_machine.system() != 'windows' and host_machine.system() != 'android'
+if get_option('threads') and host_machine.system() != 'windows' and host_machine.system() != 'android'
     thread_dep = meson.get_compiler('cpp').find_library('pthread')
     thorvg_lib_dep += [thread_dep]
 endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,4 +1,4 @@
-if (lib_type == 'static')
+if lib_type == 'static'
     compiler_flags += ['-DTVG_STATIC']
 endif
 
@@ -27,6 +27,6 @@ tests = executable('tvgUnitTests',
 
 test('Unit Tests', tests, args : ['--success'])
 
-if get_option('bindings').contains('capi') == true
+if get_option('bindings').contains('capi')
     subdir('capi')
 endif

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,4 +1,4 @@
-if (lib_type == 'static')
+if lib_type == 'static'
     compiler_flags += ['-DTVG_STATIC']
 endif
 


### PR DESCRIPTION
If a Meson option is typed as `boolean`, the `get_option` returns a boolean, and comparing it with `true` is redundant. Meson also errors if you try to compare across types, so it couldn't _not_ be a boolean.

Also, Meson is not C, so no need for parentheses around `if` conditions.