### PR TITLE
wg_engine: masking optimization - PART 3

### DIFF
--- a/src/renderer/wg_engine/tvgWgBindGroups.cpp
+++ b/src/renderer/wg_engine/tvgWgBindGroups.cpp
@@ -45,15 +45,6 @@ WGPUBindGroup WgBindGroupLayouts::createBindGroupTexSampledBuff1Un(WGPUSampler s
 }
 
 
-WGPUBindGroup WgBindGroupLayouts::createBindGroupScreen1WO(WGPUTextureView texView) {
-    const WGPUBindGroupEntry bindGroupEntrys[] = {
-        { .binding = 0, .textureView = texView }
-    };
-    const WGPUBindGroupDescriptor bindGroupDesc { .layout = layoutTexScreen1WO, .entryCount = 1, .entries = bindGroupEntrys };
-    return wgpuDeviceCreateBindGroup(device, &bindGroupDesc);
-}
-
-
 WGPUBindGroup WgBindGroupLayouts::createBindGroupStrorage1WO(WGPUTextureView texView)
 {
     const WGPUBindGroupEntry bindGroupEntrys[] = {
@@ -150,7 +141,6 @@ void WgBindGroupLayouts::initialize(WgContext& context)
     const WGPUTextureBindingLayout texture = { .sampleType = WGPUTextureSampleType_Float, .viewDimension = WGPUTextureViewDimension_2D };
     const WGPUStorageTextureBindingLayout storageTextureWO { .access = WGPUStorageTextureAccess_WriteOnly, .format = WGPUTextureFormat_RGBA8Unorm, .viewDimension = WGPUTextureViewDimension_2D };
     const WGPUStorageTextureBindingLayout storageTextureRO { .access = WGPUStorageTextureAccess_ReadOnly,  .format = WGPUTextureFormat_RGBA8Unorm, .viewDimension = WGPUTextureViewDimension_2D };
-    const WGPUStorageTextureBindingLayout storageScreenWO  { .access = WGPUStorageTextureAccess_WriteOnly, .format = WGPUTextureFormat_BGRA8Unorm, .viewDimension = WGPUTextureViewDimension_2D };
     const WGPUBufferBindingLayout bufferUniform { .type = WGPUBufferBindingType_Uniform };
 
     { // bind group layout tex sampled
@@ -172,15 +162,6 @@ void WgBindGroupLayouts::initialize(WgContext& context)
         const WGPUBindGroupLayoutDescriptor bindGroupLayoutDesc { .entryCount = 3, .entries = bindGroupLayoutEntries };
         layoutTexSampledBuff1Un = wgpuDeviceCreateBindGroupLayout(device, &bindGroupLayoutDesc);
         assert(layoutTexSampledBuff1Un);
-    }
-
-    { // bind group layout tex screen 1 RO
-        const WGPUBindGroupLayoutEntry bindGroupLayoutEntries[] {
-            { .binding = 0, .visibility = visibility_frag, .storageTexture = storageScreenWO }
-        };
-        const WGPUBindGroupLayoutDescriptor bindGroupLayoutDesc { .entryCount = 1, .entries = bindGroupLayoutEntries };
-        layoutTexScreen1WO = wgpuDeviceCreateBindGroupLayout(device, &bindGroupLayoutDesc);
-        assert(layoutTexScreen1WO);
     }
 
     { // bind group layout tex storage 1 WO
@@ -259,7 +240,6 @@ void WgBindGroupLayouts::release(WgContext& context)
     wgpuBindGroupLayoutRelease(layoutBuffer3Un);
     wgpuBindGroupLayoutRelease(layoutBuffer2Un);
     wgpuBindGroupLayoutRelease(layoutBuffer1Un);
-    wgpuBindGroupLayoutRelease(layoutTexScreen1WO);
     wgpuBindGroupLayoutRelease(layoutTexStrorage3RO);
     wgpuBindGroupLayoutRelease(layoutTexStrorage2RO);
     wgpuBindGroupLayoutRelease(layoutTexStrorage1RO);

--- a/src/renderer/wg_engine/tvgWgBindGroups.h
+++ b/src/renderer/wg_engine/tvgWgBindGroups.h
@@ -31,7 +31,6 @@ private:
 public:
     WGPUBindGroupLayout layoutTexSampled{};
     WGPUBindGroupLayout layoutTexSampledBuff1Un{};
-    WGPUBindGroupLayout layoutTexScreen1WO{};
     WGPUBindGroupLayout layoutTexStrorage1WO{};
     WGPUBindGroupLayout layoutTexStrorage1RO{};
     WGPUBindGroupLayout layoutTexStrorage2RO{};
@@ -42,7 +41,6 @@ public:
 public:
     WGPUBindGroup createBindGroupTexSampled(WGPUSampler sampler, WGPUTextureView texView);
     WGPUBindGroup createBindGroupTexSampledBuff1Un(WGPUSampler sampler, WGPUTextureView texView, WGPUBuffer buff);
-    WGPUBindGroup createBindGroupScreen1WO(WGPUTextureView texView);
     WGPUBindGroup createBindGroupStrorage1WO(WGPUTextureView texView);
     WGPUBindGroup createBindGroupStrorage1RO(WGPUTextureView texView);
     WGPUBindGroup createBindGroupStrorage2RO(WGPUTextureView texView0, WGPUTextureView texView1);

--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -48,7 +48,7 @@ void WgContext::initialize(WGPUInstance instance, WGPUSurface surface)
     // get adapter and surface properties
     WGPUFeatureName featureNames[32]{};
     size_t featuresCount = wgpuAdapterEnumerateFeatures(adapter, featureNames);
-    preferredFormat = wgpuSurfaceGetPreferredFormat(surface, adapter);
+    preferredFormat = WGPUTextureFormat_BGRA8Unorm;
 
     // request device
     const WGPUDeviceDescriptor deviceDesc { .nextInChain = nullptr, .label = "The device", .requiredFeatureCount = featuresCount, .requiredFeatures = featureNames };

--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -58,6 +58,7 @@ private:
     static WgPipelineBlendType blendMethodToBlendType(BlendMethod blendMethod);
 
     void composeRegion(WgContext& context, WgRenderStorage* src, WgRenderStorage* mask, CompositeMethod composeMethod, RenderRegion& rect);
+    RenderRegion shrinkRenderRegion(RenderRegion& rect);
 public:
     // render target dimensions
     uint32_t width{};
@@ -77,6 +78,7 @@ public:
     void blendShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
     void blendStrokes(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
     void blendImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod);
+    void blendScene(WgContext& context, WgRenderStorage* src, WgCompose* cmp);
 
     void composeShape(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask, CompositeMethod composeMethod);
     void composeStrokes(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask, CompositeMethod composeMethod);
@@ -90,6 +92,7 @@ public:
 
     void mergeMasks(WGPUCommandEncoder encoder, WgRenderStorage* mask0, WgRenderStorage* mask1);
     void blend(WGPUCommandEncoder encoder, WgRenderStorage* src, WgRenderStorage* dst, uint8_t opacity, BlendMethod blendMethod, WgRenderRasterType rasterType);
+    void blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderStorage* src, WGPUTextureView dstView);
 };
 
 #endif // _TVG_WG_COMPOSITOR_H_

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -36,12 +36,13 @@ private:
     WGPUShaderModule shaderLinear{};
     WGPUShaderModule shaderImage{};
     WGPUShaderModule shaderSceneComp{};
+    WGPUShaderModule shaderSceneBlend{};
+    WGPUShaderModule shaderBlit{};
     // compute pipeline shaders
     WGPUShaderModule shaderMergeMasks;
     WGPUShaderModule shaderBlendSolid;
     WGPUShaderModule shaderBlendGradient;
     WGPUShaderModule shaderBlendImage;
-    WGPUShaderModule shaderCopy;
 private:
     // graphics pipeline layouts
     WGPUPipelineLayout layoutStencil{};
@@ -49,10 +50,11 @@ private:
     WGPUPipelineLayout layoutGradient{};
     WGPUPipelineLayout layoutImage{};
     WGPUPipelineLayout layoutSceneComp{};
+    WGPUPipelineLayout layoutSceneBlend{};
+    WGPUPipelineLayout layoutBlit{};
     // compute pipeline layouts
     WGPUPipelineLayout layoutMergeMasks{};
     WGPUPipelineLayout layoutBlend{};
-    WGPUPipelineLayout layoutCopy{};
 public:
     // graphics pipeline
     WgBindGroupLayouts layouts;
@@ -64,13 +66,14 @@ public:
     WGPURenderPipeline linear[3]{};
     WGPURenderPipeline image[3]{};
     WGPURenderPipeline sceneComp[12];
+    WGPURenderPipeline sceneBlend;
+    WGPURenderPipeline blit{};
     WGPURenderPipeline clipPath{};
     // compute pipeline
     WGPUComputePipeline mergeMasks;
     WGPUComputePipeline blendSolid[14];
     WGPUComputePipeline blendGradient[14];
     WGPUComputePipeline blendImage[14];
-    WGPUComputePipeline copy;
 private:
     void releaseGraphicHandles(WgContext& context);
     void releaseComputeHandles(WgContext& context);
@@ -82,7 +85,7 @@ private:
         const WGPUShaderModule shaderModule, const char* vsEntryPoint, const char* fsEntryPoint,
         const WGPUPipelineLayout pipelineLayout,
         const WGPUVertexBufferLayout *vertexBufferLayouts, const uint32_t vertexBufferLayoutsCount,
-        const WGPUColorWriteMaskFlags writeMask,
+        const WGPUColorWriteMaskFlags writeMask, const WGPUTextureFormat colorTargetFormat,
         const WGPUCompareFunction stencilFunctionFrnt, const WGPUStencilOperation stencilOperationFrnt,
         const WGPUCompareFunction stencilFunctionBack, const WGPUStencilOperation stencilOperationBack,
         const WGPUPrimitiveState primitiveState, const WGPUMultisampleState multisampleState, const WGPUBlendState blendState);

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -75,11 +75,6 @@ private:
     WgPipelines mPipelines;
     WgCompositor mCompositor;
     
