### PR TITLE
gl_engine: Fix memory leak in the IndexBuffer object

### DIFF
--- a/src/renderer/gl_engine/tvgGlGpuBuffer.cpp
+++ b/src/renderer/gl_engine/tvgGlGpuBuffer.cpp
@@ -117,9 +117,13 @@ uint32_t GlStageBuffer::pushIndex(void *data, uint32_t size)
     return offset;
 }
 
-void GlStageBuffer::flushToGPU()
+bool GlStageBuffer::flushToGPU()
 {
-    if (mStageBuffer.empty()) return;
+    if (mStageBuffer.empty() || mIndexBuffer.empty()) {
+        mStageBuffer.clear();
+        mIndexBuffer.clear();
+        return false;
+    }
 
 
     mGpuBuffer.bind(GlGpuBuffer::Target::ARRAY_BUFFER);
@@ -131,6 +135,9 @@ void GlStageBuffer::flushToGPU()
     mGpuIndexBuffer.unbind(GlGpuBuffer::Target::ELEMENT_ARRAY_BUFFER);
 
     mStageBuffer.clear();
+    mIndexBuffer.clear();
+
+    return true;
 }
 
 void GlStageBuffer::bind()

--- a/src/renderer/gl_engine/tvgGlGpuBuffer.h
+++ b/src/renderer/gl_engine/tvgGlGpuBuffer.h
@@ -56,7 +56,7 @@ public:
 
     uint32_t pushIndex(void* data, uint32_t size);
 
-    void flushToGPU();
+    bool flushToGPU();
 
     void bind();
 

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -863,10 +863,11 @@ bool GlRenderer::sync()
     task->mClearBuffer = mClearBuffer;
     task->setTargetViewport({0, 0, static_cast<int32_t>(surface.w), static_cast<int32_t>(surface.h)});
 
-    mGpuBuffer->flushToGPU();
-    mGpuBuffer->bind();
+    if (mGpuBuffer->flushToGPU()) {
+        mGpuBuffer->bind();
 
-    task->run();
+        task->run();
+    }
 
     mGpuBuffer->unbind();
 


### PR DESCRIPTION
This PR fix a low-level error in GL backend :(

The CPU buffer cache in the IndexBuffer object needs to be cleared, otherwise it will cause memory leaks and reduce performance per frame