### PR TITLE
lottie: handle trim path edge cases

### DIFF
--- a/src/common/tvgMath.cpp
+++ b/src/common/tvgMath.cpp
@@ -367,8 +367,7 @@ float Bezier::angle(float t) const
 uint8_t lerp(const uint8_t &start, const uint8_t &end, float t)
 {
     auto result = static_cast<int>(start + (end - start) * t);
-    if (result > 255) result = 255;
-    else if (result < 0) result = 0;
+    tvg::clamp(result, 0, 255);
     return static_cast<uint8_t>(result);
 }
 

--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -68,6 +68,13 @@ static inline bool equal(float a, float b)
 }
 
 
+template <typename T>
+static inline void clamp(T& v, const T& min, const T& max)
+{
+    if (v < min) v = min;
+    else if (v > max) v = max;
+}
+
 /************************************************************************/
 /* Matrix functions                                                     */
 /************************************************************************/

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -141,7 +141,9 @@ void LottieImage::prepare()
 void LottieTrimpath::segment(float frameNo, float& start, float& end, LottieExpressions* exps)
 {
     start = this->start(frameNo, exps) * 0.01f;
+    tvg::clamp(start, 0.0f, 1.0f);
     end = this->end(frameNo, exps) * 0.01f;
+    tvg::clamp(end, 0.0f, 1.0f);
 
     auto o = fmodf(this->offset(frameNo, exps), 360.0f) / 360.0f;  //0 ~ 1
 


### PR DESCRIPTION
According to the definition of trim path elements,
the begin and end values are specified as percentages
in the range of 0-100% (this is also confirmed by AE,
where it's not possible to exceed this range).
Added clamping to align with specs.

before:
![before](https://github.com/user-attachments/assets/8268e585-a576-4958-8f37-df3c10636c9c)

after:
![after](https://github.com/user-attachments/assets/41da0d82-ecd8-4626-8d6a-68edde2ac059)

sample:
[part.json](https://github.com/user-attachments/files/16788631/part.json)


