### PR TITLE
api: polish the thorvg API usages

### DIFF
--- a/examples/Blending.cpp
+++ b/examples/Blending.cpp
@@ -126,7 +126,7 @@ struct UserExample : tvgexam::Example
 
         //Lighten
         auto picture = tvg::Picture::gen();
-        if (!tvgexam::verify(picture->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(picture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         picture->translate(800, 700);
         picture->rotate(40);
         picture->blend(tvg::BlendMethod::Lighten);
@@ -141,7 +141,7 @@ struct UserExample : tvgexam::Example
 
         //ColorBurn
         auto picture2 = tvg::Picture::gen();
-        if (!tvgexam::verify(picture2->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(picture2->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         picture2->translate(600, 250);
         picture2->blend(tvg::BlendMethod::ColorBurn);
         picture2->opacity(150);
@@ -149,14 +149,14 @@ struct UserExample : tvgexam::Example
 
         //HardLight
         auto picture3 = tvg::Picture::gen();
-        if (!tvgexam::verify(picture3->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(picture3->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         picture3->translate(700, 150);
         picture3->blend(tvg::BlendMethod::HardLight);
         canvas->push(std::move(picture3));
 
         //SoftLight
         auto picture4 = tvg::Picture::gen();
-        if (!tvgexam::verify(picture4->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(picture4->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         picture4->translate(350, 600);
         picture4->rotate(90);
         picture4->blend(tvg::BlendMethod::SoftLight);

--- a/examples/Duplicate.cpp
+++ b/examples/Duplicate.cpp
@@ -124,7 +124,7 @@ struct UserExample : tvgexam::Example
             file.close();
 
             auto picture1 = tvg::Picture::gen();
-            if (!tvgexam::verify(picture1->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(picture1->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             picture1->scale(0.8);
             picture1->translate(400, 450);
 

--- a/examples/InvLumaMasking.cpp
+++ b/examples/InvLumaMasking.cpp
@@ -98,7 +98,7 @@ struct UserExample : tvgexam::Example
         file.close();
 
         auto image = tvg::Picture::gen();
-        if (!tvgexam::verify(image->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         image->translate(500, 400);
 
         //Mask4

--- a/examples/InvMasking.cpp
+++ b/examples/InvMasking.cpp
@@ -98,7 +98,7 @@ struct UserExample : tvgexam::Example
         file.close();
 
         auto image = tvg::Picture::gen();
-        if (!tvgexam::verify(image->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ABGR8888, true))) return false;
         image->translate(500, 400);
         free(data);
 

--- a/examples/LumaMasking.cpp
+++ b/examples/LumaMasking.cpp
@@ -98,7 +98,7 @@ struct UserExample : tvgexam::Example
         file.close();
 
         auto image = tvg::Picture::gen();
-        if (!tvgexam::verify(image->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         image->translate(500, 400);
 
         //Mask4

--- a/examples/Masking.cpp
+++ b/examples/Masking.cpp
@@ -100,7 +100,7 @@ struct UserExample : tvgexam::Example
         file.close();
 
         auto image = tvg::Picture::gen();
-        if (!tvgexam::verify(image->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         image->translate(500, 400);
 
         //Mask4

--- a/examples/MaskingMethods.cpp
+++ b/examples/MaskingMethods.cpp
@@ -339,7 +339,7 @@ struct UserExample : tvgexam::Example
         {
             //Transformed Image + Shape Mask Add
             auto image = tvg::Picture::gen();
-            if (!tvgexam::verify(image->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image->translate(150, 650);
             image->scale(0.5f);
             image->rotate(45);
@@ -357,7 +357,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Subtract
             auto image2 = tvg::Picture::gen();
-            if (!tvgexam::verify(image2->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image2->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image2->translate(400, 650);
             image2->scale(0.5f);
             image2->rotate(45);
@@ -375,7 +375,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Intersect
             auto image3 = tvg::Picture::gen();
-            if (!tvgexam::verify(image3->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image3->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image3->translate(650, 650);
             image3->scale(0.5f);
             image3->rotate(45);
@@ -393,7 +393,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Difference
             auto image4 = tvg::Picture::gen();
-            if (!tvgexam::verify(image4->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image4->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image4->translate(900, 650);
             image4->scale(0.5f);
             image4->rotate(45);
@@ -411,7 +411,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Lighten
             auto image5 = tvg::Picture::gen();
-            if (!tvgexam::verify(image5->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image5->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image5->translate(1150, 650);
             image5->scale(0.5f);
             image5->rotate(45);
@@ -429,7 +429,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Darken
             auto image6 = tvg::Picture::gen();
-            if (!tvgexam::verify(image6->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image6->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image6->translate(1400, 650);
             image6->scale(0.5f);
             image6->rotate(45);
@@ -448,7 +448,7 @@ struct UserExample : tvgexam::Example
         {
             //Transformed Image + Shape Mask Add
             auto image = tvg::Picture::gen();
-            if (!tvgexam::verify(image->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image->translate(150, 850);
             image->scale(0.5f);
             image->rotate(45);
@@ -466,7 +466,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Subtract
             auto image2 = tvg::Picture::gen();
-            if (!tvgexam::verify(image2->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image2->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image2->translate(400, 850);
             image2->scale(0.5f);
             image2->rotate(45);
@@ -484,7 +484,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Intersect
             auto image3 = tvg::Picture::gen();
-            if (!tvgexam::verify(image3->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image3->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image3->translate(650, 850);
             image3->scale(0.5f);
             image3->rotate(45);
@@ -502,7 +502,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Difference
             auto image4 = tvg::Picture::gen();
-            if (!tvgexam::verify(image4->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image4->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image4->translate(900, 850);
             image4->scale(0.5f);
             image4->rotate(45);
@@ -520,7 +520,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Lighten
             auto image5 = tvg::Picture::gen();
-            if (!tvgexam::verify(image5->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image5->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image5->translate(1150, 850);
             image5->scale(0.5f);
             image5->rotate(45);
@@ -538,7 +538,7 @@ struct UserExample : tvgexam::Example
 
             //Transformed Image + Shape Mask Darken
             auto image6 = tvg::Picture::gen();
-            if (!tvgexam::verify(image6->load(data, 200, 300, true, true))) return false;
+            if (!tvgexam::verify(image6->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
             image6->translate(1400, 850);
             image6->scale(0.5f);
             image6->rotate(45);

--- a/examples/PictureRaw.cpp
+++ b/examples/PictureRaw.cpp
@@ -47,12 +47,12 @@ struct UserExample : tvgexam::Example
         file.close();
 
         auto picture = tvg::Picture::gen();
-        if (!tvgexam::verify(picture->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(picture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         picture->translate(400, 250);
         canvas->push(std::move(picture));
 
         auto picture2 = tvg::Picture::gen();
-        if (!tvgexam::verify(picture2->load(data, 200, 300, true, true))) return false;
+        if (!tvgexam::verify(picture2->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
 
         picture2->translate(400, 200);
         picture2->rotate(47);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1278,21 +1278,22 @@ public:
     Result size(float* w, float* h) const noexcept;
 
     /**
-     * @brief Loads raw data in ARGB8888 format from a memory block of the given size.
+     * @brief Loads raw image data in a specific format from a memory block of the given size.
      *
-     * ThorVG efficiently caches the loaded data using the specified @p data address as a key
-     * when the @p copy has @c false. This means that loading the same data again will not result in duplicate operations
-     * for the sharable @p data. Instead, ThorVG will reuse the previously loaded picture data.
+     * ThorVG efficiently caches the loaded data, using the provided @p data address as a key
+     * when @p copy is set to @c false. This allows ThorVG to avoid redundant operations
+     * by reusing the previously loaded picture data for the same sharable @p data,
+     * rather than duplicating the load process.
      *
-     * @param[in] data A pointer to a memory location where the content of the picture raw data is stored.
-     * @param[in] w The width of the image @p data in pixels.
-     * @param[in] h The height of the image @p data in pixels.
-     * @param[in] premultiplied If @c true, the given image data is alpha-premultiplied.
-     * @param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
+     * @param[in] data A pointer to the memory block where the raw image data is stored.
+     * @param[in] w The width of the image in pixels.
+     * @param[in] h The height of the image in pixels.
+     * @param[in] cs Specifies how the 32-bit color values should be interpreted.
+     * @param[in] copy If @c true, the data is copied into the engine's local buffer. If @c false, the data is not copied.
      *
      * @since 0.9
      */
-    Result load(uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy = false) noexcept;
+    Result load(uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy = false) noexcept;
 
     /**
      * @brief Retrieve a paint object from the Picture scene by its Unique ID.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -483,8 +483,6 @@ TVG_API Tvg_Canvas* tvg_swcanvas_create(void);
 * \param[in] w The width of the raster image.
 * \param[in] h The height of the raster image.
 * \param[in] cs The colorspace value defining the way the 32-bits colors should be read/written.
-* - TVG_COLORSPACE_ABGR8888
-* - TVG_COLORSPACE_ARGB8888
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_INVALID_ARGUMENTS An invalid canvas or buffer pointer passed or one of the @p stride, @p w or @p h being zero.
@@ -1922,26 +1920,25 @@ TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path);
 
 
 /*!
-* \brief Loads a picture data from a memory block of a given size.
-*
-* ThorVG efficiently caches the loaded data using the specified @p data address as a key
-* when the @p copy has @c false. This means that loading the same data again will not result in duplicate operations
-* for the sharable @p data. Instead, ThorVG will reuse the previously loaded picture data.
-*
-* \param[in] paint A Tvg_Paint pointer to the picture object.
-* \param[in] data A pointer to a memory location where the content of the picture raw data is stored.
-* \param[in] w The width of the image @p data in pixels.
-* \param[in] h The height of the image @p data in pixels.
-* \param[in] premultiplied If @c true, the given image data is alpha-premultiplied.
-* \param[in] copy If @c true the data are copied into the engine local buffer, otherwise they are not.
+ * \brief Loads raw image data in a specific format from a memory block of the given size.
+ *
+ * ThorVG efficiently caches the loaded data, using the provided @p data address as a key
+ * when @p copy is set to @c false. This allows ThorVG to avoid redundant operations
+ * by reusing the previously loaded picture data for the same sharable @p data,
+ * rather than duplicating the load process.
+ *
+ * \param[in] data A pointer to the memory block where the raw image data is stored.
+ * \param[in] w The width of the image in pixels.
+ * \param[in] h The height of the image in pixels.
+ * \param[in] cs Specifies how the 32-bit color values should be interpreted (read/write).
+ * \param[in] copy If @c true, the data is copied into the engine's local buffer. If @c false, the data is not copied.
 *
 * \return Tvg_Result enumeration.
-* \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer or no data are provided or the @p width or @p height value is zero or less.
-* \retval TVG_RESULT_FAILED_ALLOCATION A problem with memory allocation occurs.
+* \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer or no data are provided or the @p w or @p h value is zero or less.
 *
 * \since 0.9
 */
-TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, bool premultiplied, bool copy);
+TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -527,10 +527,10 @@ TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path)
 }
 
 
-TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, bool premultiplied, bool copy)
+TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, w, h, premultiplied, copy);
+    return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, w, h, static_cast<ColorSpace>(cs), copy);
 }
 
 

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -45,7 +45,7 @@ RawLoader::~RawLoader()
 }
 
 
-bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy)
+bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
 {
     if (!LoadModule::read()) return true;
 
@@ -66,9 +66,9 @@ bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, bool premulti
     surface.stride = w;
     surface.w = w;
     surface.h = h;
-    surface.cs = ColorSpace::ARGB8888;
+    surface.cs = cs;
     surface.channelSize = sizeof(uint32_t);
-    surface.premultiplied = premultiplied;
+    surface.premultiplied = (cs == ColorSpace::ABGR8888 || cs == ColorSpace::ARGB8888) ? true : false;
 
     return true;
 }

--- a/src/loaders/raw/tvgRawLoader.h
+++ b/src/loaders/raw/tvgRawLoader.h
@@ -32,7 +32,7 @@ public:
     ~RawLoader();
 
     using LoadModule::open;
-    bool open(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy);
+    bool open(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy);
     bool read() override;
 };
 

--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -395,7 +395,7 @@ LoadModule* LoaderMgr::loader(const char* data, uint32_t size, const string& mim
 }
 
 
-LoadModule* LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h, bool premultiplied, bool copy)
+LoadModule* LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
 {
     //Note that users could use the same data pointer with the different content.
     //Thus caching is only valid for shareable.
@@ -406,7 +406,7 @@ LoadModule* LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h, bool
 
     //function is dedicated for raw images only
     auto loader = new RawLoader;
-    if (loader->open(data, w, h, premultiplied, copy)) {
+    if (loader->open(data, w, h, cs, copy)) {
         if (!copy) {
             loader->hashkey = HASH_KEY((const char*)data);
             ScopedLock lock(key);

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -31,7 +31,7 @@ struct LoaderMgr
     static bool term();
     static LoadModule* loader(const string& path, bool* invalid);
     static LoadModule* loader(const char* data, uint32_t size, const string& mimeType, const string& rpath, bool copy);
-    static LoadModule* loader(const uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy);
+    static LoadModule* loader(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy);
     static LoadModule* loader(const char* name, const char* data, uint32_t size, const string& mimeType, bool copy);
     static LoadModule* loader(const char* key);
     static bool retrieve(const string& path);

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -170,11 +170,11 @@ Result Picture::load(const char* data, uint32_t size, const string& mimeType, co
 }
 
 
-Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy) noexcept
+Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy) noexcept
 {
-    if (!data || w <= 0 || h <= 0) return Result::InvalidArguments;
+    if (!data || w <= 0 || h <= 0 || cs == ColorSpace::Unknown)  return Result::InvalidArguments;
 
-    return pImpl->load(data, w, h, premultiplied, copy);
+    return pImpl->load(data, w, h, cs, copy);
 }
 
 

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -143,11 +143,11 @@ struct Picture::Impl
         return load(loader);
     }
 
-    Result load(uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy)
+    Result load(uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
     {
         if (paint || surface) return Result::InsufficientCondition;
 
-        auto loader = static_cast<ImageLoader*>(LoaderMgr::loader(data, w, h, premultiplied, copy));
+        auto loader = static_cast<ImageLoader*>(LoaderMgr::loader(data, w, h, cs, copy));
         if (!loader) return Result::FailedAllocation;
 
         return load(loader);

--- a/test/capi/capiPicture.cpp
+++ b/test/capi/capiPicture.cpp
@@ -45,13 +45,13 @@ TEST_CASE("Load Raw file in Picture", "[capiPicture]")
 
     if (data && fread(data, sizeof(uint32_t), 200*300, fp) > 0) {
         //Negative
-        REQUIRE(tvg_picture_load_raw(picture, nullptr, 100, 100, true, true) == TVG_RESULT_INVALID_ARGUMENT);
-        REQUIRE(tvg_picture_load_raw(nullptr, data, 200, 300, true, true) == TVG_RESULT_INVALID_ARGUMENT);
-        REQUIRE(tvg_picture_load_raw(picture, data, 0, 0, true, true) == TVG_RESULT_INVALID_ARGUMENT);
+        REQUIRE(tvg_picture_load_raw(picture, nullptr, 100, 100, TVG_COLORSPACE_ARGB8888, true) == TVG_RESULT_INVALID_ARGUMENT);
+        REQUIRE(tvg_picture_load_raw(nullptr, data, 200, 300, TVG_COLORSPACE_ARGB8888, true) == TVG_RESULT_INVALID_ARGUMENT);
+        REQUIRE(tvg_picture_load_raw(picture, data, 0, 0, TVG_COLORSPACE_ARGB8888, true) == TVG_RESULT_INVALID_ARGUMENT);
 
         //Positive
-        REQUIRE(tvg_picture_load_raw(picture, data, 200, 300, true, true) == TVG_RESULT_SUCCESS);
-        REQUIRE(tvg_picture_load_raw(picture, data, 200, 300, true, false) == TVG_RESULT_SUCCESS);
+        REQUIRE(tvg_picture_load_raw(picture, data, 200, 300, TVG_COLORSPACE_ARGB8888, true) == TVG_RESULT_SUCCESS);
+        REQUIRE(tvg_picture_load_raw(picture, data, 200, 300, TVG_COLORSPACE_ARGB8888, false) == TVG_RESULT_SUCCESS);
 
         //Verify Size
         float w, h;

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -50,14 +50,14 @@ TEST_CASE("Load RAW Data", "[tvgPicture]")
     file.close();
 
     //Negative cases
-    REQUIRE(picture->load(nullptr, 200, 300, true, false) == Result::InvalidArguments);
-    REQUIRE(picture->load(data, 0, 0, true, false) == Result::InvalidArguments);
-    REQUIRE(picture->load(data, 200, 0, true, false) == Result::InvalidArguments);
-    REQUIRE(picture->load(data, 0, 300, true, false) == Result::InvalidArguments);
+    REQUIRE(picture->load(nullptr, 200, 300, ColorSpace::ARGB8888, false) == Result::InvalidArguments);
+    REQUIRE(picture->load(data, 0, 0, ColorSpace::ARGB8888, false) == Result::InvalidArguments);
+    REQUIRE(picture->load(data, 200, 0, ColorSpace::ARGB8888, false) == Result::InvalidArguments);
+    REQUIRE(picture->load(data, 0, 300, ColorSpace::ARGB8888, false) == Result::InvalidArguments);
 
     //Positive cases
-    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
-    REQUIRE(picture->load(data, 200, 300, true, true) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, ColorSpace::ARGB8888, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, ColorSpace::ARGB8888, true) == Result::Success);
 
     float w, h;
     REQUIRE(picture->size(&w, &h) == Result::Success);
@@ -88,7 +88,7 @@ TEST_CASE("Load RAW file and render", "[tvgPicture]")
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
 
-    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture->size(100, 150) == Result::Success);
 
     REQUIRE(canvas->push(std::move(picture)) == Result::Success);
@@ -113,7 +113,7 @@ TEST_CASE("Picture Size", "[tvgPicture]")
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
 
-    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, ColorSpace::ARGB8888, false) == Result::Success);
 
     REQUIRE(picture->size(nullptr, nullptr) == Result::Success);
     REQUIRE(picture->size(100, 100) == Result::Success);
@@ -130,7 +130,7 @@ TEST_CASE("Picture Size", "[tvgPicture]")
     file2.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 250 * 375);
     file2.close();
 
-    REQUIRE(picture->load(data, 250, 375, true, false) == Result::Success);
+    REQUIRE(picture->load(data, 250, 375, ColorSpace::ARGB8888, false) == Result::Success);
 
     REQUIRE(picture->size(&w, &h) == Result::Success);
     REQUIRE(picture->size(w, h) == Result::Success);
@@ -150,7 +150,7 @@ TEST_CASE("Picture Duplication", "[tvgPicture]")
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
 
-    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture->size(100, 100) == Result::Success);
 
     auto dup = tvg::cast<Picture>(picture->duplicate());

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -112,7 +112,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     //Not transformed images
     auto basicPicture = Picture::gen();
     REQUIRE(basicPicture);
-    REQUIRE(basicPicture->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(basicPicture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     auto rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
     REQUIRE(rectMask->appendRect(10, 10, 30, 30) == Result::Success);
@@ -178,7 +178,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     // Transformed images
     basicPicture = Picture::gen();
     REQUIRE(basicPicture);
-    REQUIRE(basicPicture->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(basicPicture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
 
     REQUIRE(basicPicture->rotate(45) == Result::Success);
     rectMask = tvg::Shape::gen();
@@ -243,7 +243,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     // Upscaled images
     basicPicture = Picture::gen();
     REQUIRE(basicPicture);
-    REQUIRE(basicPicture->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(basicPicture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(basicPicture->scale(2) == Result::Success);
     rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
@@ -307,7 +307,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     // Downscaled images
     basicPicture = Picture::gen();
     REQUIRE(basicPicture);
-    REQUIRE(basicPicture->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(basicPicture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(basicPicture->scale(0.2f) == Result::Success);
     rectMask = tvg::Shape::gen();
     REQUIRE(rectMask);
@@ -1298,7 +1298,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
 
     auto picture = Picture::gen();
     REQUIRE(picture);
-    REQUIRE(picture->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture->clip(std::move(clipper)) == Result::Success);
     REQUIRE(canvas->push(std::move(picture)) == Result::Success);
@@ -1306,7 +1306,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     //scaled images
     auto picture2 = Picture::gen();
     REQUIRE(picture2);
-    REQUIRE(picture2->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture2->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture2->scale(2) == Result::Success);
     REQUIRE(picture2->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(canvas->push(std::move(picture2)) == Result::Success);
@@ -1318,7 +1318,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
 
     auto picture3 = Picture::gen();
     REQUIRE(picture3);
-    REQUIRE(picture3->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture3->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture3->scale(2) == Result::Success);
     REQUIRE(picture3->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture3->clip(std::move(clipper2)) == Result::Success);
@@ -1327,14 +1327,14 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     //normal image
     auto picture4 = Picture::gen();
     REQUIRE(picture4);
-    REQUIRE(picture4->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture4->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture4->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(canvas->push(std::move(picture4)) == Result::Success);
 
     //texmap image
     auto picture5 = Picture::gen();
     REQUIRE(picture5);
-    REQUIRE(picture5->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture5->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture5->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture5->rotate(45.0f) == Result::Success);
     REQUIRE(canvas->push(std::move(picture5)) == Result::Success);
@@ -1342,7 +1342,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     //texmap image with half-translucent
     auto picture6 = Picture::gen();
     REQUIRE(picture6);
-    REQUIRE(picture6->load(data, 200, 300, true, false) == Result::Success);
+    REQUIRE(picture6->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture6->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture6->rotate(45.0f) == Result::Success);
     REQUIRE(picture6->opacity(127) == Result::Success);


### PR DESCRIPTION
Use ColorSpace to support various types of raw bitmaps.

API Modifications:
- Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, bool premultiplied, bool copy = false) -> Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy = false)
- Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, bool premultiplied, bool copy) -> Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy)

issue: https://github.com/thorvg/thorvg/issues/1372