### PR TITLE
lottie: text range selector++

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1091,15 +1091,13 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
 
                     //text range process
                     for (auto s = text->ranges.begin(); s < text->ranges.end(); ++s) {
-                        float start, end;
-                        (*s)->range(frameNo, float(totalChars), start, end);
-
                         auto basedIdx = idx;
                         if ((*s)->based == LottieTextRange::Based::CharsExcludingSpaces) basedIdx = idx - space;
                         else if ((*s)->based == LottieTextRange::Based::Words) basedIdx = line + space;
                         else if ((*s)->based == LottieTextRange::Based::Lines) basedIdx = line;
 
-                        if (basedIdx < start || basedIdx >= end) continue;
+                        auto f = (*s)->factor(frameNo, float(totalChars), (float)basedIdx);
+                        if (tvg::zero(f)) continue;
                         needGroup = true;
 
                         translation = translation + (*s)->style.position(frameNo);
@@ -1141,13 +1139,13 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                         //center pivoting
                         textGroupMatrix.e13 += (pivotX * textGroupMatrix.e11 + pivotX * textGroupMatrix.e12);
                         textGroupMatrix.e23 += (pivotY * textGroupMatrix.e21 + pivotY * textGroupMatrix.e22);
-                        
+
                         textGroup->transform(textGroupMatrix);
                     }
 
                     auto& matrix = shape->transform();
                     identity(&matrix);
-                    translate(&matrix, (translation.x / scale + cursor.x) - textGroupMatrix.e13, (translation.y / scale + cursor.y) - textGroupMatrix.e23);
+                    translate(&matrix, translation.x / scale + cursor.x - textGroupMatrix.e13, translation.y / scale + cursor.y - textGroupMatrix.e23);
                     tvg::scale(&matrix, scaling.x, scaling.y);
                     shape->transform(matrix);
                 }

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1083,13 +1083,15 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                     shape->strokeFill(doc.stroke.color.rgb[0], doc.stroke.color.rgb[1], doc.stroke.color.rgb[2]);
                 }
 
-                bool needGroup = false;
+                auto needGroup = false;
+                //text range process
                 if (!text->ranges.empty()) {
                     Point scaling = {1.0f, 1.0f};
                     auto rotation = 0.0f;
                     Point translation = {0.0f, 0.0f};
+                    auto color = doc.color;
+                    auto strokeColor = doc.stroke.color;
 
-                    //text range process
                     for (auto s = text->ranges.begin(); s < text->ranges.end(); ++s) {
                         auto basedIdx = idx;
                         if ((*s)->based == LottieTextRange::Based::CharsExcludingSpaces) basedIdx = idx - space;
@@ -1100,23 +1102,36 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                         if (tvg::zero(f)) continue;
                         needGroup = true;
 
-                        translation = translation + (*s)->style.position(frameNo);
-                        scaling = scaling * (*s)->style.scale(frameNo) * 0.01f;
-                        rotation += (*s)->style.rotation(frameNo);
+                        translation = translation + f * (*s)->style.position(frameNo);
+                        scaling = scaling * (f * ((*s)->style.scale(frameNo) * 0.01f - Point{1.0f,1.0f}) + Point{1.0f,1.0f});
+                        rotation += f * (*s)->style.rotation(frameNo);
 
                         shape->opacity((*s)->style.opacity(frameNo));
 
-                        auto color = (*s)->style.fillColor(frameNo);
+                        auto rangeColor = (*s)->style.fillColor(frameNo); //TODO: use flag to check whether it was really set
+                        if (tvg::equal(f, 1.0f)) color = rangeColor;
+                        else {
+                            color.rgb[0] = lerp<uint8_t>(color.rgb[0], rangeColor.rgb[0], f);
+                            color.rgb[1] = lerp<uint8_t>(color.rgb[1], rangeColor.rgb[1], f);
+                            color.rgb[2] = lerp<uint8_t>(color.rgb[2], rangeColor.rgb[2], f);
+                        }
                         shape->fill(color.rgb[0], color.rgb[1], color.rgb[2], (*s)->style.fillOpacity(frameNo));
 
                         if (doc.stroke.render) {
-                            auto strokeColor = (*s)->style.strokeColor(frameNo);
-                            shape->strokeWidth((*s)->style.strokeWidth(frameNo) / scale);
+                            shape->strokeWidth(f * (*s)->style.strokeWidth(frameNo) / scale);
+                            auto rangeColor = (*s)->style.strokeColor(frameNo); //TODO: use flag to check whether it was really set
+                            if (tvg::equal(f, 1.0f)) strokeColor = rangeColor;
+                            else {
+                                strokeColor.rgb[0] = lerp<uint8_t>(strokeColor.rgb[0], rangeColor.rgb[0], f);
+                                strokeColor.rgb[1] = lerp<uint8_t>(strokeColor.rgb[1], rangeColor.rgb[1], f);
+                                strokeColor.rgb[2] = lerp<uint8_t>(strokeColor.rgb[2], rangeColor.rgb[2], f);
+                            }
                             shape->strokeFill(strokeColor.rgb[0], strokeColor.rgb[1], strokeColor.rgb[2], (*s)->style.strokeOpacity(frameNo));
                         }
-                        cursor.x += (*s)->style.letterSpacing(frameNo);
 
-                        auto spacing = (*s)->style.lineSpacing(frameNo);
+                        cursor.x += f * (*s)->style.letterSpacing(frameNo);
+
+                        auto spacing = f * (*s)->style.lineSpacing(frameNo);
                         if (spacing > lineSpacing) lineSpacing = spacing;
                     }
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -110,21 +110,32 @@ void LottieSlot::assign(LottieObject* target)
 }
 
 
