### PR TITLE
wg_engine: fix clip path visual artifacts

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -299,7 +299,7 @@ void WgCompositor::drawShapeClipped(WgContext& context, WgRenderDataShape* rende
     endRenderPass();
     // restore current render pass
     beginRenderPass(commandEncoder, target, false);
-    RenderRegion rect = shrinkRenderRegion(renderData->aabb);
+    RenderRegion rect { 0, 0, (int32_t)width, (int32_t)height };
     clipRegion(context, &storageInterm, mask, rect);
 }
 
@@ -322,7 +322,7 @@ void WgCompositor::drawStrokesClipped(WgContext& context, WgRenderDataShape* ren
     endRenderPass();
     // restore current render pass
     beginRenderPass(commandEncoder, target, false);
-    RenderRegion rect = shrinkRenderRegion(renderData->aabb);
+    RenderRegion rect { 0, 0, (int32_t)width, (int32_t)height };
     clipRegion(context, &storageInterm, mask, rect);
 }
 


### PR DESCRIPTION
Fixed wrongly applied clip path area.

see like.json
before/after
![image](https://github.com/user-attachments/assets/a97f22aa-919f-48d6-8ad7-dc71a4e1d7ed)
