### PR TITLE
wg_engine: avoid adding the same points to the ver buf

### DIFF
--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -119,6 +119,7 @@ struct WgVertexBuffer {
 
     // append point
     void append(const Point& p) {
+        if (vcount > 0 && vbuff[vcount - 1] == p) return;
         vbuff[vcount] = p;
         vcount++;
     }


### PR DESCRIPTION
This prevents division by zero in the later stage.

sample:
```
        auto shape1 = tvg::Shape::gen();
        shape1->appendCircle(245, 125, 50, 120);
        shape1->appendCircle(245, 365, 50, 120);
        shape1->fill(0, 50, 155, 100);
        shape1->strokeFill(0, 0, 255);
        shape1->strokeJoin(tvg::StrokeJoin::Round);
        shape1->strokeCap(tvg::StrokeCap::Round);
        shape1->strokeWidth(12);
        shape1->strokeTrim(0.5f, 0.51f, true);
        canvas->push(std::move(shape1));
```
