### PR TITLE
lottie: fix mem leak

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -254,7 +254,8 @@ void LottieParser::getValue(ColorStop& color)
 {
     if (peekType() == kArrayType) enterArray();
 
-    color.input = new Array<float>(static_cast<LottieGradient*>(context.parent)->colorStops.count);
+    if (!color.input) color.input = new Array<float>(static_cast<LottieGradient*>(context.parent)->colorStops.count);
+    else color.input->clear();
 
     while (nextArrayValue()) color.input->push(getFloat());
 }


### PR DESCRIPTION
Mem leak was observed in a case the end values
(deprecated feature) were provided for the gradient.

@Issue: https://github.com/thorvg/thorvg/issues/2667