### PR TITLE
wg_engine: fix vertices while line joining

### DIFF
--- a/src/renderer/wg_engine/tvgWgGeometry.cpp
+++ b/src/renderer/wg_engine/tvgWgGeometry.cpp
@@ -336,7 +336,7 @@ void WgGeometryData::appendStrokeJoin(const WgPoint& v0, const WgPoint& v1, cons
     if (join == StrokeJoin::Round) {
         appendCircle(v1, halfWidth);
     } else if (join == StrokeJoin::Bevel) {
-        appendRect(v1 - offset0, v1 + offset0, v1 - offset1, v1 + offset1);
+        appendRect(v1 - offset0, v1 + offset1, v1 - offset1, v1 + offset0);
     } else if (join == StrokeJoin::Miter) {
         WgPoint nrm = (nrm0 + nrm1);
         if (!tvg::zero(dir0.x * dir1.y -  dir0.y * dir1.x)) {
@@ -348,7 +348,7 @@ void WgGeometryData::appendStrokeJoin(const WgPoint& v0, const WgPoint& v1, cons
                 appendRect(v1 + nrm * (halfWidth / cosine), v1 + offset0, v1 + offset1, v1);
                 appendRect(v1 - nrm * (halfWidth / cosine), v1 - offset0, v1 - offset1, v1);
             } else {
-                appendRect(v1 - offset0, v1 + offset0, v1 - offset1, v1 + offset1);
+                appendRect(v1 - offset0, v1 + offset1, v1 - offset1, v1 + offset0);
             }
         }
     }


### PR DESCRIPTION
Vertex ordering during line join needed adjustment. Vertices were forming two partialy overlapping triangles instead of a rectangle. The issue was rarely visible since the resulting rectangle often overlapped significantly with other rectangles.

before:
<img width="300" alt="Zrzut ekranu 2024-09-17 o 22 09 45" src="https://github.com/user-attachments/assets/cad04765-d9dd-46ac-8110-a90ad01f90d2">

after:
<img width="300" alt="Zrzut ekranu 2024-09-17 o 22 08 52" src="https://github.com/user-attachments/assets/a991c62e-bf33-4089-a6fb-111342c2c602">

sample:
```
        auto shape = tvg::Shape::gen();
        shape->moveTo(-2, -40);
        shape->lineTo(34.641, 20);
        shape->lineTo(-34.641, 20);
        shape->lineTo(0, -40);
        shape->close();
        shape->strokeFill(255, 0, 0, 150);
        shape->strokeWidth(20);
        shape->strokeCap(tvg::StrokeCap::Butt);
        shape->strokeJoin(tvg::StrokeJoin::Bevel);
```

