### PR TITLE
sw_engine: increased accuracy in dashing

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -209,7 +209,7 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
             }
             _outlineCubicTo(*dash.outline, &cur.ctrl1, &cur.ctrl2, &cur.end, transform);
         }
-        if (dash.curLen < 1 && TO_SWCOORD(len) > 1) {
+        if (dash.curLen < 0.1f && TO_SWCOORD(len) > 1) {
             //move to next dash
             dash.curIdx = (dash.curIdx + 1) % dash.cnt;
             dash.curLen = dash.pattern[dash.curIdx];


### PR DESCRIPTION
The limit on leftovers was too small, which became noticeable for animations with trimming - currently implemented with the dashing alg.
The limit has been increased.

before (stuttering in animation smoothness):
![before](https://github.com/user-attachments/assets/9126a739-443a-4f9e-8ec0-c52675594f07)

after:
![after](https://github.com/user-attachments/assets/8a529eb5-0644-4d88-bd67-9a692abc0665)

sample:
[acc.json](https://github.com/user-attachments/files/16797662/acc.json)
