### PR TITLE
wg_engine: fix aabb for empty shapes and long paths

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -48,9 +48,7 @@ void WgCompositor::initialize(WgContext& context, uint32_t width, uint32_t heigh
     storageInterm.initialize(context, width, height);
     storageDstCopy.initialize(context, width, height);
     // composition and blend geometries
-    WgVertexBufferInd vertexBuffer;
-    vertexBuffer.appendBlitBox();
-    meshData.update(context, vertexBuffer);
+    meshData.blitBox(context);
 }
 
 

--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -376,6 +376,8 @@ void WgCompositor::drawClipPath(WgContext& context, WgRenderDataShape* renderDat
     assert(renderData);
     assert(renderPassEncoder);
     assert(renderData->meshGroupShapes.meshes.count == renderData->meshGroupShapesBBox.meshes.count);
+    if (renderData->renderSettingsShape.skip) return;
+    if (renderData->meshGroupShapes.meshes.count == 0) return;
     if ((renderData->viewport.w <= 0) || (renderData->viewport.h <= 0)) return;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x, renderData->viewport.y, renderData->viewport.w, renderData->viewport.h);
     // setup stencil rules
@@ -404,6 +406,7 @@ void WgCompositor::drawShape(WgContext& context, WgRenderDataShape* renderData, 
     assert(renderData->meshGroupShapes.meshes.count == renderData->meshGroupShapesBBox.meshes.count);
     uint32_t blendTypeInd = (uint32_t)blendType;
     if (renderData->renderSettingsShape.skip) return;
+    if (renderData->meshGroupShapes.meshes.count == 0) return;
     if ((renderData->viewport.w <= 0) || (renderData->viewport.h <= 0)) return;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x, renderData->viewport.y, renderData->viewport.w, renderData->viewport.h);
     // setup stencil rules
@@ -442,6 +445,7 @@ void WgCompositor::drawStrokes(WgContext& context, WgRenderDataShape* renderData
     assert(renderData->meshGroupStrokes.meshes.count == renderData->meshGroupStrokesBBox.meshes.count);
     uint32_t blendTypeInd = (uint32_t)blendType;
     if (renderData->renderSettingsStroke.skip) return;
+    if (renderData->meshGroupStrokes.meshes.count == 0) return;
     if ((renderData->viewport.w <= 0) || (renderData->viewport.h <= 0)) return;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x, renderData->viewport.y, renderData->viewport.w, renderData->viewport.h);
     // draw strokes to stencil (first pass)

