### PR TITLE
wg_engine: fix stroke trimming

### DIFF
--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -174,9 +174,11 @@ struct WgVertexBuffer {
         // append points
         float t_beg = len_seg_beg > 0.0f ? 1.0f - (len_total_beg - len_beg) / len_seg_beg : 0.0f;
         float t_end = len_seg_end > 0.0f ? 1.0f - (len_total_end - len_end) / len_seg_end : 0.0f;
-        if (index_beg > 0) append(lerp(buff.vbuff[index_beg-1], buff.vbuff[index_beg], t_beg));
+        //t_beg == 1 handled in appendRange
+        if (index_beg > 0 && t_beg != 1.0f) append(lerp(buff.vbuff[index_beg-1], buff.vbuff[index_beg], t_beg));
         appendRange(buff, index_beg, index_end);
-        if (index_end > 0) append(lerp(buff.vbuff[index_end-1], buff.vbuff[index_end], t_end));
+        //t_end == 0 handled in appendRange
+        if (index_end > 0 && t_end != 0.0f) append(lerp(buff.vbuff[index_end-1], buff.vbuff[index_end], t_end));
     }
 
 

--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -125,15 +125,8 @@ struct WgVertexBuffer {
 
     // append source vertex buffer in index range from start to end (end not included)
     void appendRange(const WgVertexBuffer& buff, size_t start_index, size_t end_index) {
-        if (start_index <= end_index)
-            for (size_t i = start_index; i < end_index; i++)
-                append(buff.vbuff[i]);
-        if (start_index > end_index) {
-            for (size_t i = start_index; i < buff.vcount; i++)
-                append(buff.vbuff[i]);
-            for (size_t i = 0; i < end_index; i++)
-                append(buff.vbuff[i]);
-        }
+        for (size_t i = start_index; i < end_index; i++)
+            append(buff.vbuff[i]);
     }
 
     // append circle (list of triangles)


### PR DESCRIPTION
[wg_engine: fix stroke trimming](https://github.com/thorvg/thorvg/commit/8e907fc62d4eccb97d4c0c07f4125e8d41dc337c) 

Fix cases when begin < 0 - this require handling the stroke
in two parts: begin - 0 and 0 - end.
Improve trimming for simultaneous=true.


[wg_engine: prevent adding duplicate points while trimming](https://github.com/thorvg/thorvg/commit/6edf12830df606db865ad75802c3d4ff3d743801) 

In cases where the distance between points is 0, further
processing of the points results in division by zero.
To avoid this check, we ensure that duplicate points are
not added during trimming.

1) SIMUL = TRUE:
before (sw vs wg):
<img width="1432" alt="beforeSimTrue" src="https://github.com/user-attachments/assets/d0de0fd8-1847-4f0c-bcfc-bb792f9adc02">

after:
<img width="1436" alt="afterSimTrue" src="https://github.com/user-attachments/assets/9e21701a-567a-4575-bef8-ba381142b361">

2) SIMUL = FALSE:
before (sw vs wg):
<img width="1435" alt="beforeSimFalse" src="https://github.com/user-attachments/assets/bca1ff95-0189-4d97-ad30-8bb683af450f">

after:
<img width="1435" alt="afterSimFalse" src="https://github.com/user-attachments/assets/b8e2906d-f4c7-4914-b8cc-e6ed8b03c115">


sample:
```
        auto sim = false;

        auto shape1 = tvg::Shape::gen();
        shape1->appendRect(10, 10, 100, 100);
        shape1->appendRect(210, 10, 100, 100);
        shape1->appendRect(410, 10, 100, 100);
        shape1->appendRect(610, 10, 100, 100);
        shape1->fill(0, 50, 155, 100);
        shape1->strokeFill(0, 0, 255);
        shape1->strokeJoin(tvg::StrokeJoin::Round);
        shape1->strokeCap(tvg::StrokeCap::Round);
        shape1->strokeWidth(5);
        shape1->strokeTrim(0.25f, 0.5f, sim);

        auto shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
        shape2->translate(0, 110);
        shape2->strokeTrim(0.249f, 0.501f, sim);
        canvas->push(std::move(shape2));

        shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
        shape2->translate(0, 220);
        shape2->strokeTrim(0.0f, 0.1f, sim);
        canvas->push(std::move(shape2));

        shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
        shape2->translate(0, 330);
        shape2->strokeTrim(0.9f, 1.0f, sim);
        canvas->push(std::move(shape2));

        shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
        shape2->translate(0, 440);
        shape2->strokeTrim(-0.25f, 0.1f, sim);
        canvas->push(std::move(shape2));

        shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
        shape2->translate(0, 550);
        shape2->strokeTrim(-0.5f, 0.0f, sim);
        canvas->push(std::move(shape2));

        shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
        shape2->translate(0, 660);
        shape2->strokeTrim(0.75f, 1.5f, sim);
        canvas->push(std::move(shape2));

        canvas->push(std::move(shape1));
```

