### PR TITLE
sw_engine: portability++

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -33,8 +33,8 @@
 #define SW_ANGLE_2PI (SW_ANGLE_PI << 1)
 #define SW_ANGLE_PI2 (SW_ANGLE_PI >> 1)
 
-using SwCoord = signed long;
-using SwFixed = signed long long;
+using SwCoord = int64_t;
+using SwFixed = int64_t;
 
 
 static inline float TO_FLOAT(SwCoord val)

--- a/src/renderer/sw_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/sw_engine/tvgSwPostEffect.cpp
@@ -169,7 +169,7 @@ bool effectGaussianBlur(SwImage& image, SwImage& buffer, const SwBBox& bbox, con
     auto back = buffer.buf8;
     auto swapped = false;
 
-    TVGLOG("SW_ENGINE", "GaussianFilter region(%ld, %ld, %ld, %ld) params(%f %d %d), level(%d)", bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y, params->sigma, params->direction, params->border, data->level);
+    TVGLOG("SW_ENGINE", "GaussianFilter region(%lld, %lld, %lld, %lld) params(%f %d %d), level(%d)", bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y, params->sigma, params->direction, params->border, data->level);
 
     //horizontal
     if (params->direction == 0 || params->direction == 1) {

--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -369,7 +369,7 @@ static bool _rasterMaskedRect(SwSurface* surface, const SwBBox& region, uint8_t 
     //8bit masking channels composition
     if (surface->channelSize != sizeof(uint8_t)) return false;
 
-    TVGLOG("SW_ENGINE", "Masked(%d) Rect [Region: %lu %lu %lu %lu]", (int)surface->compositor->method, region.min.x, region.min.y, region.max.x - region.min.x, region.max.y - region.min.y);
+    TVGLOG("SW_ENGINE", "Masked(%d) Rect [Region: %lld %lld %lld %lld]", (int)surface->compositor->method, region.min.x, region.min.y, region.max.x - region.min.x, region.max.y - region.min.y);
 
     auto maskOp = _getMaskOp(surface->compositor->method);
     if (_direct(surface->compositor->method)) return _rasterDirectMaskedRect(surface, region, maskOp, r, g, b, a);
@@ -386,7 +386,7 @@ static bool _rasterMattedRect(SwSurface* surface, const SwBBox& region, uint8_t 
     auto cbuffer = surface->compositor->image.buf8 + ((region.min.y * surface->compositor->image.stride + region.min.x) * csize);   //compositor buffer
     auto alpha = surface->alpha(surface->compositor->method);
 
-    TVGLOG("SW_ENGINE", "Matted(%d) Rect [Region: %lu %lu %u %u]", (int)surface->compositor->method, region.min.x, region.min.y, w, h);
+    TVGLOG("SW_ENGINE", "Matted(%d) Rect [Region: %lld %lld %u %u]", (int)surface->compositor->method, region.min.x, region.min.y, w, h);
     
     //32bits channels
     if (surface->channelSize == sizeof(uint32_t)) {
@@ -933,7 +933,7 @@ static bool _rasterScaledMattedImage(SwSurface* surface, const SwImage* image, c
     auto cbuffer = surface->compositor->image.buf8 + (region.min.y * surface->compositor->image.stride + region.min.x) * csize;
     auto alpha = surface->alpha(surface->compositor->method);
 
-    TVGLOG("SW_ENGINE", "Scaled Matted(%d) Image [Region: %lu %lu %lu %lu]", (int)surface->compositor->method, region.min.x, region.min.y, region.max.x - region.min.x, region.max.y - region.min.y);
+    TVGLOG("SW_ENGINE", "Scaled Matted(%d) Image [Region: %lld %lld %lld %lld]", (int)surface->compositor->method, region.min.x, region.min.y, region.max.x - region.min.x, region.max.y - region.min.y);
 
     auto scaleMethod = image->scale < DOWN_SCALE_TOLERANCE ? _interpDownScaler : _interpUpScaler;
     auto sampleSize = _sampleSize(image->scale);
@@ -1055,7 +1055,7 @@ static bool _rasterDirectMattedImage(SwSurface* surface, const SwImage* image, c
     auto sbuffer = image->buf32 + (region.min.y + image->oy) * image->stride + (region.min.x + image->ox);
     auto cbuffer = surface->compositor->image.buf8 + (region.min.y * surface->compositor->image.stride + region.min.x) * csize; //compositor buffer
 
-    TVGLOG("SW_ENGINE", "Direct Matted(%d) Image  [Region: %lu %lu %u %u]", (int)surface->compositor->method, region.min.x, region.min.y, w, h);
+    TVGLOG("SW_ENGINE", "Direct Matted(%d) Image  [Region: %lld %lld %u %u]", (int)surface->compositor->method, region.min.x, region.min.y, w, h);
 
     //32 bits
     if (surface->channelSize == sizeof(uint32_t)) {
@@ -1298,7 +1298,7 @@ static bool _rasterGradientMaskedRect(SwSurface* surface, const SwBBox& region, 
 {
     auto method = surface->compositor->method;
 
-    TVGLOG("SW_ENGINE", "Masked(%d) Gradient [Region: %lu %lu %lu %lu]", (int)method, region.min.x, region.min.y, region.max.x - region.min.x, region.max.y - region.min.y);
+    TVGLOG("SW_ENGINE", "Masked(%d) Gradient [Region: %lld %lld %lld %lld]", (int)method, region.min.x, region.min.y, region.max.x - region.min.x, region.max.y - region.min.y);
 
     auto maskOp = _getMaskOp(method);
 
@@ -1319,7 +1319,7 @@ static bool _rasterGradientMattedRect(SwSurface* surface, const SwBBox& region, 
     auto cbuffer = surface->compositor->image.buf8 + (region.min.y * surface->compositor->image.stride + region.min.x) * csize;
     auto alpha = surface->alpha(surface->compositor->method);
 
-    TVGLOG("SW_ENGINE", "Matted(%d) Gradient [Region: %lu %lu %u %u]", (int)surface->compositor->method, region.min.x, region.min.y, w, h);
+    TVGLOG("SW_ENGINE", "Matted(%d) Gradient [Region: %lld %lld %u %u]", (int)surface->compositor->method, region.min.x, region.min.y, w, h);
 
     for (uint32_t y = 0; y < h; ++y) {
         fillMethod()(fill, buffer, region.min.y + y, region.min.x, w, cbuffer, alpha, csize, 255);

--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -200,7 +200,7 @@
 constexpr auto PIXEL_BITS = 8;   //must be at least 6 bits!
 constexpr auto ONE_PIXEL = (1L << PIXEL_BITS);
 
-using Area = long;
+using Area = int64_t;
 
 struct Band
 {
@@ -257,7 +257,7 @@ struct RleWorker
 
 static inline SwPoint UPSCALE(const SwPoint& pt)
 {
-    return {SwCoord(((unsigned long) pt.x) << (PIXEL_BITS - 6)), SwCoord(((unsigned long) pt.y) << (PIXEL_BITS - 6))};
+    return {SwCoord(((uint64_t) pt.x) << (PIXEL_BITS - 6)), SwCoord(((uint64_t) pt.y) << (PIXEL_BITS - 6))};
 }
 
 
@@ -275,13 +275,13 @@ static inline SwCoord TRUNC(const SwCoord x)
 
 static inline SwPoint SUBPIXELS(const SwPoint& pt)
 {
-    return {SwCoord(((unsigned long) pt.x) << PIXEL_BITS), SwCoord(((unsigned long) pt.y) << PIXEL_BITS)};
+    return {SwCoord(((uint64_t) pt.x) << PIXEL_BITS), SwCoord(((uint64_t) pt.y) << PIXEL_BITS)};
 }
 
 
 static inline SwCoord SUBPIXELS(const SwCoord x)
 {
-    return SwCoord(((unsigned long) x) << PIXEL_BITS);
+    return SwCoord(((uint64_t) x) << PIXEL_BITS);
 }
 
 /*
@@ -501,8 +501,8 @@ static void _moveTo(RleWorker& rw, const SwPoint& to)
 static void _lineTo(RleWorker& rw, const SwPoint& to)
 {
 #define SW_UDIV(a, b) \
-    static_cast<SwCoord>(((unsigned long)(a) * (unsigned long)(b)) >> \
-    (sizeof(long) * CHAR_BIT - PIXEL_BITS))
+    static_cast<SwCoord>(((uint64_t)(a) * (uint64_t)(b)) >> \
+    (sizeof(int64_t) * CHAR_BIT - PIXEL_BITS))
 
     auto e1 = TRUNC(rw.pos);
     auto e2 = TRUNC(to);
@@ -552,8 +552,8 @@ static void _lineTo(RleWorker& rw, const SwPoint& to)
 
         /* These macros speed up repetitive divisions by replacing them
            with multiplications and right shifts. */
-        auto dx_r = static_cast<long>(ULONG_MAX >> PIXEL_BITS) / (diff.x);
-        auto dy_r = static_cast<long>(ULONG_MAX >> PIXEL_BITS) / (diff.y);
+        auto dx_r = static_cast<int64_t>(UINT64_MAX >> PIXEL_BITS) / (diff.x);
+        auto dy_r = static_cast<int64_t>(UINT64_MAX >> PIXEL_BITS) / (diff.y);
 
         /* The fundamental value `prod' determines which side and the  */
         /* exact coordinate where the line exits current cell.  It is  */


### PR DESCRIPTION
Replace long and long long with int64_t to ensure
sufficient viriables size.

@Issue: https://github.com/thorvg/thorvg/issues/2651

note:
the overflow occured in tvgSwRle.cpp in _lineTo() below line 564.
`prod`, `px`, `py` exceeded 1e9 (ignoring the sign here) and adding/subtracting them caused the result to exceed the maximum value of long