### PR TITLE
lottie/text: Fix incorrect text range without end condition

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1060,6 +1060,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                 }
                 shape->fill(doc.color.rgb[0], doc.color.rgb[1], doc.color.rgb[2]);
                 shape->translate(cursor.x, cursor.y);
+                shape->opacity(255);
 
                 if (doc.stroke.render) {
                     shape->strokeJoin(StrokeJoin::Round);

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -180,7 +180,7 @@ struct LottieTextRange
     LottieFloat maxAmount = 0.0f;
     LottieFloat smoothness = 0.0f;
     LottieFloat start = 0.0f;
-    LottieFloat end = 0.0f;
+    LottieFloat end = FLT_MAX;
     Based based = Chars;
     Shape shape = Square;
     Unit rangeUnit = Percent;


### PR DESCRIPTION
Improving text render compatibility by fixing wrong Text Range.

When lottie doesn't have `end` prop in the range, system must ignore condition regarding to `end`.

The original logic unintentionally swaps `start` and `end` prop, because `end` is the zero in this case. Then the text range animation behaves the opposite.

---

This fixes 5 animations below. It might work for the others which look opposite in animation and run by text range selector.

- [27329.json](https://github.com/user-attachments/files/17039125/27329.json)
- [18580.json](https://github.com/user-attachments/files/17039136/18580.json)
- [17939.json](https://github.com/user-attachments/files/17039138/17939.json)
- [36644.json](https://github.com/user-attachments/files/17039139/36644.json)
- [32248.json](https://github.com/user-attachments/files/17039308/32248.json)


---

**[ThorVG Before]**

https://github.com/user-attachments/assets/c80271f3-f79d-4c83-8a41-312736575e0c

**[ThorVG After]**


https://github.com/user-attachments/assets/164b7647-30cd-4a11-90f1-4e6471c2730c


**[lottie-web]**


https://github.com/user-attachments/assets/eef8be6e-f2eb-402b-9d50-b88ad10bdedd

