### PR TITLE
lottie: release memory immediately after loading is complete.

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -77,6 +77,7 @@ private:
     void clear();
     float startFrame();
     void run(unsigned tid) override;
+    void release();
 };
 
 


### PR DESCRIPTION
there is no need to retain the data,
as the Lottie source is not reusable
and is affected by the parsing mechanism.

issue: https://github.com/thorvg/thorvg/issues/2647