-    // screen buffer
-    WGPUTexture mTexScreen{};
-    WGPUTextureView mTexViewScreen{};
-    WGPUBindGroup mBindGroupScreen{};
-
     Surface mTargetSurface;
     BlendMethod mBlendMethod{};
     RenderRegion mViewport{};

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -291,6 +291,58 @@ fn fs_main_DarkenMask(in: VertexOutput) -> @location(0) vec4f {
 };
 )";
 
+
+//************************************************************************
+// graphics shader source: scene blend
+//************************************************************************
+
+const char* cShaderSrc_Scene_Blend = R"(
+struct VertexInput { @location(0) position: vec2f, @location(1) texCoord: vec2f };
+struct VertexOutput { @builtin(position) position: vec4f, @location(0) texCoord: vec2f };
+
+@group(0) @binding(0) var uSamplerSrc : sampler;
+@group(0) @binding(1) var uTextureSrc : texture_2d<f32>;
+@group(1) @binding(0) var<uniform> So : f32;
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.position = vec4f(in.position.xy, 0.0, 1.0);
+    out.texCoord = in.texCoord;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+    return textureSample(uTextureSrc, uSamplerSrc, in.texCoord.xy) * So;
+};
+)";
+
+//************************************************************************
+// graphics shader source: texture blit
+//************************************************************************
+
+const char* cShaderSrc_Blit = R"(
+struct VertexInput { @location(0) position: vec2f, @location(1) texCoord: vec2f };
+struct VertexOutput { @builtin(position) position: vec4f, @location(0) texCoord: vec2f };
+
+@group(0) @binding(0) var uSamplerSrc : sampler;
+@group(0) @binding(1) var uTextureSrc : texture_2d<f32>;
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.position = vec4f(in.position.xy, 0.0, 1.0);
+    out.texCoord = in.texCoord;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+    return textureSample(uTextureSrc, uSamplerSrc, in.texCoord.xy);
+};
+)";
+
 //************************************************************************
 // compute shader source: merge clip path masks
 //************************************************************************
