### PR TITLE
gl_engine: seperate the index buffer from vertex buffer

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -142,7 +142,7 @@ bool GlGeometry::draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdate
     if (indexBuffer->count == 0) return false;
 
     uint32_t vertexOffset = gpuBuffer->push(vertexBuffer->data, vertexBuffer->count * sizeof(float));
-    uint32_t indexOffset = gpuBuffer->push(indexBuffer->data, indexBuffer->count * sizeof(uint32_t));
+    uint32_t indexOffset = gpuBuffer->pushIndex(indexBuffer->data, indexBuffer->count * sizeof(uint32_t));
 
     // vertex layout
     if (flag & RenderUpdateFlag::Image) {

--- a/src/renderer/gl_engine/tvgGlGpuBuffer.h
+++ b/src/renderer/gl_engine/tvgGlGpuBuffer.h
@@ -23,8 +23,6 @@
 #ifndef _TVG_GL_GPU_BUFFER_H_
 #define _TVG_GL_GPU_BUFFER_H_
 
-#include <memory>
-
 #include "tvgGlCommon.h"
 
 class GlGpuBuffer
@@ -56,6 +54,8 @@ public:
 
     uint32_t push(void* data, uint32_t size, bool alignGpuOffset = false);
 
+    uint32_t pushIndex(void* data, uint32_t size);
+
     void flushToGPU();
 
     void bind();
@@ -67,8 +67,10 @@ private:
     void alignOffset(uint32_t size);
 private:
     GLuint mVao = 0;
-    unique_ptr<GlGpuBuffer> mGpuBuffer = {};
+    GlGpuBuffer mGpuBuffer = {};
+    GlGpuBuffer mGpuIndexBuffer = {};
     Array<uint8_t> mStageBuffer = {};
+    Array<uint8_t> mIndexBuffer = {};
 };
 
 #endif /* _TVG_GL_GPU_BUFFER_H_ */

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -435,7 +435,7 @@ void GlRenderer::drawClip(Array<RenderData>& clips)
     mat4[15] = 1.f;
 
     auto identityVertexOffset = mGpuBuffer->push(identityVertex.data, 8 * sizeof(float));
-    auto identityIndexOffset = mGpuBuffer->push(identityIndex.data, 6 * sizeof(uint32_t));
+    auto identityIndexOffset = mGpuBuffer->pushIndex(identityIndex.data, 6 * sizeof(uint32_t));
     auto mat4Offset = mGpuBuffer->push(mat4, 16 * sizeof(float), true);
 
     Array<int32_t> clipDepths(clips.count);
@@ -678,7 +678,7 @@ void GlRenderer::prepareCmpTask(GlRenderTask* task, const RenderRegion& vp, uint
     indices.push(3);
 
     uint32_t vertexOffset = mGpuBuffer->push(vertices.data, vertices.count * sizeof(float));
-    uint32_t indexOffset = mGpuBuffer->push(indices.data, indices.count * sizeof(uint32_t));
+    uint32_t indexOffset = mGpuBuffer->pushIndex(indices.data, indices.count * sizeof(uint32_t));
 
     task->addVertexLayout(GlVertexLayout{0, 2, 4 * sizeof(float), vertexOffset});
     task->addVertexLayout(GlVertexLayout{1, 2, 4 * sizeof(float), vertexOffset + 2 * sizeof(float)});


### PR DESCRIPTION
WebGL has a strict rule that does not allow the same GLBuffer to be bound to both ARRAY_BUFFER and ELEMENT_ARRAY_BUFFER at the same time. (https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5)

To support WebGL in the future, a separate GLBuffer is used to store index data.

prepare for #2837 