### PR TITLE
svg_loader: fix circle radius if in percentages

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1615,7 +1615,7 @@ static constexpr struct
 } circleTags[] = {
     {"cx", SvgParserLengthType::Horizontal, sizeof("cx"), offsetof(SvgCircleNode, cx)},
     {"cy", SvgParserLengthType::Vertical, sizeof("cy"), offsetof(SvgCircleNode, cy)},
-    {"r", SvgParserLengthType::Other, sizeof("r"), offsetof(SvgCircleNode, r)}
+    {"r", SvgParserLengthType::Diagonal, sizeof("r"), offsetof(SvgCircleNode, r)}
 };
 
 


### PR DESCRIPTION
regarding https://github.com/thorvg/thorvg/pull/2750#issuecomment-2364333927 by @MewPurPur 

before:
<img width="226" alt="Zrzut ekranu 2024-09-23 o 13 56 15" src="https://github.com/user-attachments/assets/cf67e75f-9c4f-441a-9f35-ab42f7986696">

after:
<img width="233" alt="Zrzut ekranu 2024-09-23 o 13 55 38" src="https://github.com/user-attachments/assets/8f5f1ff1-0a4b-43e3-915b-7780cc5eae71">

sample:
```
<svg width="1600" height="600" xmlns="http://www.w3.org/2000/svg">
     <rect x="10%" y="100" width="40%" height="400" fill="none" stroke="#00f" stroke-width="10%" />
     <circle cx="20%" cy="250" r="10%" opacity="0.5" />
</svg>
```