### PR TITLE
lottie: add support for mask expansion

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1129,12 +1129,21 @@ void LottieBuilder::updateMaskings(LottieLayer* layer, float frameNo)
     auto pMask = static_cast<LottieMask*>(layer->masks[0]);
     auto pMethod = pMask->method;
     auto opacity = pMask->opacity(frameNo);
+    auto expand = pMask->expand(frameNo);
 
     auto pShape = layer->pooling();
     pShape->reset();
     pShape->fill(255, 255, 255, opacity);
     pShape->transform(layer->cache.matrix);
-    pMask->pathset(frameNo, P(pShape)->rs.path.cmds, P(pShape)->rs.path.pts, nullptr, nullptr, nullptr, exps);
+
+    //Apply Masking Expansion (Offset)
+    if (expand == 0.0f) {
+        pMask->pathset(frameNo, P(pShape)->rs.path.cmds, P(pShape)->rs.path.pts, nullptr, nullptr, nullptr, exps);
+    } else {
+        //TODO: Once path direction support is implemented, ensure that the direction is ignored here
+        auto offset = LottieOffsetModifier(pMask->expand(frameNo));
+        pMask->pathset(frameNo, P(pShape)->rs.path.cmds, P(pShape)->rs.path.pts, nullptr, nullptr, &offset, exps);
+    }
 
     auto compMethod = (pMethod == CompositeMethod::SubtractMask || pMethod == CompositeMethod::InvAlphaMask) ? CompositeMethod::InvAlphaMask : CompositeMethod::AlphaMask;
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -107,6 +107,7 @@ struct LottieGaussianBlur : LottieEffect
 struct LottieMask
 {
     LottiePathSet pathset;
+    LottieFloat expand = 0.0f;
     LottieOpacity opacity = 255;
     CompositeMethod method;
     bool inverse = false;

--- a/src/loaders/lottie/tvgLottieModifier.h
+++ b/src/loaders/lottie/tvgLottieModifier.h
@@ -47,7 +47,7 @@ struct LottieOffsetModifier
     float miterLimit;
     StrokeJoin join;
 
-    LottieOffsetModifier(float offset, float miter, StrokeJoin join) : offset(offset), miterLimit(miter), join(join) {};
+    LottieOffsetModifier(float offset, float miter = 4.0f, StrokeJoin join = StrokeJoin::Round) : offset(offset), miterLimit(miter), join(join) {};
 
     bool modifyPath(const PathCommand* inCmds, uint32_t inCmdsCnt, const Point* inPts, uint32_t inPtsCnt, Array<PathCommand>& outCmds, Array<Point>& outPts, bool clockwise) const;
     bool modifyPolystar(const Array<PathCommand>& inCmds, const Array<Point>& inPts, Array<PathCommand>& outCmds, Array<Point>& outPts, bool clockwise) const;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1233,6 +1233,7 @@ LottieMask* LottieParser::parseMask()
         }
         else if (valid && KEY_AS("pt")) getPathSet(mask->pathset);
         else if (valid && KEY_AS("o")) parseProperty<LottieProperty::Type::Opacity>(mask->opacity);
+        else if (valid && KEY_AS("x")) parseProperty<LottieProperty::Type::Float>(mask->expand);
         else skip(key);
     }
 


### PR DESCRIPTION
Implemented the mask attribute 'x' - expand mask.
Enforced rounded lines join according to tests in AE.

@Issue: https://github.com/thorvg/thorvg/issues/2832

sample: 
[expansion.json](https://github.com/user-attachments/files/17304492/expansion.json)

![Oct-09-2024 14-56-16](https://github.com/user-attachments/assets/d2c62909-7f3a-4ce0-80af-37dc92e5f914)
