### PR TITLE
common: uint8_t version of the lerp

### DIFF
--- a/src/common/tvgMath.cpp
+++ b/src/common/tvgMath.cpp
@@ -363,4 +363,14 @@ float Bezier::angle(float t) const
     return rad2deg(tvg::atan2(pt.y, pt.x));
 }
 
+
+uint8_t lerp(const uint8_t &start, const uint8_t &end, float t)
+{
+    auto result = static_cast<int>(start + (end - start) * t);
+    if (result > 255) result = 255;
+    else if (result < 0) result = 0;
+    return static_cast<uint8_t>(result);
 }
+
+}
+

--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -286,6 +286,8 @@ static inline T lerp(const T &start, const T &end, float t)
     return static_cast<T>(start + (end - start) * t);
 }
 
+uint8_t lerp(const uint8_t &start, const uint8_t &end, float t);
+
 }
 
 #endif //_TVG_MATH_H_


### PR DESCRIPTION
An uint8_t version of the lerp function
is introduced to handle cases where
the interpolation factor t exceeds 1, which
previously caused overflow issues due to casting.

[sample.json](https://github.com/user-attachments/files/16715605/sample.json)

before:
<img width="400" alt="before" src="https://github.com/user-attachments/assets/105b4f7f-638b-4222-b031-d6e0bbfa4785">

after:
<img width="400" alt="after" src="https://github.com/user-attachments/assets/211bb1bc-92db-4c85-bf03-2c1b5e28f935">

