### PR TITLE
lottie: fix trim

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -871,6 +871,7 @@ void LottieBuilder::updateTrimpath(TVG_UNUSED LottieGroup* parent, LottieObject*
     }
 
     P(ctx->propagator)->strokeTrim(begin, end, trimpath->type == LottieTrimpath::Type::Simultaneous);
+    ctx->merging = nullptr;
 }
 
 


### PR DESCRIPTION
The bug caused the trim path to not be applied
when it appeared in a group between different
shapes.

before:
<img width="200" alt="Zrzut ekranu 2024-08-28 o 00 09 30" src="https://github.com/user-attachments/assets/cc438099-1af4-40b0-a904-6f692b1857ce">

after:
<img width="200" alt="Zrzut ekranu 2024-08-28 o 00 09 53" src="https://github.com/user-attachments/assets/da2d9cb3-efc9-452c-babc-3e1111c86712">


sample:
[trim.json](https://github.com/user-attachments/files/16770152/trim.json)
