### PR TITLE
lottie: fix gradient populating

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -216,7 +216,7 @@ uint32_t LottieGradient::populate(ColorStop& color)
             if (output.count > 0) {
                 auto p = ((*color.input)[cidx] - output.last().offset) / ((*color.input)[aidx] - output.last().offset);
                 cs.a = lerp<uint8_t>(output.last().a, (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f), p);
-            } else cs.a = 255;
+            } else cs.a = (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f);
             cidx += 4;
         } else {
             cs.offset = (*color.input)[aidx];
@@ -227,7 +227,11 @@ uint32_t LottieGradient::populate(ColorStop& color)
                 cs.r = lerp<uint8_t>(output.last().r, (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f), p);
                 cs.g = lerp<uint8_t>(output.last().g, (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f), p);
                 cs.b = lerp<uint8_t>(output.last().b, (uint8_t)nearbyint((*color.input)[cidx + 3] * 255.0f), p);
-            } else cs.r = cs.g = cs.b = 255;
+            } else {
+                cs.r = (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f);
+                cs.g = (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f);
+                cs.b = (uint8_t)nearbyint((*color.input)[cidx + 3] * 255.0f);
+            }
             aidx += 2;
         }
         output.push(cs);


### PR DESCRIPTION
When populating the gradient, the color/alpha should be assigned the first possible value from the provided ones, rather than the default value of 255.

this problem is preset in https://github.com/thorvg/thorvg/issues/2765 in 23.json file, but this is not the main issue.

before:
<img width="129" alt="Zrzut ekranu 2024-09-30 o 14 12 02" src="https://github.com/user-attachments/assets/1ced798f-52bf-4f91-a960-eeca7ffbd36d">

after (same as skottie, lottie web SVG; lottie web canvas seems not to use alpha):
<img width="124" alt="Zrzut ekranu 2024-09-30 o 14 12 51" src="https://github.com/user-attachments/assets/45991dd9-1e9e-4160-92d3-4ff62806387c">

sample:
[fixPopulate.json](https://github.com/user-attachments/files/17189552/fixPopulate.json)
