### PR TITLE
wg_engine: clippath optimization

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -51,8 +51,6 @@ private:
     WGPUCommandEncoder commandEncoder{};
     WgRenderStorage* currentTarget{};
     // intermediate render storages
-    WgRenderStorage storageInterm;
-    WgRenderStorage storageClipPath;
     WgRenderStorage storageDstCopy;
     // composition and blend geometries
     WgMeshData meshData;
@@ -82,27 +80,24 @@ private:
     // shapes
     void drawShape(WgContext& context, WgRenderDataShape* renderData);
     void blendShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
-    void clipShape(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask); // TODO: optimize
+    void clipShape(WgContext& context, WgRenderDataShape* renderData);
 
     // strokes
     void drawStrokes(WgContext& context, WgRenderDataShape* renderData);
     void blendStrokes(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
-    void clipStrokes(WgContext& context, WgRenderDataShape* renderData, WgRenderStorage* mask); // TODO: optimize
+    void clipStrokes(WgContext& context, WgRenderDataShape* renderData);
 
     // images
     void drawImage(WgContext& context, WgRenderDataPicture* renderData);
     void blendImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod);
-    void clipImage(WgContext& context, WgRenderDataPicture* renderData, WgRenderStorage* mask); // TODO: optimize
+    void clipImage(WgContext& context, WgRenderDataPicture* renderData);
 
     // scenes
     void drawScene(WgContext& context, WgRenderStorage* scene, WgCompose* compose);
     void blendScene(WgContext& context, WgRenderStorage* src, WgCompose* compose);
 private:
-    // clip path utils (TODO: optimize)
-    void drawClipPath(WgContext& context, WgRenderDataShape* renderData);
-    void clipRegion(WgContext& context, WgRenderStorage* src, WgRenderStorage* mask, RenderRegion& rect);
-    void renderClipPath(WgContext& context, WgRenderDataPaint* renderData, WgRenderStorage* dst);
-    void mergeMasks(WGPUCommandEncoder encoder, WgRenderStorage* mask0, WgRenderStorage* mask1);
+    void renderClipPath(WgContext& context, WgRenderDataPaint* paint);
+    void clearClipPath(WgContext& context, WgRenderDataPaint* paint);
 };
 
 #endif // _TVG_WG_COMPOSITOR_H_

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -29,6 +29,7 @@ class WgPipelines {
 private:
     // shaders helpers
     WGPUShaderModule shader_stencil{};
+    WGPUShaderModule shader_depth{};
     // shaders normal blend
     WGPUShaderModule shader_solid{};
     WGPUShaderModule shader_radial{};
@@ -43,12 +44,12 @@ private:
     WGPUShaderModule shader_scene_blend{};
     // shader scene compose
     WGPUShaderModule shader_scene_compose{};
-    WGPUShaderModule shader_merge_masks;
     // shader blit
     WGPUShaderModule shader_blit{};
 private:
     // layouts helpers
     WGPUPipelineLayout layout_stencil{};
+    WGPUPipelineLayout layout_depth{};
     // layouts normal blend
     WGPUPipelineLayout layout_solid{};
     WGPUPipelineLayout layout_gradient{};
@@ -61,15 +62,19 @@ private:
     WGPUPipelineLayout layout_scene_blend{};
     // layouts scene compose
     WGPUPipelineLayout layout_scene_compose{};
-    WGPUPipelineLayout layout_merge_masks{};
     // layouts blit
     WGPUPipelineLayout layout_blit{};
 public:
-    // pipelines helpers
+    // pipelines stencil markup
     WGPURenderPipeline winding{};
     WGPURenderPipeline evenodd{};
     WGPURenderPipeline direct{};
-    WGPURenderPipeline clip_path{};
+    // pipelines clip path markup
+    WGPURenderPipeline copy_stencil_to_depth{};        // depth 0.50, clear stencil
+    WGPURenderPipeline copy_stencil_to_depth_interm{}; // depth 0.75, clear stencil
+    WGPURenderPipeline copy_depth_to_stencil{}; // depth 0.50 and 0.75, update stencil
+    WGPURenderPipeline merge_depth_stencil{};   // depth 0.75, update stencil
+    WGPURenderPipeline clear_depth{}; // depth 1.00, clear ctencil
     // pipelines normal blend
     WGPURenderPipeline solid{};
     WGPURenderPipeline radial{};
@@ -84,8 +89,6 @@ public:
     WGPURenderPipeline scene_blend[18]{};
     // pipelines compose
     WGPURenderPipeline scene_compose[11]{};
-    WGPURenderPipeline scene_clip{};
-    WGPUComputePipeline merge_masks{};
     // pipeline blit
     WGPURenderPipeline blit{};
 public:
@@ -93,7 +96,6 @@ public:
     WgBindGroupLayouts layouts;
 private:
     void releaseGraphicHandles(WgContext& context);
-    void releaseComputeHandles(WgContext& context);
 private:
     WGPUShaderModule createShaderModule(WGPUDevice device, const char* label, const char* code);
     WGPUPipelineLayout createPipelineLayout(WGPUDevice device, const WGPUBindGroupLayout* bindGroupLayouts, const uint32_t bindGroupLayoutsCount);
@@ -105,7 +107,7 @@ private:
         const WGPUColorWriteMaskFlags writeMask, const WGPUTextureFormat colorTargetFormat,
         const WGPUCompareFunction stencilFunctionFrnt, const WGPUStencilOperation stencilOperationFrnt,
         const WGPUCompareFunction stencilFunctionBack, const WGPUStencilOperation stencilOperationBack,
-        const WGPUPrimitiveState primitiveState, const WGPUMultisampleState multisampleState, const WGPUBlendState blendState);
+        const WGPUCompareFunction depthCompare, WGPUBool depthWriteEnabled, const WGPUMultisampleState multisampleState, const WGPUBlendState blendState);
     WGPUComputePipeline createComputePipeline(
         WGPUDevice device, const char* pipelineLabel,
         const WGPUShaderModule shaderModule, const char* entryPoint,

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -50,6 +50,32 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 )";
 
 //************************************************************************
