### PR TITLE
sw_engine: prevent long overflow

### DIFF
--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -558,7 +558,12 @@ static void _lineTo(RleWorker& rw, const SwPoint& to)
         /* The fundamental value `prod' determines which side and the  */
         /* exact coordinate where the line exits current cell.  It is  */
         /* also easily updated when moving from one cell to the next.  */
+        size_t iter = 0;
         do {
+            if (++iter > UINT32_MAX) {
+                TVGLOG("SW_ENGINE", "Iteration limit reached during RLE generation. The resulting render may be incorrect.");
+                break;
+            }
             auto px = diff.x * ONE_PIXEL;
             auto py = diff.y * ONE_PIXEL;
 


### PR DESCRIPTION
If long has 32 bits on the system, it is possible
to go beyond the range of variable values.
As a workaroung introduced counter to prevent infinite loop.

@Issue: https://github.com/thorvg/thorvg/issues/2651