### PR TITLE
lottie/text: Support line spacing

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1003,6 +1003,8 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
     auto scene = Scene::gen();
     int line = 0;
     int space = 0;
+    auto lineSpacing = 0.0f;
+    auto totalLineSpacing = 0.0f;
 
     //text string
     int idx = 0;
@@ -1028,10 +1030,13 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
             if (*p == '\0') break;
             ++p;
 
+            totalLineSpacing += lineSpacing;
+            lineSpacing = 0.0f;
+
             //new text group, single scene for each line
             scene = Scene::gen();
             cursor.x = 0.0f;
-            cursor.y = ++line * (doc.height / scale);
+            cursor.y = (++line * doc.height + totalLineSpacing) / scale;
             continue;
         }
 
@@ -1100,6 +1105,9 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                         shape->strokeFill(strokeColor.rgb[0], strokeColor.rgb[1], strokeColor.rgb[2], (*s)->style.strokeOpacity(frameNo));
                     }
                     cursor.x += (*s)->style.letterSpacing(frameNo);
+
+                    auto spacing = (*s)->style.lineSpacing(frameNo);
+                    if (spacing > lineSpacing) lineSpacing = spacing;
                 }
 
                 scene->push(cast(shape));

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -158,6 +158,7 @@ struct LottieTextStyle
     LottiePosition position = Point{0, 0};
     LottiePoint scale = Point{100, 100};
     LottieFloat letterSpacing = 0.0f;
+    LottieFloat lineSpacing = 0.0f;
     LottieFloat strokeWidth = 0.0f;
     LottieFloat rotation = 0.0f;
     LottieOpacity fillOpacity = 255;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1136,6 +1136,7 @@ void LottieParser::parseTextRange(LottieText* text)
                 enterObject();
                 while (auto key = nextObjectKey()) {
                     if (KEY_AS("t")) parseProperty<LottieProperty::Type::Float>(selector->style.letterSpacing);
+                    else if (KEY_AS("ls")) parseProperty<LottieProperty::Type::Color>(selector->style.lineSpacing);
                     else if (KEY_AS("fc")) parseProperty<LottieProperty::Type::Color>(selector->style.fillColor);
                     else if (KEY_AS("fo")) parseProperty<LottieProperty::Type::Color>(selector->style.fillOpacity);
                     else if (KEY_AS("sw")) parseProperty<LottieProperty::Type::Float>(selector->style.strokeWidth);


### PR DESCRIPTION
Issue: #2178 

Compute line spacing based on the text range selector, applying the maximum spacing value for each line.

---

[line-spacing-10px-sample.json](https://github.com/user-attachments/files/16925626/line-spacing-10px-sample.json)

![CleanShot 2024-09-09 at 14 04 25@2x](https://github.com/user-attachments/assets/710045d1-c74c-4851-9bb7-93fb82fd5bd8)
