### PR TITLE
gl_engine: implement darken and lighten mask method

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -99,6 +99,8 @@ void GlRenderer::initShaders()
     mPrograms.push_back(make_unique<GlProgram>(GlShader::gen(MASK_VERT_SHADER, MASK_SUB_FRAG_SHADER)));
     mPrograms.push_back(make_unique<GlProgram>(GlShader::gen(MASK_VERT_SHADER, MASK_INTERSECT_FRAG_SHADER)));
     mPrograms.push_back(make_unique<GlProgram>(GlShader::gen(MASK_VERT_SHADER, MASK_DIFF_FRAG_SHADER)));
+    mPrograms.push_back(make_unique<GlProgram>(GlShader::gen(MASK_VERT_SHADER, MASK_LIGHTEN_FRAG_SHADER)));
+    mPrograms.push_back(make_unique<GlProgram>(GlShader::gen(MASK_VERT_SHADER, MASK_DARKEN_FRAG_SHADER)));
     // stencil Renderer
     mPrograms.push_back(make_unique<GlProgram>(GlShader::gen(STENCIL_VERT_SHADER, STENCIL_FRAG_SHADER)));
     // blit Renderer
@@ -796,6 +798,12 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
                 break;
             case CompositeMethod::DifferenceMask:
                 program = mPrograms[RT_MaskDifference].get();
+                break;
+            case CompositeMethod::LightenMask:
+                program = mPrograms[RT_MaskLighten].get();
+                break;
+            case CompositeMethod::DarkenMask:
+                program = mPrograms[RT_MaskDarken].get();
                 break;
             default:
                 break;

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -47,6 +47,8 @@ public:
         RT_MaskSub,
         RT_MaskIntersect,
         RT_MaskDifference,
+        RT_MaskLighten,
+        RT_MaskDarken,
         RT_Stencil,
         RT_Blit,
         RT_MultiplyBlend,

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -473,6 +473,42 @@ void main() {                                                           \n
 }                                                                       \n
 );
 
+const char* MASK_DARKEN_FRAG_SHADER = TVG_COMPOSE_SHADER(
+uniform sampler2D uSrcTexture;                                          \n
+uniform sampler2D uMaskTexture;                                         \n
+                                                                        \n
+in vec2 vUV;                                                            \n
+                                                                        \n
+out vec4 FragColor;                                                     \n
+                                                                        \n
+void main() {                                                           \n
+    vec4 srcColor = texture(uSrcTexture, vUV);                          \n
+    vec4 maskColor = texture(uMaskTexture, vUV);                        \n
+    if (srcColor.a > 0.0) srcColor.rgb /= srcColor.a;                   \n
+    float alpha = min(srcColor.a, maskColor.a);                         \n
+                                                                        \n
+    FragColor = vec4(srcColor.rgb * alpha, alpha);                      \n
+}                                                                       \n
+);
+
+const char* MASK_LIGHTEN_FRAG_SHADER = TVG_COMPOSE_SHADER(
+uniform sampler2D uSrcTexture;                                          \n
+uniform sampler2D uMaskTexture;                                         \n
+                                                                        \n
+in vec2 vUV;                                                            \n
+                                                                        \n
+out vec4 FragColor;                                                     \n
+                                                                        \n
+void main() {                                                           \n
+    vec4 srcColor = texture(uSrcTexture, vUV);                          \n
+    vec4 maskColor = texture(uMaskTexture, vUV);                        \n
+    if (srcColor.a > 0.0) srcColor.rgb /= srcColor.a;                   \n
+    float alpha = max(srcColor.a, maskColor.a);                         \n
+                                                                        \n
+    FragColor = vec4(srcColor.rgb * alpha, alpha);                      \n
+}                                                                       \n
+);
+
 const char* STENCIL_VERT_SHADER = TVG_COMPOSE_SHADER(
     uniform float uDepth;                                           \n
     layout(location = 0) in vec2 aLocation;                         \n

--- a/src/renderer/gl_engine/tvgGlShaderSrc.h
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.h
@@ -39,6 +39,8 @@ extern const char* MASK_ADD_FRAG_SHADER;
 extern const char* MASK_SUB_FRAG_SHADER;
 extern const char* MASK_INTERSECT_FRAG_SHADER;
 extern const char* MASK_DIFF_FRAG_SHADER;
+extern const char* MASK_DARKEN_FRAG_SHADER;
+extern const char* MASK_LIGHTEN_FRAG_SHADER;
 extern const char* STENCIL_VERT_SHADER;
 extern const char* STENCIL_FRAG_SHADER;
 extern const char* BLIT_VERT_SHADER;


### PR DESCRIPTION
Add new shader to support darken and lighten mask method.
---------
Now the MaskingMethod example is correct:
<img width="1495" alt="截屏2024-09-30 19 05 33" src="https://github.com/user-attachments/assets/3f1a4ebf-eade-47a8-9b7d-5d4f35a7eb69">
