### PR TITLE
lottie: fix rotation in text range selector

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1060,41 +1060,48 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                     shape->strokeFill(doc.stroke.color.rgb[0], doc.stroke.color.rgb[1], doc.stroke.color.rgb[2]);
                 }
 
-                //text range process
-                for (auto s = text->ranges.begin(); s < text->ranges.end(); ++s) {
-                    float start, end;
-                    (*s)->range(frameNo, float(totalChars), start, end);
+                if (!text->ranges.empty()) {
+                    Point scaling = {1.0f, 1.0f};
+                    auto rotation = 0.0f;
+                    auto translation = cursor;
 
-                    auto basedIdx = idx;
-                    if ((*s)->based == LottieTextRange::Based::CharsExcludingSpaces) basedIdx = idx - space;
-                    else if ((*s)->based == LottieTextRange::Based::Words) basedIdx = line + space;
-                    else if ((*s)->based == LottieTextRange::Based::Lines) basedIdx = line;
+                    //text range process
+                    for (auto s = text->ranges.begin(); s < text->ranges.end(); ++s) {
+                        float start, end;
+                        (*s)->range(frameNo, float(totalChars), start, end);
 
-                    if (basedIdx < start || basedIdx >= end) continue;
-                    auto& matrix = shape->transform();
+                        auto basedIdx = idx;
+                        if ((*s)->based == LottieTextRange::Based::CharsExcludingSpaces) basedIdx = idx - space;
+                        else if ((*s)->based == LottieTextRange::Based::Words) basedIdx = line + space;
+                        else if ((*s)->based == LottieTextRange::Based::Lines) basedIdx = line;
 
-                    shape->opacity((*s)->style.opacity(frameNo));
+                        if (basedIdx < start || basedIdx >= end) continue;
 
-                    auto color = (*s)->style.fillColor(frameNo);
-                    shape->fill(color.rgb[0], color.rgb[1], color.rgb[2], (*s)->style.fillOpacity(frameNo));
+                        translation = translation + (*s)->style.position(frameNo);
+                        scaling = scaling * (*s)->style.scale(frameNo) * 0.01f;
+                        rotation += (*s)->style.rotation(frameNo);
 
-                    rotate(&matrix, (*s)->style.rotation(frameNo));
+                        shape->opacity((*s)->style.opacity(frameNo));
 
-                    auto glyphScale = (*s)->style.scale(frameNo) * 0.01f;
-                    tvg::scale(&matrix, glyphScale.x, glyphScale.y);
+                        auto color = (*s)->style.fillColor(frameNo);
+                        shape->fill(color.rgb[0], color.rgb[1], color.rgb[2], (*s)->style.fillOpacity(frameNo));
 
-                    auto position = (*s)->style.position(frameNo);
-                    translate(&matrix, position.x, position.y);
+                        if (doc.stroke.render) {
+                            auto strokeColor = (*s)->style.strokeColor(frameNo);
+                            shape->strokeWidth((*s)->style.strokeWidth(frameNo) / scale);
+                            shape->strokeFill(strokeColor.rgb[0], strokeColor.rgb[1], strokeColor.rgb[2], (*s)->style.strokeOpacity(frameNo));
+                        }
+                        cursor.x += (*s)->style.letterSpacing(frameNo);
 
-                    if (doc.stroke.render) {
-                        auto strokeColor = (*s)->style.strokeColor(frameNo);
-                        shape->strokeWidth((*s)->style.strokeWidth(frameNo) / scale);
-                        shape->strokeFill(strokeColor.rgb[0], strokeColor.rgb[1], strokeColor.rgb[2], (*s)->style.strokeOpacity(frameNo));
+                        auto spacing = (*s)->style.lineSpacing(frameNo);
+                        if (spacing > lineSpacing) lineSpacing = spacing;
                     }
-                    cursor.x += (*s)->style.letterSpacing(frameNo);
-
-                    auto spacing = (*s)->style.lineSpacing(frameNo);
-                    if (spacing > lineSpacing) lineSpacing = spacing;
+                    auto& matrix = shape->transform();
+                    identity(&matrix);
+                    translate(&matrix, translation.x, translation.y);
+                    tvg::scale(&matrix, scaling.x, scaling.y);
+                    rotate(&matrix, rotation);
+                    shape->transform(matrix);
                 }
 
                 scene->push(cast(shape));

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -107,7 +107,7 @@ namespace tvg
 
         bool transform(const Matrix& m)
         {
-            tr.m = m;
+            if (&tr.m != &m) tr.m = m;
             tr.overriding = true;
             renderFlag |= RenderUpdateFlag::Transform;
 


### PR DESCRIPTION
Since the translate API was used while text updating, the subsequent range selector transformations gets overwritten when updating the shape (scale and rotate, adding another translation will persist). This caused unexpected results. Fixed by using the transform API when additional transformations are needed.

before:
<img width="371" alt="Zrzut ekranu 2024-10-21 o 22 06 39" src="https://github.com/user-attachments/assets/87b4ced6-4ed1-41c9-81d4-0786d79599b2">

after:
<img width="377" alt="Zrzut ekranu 2024-10-21 o 22 04 40" src="https://github.com/user-attachments/assets/b5d1e667-665e-483a-8822-113f0c37e42f">

sample:
[textRS.json](https://github.com/user-attachments/files/17463027/textRS.json)
