### PR TITLE
lottie: fix trim path regression

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -157,6 +157,7 @@ void LottieTrimpath::segment(float frameNo, float& start, float& end, LottieExpr
         return;
     }
 
+    if (start > end) std::swap(start, end);
     start += o;
     end += o;
 }


### PR DESCRIPTION
To avoid editing the trim path values provided
by the user, the logic for their interpretation
was moved from the API to the renderer (7c87d8e).
This caused an issue in the lottie animations when the trim path is applied more than once. Now fixed.

@issue: https://github.com/thorvg/thorvg/issues/2670


before:
<img width="200" alt="before" src="https://github.com/user-attachments/assets/282e2359-dc51-4484-8181-f1db29fc293d">

after:
<img width="200" alt="after" src="https://github.com/user-attachments/assets/80a8f6cf-3c6d-4067-a61a-fcbde5cf5f3c">

sample:
[11483_part.json](https://github.com/user-attachments/files/16770250/11483_part.json)