### PR TITLE
renderer: fix clipped clippers

### DIFF
--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -278,7 +278,7 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
     if (this->clipper) {
         P(this->clipper)->ctxFlag &= ~ContextFlag::FastTrack;   //reset
         viewport = renderer->viewport();
-        if ((compFastTrack = _compFastTrack(renderer, this->clipper, pm, viewport)) == Result::Success) {
+        if (!P(this->clipper)->clipper && (compFastTrack = _compFastTrack(renderer, this->clipper, pm, viewport)) == Result::Success) {
             P(this->clipper)->ctxFlag |= ContextFlag::FastTrack;
         }
         if (compFastTrack == Result::InsufficientCondition) {


### PR DESCRIPTION
Fast track was applied for clippers even if they
were also clipped. As a result their clips were
omitted.

@Issue: https://github.com/thorvg/thorvg/issues/2777

before:
<img width="273" alt="Zrzut ekranu 2024-09-27 o 12 20 47" src="https://github.com/user-attachments/assets/5404608b-033e-4b4d-aff9-66ccc424122f">

after:
<img width="216" alt="Zrzut ekranu 2024-09-27 o 12 20 26" src="https://github.com/user-attachments/assets/a4c939f7-876f-48c8-b23c-7b29fecc91c6">

sample:
```
        //correct
        {
            auto rect1 = tvg::Shape::gen();
            rect1->appendRect(0,0,800,800);
            rect1->fill(0,0,255);

            auto shape1 = tvg::Shape::gen();
            shape1->moveTo(65, 15);
            shape1->lineTo(165, 15);
            shape1->lineTo(165, 115);
            shape1->lineTo(65, 115);
            shape1->lineTo(65, 15);
            shape1->close();
            shape1->fill(255, 0, 0);

            auto bbox1 = tvg::Shape::gen();
            bbox1->appendRect(70, 20, 20, 100);
            shape1->composite(std::move(bbox1), tvg::CompositeMethod::ClipPath);

            rect1->composite(std::move(shape1), tvg::CompositeMethod::ClipPath);

            canvas->push(std::move(rect1));
        }

        //not correct
        {
            float shift = 100;

            auto rect1 = tvg::Shape::gen();
            rect1->appendRect(0,0,800,800);
            rect1->fill(0,0,255);

            auto shape1 = tvg::Shape::gen();
            shape1->moveTo(65 + shift, 15);
            shape1->lineTo(165 + shift, 15);
            shape1->lineTo(165 + shift, 115);
            shape1->lineTo(65 + shift, 115);
            shape1->close();
            shape1->fill(255, 0, 0);

            auto bbox1 = tvg::Shape::gen();
            bbox1->appendRect(70 + shift, 20, 20, 100);
            shape1->composite(std::move(bbox1), tvg::CompositeMethod::ClipPath);

            rect1->composite(std::move(shape1), tvg::CompositeMethod::ClipPath);

            canvas->push(std::move(rect1));
        }
```