### PR TITLE
wg_engine: use tvg math constants

### DIFF
--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -348,7 +348,7 @@ struct WgVertexBufferInd
         float cosine = dot(nrm, nrm1);
         if (tvg::zero(cosine)) return;
         float angle = std::acos(dot(nrm1, -nrm2));
-        if (tvg::zero(angle) || tvg::equal(angle, M_PI)) return;
+        if (tvg::zero(angle) || tvg::equal(angle, MATH_PI)) return;
         float miterRatio = 1.0f / (std::sin(angle) * 0.5f);
         if (miterRatio <= miterLimit) {
             appendQuad(v1 + nrm * (halfWidth / cosine), v1 + offset2, v1 + offset1, v1);


### PR DESCRIPTION
Use tvg pi constant instead of cmath. better mingw compiler support on windows