### PR TITLE
lottie: fixed a corrupted colorstop population

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -183,15 +183,14 @@ void LottieTrimpath::segment(float frameNo, float& start, float& end, LottieExpr
 }
 
 
-uint32_t LottieGradient::populate(ColorStop& color)
+uint32_t LottieGradient::populate(ColorStop& color, size_t count)
 {
-    colorStops.populated = true;
     if (!color.input) return 0;
 
-    uint32_t alphaCnt = (color.input->count - (colorStops.count * 4)) / 2;
-    Array<Fill::ColorStop> output(colorStops.count + alphaCnt);
+    uint32_t alphaCnt = (color.input->count - (count * 4)) / 2;
+    Array<Fill::ColorStop> output(count + alphaCnt);
     uint32_t cidx = 0;               //color count
-    uint32_t clast = colorStops.count * 4;
+    uint32_t clast = count * 4;
     if (clast > color.input->count) clast = color.input->count;
     uint32_t aidx = clast;           //alpha count
     Fill::ColorStop cs;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -558,13 +558,15 @@ struct LottieGradient : LottieObject
     bool prepare()
     {
         if (!colorStops.populated) {
+            auto count = colorStops.count;  //colorstop count can be modified after population
             if (colorStops.frames) {
                 for (auto v = colorStops.frames->begin(); v < colorStops.frames->end(); ++v) {
-                    colorStops.count = populate(v->value);
+                    colorStops.count = populate(v->value, count);
                 }
             } else {
-                colorStops.count = populate(colorStops.value);
+                colorStops.count = populate(colorStops.value, count);
             }
+            colorStops.populated = true;
         }
         if (start.frames || end.frames || height.frames || angle.frames || opacity.frames || colorStops.frames) return true;
         return false;
@@ -582,7 +584,7 @@ struct LottieGradient : LottieObject
     }
 
 
-    uint32_t populate(ColorStop& color);
+    uint32_t populate(ColorStop& color, size_t count);
     Fill* fill(float frameNo, LottieExpressions* exps);
 
     LottiePoint start = Point{0.0f, 0.0f};


### PR DESCRIPTION
the color stop number should be retained during
the population of frames

issue: https://github.com/thorvg/thorvg/issues/2765