### PR TITLE
wasm: increase stack size for WebGPU

### DIFF
--- a/cross/wasm32_wg.txt
+++ b/cross/wasm32_wg.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sASYNCIFY=1']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sASYNCIFY=1', '-sSTACK_SIZE=2MB']
 
 [host_machine]
 system = 'emscripten'


### PR DESCRIPTION
Current WG Engine requires a minimum stack size of 1024KB to function properly.

---
STACK_SIZE must be increased for WG Engine's requirements.

As a result, less than 1024KB doesn't work with WebGPU, increased to minimal size.