### PR TITLE
wg_engine: Enable premultiplied canvas on browser

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -324,6 +324,7 @@ bool WgRenderer::target(WGPUSurface surface, uint32_t w, uint32_t h) {
         .usage = WGPUTextureUsage_RenderAttachment,
         .width = w, .height = h,
         #ifdef __EMSCRIPTEN__
+        .alphaMode = WGPUCompositeAlphaMode_Premultiplied,
         .presentMode = WGPUPresentMode_Fifo,
         #else
         .presentMode = WGPUPresentMode_Immediate


### PR DESCRIPTION
Emscripten 3.1.66 includes support for WebGPU's premultiplied canvas.

Surface configurations have been updated with premultiplied alpha mode to support this feature.

see: https://github.com/emscripten-core/emscripten/commit/c82a307c612d430028a3d06ddf8b3fdd2852b2fb


![CleanShot 2024-09-12 at 17 47 12@2x](https://github.com/user-attachments/assets/b5580a43-8060-4303-8b87-ac45cb326334)
