### PR TITLE
sw_engine: ignore small cubics

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -486,7 +486,7 @@ SwFixed mathSin(SwFixed angle);
 void mathSplitCubic(SwPoint* base);
 SwFixed mathDiff(SwFixed angle1, SwFixed angle2);
 SwFixed mathLength(const SwPoint& pt);
-bool mathSmallCubic(const SwPoint* base, SwFixed& angleIn, SwFixed& angleMid, SwFixed& angleOut);
+bool mathSmallCubic(const SwPoint* base, SwFixed& angleIn, SwFixed& angleMid, SwFixed& angleOut, bool& ignore);
 SwFixed mathMean(SwFixed angle1, SwFixed angle2);
 SwPoint mathTransform(const Point* to, const Matrix& transform);
 bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, bool fastTrack);

--- a/src/renderer/sw_engine/tvgSwMath.cpp
+++ b/src/renderer/sw_engine/tvgSwMath.cpp
@@ -44,16 +44,18 @@ SwFixed mathMean(SwFixed angle1, SwFixed angle2)
 }
 
 
-bool mathSmallCubic(const SwPoint* base, SwFixed& angleIn, SwFixed& angleMid, SwFixed& angleOut)
+bool mathSmallCubic(const SwPoint* base, SwFixed& angleIn, SwFixed& angleMid, SwFixed& angleOut, bool& ignore)
 {
     auto d1 = base[2] - base[3];
     auto d2 = base[1] - base[2];
     auto d3 = base[0] - base[1];
+    ignore = false;
 
     if (d1.small()) {
         if (d2.small()) {
             if (d3.small()) {
                 angleIn = angleMid = angleOut = 0;
+                ignore = true;
                 return true;
             } else {
                 angleIn = angleMid = angleOut = mathAtan(d3);

--- a/src/renderer/sw_engine/tvgSwStroke.cpp
+++ b/src/renderer/sw_engine/tvgSwStroke.cpp
@@ -441,7 +441,17 @@ static void _cubicTo(SwStroke& stroke, const SwPoint& ctrl1, const SwPoint& ctrl
         //initialize with current direction
         angleIn = angleOut = angleMid = stroke.angleIn;
 
-        if (arc < limit && !mathSmallCubic(arc, angleIn, angleMid, angleOut)) {
+        bool ignore;
+        auto small = mathSmallCubic(arc, angleIn, angleMid, angleOut, ignore);
+        if (ignore) {
+            if (arc == bezStack) {
+                stroke.center = to;
+                return;
+            }
+            arc -= 3;
+            continue;
+        }
+        if (arc < limit && !small) {
             if (stroke.firstPt) stroke.angleIn = angleIn;
             mathSplitCubic(arc);
             arc += 3;


### PR DESCRIPTION
During the stroke's outline calculation, the function handling small cubics set all angles to zero. When the cubic was small but not zero, this resulted in incorrect outlines. Now such curves are ignored.

Issue: https://github.com/thorvg/thorvg/issues/2776
Issue: https://github.com/thorvg/thorvg/issues/2712
issue: https://github.com/thorvg/thorvg/issues/2759