### PR TITLE
svg_loader: Fix calculation when stroke-width unit is percentage

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -177,6 +177,7 @@ static float _toFloat(const SvgParser* svgParse, const char* str, SvgParserLengt
     else if (strstr(str, "%")) {
         if (type == SvgParserLengthType::Vertical) parsedValue = (parsedValue / 100.0f) * svgParse->global.h;
         else if (type == SvgParserLengthType::Horizontal) parsedValue = (parsedValue / 100.0f) * svgParse->global.w;
+        else if (type == SvgParserLengthType::Diagonal) parsedValue = (sqrtf(powf(svgParse->global.w, 2) + powf(svgParse->global.h, 2)) / sqrtf(2.0f)) * (parsedValue / 100.0f);
         else //if other than it's radius
         {
             float max = svgParse->global.w;
@@ -1066,7 +1067,7 @@ static void _handleStrokeDashOffsetAttr(SvgLoaderData* loader, SvgNode* node, co
 static void _handleStrokeWidthAttr(SvgLoaderData* loader, SvgNode* node, const char* value)
 {
     node->style->stroke.flags = (node->style->stroke.flags | SvgStrokeFlags::Width);
-    node->style->stroke.width = _toFloat(loader->svgParse, value, SvgParserLengthType::Horizontal);
+    node->style->stroke.width = _toFloat(loader->svgParse, value, SvgParserLengthType::Diagonal);
 }
 
 

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -215,6 +215,7 @@ enum class SvgParserLengthType
 {
     Vertical,
     Horizontal,
+    Diagonal,
     //In case of, for example, radius of radial gradient
     Other
 };


### PR DESCRIPTION
When stroke-width unit is percentage, loader refer to the normalized diagonal of viewport.
+) Add Width type so as not to affect existing types.

https://svgwg.org/svg2-draft/painting.html#StrokeWidth
https://svgwg.org/svg2-draft/coords.html#Units

example)
```
<svg width="100" height="50" xmlns="http://www.w3.org/2000/svg">
   <rect x="15" y="15" width="70" height="20" fill="none" stroke="#F00" stroke-width="10%"/>
   <rect x="15" y="15" width="70" height="20" fill="none" stroke="#00F" stroke-opacity=".3" stroke-width="10"/>
</svg>

```

related issue: https://github.com/thorvg/thorvg/issues/2131