### PR TITLE
gl_engine: ignore masking alpha when calculate inv luma masking

### DIFF
--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -387,7 +387,6 @@ void main() {                                                                   
     vec4 maskColor = texture(uMaskTexture, vUV);                                    \n
                                                                                     \n
     float luma = (0.299 * maskColor.r + 0.587 * maskColor.g + 0.114 * maskColor.b); \n
-    luma *= maskColor.a;                                                            \n
     FragColor = srcColor * (1.0 - luma);                                            \n
 }                                                                                   \n
 );


### PR DESCRIPTION
Change the shader to ignore the alpha from masking color.


<img width="1606" alt="截屏2024-10-19 10 09 12" src="https://github.com/user-attachments/assets/99fcdfea-73d5-4797-ab6f-d6d891a904cd">

related issue: #2879