### PR TITLE
svg_loader: Adjust hsl values out of range

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -588,6 +588,11 @@ static bool _hslToRgb(float hue, float saturation, float brightness, uint8_t* re
     float _red = 0, _green = 0, _blue = 0;
     uint32_t i = 0;
 
+    while (hue < 0) hue += 360.0f;
+    hue = fmod(hue, 360.0f);
+    saturation = saturation > 0 ? std::min(saturation, 1.0f) : 0.0f;
+    brightness = brightness > 0 ? std::min(brightness, 1.0f) : 0.0f;
+
     if (tvg::zero(saturation))  _red = _green = _blue = brightness;
     else {
         if (tvg::equal(hue, 360.0)) hue = 0.0f;
@@ -714,7 +719,6 @@ static bool _toColor(const char* str, uint8_t* r, uint8_t* g, uint8_t* b, char**
         const char* hue = nullptr;
         if (_parseNumber(&content, &hue, &th) && hue) {
             const char* saturation = nullptr;
-            th = float(uint32_t(th) % 360);
             hue = _skipSpace(hue, nullptr);
             hue = (char*)_skipComma(hue);
             hue = _skipSpace(hue, nullptr);


### PR DESCRIPTION
The range of saturation and brightness values is 0 ~ 100% and range of hue is 0 ~ 360.
If a value greater than 100% is loaded, it will be modified to be 100%.

issue: https://github.com/thorvg/thorvg/issues/2678