--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -335,7 +335,9 @@ struct WgVertexBufferInd {
         Point offset2 = nrm2 * halfWidth;
         Point nrm = normalize(nrm1 + nrm2);
         float cosine = dot(nrm, nrm1);
+        if (tvg::zero(cosine)) return;
         float angle = std::acos(dot(nrm1, -nrm2));
+        if (tvg::zero(angle) || tvg::equal(angle, M_PI)) return;
         float miterRatio = 1.0f / (std::sin(angle) * 0.5f);
         if (miterRatio <= miterLimit) {
             appendQuad(v1 + nrm * (halfWidth / cosine), v1 + offset2, v1 + offset1, v1);

--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -216,9 +216,9 @@ struct WgVertexBuffer {
 
 // simple indexed vertex buffer
 struct WgVertexBufferInd {
-    Point vbuff[WG_POINTS_COUNT*4];
-    Point tbuff[WG_POINTS_COUNT*4];
-    uint32_t ibuff[WG_POINTS_COUNT*8];
+    Point vbuff[WG_POINTS_COUNT*16];
+    Point tbuff[WG_POINTS_COUNT*16];
+    uint32_t ibuff[WG_POINTS_COUNT*16];
     size_t vcount = 0;
     size_t icount = 0;
 
@@ -235,42 +235,6 @@ struct WgVertexBufferInd {
             pmin = min(pmin, vbuff[i]);
             pmax = max(pmax, vbuff[i]);
         }
-    }
-
-    // append image box with tex coords
-    void appendImageBox(float w, float h) {
-        Point points[4] { { 0.0f, 0.0f }, { w, 0.0f }, { w, h }, { 0.0f, h } };
-        appendImageBox(points);
-    }
-
-    // append blit box with tex coords
-    void appendBlitBox() {
-        Point points[4] { { -1.0f, +1.0f }, { +1.0f, +1.0f }, { +1.0f, -1.0f }, { -1.0f, -1.0f } };
-        appendImageBox(points);
-    }
-
-    // append image box with tex coords
-    void appendImageBox(Point points[4]) {
-        // append vertexes
-        vbuff[vcount+0] = points[0];
-        vbuff[vcount+1] = points[1];
-        vbuff[vcount+2] = points[2];
-        vbuff[vcount+3] = points[3];
-        // append tex coords
-        tbuff[vcount+0] = { 0.0f, 0.0f };
-        tbuff[vcount+1] = { 1.0f, 0.0f };
-        tbuff[vcount+2] = { 1.0f, 1.0f };
-        tbuff[vcount+3] = { 0.0f, 1.0f };
-        // append indexes
-        ibuff[icount+0] = vcount + 0;
-        ibuff[icount+1] = vcount + 1;
-        ibuff[icount+2] = vcount + 2;
-        ibuff[icount+3] = vcount + 0;
-        ibuff[icount+4] = vcount + 2;
-        ibuff[icount+5] = vcount + 3;
-        // update buffer
-        vcount += 4;
-        icount += 6;
     }
 
     // append quad - two triangles formed from four points
@@ -362,7 +326,7 @@ struct WgVertexBufferInd {
     }
 
     // append miter joint
-    void appendMitter(const Point& v0, const Point& v1, const Point& v2, float dist1, float dist2, float halfWidth, float miterLimit) {
+    void appendMiter(const Point& v0, const Point& v1, const Point& v2, float dist1, float dist2, float halfWidth, float miterLimit) {
         Point sub1 = v1 - v0;
         Point sub2 = v2 - v1;
         Point nrm1 { +sub1.y / dist1, -sub1.x / dist1 };
@@ -433,7 +397,7 @@ struct WgVertexBufferInd {
                 appendBevel(buff.last(1), buff.vbuff[0], buff.vbuff[1], buff.lastDist(0), buff.vdist[1], halfWidth);
             // close by mitter
             else if (rstroke->join == StrokeJoin::Miter) {
-                appendMitter(buff.last(1), buff.vbuff[0], buff.vbuff[1], buff.lastDist(0), buff.vdist[1], halfWidth, rstroke->miterlimit);
+                appendMiter(buff.last(1), buff.vbuff[0], buff.vbuff[1], buff.lastDist(0), buff.vdist[1], halfWidth, rstroke->miterlimit);
             }
         }
 
@@ -444,7 +408,7 @@ struct WgVertexBufferInd {
         // append joints (mitter)
         } else if (rstroke->join == StrokeJoin::Miter) {
             for (size_t i = 1; i < buff.vcount - 1; i++)
-                appendMitter(buff.vbuff[i-1], buff.vbuff[i], buff.vbuff[i+1], buff.vdist[i], buff.vdist[i+1], halfWidth, rstroke->miterlimit);
+                appendMiter(buff.vbuff[i-1], buff.vbuff[i], buff.vbuff[i+1], buff.vdist[i], buff.vdist[i+1], halfWidth, rstroke->miterlimit);
         }
     }
 };

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -84,7 +84,7 @@ void WgMeshData::update(WgContext& context, const WgVertexBufferInd& vertexBuffe
 };
 
 
-void WgMeshData::update(WgContext& context, const Point pmin, const Point pmax)
+void WgMeshData::bbox(WgContext& context, const Point pmin, const Point pmax)
 {
     vertexCount = 4;
     indexCount = 6;
@@ -94,6 +94,32 @@ void WgMeshData::update(WgContext& context, const Point pmin, const Point pmax)
     };
     context.allocateBufferVertex(bufferPosition, data, sizeof(data));
     context.allocateBufferIndexFan(vertexCount);
+}
+
+
+void WgMeshData::imageBox(WgContext& context, float w, float h)
+{
+    vertexCount = 4;
+    indexCount = 6;
+    const float vdata[] = { 0.0f, 0.0f,    w, 0.0f,   w,    h,  0.0f, h    };
+    const float tdata[] = { 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f };
+    const uint32_t idata[] = { 0, 1, 2, 0, 2, 3 };
+    context.allocateBufferVertex(bufferPosition, vdata, sizeof(vdata));
+    context.allocateBufferVertex(bufferTexCoord, tdata, sizeof(tdata));
+    context.allocateBufferIndex(bufferIndex, idata, sizeof(idata));
+}
+
+
+void WgMeshData::blitBox(WgContext& context)
+{
+    vertexCount = 4;
+    indexCount = 6;
+    const float vdata[] = { -1.0f, +1.0f, +1.0f, +1.0f, +1.0f, -1.0f, -1.0f, -1.0f };
+    const float tdata[] = { +0.0f, +0.0f, +1.0f, +0.0f, +1.0f, +1.0f, +0.0f, +1.0f };
+    const uint32_t idata[] = { 0, 1, 2, 0, 2, 3 };
+    context.allocateBufferVertex(bufferPosition, vdata, sizeof(vdata));
+    context.allocateBufferVertex(bufferTexCoord, tdata, sizeof(tdata));
+    context.allocateBufferIndex(bufferIndex, idata, sizeof(idata));
 }
 
 
@@ -164,7 +190,7 @@ void WgMeshDataGroup::append(WgContext& context, const WgVertexBufferInd& vertex
 void WgMeshDataGroup::append(WgContext& context, const Point pmin, const Point pmax)
 {
     meshes.push(gMeshDataPool->allocate(context));
-    meshes.last()->update(context, pmin, pmax);
+    meshes.last()->bbox(context, pmin, pmax);
 }
 
 
@@ -272,6 +298,8 @@ void WgRenderSettings::release(WgContext& context)
 //***********************************************************************
 // WgRenderDataPaint
 //***********************************************************************
+
+WgVertexBufferInd* WgRenderDataPaint::gStrokesGenerator = nullptr;
 
 void WgRenderDataPaint::release(WgContext& context)
 {
@@ -412,11 +440,11 @@ void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rsha
             });
         }
     } 
