### PR TITLE
gl_engine: correct the ColorSpace when render Image

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -1194,6 +1194,10 @@ RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matr
         sdata->texId = _genTexture(image);
         sdata->opacity = opacity;
         sdata->texColorSpace = image->cs;
+        if (!image->premultiplied) {
+            if (image->cs == ColorSpace::ABGR8888) sdata->texColorSpace = ColorSpace::ABGR8888S;
+            else if (image->cs == ColorSpace::ARGB8888) sdata->texColorSpace = ColorSpace::ARGB8888S;
+        }
         sdata->texFlipY = 1;
         sdata->geometry = make_unique<GlGeometry>();
     }

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -294,11 +294,11 @@ const char* IMAGE_FRAG_SHADER = TVG_COMPOSE_SHADER(
             result.b = color.r * color.a;                                                   \n
             result.a = color.a;                                                             \n
         } else if (uColorInfo.format == 2) { /* FMT_ABGR8888S */                            \n
-            result = color;                                                                 \n
+            result = vec4(color.rgb * color.a, color.a);                                    \n
         } else if (uColorInfo.format == 3) { /* FMT_ARGB8888S */                            \n
-            result.r = color.b;                                                             \n
-            result.g = color.g;                                                             \n
-            result.b = color.b;                                                             \n
+            result.r = color.b * color.a;                                                   \n
+            result.g = color.g * color.a;                                                   \n
+            result.b = color.b * color.a;                                                   \n
             result.a = color.a;                                                             \n
         }                                                                                   \n
         float opacity = float(uColorInfo.opacity) / 255.0;                                  \n


### PR DESCRIPTION
Need handle ColorSpace correct when prepare Image texture. If premultiplied is not marked. Needs to change the ColorSpace.

related issue: #2863