### PR TITLE
sw_engine: handle dashed stroke only if big enough

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -141,14 +141,14 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix& trans
         }
         //leftovers
         dash.curLen -= len;
-        if (!dash.curOpGap) {
+        if (!dash.curOpGap && TO_SWCOORD(len) > 2) {
             if (dash.move) {
                 _outlineMoveTo(*dash.outline, &cur.pt1, transform);
                 dash.move = false;
             }
             _outlineLineTo(*dash.outline, &cur.pt2, transform);
         }
-        if (dash.curLen < 1 && TO_SWCOORD(len) > 1) {
+        if (dash.curLen < 0.1f && TO_SWCOORD(len) > 1) {
             //move to next dash
             dash.curIdx = (dash.curIdx + 1) % dash.cnt;
             dash.curLen = dash.pattern[dash.curIdx];
@@ -202,7 +202,7 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
         }
         //leftovers
         dash.curLen -= len;
-        if (!dash.curOpGap) {
+        if (!dash.curOpGap && TO_SWCOORD(len) > 2) {
             if (dash.move) {
                 _outlineMoveTo(*dash.outline, &cur.start, transform);
                 dash.move = false;


### PR DESCRIPTION
Dividing cubic curves can generate very short segments, which may cause rendering errors. Now, if a segment is too short, it is ignored.

@issue: https://github.com/godotengine/godot/issues/96262

before:
<img width="93" alt="Zrzut ekranu 2024-09-5 o 01 31 19" src="https://github.com/user-attachments/assets/b629eb98-d6f1-4ec1-b98a-d78e6f623a73">

after:
<img width="95" alt="Zrzut ekranu 2024-09-5 o 01 32 28" src="https://github.com/user-attachments/assets/37d45804-f76d-47d4-9e81-c40bf53ce508">

sample (to reproduce no scaling can be applied):
[err.svg.zip](https://github.com/user-attachments/files/16882070/err.svg.zip)