-    // update shapes bbox (with empty path hadnling)
+    // update shapes bbox (with empty path handling)
     if ((this->meshGroupShapesBBox.meshes.count > 0 ) ||
         (this->meshGroupStrokesBBox.meshes.count > 0)) {
         updateAABB(tr);
-        meshDataBBox.update(context, pMin, pMax);
+        meshDataBBox.bbox(context, pMin, pMax);
     } else aabb = {0, 0, 0, 0};
 }
 
@@ -424,7 +452,7 @@ void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rsha
 void WgRenderDataShape::proceedStrokes(WgContext context, const RenderStroke* rstroke, float tbeg, float tend, const WgVertexBuffer& buff)
 {
     assert(rstroke);
-    WgVertexBufferInd stroke_buff;
+    gStrokesGenerator->reset();
     // trim -> dash -> stroke
     if ((tbeg != 0.0f) || (tend != 1.0f)) {
         if (tbeg == tend) return;
@@ -432,17 +460,17 @@ void WgRenderDataShape::proceedStrokes(WgContext context, const RenderStroke* rs
         trimed_buff.trim(buff, tbeg, tend);
         trimed_buff.updateDistances();
         // trim ->dash -> stroke
-        if (rstroke->dashPattern) stroke_buff.appendStrokesDashed(trimed_buff, rstroke);
+        if (rstroke->dashPattern) gStrokesGenerator->appendStrokesDashed(trimed_buff, rstroke);
         // trim -> stroke
-        else stroke_buff.appendStrokes(trimed_buff, rstroke);
+        else gStrokesGenerator->appendStrokes(trimed_buff, rstroke);
     } else
     // dash -> stroke
     if (rstroke->dashPattern) {
-        stroke_buff.appendStrokesDashed(buff, rstroke);
+        gStrokesGenerator->appendStrokesDashed(buff, rstroke);
     // stroke
     } else
-        stroke_buff.appendStrokes(buff, rstroke);
-    appendStroke(context, stroke_buff);
+        gStrokesGenerator->appendStrokes(buff, rstroke);
+    appendStroke(context, *gStrokesGenerator);
 }
 
 

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -412,9 +412,12 @@ void WgRenderDataShape::updateMeshes(WgContext &context, const RenderShape &rsha
             });
         }
     } 