-void LottieTextRange::range(float frameNo, float totalLen, float& start, float& end)
+float LottieTextRange::factor(float frameNo, float totalLen, float idx)
 {
+    auto offset = this->offset(frameNo);
+    auto start = this->start(frameNo) + offset;
+    auto end = this->end(frameNo) + offset;
+
+    if (random > 0) {
+        auto range = end - start;
+        auto len = (rangeUnit == Unit::Percent) ? 100.0f : totalLen;
+        start = static_cast<float>(random % int(len - range));
+        end = start + range;
+    }
+
     auto divisor = (rangeUnit == Unit::Percent) ? (100.0f / totalLen) : 1.0f;
-    auto offset = this->offset(frameNo) / divisor;
-    start = nearbyintf(this->start(frameNo) / divisor) + offset;
-    end = nearbyintf(this->end(frameNo) / divisor) + offset;
+    start /= divisor;
+    end /= divisor;
 
-    if (start > end) std::swap(start, end);
+    auto f = 0.0f;
 
-    if (random == 0) return;
+    if (idx >= std::floor(start)) {
+        auto diff = idx - start;
+        f = diff < 0.0f ? std::min(end, 1.0f) + diff : end - idx;
+        clamp(f, 0.0f, 1.0f);
+    }
 
-    auto range = end - start;
-    auto len = (rangeUnit == Unit::Percent) ? 100.0f : totalLen;
-    start = static_cast<float>(random % int(len - range));
-    end = start + range;
+    return f;
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -143,7 +143,7 @@ float LottieTextRange::factor(float frameNo, float totalLen, float idx)
         clamp(f, 0.0f, 1.0f);
     }
 
-    return f;
+    return f * this->maxAmount(frameNo) * 0.01f;
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -135,6 +135,14 @@ float LottieTextRange::factor(float frameNo, float totalLen, float idx)
         clamp(f, 0.0f, 1.0f);
     }
 
+    //apply smoothness
+    auto smoothness = this->smoothness(frameNo);
+    if (smoothness < 100.0f) {
+        smoothness *= 0.01f;
+        f = (f - (1.0f - smoothness) * 0.5f) / smoothness;
+        clamp(f, 0.0f, 1.0f);
+    }
+
     return f;
 }
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -228,7 +228,7 @@ struct LottieTextRange
     uint8_t random = 0;
     bool expressible = false;
 
-    void range(float frameNo, float totalLen, float& start, float& end);
+    float factor(float frameNo, float totalLen, float idx);
 };
 
 


### PR DESCRIPTION
Change in the algorithm for selecting characters included in the range selector. This is the first step towards adding support for maxAmount, smoothness, and easing.
Smoothness and maxAmount added.

@Issue: https://github.com/thorvg/thorvg/issues/2178

AE vs this pr (not sync)
![sm](https://github.com/user-attachments/assets/ffd0da05-5183-490f-85b8-2044a8bf76e0)

[smoothness.json](https://github.com/user-attachments/files/17581496/smoothness.json)
