### PR TITLE
common: precision increase while matrix inversion

### DIFF
--- a/src/common/tvgMath.cpp
+++ b/src/common/tvgMath.cpp
@@ -120,9 +120,8 @@ bool inverse(const Matrix* m, Matrix* out)
                m->e12 * (m->e21 * m->e33 - m->e23 * m->e31) +
                m->e13 * (m->e21 * m->e32 - m->e22 * m->e31);
 
-    if (tvg::zero(det)) return false;
-
-    auto invDet = 1 / det;
+    auto invDet = 1.0f / det;
+    if (!std::isfinite(invDet)) return false;
 
     out->e11 = (m->e22 * m->e33 - m->e32 * m->e23) * invDet;
     out->e12 = (m->e13 * m->e32 - m->e12 * m->e33) * invDet;

--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -26,7 +26,7 @@
  #define _USE_MATH_DEFINES
 
 #include <float.h>
-#include <math.h>
+#include <cmath>
 #include "tvgCommon.h"
 
 namespace tvg


### PR DESCRIPTION
A numerically motivated limit on the matrix determinant set at 1e-6 was not sufficient. The limit has been increased.

before:
<img width="300" alt="Zrzut ekranu 2024-09-3 o 17 35 17" src="https://github.com/user-attachments/assets/d93d3ca0-abed-4aaf-b054-d214b5abb450">

after:
<img width="300" alt="Zrzut ekranu 2024-09-3 o 17 34 43" src="https://github.com/user-attachments/assets/af38db5e-3aac-4fe1-ac66-792d223954ae">

sample:
[icons.svg.zip](https://github.com/user-attachments/files/16851194/icons.svg.zip)

