### PR TITLE
capi: support gl/wg canvases

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -110,6 +110,7 @@ typedef struct _Tvg_Animation Tvg_Animation;
 typedef enum {
     TVG_ENGINE_SW = (1 << 1),   ///< CPU rasterizer
     TVG_ENGINE_GL = (1 << 2),   ///< OpenGL rasterizer
+    TVG_ENGINE_WG = (1 << 3)    ///< WebGPU rasterizer
 } Tvg_Engine;
 
 
@@ -487,6 +488,93 @@ TVG_API Tvg_Result tvg_swcanvas_set_target(Tvg_Canvas* canvas, uint32_t* buffer,
 TVG_API Tvg_Result tvg_swcanvas_set_mempool(Tvg_Canvas* canvas, Tvg_Mempool_Policy policy);
 
 /** \} */   // end defgroup ThorVGCapi_SwCanvas
+
+
+/**
+* \defgroup ThorVGCapi_GlCanvas SwCanvas
+* \ingroup ThorVGCapi_Canvas
+*
+* \brief A module for rendering the graphical elements using the opengl engine.
+*
+* \{
+*/
+
+/************************************************************************/
+/* GlCanvas API                                                         */
+/************************************************************************/
+
+/*!
+* \brief Creates a OpenGL rasterizer Canvas object.
+*
+* \return A new Tvg_Canvas object.
+*
+* \since 1.0.0
+*/
+TVG_API Tvg_Canvas* tvg_glcanvas_create(void);
+
+
+/*!
+* \brief Sets the drawing target for rasterization.
+*
+* This function specifies the drawing target where the rasterization will occur. It can target
+* a specific framebuffer object (FBO) or the main surface.
+*
+* \param[in] id The GL target ID, usually indicating the FBO ID. A value of @c 0 specifies the main surface.
+* \param[in] w The width (in pixels) of the raster image.
+* \param[in] h The height (in pixels) of the raster image.
+*
+* \return Tvg_Result enumeration.
+* \retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
+* \retval TVG_RESULT_NOT_SUPPORTED In case the gl engine is not supported.
+*
+* \note Currently, this only allows the GL_RGBA8 color space format.
+* \note Experimental API
+*/
+TVG_API Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas* canvas, int32_t id, uint32_t w, uint32_t h);
+
+/** \} */   // end defgroup ThorVGCapi_GlCanvas
+
+
+/**
+* \defgroup ThorVGCapi_WgCanvas WGCanvas
+* \ingroup ThorVGCapi_Canvas
+*
+* \brief A module for rendering the graphical elements using the webgpu engine.
+*
+* \{
+*/
+
+/************************************************************************/
+/* WgCanvas API                                                         */
+/************************************************************************/
+
+/*!
+* \brief Creates a WebGPU rasterizer Canvas object.
+*
+* \return A new Tvg_Canvas object.
+*
+* \since 1.0.0
+*/
+TVG_API Tvg_Canvas* tvg_wgcanvas_create(void);
+
+/*!
+* \brief Sets the drawing target for the rasterization.
+*
+* \param[in] instance WGPUInstance, context for all other wgpu objects.
+* \param[in] surface WGPUSurface, handle to a presentable surface.
+* \param[in] w The width of the surface.
+* \param[in] h The height of the surface.
+* \param[in] device WGPUDevice, a desired handle for the wgpu device. If it is @c nullptr, ThorVG will assign an appropriate device internally.
+*
+* \return Tvg_Result enumeration.
+* \retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
+* \retval TVG_RESULT_NOT_SUPPORTED In case the wg engine is not supported.
+*
+* \note Experimental API
+*/
+TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* instance, void* surface, uint32_t w, uint32_t h, void* device);
+
+/** \} */   // end defgroup ThorVGCapi_WgCanvas
 
 
 /************************************************************************/

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -68,6 +68,18 @@ TVG_API Tvg_Canvas* tvg_swcanvas_create()
 }
 
 
+TVG_API Tvg_Canvas* tvg_glcanvas_create()
+{
+    return (Tvg_Canvas*) GlCanvas::gen().release();
+}
+
+
+TVG_API Tvg_Canvas* tvg_wgcanvas_create()
+{
+    return (Tvg_Canvas*) WgCanvas::gen().release();
+}
+
+
 TVG_API Tvg_Result tvg_canvas_destroy(Tvg_Canvas* canvas)
 {
     if (!canvas) return TVG_RESULT_INVALID_ARGUMENT;
@@ -87,6 +99,20 @@ TVG_API Tvg_Result tvg_swcanvas_set_target(Tvg_Canvas* canvas, uint32_t* buffer,
 {
     if (!canvas) return TVG_RESULT_INVALID_ARGUMENT;
     return (Tvg_Result) reinterpret_cast<SwCanvas*>(canvas)->target(buffer, stride, w, h, static_cast<ColorSpace>(cs));
+}
+
+
+TVG_API Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas* canvas, int32_t id, uint32_t w, uint32_t h)
+{
+    if (!canvas) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<GlCanvas*>(canvas)->target(id, w, h);
+}
+
+
+TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* instance, void* surface, uint32_t w, uint32_t h, void* device)
+{
+    if (!canvas) return TVG_RESULT_INVALID_ARGUMENT;
+    return (Tvg_Result) reinterpret_cast<WgCanvas*>(canvas)->target(instance, surface, w, h, device);
 }
 
 

--- a/tools/lottie2gif/lottie2gif.cpp
+++ b/tools/lottie2gif/lottie2gif.cpp
@@ -92,7 +92,7 @@ private:
       if (saver->save(std::move(animation), out, 100, fps) != Result::Success) return false;
       if (saver->sync() != Result::Success) return false;
 
-      if (Initializer::term(CanvasEngine::Sw) != Result::Success) return false;
+      if (Initializer::term() != Result::Success) return false;
 
       return true;
    }

--- a/tools/svg2png/svg2png.cpp
+++ b/tools/svg2png/svg2png.cpp
@@ -162,8 +162,7 @@ public:
 
     void terminate()
     {
-        //Terminate ThorVG Engine
-        tvg::Initializer::term(tvg::CanvasEngine::Sw);
+        tvg::Initializer::term();
         free(buffer);
     }
 


### PR DESCRIPTION
New APIs:
 - Tvg_Canvas* tvg_glcanvas_create(void)
 - Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas* canvas, int32_t id, uint32_t w, uint32_t h)
 - Tvg_Canvas* tvg_wgcanvas_create(void)
 - Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* instance, void* surface, uint32_t w, uint32_t h, void* device)

issue: https://github.com/thorvg/thorvg/issues/2855