### PR TITLE
sw_engine: fix translucent grad rastering

### DIFF
--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -1507,7 +1507,8 @@ static bool _rasterTranslucentGradientRle(SwSurface* surface, const SwRle* rle, 
     } else if (surface->channelSize == sizeof(uint8_t)) {
         for (uint32_t i = 0; i < rle->size; ++i, ++span) {
             auto dst = &surface->buf8[span->y * surface->stride + span->x];
-            fillMethod()(fill, dst, span->y, span->x, span->len, _opMaskAdd, 255);
+            if (span->coverage == 255) fillMethod()(fill, dst, span->y, span->x, span->len, _opMaskNone, 255);
+            else fillMethod()(fill, dst, span->y, span->x, span->len, _opMaskAdd, span->coverage);
         }
     }
     return true;


### PR DESCRIPTION
8bit translucent gradient rle were missing AA. Fixed.

sample: 
[mask_op_99_rle.json](https://github.com/user-attachments/files/17156436/mask_op_99_rle.json)

before (see corners):
<img width="334" alt="Zrzut ekranu 2024-09-27 o 00 01 49" src="https://github.com/user-attachments/assets/e7a1aac2-548d-441b-9b4c-d2692efd9d77">

after:
<img width="336" alt="Zrzut ekranu 2024-09-27 o 00 02 01" src="https://github.com/user-attachments/assets/07b8e1ab-e2b6-46ff-9864-050cf2a3ef78">
