### PR TITLE
lottie: fix text update

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1055,6 +1055,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
             scene = Scene::gen();
             cursor.x = 0.0f;
             cursor.y = ++line * (doc.height / scale);
+            continue;
         }
         //find the glyph
         bool found = false;


### PR DESCRIPTION
The occurrence of a 'carriage return' (13) or 'end of text' (3) caused the skipping of the next character check, immediately searching for it in the list of available characters. If the next character was also 13 or 3, it led to incorrect interpretation; however, if it was the last character in the sequence, a crash occurred.


modified sample (line 108: ```"t": "START\r\rSTART",```:
[text.json](https://github.com/user-attachments/files/16674490/text.json)

before (missing one \r):
<img width="300" alt="Zrzut ekranu 2024-08-20 o 12 42 11" src="https://github.com/user-attachments/assets/d18cc142-d820-4fe5-99cd-cbc306196c22">

after:
<img width="300" alt="Zrzut ekranu 2024-08-20 o 12 41 08" src="https://github.com/user-attachments/assets/67b757dd-e526-4cc6-ba2d-4b216ea32ccd">


for line 108: ```"t": "START\r",``` crashed occured before this change