### PR TITLE
examples: clear canvas while updating

### DIFF
--- a/examples/AnimateMasking.cpp
+++ b/examples/AnimateMasking.cpp
@@ -75,6 +75,7 @@ struct UserExample : tvgexam::Example
     bool update(tvg::Canvas* canvas, uint32_t elapsed) override
     {
         if (!canvas) return false;
+        if (!tvgexam::verify(canvas->clear(false))) return false;
 
         /* Update shape directly.
            You can update only necessary properties of this shape,

--- a/examples/Animation.cpp
+++ b/examples/Animation.cpp
@@ -70,6 +70,7 @@ struct UserExample : tvgexam::Example
     bool update(tvg::Canvas* canvas, uint32_t elapsed) override
     {
         if (!canvas) return false;
+        if (!tvgexam::verify(canvas->clear(false))) return false;
 
         auto progress = tvgexam::progress(elapsed, animation->duration());
 

--- a/examples/Lottie.cpp
+++ b/examples/Lottie.cpp
@@ -78,6 +78,7 @@ struct UserExample : tvgexam::Example
     bool update(tvg::Canvas* canvas, uint32_t elapsed) override
     {
         if (!canvas) return false;
+        if (!tvgexam::verify(canvas->clear(false))) return false;
 
         for (auto& animation : animations) {
             auto progress = tvgexam::progress(elapsed, animation->duration());


### PR DESCRIPTION
An issue was observed while drawing without background.