@@ -516,19 +568,5 @@ fn cs_main_SoftLight(@builtin(global_invocation_id) id: vec3u) {
     let One = vec3f(1.0, 1.0, 1.0);
     let Rc = min(One, (One - 2 * d.Sc) * d.Dc * d.Dc + 2.0 * d.Sc * d.Dc);
     textureStore(imageTgt, id.xy, postProcess(d, vec4f(Rc, 1.0)));
-};
-)";
-
-//************************************************************************
-// compute shader source: copy
-//************************************************************************
-
-const char* cShaderSrc_Copy = R"(
-@group(0) @binding(0) var imageSrc : texture_storage_2d<rgba8unorm, read>;
-@group(1) @binding(0) var imageDst : texture_storage_2d<bgra8unorm, write>;
-
-@compute @workgroup_size(8, 8)
-fn cs_main(@builtin(global_invocation_id) id: vec3u) {
-    textureStore(imageDst, id.xy, textureLoad(imageSrc, id.xy));
 };
 )";

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -30,6 +30,8 @@ extern const char* cShaderSrc_Linear;
 extern const char* cShaderSrc_Radial;
 extern const char* cShaderSrc_Image;
 extern const char* cShaderSrc_Scene_Comp;
+extern const char* cShaderSrc_Scene_Blend;
+extern const char* cShaderSrc_Blit;
 
 // compute shader sources: blend, compose and merge path
 extern const char* cShaderSrc_MergeMasks;
@@ -37,6 +39,5 @@ extern const char* cShaderSrc_BlendHeader_Solid;
 extern const char* cShaderSrc_BlendHeader_Gradient;
 extern const char* cShaderSrc_BlendHeader_Image;
 extern const char* cShaderSrc_Blend_Funcs;
-extern const char* cShaderSrc_Copy;
 
 #endif // _TVG_WG_SHEDER_SRC_H_


### PR DESCRIPTION
Masking workflows optimized:
* used hardware blending stage for scene blending
* used AABB for scene blending
* reduced number of offfscreen buffers coping
* reduced number of render pass switching
* used render pipelines abilities to convert offscreen pixel format to screen pixel format
* removed unused shaders

+15% performance boost in avarage in animations with masks

masking.json animation:
before - 200 fps, after - 235 fps