### PR TITLE
renderer: hotfix a crash

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -202,7 +202,6 @@ void GlRenderer::drawPrimitive(GlShape& sdata, uint8_t r, uint8_t g, uint8_t b, 
 
 void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFlag flag, int32_t depth)
 {
-
     const auto& vp = currentPass()->getViewport();
     auto bbox = sdata.geometry->getViewport();
 
@@ -1006,7 +1005,6 @@ bool GlRenderer::renderImage(void* data)
 bool GlRenderer::renderShape(RenderData data)
 {
     auto sdata = static_cast<GlShape*>(data);
-    if (!sdata) return false;
 
     if (currentPass()->isEmpty()) return true;
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -51,8 +51,9 @@ struct Shape::Impl
 
     bool render(RenderMethod* renderer)
     {
+        if (!rd) return false;
+
         Compositor* cmp = nullptr;
-        bool ret;
 
         renderer->blend(shape->blend());
 
@@ -61,7 +62,7 @@ struct Shape::Impl
             renderer->beginComposite(cmp, CompositeMethod::None, opacity);
         }
 
-        ret = renderer->renderShape(rd);
+        auto ret = renderer->renderShape(rd);
         if (cmp) renderer->endComposite(cmp);
         return ret;
     }
@@ -117,6 +118,7 @@ struct Shape::Impl
 
     RenderRegion bounds(RenderMethod* renderer)
     {
+        if (!rd) return {0, 0, 0, 0};
         return renderer->region(rd);
     }
 


### PR DESCRIPTION
prevent a nullptr memory access
regression by f5337015e971d24379d2ee664895503ab8945e13

issue: https://github.com/godotengine/godot/issues/97078