### PR TITLE
wg_engine: fix custom scene blending with opacity

### DIFF
--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -435,13 +435,11 @@ fn getFragData(id: vec2u) -> FragData {
     data.Dc = colorDst.rgb;
     data.Da = colorDst.a;
     data.skip = false;
-    data.Sc = data.Sc * So;
-    data.Sa = data.Sa * So;
     return data;
 };
 
 fn postProcess(d: FragData, R: vec4f) -> vec4f {
-    return mix(vec4(d.Dc, d.Da), R, d.Sa);
+    return mix(vec4(d.Dc, d.Da), R, d.Sa * So);
 };
 )";
 


### PR DESCRIPTION
fixed incorrect opacity applience for scene blending

See guitar.json
Before/After
![image](https://github.com/user-attachments/assets/fbea087e-a226-44b1-883c-88ff5d87aa85)
