### PR TITLE
svg_loader: fix text nodes issue

### DIFF
--- a/src/common/tvgStr.cpp
+++ b/src/common/tvgStr.cpp
@@ -219,6 +219,21 @@ char* strDuplicate(const char *str, size_t n)
     return (char *) memcpy(ret, str, n);
 }
 
+char* strAppend(char* lhs, const char* rhs, size_t n)
+{
+    if (!rhs) return lhs;
+    if (!lhs) return strDuplicate(rhs, n);
+
+    if (auto ret = (char*)malloc(strlen(lhs) + n + 1)) {
+        ret[0] = '\0';
+        strcat(ret, lhs);
+        free(lhs);
+        return strncat(ret, rhs, n);
+    }
+
+    return nullptr;
+}
+
 char* strDirname(const char* path)
 {
     const char *ptr = strrchr(path, '/');

--- a/src/common/tvgStr.h
+++ b/src/common/tvgStr.h
@@ -30,6 +30,7 @@ namespace tvg
 
 float strToFloat(const char *nPtr, char **endPtr);  //convert to float
 char* strDuplicate(const char *str, size_t n);      //copy the string
+char* strAppend(char* lhs, const char* rhs, size_t n);  //append the source to the target
 char* strDirname(const char* path);                 //return the full directory name
 
 }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2183,6 +2183,7 @@ static SvgNode* _createTextNode(SvgLoaderData* loader, SvgNode* parent, const ch
     //TODO: support the def font and size as used in a system?
     loader->svgParse->node->node.text.fontSize = 10.0f;
     loader->svgParse->node->node.text.fontFamily = nullptr;
+    loader->svgParse->node->node.text.text = nullptr;
 
     func(buf, bufLength, _attrParseTextNode, loader);
 
@@ -3400,8 +3401,7 @@ static void _svgLoaderParserXmlOpen(SvgLoaderData* loader, const char* content, 
 static void _svgLoaderParserText(SvgLoaderData* loader, const char* content, unsigned int length)
 {
     auto text = &loader->svgParse->node->node.text;
-    if (text->text) free(text->text);
-    text->text = strDuplicate(content, length);
+    text->text = strAppend(text->text, content, length);
 }
 
 


### PR DESCRIPTION
Text can be added in parts due to the presence
of the <tspan> tag. This requires that each
subsequent piece of text is appended rather than
overwriting the previous one.

before:
<img width="631" alt="Zrzut ekranu 2024-09-10 o 11 24 40" src="https://github.com/user-attachments/assets/3381ca31-784c-4787-973e-f42ca19c4c6c">

after:
<img width="620" alt="Zrzut ekranu 2024-09-10 o 11 22 17" src="https://github.com/user-attachments/assets/8df257ac-1abd-4ec5-8570-099988c2cb7e">

sample:
[textAppend.svg.zip](https://github.com/user-attachments/files/16942598/textAppend.svg.zip)




already merged:
Since the text node doesn't get pushed onto the loader's stack, closing the text node incorrectly popped an element from the stack (if one was present). This could result in elements that were supposed to have that element as a parent being rendered incorrectly or not being rendered at all.

@Issue: https://github.com/thorvg/thorvg/issues/2706

before:
<img width="400" alt="Zrzut ekranu 2024-09-4 o 00 05 08" src="https://github.com/user-attachments/assets/e436b19c-5926-4f83-a3fd-5b9ccb4de073">

after:
<img width="400" alt="Zrzut ekranu 2024-09-4 o 00 05 33" src="https://github.com/user-attachments/assets/a52bb6b3-cbd2-4dbb-9877-970e3143e234">

samples from the issue: https://github.com/thorvg/thorvg/issues/2706