### PR TITLE
lottie: correct the array reserved size

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -254,7 +254,7 @@ void LottieParser::getValue(ColorStop& color)
 {
     if (peekType() == kArrayType) enterArray();
 
-    if (!color.input) color.input = new Array<float>(static_cast<LottieGradient*>(context.parent)->colorStops.count);
+    if (!color.input) color.input = new Array<float>(static_cast<LottieGradient*>(context.parent)->colorStops.count * 6);
     else color.input->clear();
 
     while (nextArrayValue()) color.input->push(getFloat());


### PR DESCRIPTION
The color input will contain at least colorStops.count * 4 elements (not including alpha). Since the alpha offset values don't have to much colorStops, estimation is used.