### PR TITLE
lottie: fix gradient with transparency stops

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -188,10 +188,10 @@ uint32_t LottieGradient::populate(ColorStop& color)
     colorStops.populated = true;
     if (!color.input) return 0;
 
-    uint32_t alphaCnt = (color.input->count - (colorStops.count * 4)) / 2;
-    Array<Fill::ColorStop> output(colorStops.count + alphaCnt);
+    uint32_t alphaCnt = (color.input->count - (colorStops.countOrg * 4)) / 2;
+    Array<Fill::ColorStop> output(colorStops.countOrg + alphaCnt);
     uint32_t cidx = 0;               //color count
-    uint32_t clast = colorStops.count * 4;
+    uint32_t clast = colorStops.countOrg * 4;
     if (clast > color.input->count) clast = color.input->count;
     uint32_t aidx = clast;           //alpha count
     Fill::ColorStop cs;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -735,7 +735,7 @@ void LottieParser::parseGradient(LottieGradient* gradient, const char* key)
     {
         enterObject();
         while (auto key = nextObjectKey()) {
-            if (KEY_AS("p")) gradient->colorStops.count = getInt();
+            if (KEY_AS("p")) gradient->colorStops.countOrg = getInt();
             else if (KEY_AS("k")) parseProperty<LottieProperty::Type::ColorStop>(gradient->colorStops, gradient);
             else skip(key);
         }

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -502,6 +502,7 @@ struct LottieColorStop : LottieProperty
     Array<LottieScalarFrame<ColorStop>>* frames = nullptr;
     ColorStop value;
     uint16_t count = 0;     //colorstop count
+    uint16_t countOrg = 0;  //originaly declared number of colors in a frame
     bool populated = false;
 
     ~LottieColorStop()
@@ -620,6 +621,7 @@ struct LottieColorStop : LottieProperty
         }
         populated = other.populated;
         count = other.count;
+        countOrg = other.countOrg;
 
         return *this;
     }


### PR DESCRIPTION
In cases where transparency stops were provided
with different offset values than color stops,
the interpolated colors/alpha values were incorrect. Additionally, there was an out-of-bounds access
in the colorStops array. Both fixed.

@Issue: https://github.com/thorvg/thorvg/issues/2765

before:
https://github.com/user-attachments/assets/d680d5ee-9fc5-449d-a372-7817bacab2ad


after:
https://github.com/user-attachments/assets/702eab1f-7704-42cd-a0a5-8392a03f1c3e


samples:
[alphaOver.json](https://github.com/user-attachments/files/17171823/alphaOver.json)
[23.json](https://github.com/user-attachments/files/17171822/23.json)
