### PR TITLE
wg_engine: CompositeMethod::ClipPath will be replaced with the Scene::clip()

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -59,7 +59,7 @@ private:
 
     static WgPipelineBlendType blendMethodToBlendType(BlendMethod blendMethod);
 
-    void composeRegion(WgContext& context, WgRenderStorage* src, WgRenderStorage* mask, CompositeMethod composeMethod, RenderRegion& rect);
+    void clipRegion(WgContext& context, WgRenderStorage* src, WgRenderStorage* mask, RenderRegion& rect);
     RenderRegion shrinkRenderRegion(RenderRegion& rect);
 public:
     // render target dimensions
@@ -82,9 +82,10 @@ public:
     void blendImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod);
     void blendScene(WgContext& context, WgRenderStorage* src, WgCompose* cmp);
 
-    void composeShape(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask, CompositeMethod composeMethod);
-    void composeStrokes(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask, CompositeMethod composeMethod);
-    void composeImage(WgContext& context, WgRenderDataPicture* renderData, WgRenderStorage* mask, CompositeMethod composeMethod);
+    void drawShapeClipped(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask);
+    void drawStrokesClipped(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask);
+    void drawImageClipped(WgContext& context, WgRenderDataPicture* renderData, WgRenderStorage* mask);
+    
     void composeScene(WgContext& context, WgRenderStorage* src, WgRenderStorage* mask, WgCompose* cmp);
 
     void drawClipPath(WgContext& context, WgRenderDataShape* renderData);

--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -324,7 +324,7 @@ void WgPipelines::initialize(WgContext& context)
             WGPUCompareFunction_Always, WGPUStencilOperation_Zero,
             primitiveState, multisampleState, blendStateSrc);
 
-    // render pipeline blit
+    // render pipeline blend
     sceneBlend = createRenderPipeline(context.device, "The render pipeline scene blend",
             shaderSceneBlend, "vs_main", "fs_main", layoutSceneBlend,
             vertexBufferLayoutsImage, 2,
@@ -333,10 +333,21 @@ void WgPipelines::initialize(WgContext& context)
             WGPUCompareFunction_Always, WGPUStencilOperation_Zero,
             primitiveState, multisampleState, blendStateNrm);
 
+    // render pipeline scene clip path
+    sceneClip = createRenderPipeline(
+        context.device, "The render pipeline scene clip path",
+        shaderSceneComp, "vs_main", "fs_main_ClipPath", layoutSceneComp,
+        vertexBufferLayoutsImage, 2,
+        WGPUColorWriteMask_All, offscreenTargetFormat,
+        WGPUCompareFunction_Always, WGPUStencilOperation_Zero,
+        WGPUCompareFunction_Always, WGPUStencilOperation_Zero,
+        primitiveState, multisampleState, blendStateNrm);
+
+    // TODO: remove fs_main_ClipPath shader from list after removing CompositeMethod::ClipPath value
     // compose shader names
     const char* shaderComposeNames[] {
         "fs_main_None",
-        "fs_main_ClipPath",
+        "fs_main_ClipPath", // TODO: remove after CompositeMethod updated
         "fs_main_AlphaMask",
         "fs_main_InvAlphaMask",
         "fs_main_LumaMask",
@@ -349,10 +360,11 @@ void WgPipelines::initialize(WgContext& context)
         "fs_main_DarkenMask"
     };
 
+    // TODO: remove fs_main_ClipPath shader from list after removing CompositeMethod::ClipPath value
     // compose shader blend states
     const WGPUBlendState composeBlends[] {
         blendStateNrm, // None
-        blendStateNrm, // ClipPath
+        blendStateNrm, // ClipPath // TODO: remove after CompositeMethod updated
         blendStateNrm, // AlphaMask
         blendStateNrm, // InvAlphaMask
         blendStateNrm, // LumaMask
@@ -429,6 +441,7 @@ void WgPipelines::releaseGraphicHandles(WgContext& context)
     releaseRenderPipeline(blit);
     releaseRenderPipeline(clipPath);
     releaseRenderPipeline(sceneBlend);
+    releaseRenderPipeline(sceneClip);
     size_t pipesSceneCompCnt = sizeof(sceneComp) / sizeof(sceneComp[0]);
     for (uint32_t i = 0; i < pipesSceneCompCnt; i++)
         releaseRenderPipeline(sceneComp[i]);

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -65,7 +65,8 @@ public:
     WGPURenderPipeline radial[2]{};
     WGPURenderPipeline linear[2]{};
     WGPURenderPipeline image[2]{};
-    WGPURenderPipeline sceneComp[12];
+    WGPURenderPipeline sceneClip;
+    WGPURenderPipeline sceneComp[12]; // TODO: update to 11 after removing CompositeMethod::ClipPath enum value
     WGPURenderPipeline sceneBlend;
     WGPURenderPipeline blit{};
     WGPURenderPipeline clipPath{};


### PR DESCRIPTION
wg_engine needs to refactor to remove the enum value usage before proceeding with its removal.
Please, see TODO in tvgWgPipelines.h/cpp

see https://github.com/thorvg/thorvg/issues/2783