### PR TITLE
lottie/text: hotfix for parsing text range issue

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1123,7 +1123,7 @@ void LottieParser::parseTextRange(LottieText* text)
                     else if (KEY_AS("ne")) parseProperty<LottieProperty::Type::Float>(selector->minEase);
                     else if (KEY_AS("a")) parseProperty<LottieProperty::Type::Float>(selector->maxAmount);
                     else if (KEY_AS("b")) selector->based = (LottieTextRange::Based) getInt();
-                    else if (KEY_AS("rn") && getInt()) selector->random = rand();
+                    else if (KEY_AS("rn")) selector->random = getInt() ? rand() : 0;
                     else if (KEY_AS("sh")) selector->shape = (LottieTextRange::Shape) getInt();
                     else if (KEY_AS("o")) parseProperty<LottieProperty::Type::Float>(selector->offset);
                     else if (KEY_AS("r")) selector->rangeUnit = (LottieTextRange::Unit) getInt();


### PR DESCRIPTION
If randomize is not enabled, "rn" prop falls into skip()

---

[36644.json](https://github.com/user-attachments/files/17054054/36644.json)

It won't be rendered after latest text range patch.