### PR TITLE
gl_engine: fix mistake in the calculation of stroke miter limit

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.h
+++ b/src/renderer/gl_engine/tvgGlGeometry.h
@@ -27,7 +27,7 @@
 #include "tvgGlCommon.h"
 #include "tvgMath.h"
 
-#define MIN_GL_STROKE_WIDTH 0.5f
+#define MIN_GL_STROKE_WIDTH 1.0f
 
 #define MVP_MATRIX(w, h) \
     float mvp[4*4] = { \

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -140,7 +140,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, uint8_t r, uint8_t g, uint8_t b, 
     a = MULTIPLY(a, sdata.opacity);
 
     if (flag & RenderUpdateFlag::Stroke) {
-        float strokeWidth = sdata.rshape->strokeWidth();
+        float strokeWidth = sdata.rshape->strokeWidth() * sdata.geometry->getTransformMatrix().e11;
         if (strokeWidth < MIN_GL_STROKE_WIDTH) {
             float alpha = strokeWidth / MIN_GL_STROKE_WIDTH;
             a = MULTIPLY(a, static_cast<uint8_t>(alpha * 255));


### PR DESCRIPTION
This PR fix the stroke miter not working as expect and contains the following changes:

* correct the stroke width and color calculation with scaling
* fix the miter limit calculation to make bevel join fallback correct

<img width="799" alt="截屏2024-08-23 上午11 32 23" src="https://github.com/user-attachments/assets/98ae064e-f5c1-4aac-8397-04cea1dae185">

issue: https://github.com/thorvg/thorvg/issues/2435