-    // update shapes bbox
-    updateAABB(tr);
-    meshDataBBox.update(context, pMin, pMax);
+    // update shapes bbox (with empty path hadnling)
+    if ((this->meshGroupShapesBBox.meshes.count > 0 ) ||
+        (this->meshGroupStrokesBBox.meshes.count > 0)) {
+        updateAABB(tr);
+        meshDataBBox.update(context, pMin, pMax);
+    } else aabb = {0, 0, 0, 0};
 }
 
 
@@ -451,6 +454,7 @@ void WgRenderDataShape::releaseMeshes(WgContext &context)
     meshGroupShapes.release(context);
     pMin = {FLT_MAX, FLT_MAX};
     pMax = {0.0f, 0.0f};
+    aabb = {0, 0, 0, 0};
     clips.clear();
 }
 

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -39,7 +39,9 @@ struct WgMeshData {
 
     void update(WgContext& context, const WgVertexBuffer& vertexBuffer);
     void update(WgContext& context, const WgVertexBufferInd& vertexBufferInd);
-    void update(WgContext& context, const Point pmin, const Point pmax);
+    void bbox(WgContext& context, const Point pmin, const Point pmax);
+    void imageBox(WgContext& context, float w, float h);
+    void blitBox(WgContext& context);
     void release(WgContext& context);
 };
 
@@ -94,6 +96,9 @@ struct WgRenderSettings
 
 struct WgRenderDataPaint
 {
+    // global strokes generator. single instance
+    static WgVertexBufferInd* gStrokesGenerator;
+
     WGPUBuffer bufferModelMat{};
     WGPUBuffer bufferBlendSettings{};
     WGPUBindGroup bindGroupPaint{};

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -38,6 +38,7 @@ void WgRenderer::initialize()
 {
     mPipelines.initialize(mContext);
     WgMeshDataGroup::gMeshDataPool = new WgMeshDataPool();
+    WgRenderDataShape::gStrokesGenerator = new WgVertexBufferInd();
 }
 
 
@@ -47,6 +48,7 @@ void WgRenderer::release()
     mStorageRoot.release(mContext);
     mRenderStoragePool.release(mContext);
     mRenderDataShapePool.release(mContext);
+    delete WgRenderDataShape::gStrokesGenerator;
     WgMeshDataGroup::gMeshDataPool->release(mContext);
     delete WgMeshDataGroup::gMeshDataPool;
     mCompositorStack.clear();
@@ -128,11 +130,9 @@ RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
 
     // update image data
     if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Image)) {
-        WgVertexBufferInd vertexBufferInd;
-        vertexBufferInd.appendImageBox(surface->w, surface->h);
         mContext.pipelines->layouts.releaseBindGroup(renderDataPicture->bindGroupPicture);
         renderDataPicture->meshData.release(mContext);
-        renderDataPicture->meshData.update(mContext, vertexBufferInd);
+        renderDataPicture->meshData.imageBox(mContext, surface->w, surface->h);
         renderDataPicture->imageData.update(mContext, surface);
         renderDataPicture->bindGroupPicture = mContext.pipelines->layouts.createBindGroupTexSampled(
             mContext.samplerLinearRepeat, renderDataPicture->imageData.textureView


### PR DESCRIPTION
see https://github.com/thorvg/thorvg/issues/2843
fixed zero points path hendling
created a single shared instance of stoke generator in heap, instead of stack. No performace impact in this case