### PR TITLE
wg_engine: fix equals gradient offsets

### DIFF
--- a/src/renderer/wg_engine/tvgWgShaderTypes.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.cpp
@@ -146,6 +146,8 @@ void WgShaderTypeGradient::updateTexData(const Fill::ColorStop* stops, uint32_t 
     for (uint32_t i = 1; i < stopCnt; i++)
         if (sstops.last().offset < stops[i].offset)
             sstops.push(stops[i]);
+        else if (sstops.last().offset == stops[i].offset)
+            sstops.last() = stops[i];
     // head
     uint32_t range_s = 0;
     uint32_t range_e = uint32_t(sstops[0].offset * (WG_TEXTURE_GRADIENT_SIZE-1));


### PR DESCRIPTION
In case if gradient offsets are equal the last color are used instead of first

f.e
```
//Gradient Color Stops
tvg::Fill::ColorStop colorStops[3];
colorStops[0] = {0, 0, 0, 0, 255};
colorStops[1] = {0, 128, 128, 128, 255};
colorStops[2] = {1, 255, 255, 255, 255};
```
(128, 128, 128) will be used instaed of (0, 0, 0)

See _rg1024_Ufo_in_metalic_style.svg_
https://github.com/thorvg/thorvg/issues/2592

Reference:
![image](https://github.com/user-attachments/assets/763055f5-4876-44e1-a848-018ad5721904)

Before:
![image](https://github.com/user-attachments/assets/0ccb1b86-117d-42c4-bb90-df63dc32dabf)

After:
![image](https://github.com/user-attachments/assets/c074e478-e878-42a8-bffb-1cbafdf0e5db)