+// graphics shader source: depth
+//************************************************************************
+
+const char* cShaderSrc_Depth = R"(
+struct VertexInput { @location(0) position: vec2f };
+struct VertexOutput { @builtin(position) position: vec4f };
+
+@group(0) @binding(0) var<uniform> uViewMat  : mat4x4f;
+@group(1) @binding(0) var<uniform> uModelMat : mat4x4f;
+@group(2) @binding(0) var<uniform> uDepth : f32;
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.position = uViewMat * uModelMat * vec4f(in.position.xy, 0.0, 1.0);
+    out.position.z = uDepth;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+    return vec4f(1.0, 0.5, 0.0, 1.0);
+}
+)";
+
+//************************************************************************
 // graphics shader source: solid normal blend
 //************************************************************************
 

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -25,6 +25,7 @@
 
 // helper shaders
 extern const char* cShaderSrc_Stencil;
+extern const char* cShaderSrc_Depth;
 // shaders normal blend
 extern const char* cShaderSrc_Solid;
 extern const char* cShaderSrc_Linear;


### PR DESCRIPTION
Full review of clipping workflow.

Before we are used separate render target for each clip path and compute shader to find clip path intersections with AND logic.
Now we are using depth buffer and transactions from depth to stencil and back to get AND logic intersections,
Compute shaders, layouts and pipelines was removed

Result:
![image](https://github.com/user-attachments/assets/ca528dfb-641f-42a8-8984-ac07f2252553)

Few clippathes on the single frame, frog_vr.json (Before/After)
![image](https://github.com/user-attachments/assets/ba8bcbc6-dbc3-4bc2-a8ff-be5174c6d86c)


Massive clippathes on the single frame, 5317-fireworkds.json (Before/After)
![image](https://github.com/user-attachments/assets/59c598cc-142e-4d7a-8207-2d854c67535b)
