### PR TITLE
lottie: fix text range selector translation

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1063,7 +1063,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                 if (!text->ranges.empty()) {
                     Point scaling = {1.0f, 1.0f};
                     auto rotation = 0.0f;
-                    auto translation = cursor;
+                    Point translation = {0.0f, 0.0f};
 
                     //text range process
                     for (auto s = text->ranges.begin(); s < text->ranges.end(); ++s) {
@@ -1098,7 +1098,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                     }
                     auto& matrix = shape->transform();
                     identity(&matrix);
-                    translate(&matrix, translation.x, translation.y);
+                    translate(&matrix, translation.x / scale + cursor.x, translation.y / scale + cursor.y);
                     tvg::scale(&matrix, scaling.x, scaling.y);
                     rotate(&matrix, rotation);
                     shape->transform(matrix);


### PR DESCRIPTION
Scaling the entire scene caused unintended scaling of the translation in the text range selector.

before: 
<img width="400" alt="Zrzut ekranu 2024-10-29 o 11 36 30" src="https://github.com/user-attachments/assets/6d3dbcc5-44a6-4673-9b45-f96a8fc78f44">

after:
<img width="400" alt="Zrzut ekranu 2024-10-29 o 11 35 34" src="https://github.com/user-attachments/assets/7cc2145e-8bb1-4cf7-bb8a-6313ecd686cd">

sample:
[size30.json](https://github.com/user-attachments/files/17551634/size30.json)
[size50.json](https://github.com/user-attachments/files/17551636/size50.json)

