### PR TITLE
lottie/text: Support Text Randomize

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1069,14 +1069,10 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
 
                 //text range process
                 for (auto s = text->ranges.begin(); s < text->ranges.end(); ++s) {
+                    float start, end;
+                    (*s)->range(frameNo, totalChars, start, end);
+
                     auto basedIdx = idx;
-                    float divisor = (*s)->rangeUnit == LottieTextRange::Unit::Percent ? (100.0f / totalChars) : 1;
-                    auto offset = (*s)->offset(frameNo) / divisor;
-                    auto start = nearbyintf((*s)->start(frameNo) / divisor) + offset;
-                    auto end = nearbyintf((*s)->end(frameNo) / divisor) + offset;
-
-                    if (start > end) std::swap(start, end);
-
                     if ((*s)->based == LottieTextRange::Based::CharsExcludingSpaces) basedIdx = idx - space;
                     else if ((*s)->based == LottieTextRange::Based::Words) basedIdx = line + space;
                     else if ((*s)->based == LottieTextRange::Based::Lines) basedIdx = line;

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -110,6 +110,25 @@ void LottieSlot::assign(LottieObject* target)
 }
 
 
+void LottieTextRange::range(float frameNo, size_t totalLen, float& start, float& end)
+{
+    float divisor = rangeUnit == Unit::Percent ? (100.0f / totalLen) : 1;
+    auto offset = this->offset(frameNo) / divisor;
+    start = nearbyintf(this->start(frameNo) / divisor) + offset;
+    end = nearbyintf(this->end(frameNo) / divisor) + offset;
+
+    if (start > end) std::swap(start, end);
+
+    if (random) {
+        auto range = end - start;
+        auto len = rangeUnit == Unit::Percent ? 100 : totalLen;
+
+        start = random % int(len - range);
+        end = start + range;
+    }
+}
+
+
 LottieImage::~LottieImage()
 {
     free(b64Data);

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -184,8 +184,10 @@ struct LottieTextRange
     Based based = Chars;
     Shape shape = Square;
     Unit rangeUnit = Percent;
+    uint8_t random = 0;
     bool expressible = false;
-    bool randomize = false;
+
+    void range(float frameNo, size_t totalLen, float& start, float& end);
 };
 
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1123,7 +1123,9 @@ void LottieParser::parseTextRange(LottieText* text)
                     else if (KEY_AS("ne")) parseProperty<LottieProperty::Type::Float>(selector->minEase);
                     else if (KEY_AS("a")) parseProperty<LottieProperty::Type::Float>(selector->maxAmount);
                     else if (KEY_AS("b")) selector->based = (LottieTextRange::Based) getInt();
-                    else if (KEY_AS("rn")) selector->randomize = (bool) getInt();
+                    else if (KEY_AS("rn")) {
+                        if (getInt()) selector->random = rand();
+                    }
                     else if (KEY_AS("sh")) selector->shape = (LottieTextRange::Shape) getInt();
                     else if (KEY_AS("o")) parseProperty<LottieProperty::Type::Float>(selector->offset);
                     else if (KEY_AS("r")) selector->rangeUnit = (LottieTextRange::Unit) getInt();


### PR DESCRIPTION
Issue: #2178 

[text-range-randomize.json](https://github.com/user-attachments/files/17008794/text-range-randomize.json)


https://github.com/user-attachments/assets/00003b27-efcd-4e32-87ca-acc7dfe1c14d

---

Applied Text Range randomization.

On each parse, if the `randomize` is enabled, the start and end of the Text Range are redefined with the same gap as the original range.