### PR TITLE
sw_engine: fix TexmapPolygon rastering

### DIFF
--- a/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -53,12 +53,10 @@ static bool _arrange(const SwImage* image, const SwBBox* region, int& yStart, in
         regionBottom = image->rle->spans[image->rle->size - 1].y;
     }
 
-    if (yStart >= regionBottom) return false;
-
     if (yStart < regionTop) yStart = regionTop;
     if (yEnd > regionBottom) yEnd = regionBottom;
 
-    return true;
+    return yEnd > yStart;
 }
 
 


### PR DESCRIPTION
The y range initialization was missing a check to ensure that the height is a positive value. This could lead to an attempt to call malloc with a negative argument, which cast to an unsigned value, caused a crash.