### PR TITLE
sw_engine: fix render fill region

### DIFF
--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -498,6 +498,8 @@ bool shapePrepare(SwShape* shape, const RenderShape* rshape, const Matrix& trans
     if (!_genOutline(shape, rshape, transform, mpool, tid, hasComposite)) return false;
     if (!mathUpdateOutlineBBox(shape->outline, clipRegion, renderRegion, shape->fastTrack)) return false;
 
+    shape->bbox = renderRegion;
+
     //Check valid region
     if (renderRegion.max.x - renderRegion.min.x < 1 && renderRegion.max.y - renderRegion.min.y < 1) return false;
 


### PR DESCRIPTION
Shape's bbox represents only fill's render region. Render region of fill and stroke is stored in SwTask. This was visible while rendering shapes with a stroke - fill was to big.

@Issue: https://github.com/thorvg/thorvg/issues/2908

before - fill drawn under the whole stroke
<img width="200" alt="Zrzut ekranu 2024-10-30 o 23 53 08" src="https://github.com/user-attachments/assets/13f768de-4c80-47c4-b92d-11cc57c9675c">

after - fill drawn under half of the stroke - as expected
<img width="200" alt="Zrzut ekranu 2024-10-30 o 23 42 54" src="https://github.com/user-attachments/assets/9d21c3ec-85d6-4bb8-9773-2e55f161379d">

sample:
```
<svg viewBox="0 0 800 800" xmlns="http://www.w3.org/2000/svg">
    <rect fill="red" stroke="white" stroke-width="100" stroke-opacity="0.5" x="300" y="0" width="200" height="600"/>
</svg>
```