### PR TITLE
examples: fix mingw build error

### DIFF
--- a/examples/ImageRotation.cpp
+++ b/examples/ImageRotation.cpp
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#define _USE_MATH_DEFINES
 
 #include <cmath>
 #include "Example.h"


### PR DESCRIPTION
M_PI was not declared error solved