### PR TITLE
renderer: ++reliability in text drawing

### DIFF
--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -89,6 +89,7 @@ struct Text::Impl
 
     bool render(RenderMethod* renderer)
     {
+        if (!loader) return true;
         renderer->blend(paint->blend());
         return PP(shape)->render(renderer);
     }


### PR DESCRIPTION
Allow the canvas to pass through
even if text elements are not properly supported.

issue: https://github.com/thorvg/thorvg/issues/2715