### PR TITLE
gl_engine: implement path trim in tvgGlTessellator

### DIFF
--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -186,6 +186,29 @@ private:
     GlPoint mPtCur;
 };
 
+class PathTrim
+{
+public:
+    PathTrim(): mCmds(), mPts() {}
+
+    ~PathTrim() = default;
+
+    bool trim(const PathCommand* cmds, uint32_t cmd_count, const Point* pts, uint32_t pts_count, float start, float end);
+
+    const Array<PathCommand>& cmds() const { return mCmds; }
+
+    const Array<Point>& pts() const { return mPts; }
+
+private:
+    float pathLength(const PathCommand* cmds, uint32_t cmd_count, const Point* pts, uint32_t pts_count);
+
+    void trimPath(const PathCommand* cmds, uint32_t cmd_count, const Point* pts, uint32_t pts_count, float start, float end);
+
+private:
+    Array<PathCommand> mCmds;
+    Array<Point> mPts;
+};
+
 class BWTessellator
 {
 public:


### PR DESCRIPTION
Implement the path trim claculation, and handle the strokeTrim before doing Path stroke.

The StrokeTrim example is correct, but I'm worried there might be other things I haven't considered.
> BTW, I think this kind of general geometric calculation can be handled uniformly at the upper level.
<img width="811" alt="截屏2024-10-13 20 43 55" src="https://github.com/user-attachments/assets/f842fec4-3266-4b9c-b910-7f8c8942719f">
