### PR TITLE
api: revise the spec

### DIFF
--- a/examples/Accessor.cpp
+++ b/examples/Accessor.cpp
@@ -38,7 +38,7 @@ struct UserExample : tvgexam::Example
         if (!tvgexam::verify(result)) return false;
         picture->size(w, h);
 
-        auto accessor = tvg::Accessor::gen();
+        auto accessor = unique_ptr<tvg::Accessor>(tvg::Accessor::gen());
 
         //The callback function from lambda expression.
         //This function will be called for every paint nodes of the picture tree.
@@ -58,7 +58,7 @@ struct UserExample : tvgexam::Example
             return true;
         };
 
-        if (!tvgexam::verify(accessor->set(picture.get(), f, nullptr))) return false;
+        if (!tvgexam::verify(accessor->set(picture, f, nullptr))) return false;
 
         // Try to retrieve the shape that corresponds to the SVG node with the unique ID "star".
         if (auto paint = picture->paint(tvg::Accessor::id("star"))) {
@@ -67,7 +67,7 @@ struct UserExample : tvgexam::Example
             shape->strokeWidth(5);
         }
 
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         return true;
     }

--- a/examples/AnimateMasking.cpp
+++ b/examples/AnimateMasking.cpp
@@ -28,8 +28,8 @@
 
 struct UserExample : tvgexam::Example
 {
-    tvg::Shape *pMaskShape = nullptr;
-    tvg::Shape *pMask = nullptr;
+    tvg::Shape* maskShape = nullptr;
+    tvg::Shape* mask = nullptr;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
@@ -39,35 +39,33 @@ struct UserExample : tvgexam::Example
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);
         bg->fill(255, 255, 255);
-        canvas->push(std::move(bg));
+        canvas->push(bg);
 
         //image
         auto picture1 = tvg::Picture::gen();
         if (!tvgexam::verify(picture1->load(EXAMPLE_DIR"/svg/cartman.svg"))) return false;
         picture1->size(400, 400);
-        canvas->push(std::move(picture1));
+        canvas->push(picture1);
 
         auto picture2 = tvg::Picture::gen();
         picture2->load(EXAMPLE_DIR"/svg/logo.svg");
         picture2->size(400, 400);
 
         //mask
-        auto maskShape = tvg::Shape::gen();
-        pMaskShape = maskShape.get();
+        maskShape = tvg::Shape::gen();
         maskShape->appendCircle(180, 180, 75, 75);
         maskShape->fill(125, 125, 125);
         maskShape->strokeFill(25, 25, 25);
         maskShape->strokeJoin(tvg::StrokeJoin::Round);
         maskShape->strokeWidth(10);
-        canvas->push(std::move(maskShape));
+        canvas->push(maskShape);
 
-        auto mask = tvg::Shape::gen();
-        pMask = mask.get();
+        mask = tvg::Shape::gen();
         mask->appendCircle(180, 180, 75, 75);
         mask->fill(255, 255, 255);         //AlphaMask RGB channels are unused.
 
-        picture2->mask(std::move(mask), tvg::MaskMethod::Alpha);
-        canvas->push(std::move(picture2));
+        picture2->mask(mask, tvg::MaskMethod::Alpha);
+        canvas->push(picture2);
 
         return true;
     }
@@ -82,8 +80,8 @@ struct UserExample : tvgexam::Example
         auto progress = tvgexam::progress(elapsed, 3.0f, true);  //play time 3 sec.
 
         // Translate mask object with its stroke & update
-        pMaskShape->translate(0 , progress * 300 - 100);
-        pMask->translate(0 , progress * 300 - 100);
+        maskShape->translate(0 , progress * 300 - 100);
+        mask->translate(0 , progress * 300 - 100);
 
         canvas->update();
 

--- a/examples/Animation.cpp
+++ b/examples/Animation.cpp
@@ -33,7 +33,7 @@ struct UserExample : tvgexam::Example
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
         //Animation Controller
-        animation = tvg::Animation::gen();
+        animation = unique_ptr<tvg::Animation>(tvg::Animation::gen());
         auto picture = animation->picture();
 
         //Background
@@ -41,7 +41,7 @@ struct UserExample : tvgexam::Example
         shape->appendRect(0, 0, w, h);
         shape->fill(50, 50, 50);
 
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/sample.json"))) return false;
 
@@ -62,7 +62,7 @@ struct UserExample : tvgexam::Example
         picture->scale(scale);
         picture->translate(shiftX, shiftY);
 
-        canvas->push(tvg::cast(picture));
+        canvas->push(picture);
 
         return true;
     }

--- a/examples/Blending.cpp
+++ b/examples/Blending.cpp
@@ -37,21 +37,21 @@ struct UserExample : tvgexam::Example
         shape1->appendRect(0, 0, 400, 400, 50, 50);
         shape1->fill(0, 255, 255);
         shape1->blend(tvg::BlendMethod::Normal);
-        canvas->push(std::move(shape1));
+        canvas->push(shape1);
 
         //Add
         auto shape2 = tvg::Shape::gen();
         shape2->appendCircle(400, 400, 200, 200);
         shape2->fill(255, 255, 0, 170);
         shape2->blend(tvg::BlendMethod::Add);
-        canvas->push(std::move(shape2));
+        canvas->push(shape2);
 
         //Multiply
         auto shape3 = tvg::Shape::gen();
         shape3->appendCircle(400, 400, 250, 100);
         shape3->fill(255, 255, 255, 100);
         shape3->blend(tvg::BlendMethod::Multiply);
-        canvas->push(std::move(shape3));
+        canvas->push(shape3);
 
         //Overlay
         auto shape4 = tvg::Shape::gen();
@@ -68,7 +68,7 @@ struct UserExample : tvgexam::Example
         shape4->close();
         shape4->fill(255, 0, 200, 200);
         shape4->blend(tvg::BlendMethod::Overlay);
-        canvas->push(std::move(shape4));
+        canvas->push(shape4);
 
         //Difference
         auto shape5 = tvg::Shape::gen();
@@ -84,9 +84,9 @@ struct UserExample : tvgexam::Example
         colorStops[1] = {1, 255, 255, 255, 100};
         fill->colorStops(colorStops, 2);
 
-        shape5->fill(std::move(fill));
+        shape5->fill(fill);
         shape5->blend(tvg::BlendMethod::Difference);
-        canvas->push(std::move(shape5));
+        canvas->push(shape5);
 
         //Exclusion
         auto shape6 = tvg::Shape::gen();
@@ -97,23 +97,23 @@ struct UserExample : tvgexam::Example
         fill2->radial(300, 800, 150, 300, 800, 0);
         fill2->colorStops(colorStops, 2);
 
-        shape6->fill(std::move(fill2));
+        shape6->fill(fill2);
         shape6->blend(tvg::BlendMethod::Exclusion);
-        canvas->push(std::move(shape6));
+        canvas->push(shape6);
 
         //Screen
         auto shape7 = tvg::Shape::gen();
         shape7->appendCircle(600, 650, 200, 150);
         shape7->blend(tvg::BlendMethod::Screen);
         shape7->fill(0, 0, 255);
-        canvas->push(std::move(shape7));
+        canvas->push(shape7);
 
         //Darken
         auto shape9 = tvg::Shape::gen();
         shape9->appendRect(600, 650, 350, 250);
         shape9->blend(tvg::BlendMethod::Darken);
         shape9->fill(10, 255, 155);
-        canvas->push(std::move(shape9));
+        canvas->push(shape9);
 
         //Prepare Transformed Image
         string path(EXAMPLE_DIR"/image/rawimage_200x300.raw");
@@ -130,14 +130,14 @@ struct UserExample : tvgexam::Example
         picture->translate(800, 700);
         picture->rotate(40);
         picture->blend(tvg::BlendMethod::Lighten);
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         //ColorDodge
         auto shape10 = tvg::Shape::gen();
         shape10->appendRect(0, 0, 200, 200, 50, 50);
         shape10->blend(tvg::BlendMethod::ColorDodge);
         shape10->fill(255, 255, 255, 250);
-        canvas->push(std::move(shape10));
+        canvas->push(shape10);
 
         //ColorBurn
         auto picture2 = tvg::Picture::gen();
@@ -145,14 +145,14 @@ struct UserExample : tvgexam::Example
         picture2->translate(600, 250);
         picture2->blend(tvg::BlendMethod::ColorBurn);
         picture2->opacity(150);
-        canvas->push(std::move(picture2));
+        canvas->push(picture2);
 
         //HardLight
         auto picture3 = tvg::Picture::gen();
         if (!tvgexam::verify(picture3->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         picture3->translate(700, 150);
         picture3->blend(tvg::BlendMethod::HardLight);
-        canvas->push(std::move(picture3));
+        canvas->push(picture3);
 
         //SoftLight
         auto picture4 = tvg::Picture::gen();
@@ -160,7 +160,7 @@ struct UserExample : tvgexam::Example
         picture4->translate(350, 600);
         picture4->rotate(90);
         picture4->blend(tvg::BlendMethod::SoftLight);
-        canvas->push(std::move(picture4));
+        canvas->push(picture4);
 
         free(data);
 

--- a/examples/Clipping.cpp
+++ b/examples/Clipping.cpp
@@ -51,13 +51,13 @@ struct UserExample : tvgexam::Example
         auto shape = tvg::Shape::gen();
         shape->appendRect(0, 0, w, h);
         shape->fill(255, 255, 255);
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         //////////////////////////////////////////////
         auto scene = tvg::Scene::gen();
 
         auto star1 = tvg::Shape::gen();
-        compose(star1.get());
+        compose(star1);
         star1->fill(255, 255, 0);
         star1->strokeFill(255 ,0, 0);
         star1->strokeWidth(10);
@@ -70,10 +70,10 @@ struct UserExample : tvgexam::Example
         clipStar->appendCircle(200, 230, 110, 110);
         clipStar->translate(10, 10);
 
-        star1->clip(std::move(clipStar));
+        star1->clip((clipStar));
 
         auto star2 = tvg::Shape::gen();
-        compose(star2.get());
+        compose(star2);
         star2->fill(0, 255, 255);
         star2->strokeFill(0 ,255, 0);
         star2->strokeWidth(10);
@@ -87,17 +87,17 @@ struct UserExample : tvgexam::Example
         clip->appendCircle(200, 230, 130, 130);
         clip->translate(10, 10);
 
-        scene->push(std::move(star1));
-        scene->push(std::move(star2));
+        scene->push(star1);
+        scene->push(star2);
 
         //Clipping scene to shape
-        scene->clip(std::move(clip));
+        scene->clip(clip);
 
-        canvas->push(std::move(scene));
+        canvas->push(scene);
 
         //////////////////////////////////////////////
         auto star3 = tvg::Shape::gen();
-        compose(star3.get());
+        compose(star3);
 
         //Fill Gradient
         auto fill = tvg::LinearGradient::gen();
@@ -106,7 +106,7 @@ struct UserExample : tvgexam::Example
         colorStops[0] = {0, 0, 0, 0, 255};
         colorStops[1] = {1, 255, 255, 255, 255};
         fill->colorStops(colorStops, 2);
-        star3->fill(std::move(fill));
+        star3->fill(fill);
 
         star3->strokeFill(255 ,0, 0);
         star3->strokeWidth(10);
@@ -118,9 +118,9 @@ struct UserExample : tvgexam::Example
         clipRect->translate(20, 20);
 
         //Clipping scene to rect(shape)
-        star3->clip(std::move(clipRect));
+        star3->clip(clipRect);
 
-        canvas->push(std::move(star3));
+        canvas->push(star3);
 
         //////////////////////////////////////////////
         auto picture = tvg::Picture::gen();
@@ -136,9 +136,9 @@ struct UserExample : tvgexam::Example
         clipPath->translate(20, 20);
 
         //Clipping picture to path
-        picture->clip(std::move(clipPath));
+        picture->clip(clipPath);
 
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         //////////////////////////////////////////////
         auto shape1 = tvg::Shape::gen();
@@ -150,9 +150,9 @@ struct UserExample : tvgexam::Example
         clipShape->appendRect(600, 420, 100, 100);
 
         //Clipping shape1 to clipShape
-        shape1->clip(std::move(clipShape));
+        shape1->clip(clipShape);
 
-        canvas->push(std::move(shape1));
+        canvas->push(shape1);
 
         return true;
     }

--- a/examples/CustomTransform.cpp
+++ b/examples/CustomTransform.cpp
@@ -95,7 +95,7 @@ struct UserExample : tvgexam::Example
 
         shape->transform(m);
 
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         return true;
     }

--- a/examples/DataLoad.cpp
+++ b/examples/DataLoad.cpp
@@ -39,14 +39,14 @@ struct UserExample : tvgexam::Example
         shape->appendRect(0, 0, w, h);          //x, y, w, h
         shape->fill(255, 255, 255);             //r, g, b
 
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         auto picture = tvg::Picture::gen();
         if (!tvgexam::verify(picture->load(svg, strlen(svg), "svg"))) return false;
 
         picture->size(w, h);
 
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         return true;
     }

--- a/examples/DirectUpdate.cpp
+++ b/examples/DirectUpdate.cpp
@@ -40,39 +40,26 @@ struct UserExample : tvgexam::Example
         //Shape (for BG)
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);
-
-        //fill property will be retained
         bg->fill(255, 255, 255);
-
-        canvas->push(std::move(bg));
+        canvas->push(bg);
 
         //Solid Shape
         {
-            auto shape = tvg::Shape::gen();
-
-            /* Acquire shape pointer to access it again.
-            instead, you should consider not to interrupt this pointer life-cycle. */
-            solid = shape.get();
-
-            shape->appendRect(-100, -100, 200, 200);
+            solid = tvg::Shape::gen();
+            solid->appendRect(-100, -100, 200, 200);
 
             //fill property will be retained
-            shape->fill(127, 255, 255);
-            shape->strokeFill(0, 0, 255);
-            shape->strokeWidth(1);
+            solid->fill(127, 255, 255);
+            solid->strokeFill(0, 0, 255);
+            solid->strokeWidth(1);
 
-            canvas->push(std::move(shape));
+            canvas->push(solid);
         }
 
         //Gradient Shape
         {
-            auto shape = tvg::Shape::gen();
-
-            /* Acquire shape pointer to access it again.
-            instead, you should consider not to interrupt this pointer life-cycle. */
-            gradient = shape.get();
-
-            shape->appendRect(w - 200, 0, 200, 200);
+            gradient = tvg::Shape::gen();
+            gradient->appendRect(w - 200, 0, 200, 200);
 
             //LinearGradient
             auto fill = tvg::LinearGradient::gen();
@@ -85,9 +72,9 @@ struct UserExample : tvgexam::Example
             colorStops[2] = {1, 255, 255, 255, 127};
 
             fill->colorStops(colorStops, 3);
-            shape->fill(std::move(fill));
+            gradient->fill(fill);
 
-            canvas->push(std::move(shape));
+            canvas->push(gradient);
         }
 
         this->w = w;

--- a/examples/Duplicate.cpp
+++ b/examples/Duplicate.cpp
@@ -47,7 +47,7 @@ struct UserExample : tvgexam::Example
             shape1->fill(255, 0, 0);
 
             //Duplicate Shape, Switch fill method
-            auto shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
+            auto shape2 = static_cast<tvg::Shape*>(shape1->duplicate());
             shape2->translate(0, 220);
 
             auto fill = tvg::LinearGradient::gen();
@@ -58,15 +58,15 @@ struct UserExample : tvgexam::Example
             colorStops[1] = {1, 255, 255, 255, 255};
             fill->colorStops(colorStops, 2);
 
-            shape2->fill(std::move(fill));
+            shape2->fill(fill);
 
             //Duplicate Shape 2
-            auto shape3 = tvg::cast<tvg::Shape>(shape2->duplicate());
+            auto shape3 = shape2->duplicate();
             shape3->translate(0, 440);
 
-            canvas->push(std::move(shape1));
-            canvas->push(std::move(shape2));
-            canvas->push(std::move(shape3));
+            canvas->push(shape1);
+            canvas->push(shape2);
+            canvas->push(shape3);
         }
 
         //Duplicate Scene
@@ -77,27 +77,27 @@ struct UserExample : tvgexam::Example
             auto shape1 = tvg::Shape::gen();
             shape1->appendRect(0, 0, 400, 400, 50, 50);
             shape1->fill(0, 255, 0);
-            scene1->push(std::move(shape1));
+            scene1->push(shape1);
 
             auto shape2 = tvg::Shape::gen();
             shape2->appendCircle(400, 400, 200, 200);
             shape2->fill(255, 255, 0);
-            scene1->push(std::move(shape2));
+            scene1->push(shape2);
 
             auto shape3 = tvg::Shape::gen();
             shape3->appendCircle(600, 600, 150, 100);
             shape3->fill(0, 255, 255);
-            scene1->push(std::move(shape3));
+            scene1->push(shape3);
 
             scene1->scale(0.25);
             scene1->translate(400, 0);
 
             //Duplicate Scene1
-            auto scene2 = tvg::cast<tvg::Scene>(scene1->duplicate());
+            auto scene2 = scene1->duplicate();
             scene2->translate(600, 0);
 
-            canvas->push(std::move(scene1));
-            canvas->push(std::move(scene2));
+            canvas->push(scene1);
+            canvas->push(scene2);
         }
 
         //Duplicate Picture - svg
@@ -107,11 +107,11 @@ struct UserExample : tvgexam::Example
             picture1->translate(350, 200);
             picture1->scale(0.25);
 
-            auto picture2 = tvg::cast<tvg::Picture>(picture1->duplicate());
+            auto picture2 = picture1->duplicate();
             picture2->translate(550, 250);
 
-            canvas->push(std::move(picture1));
-            canvas->push(std::move(picture2));
+            canvas->push(picture1);
+            canvas->push(picture2);
         }
 
         //Duplicate Picture - raw
@@ -128,13 +128,13 @@ struct UserExample : tvgexam::Example
             picture1->scale(0.8);
             picture1->translate(400, 450);
 
-            auto picture2 = tvg::cast<tvg::Picture>(picture1->duplicate());
+            auto picture2 = picture1->duplicate();
             picture2->translate(600, 550);
             picture2->scale(0.7);
             picture2->rotate(8);
 
-            canvas->push(std::move(picture1));
-            canvas->push(std::move(picture2));
+            canvas->push(picture1);
+            canvas->push(picture2);
 
             free(data);
         }
@@ -148,11 +148,11 @@ struct UserExample : tvgexam::Example
             text->text("ThorVG Text");
             text->fill(100, 100, 255);
 
-            auto text2 = tvg::cast<tvg::Text>(text->duplicate());
+            auto text2 = text->duplicate();
             text2->translate(0, 700);
 
-            canvas->push(std::move(text));
-            canvas->push(std::move(text2));
+            canvas->push(text);
+            canvas->push(text2);
         }
 
         return true;

--- a/examples/EffectDropShadow.cpp
+++ b/examples/EffectDropShadow.cpp
@@ -28,9 +28,9 @@
 
 struct UserExample : tvgexam::Example
 {
-    tvg::Scene* pScene1 = nullptr;
-    tvg::Scene* pScene2 = nullptr;
-    tvg::Scene* pScene3 = nullptr;
+    tvg::Scene* scene1 = nullptr;
+    tvg::Scene* scene2 = nullptr;
+    tvg::Scene* scene3 = nullptr;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
@@ -40,14 +40,13 @@ struct UserExample : tvgexam::Example
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);
         bg->fill(255, 255, 255);
-        canvas->push(std::move(bg));
+        canvas->push(bg);
 
         float pw, ph;
 
         //Prepare a scene for post effects
         {
-            auto scene = tvg::Scene::gen();
-            pScene1 = scene.get();
+            scene1 = tvg::Scene::gen();
 
             auto picture = tvg::Picture::gen();
             picture->load(EXAMPLE_DIR"/svg/LottieFiles_logo.svg");
@@ -56,14 +55,13 @@ struct UserExample : tvgexam::Example
             picture->size(pw * 0.5f, ph * 0.5f);
             picture->translate(pw * 0.175f, 0.0f);
 
-            scene->push(std::move(picture));
-            canvas->push(std::move(scene));
+            scene1->push(picture);
+            canvas->push(scene1);
         }
 
         //Prepare a scene for post effects
         {
-            auto scene = tvg::Scene::gen();
-            pScene2 = scene.get();
+            scene2 = tvg::Scene::gen();
 
             auto picture = tvg::Picture::gen();
             picture->load(EXAMPLE_DIR"/svg/152932619-bd3d6921-72df-4f09-856b-f9743ae32a14.svg");
@@ -72,14 +70,13 @@ struct UserExample : tvgexam::Example
             picture->translate(pw * 0.45f, ph * 0.45f);
             picture->size(pw * 0.75f, ph * 0.75f);
 
-            scene->push(std::move(picture));
-            canvas->push(std::move(scene));
+            scene2->push(picture);
+            canvas->push(scene2);
         }
 
         //Prepare a scene for post effects
         {
-            auto scene = tvg::Scene::gen();
-            pScene3 = scene.get();
+            scene3 = tvg::Scene::gen();
 
             auto picture = tvg::Picture::gen();
             picture->load(EXAMPLE_DIR"/svg//circles1.svg");
@@ -88,8 +85,8 @@ struct UserExample : tvgexam::Example
             picture->translate(w * 0.3f, h * 0.65f);
             picture->size(pw * 0.75f, ph * 0.75f);
 
-            scene->push(std::move(picture));
-            canvas->push(std::move(scene));
+            scene3->push(picture);
+            canvas->push(scene3);
         }
 
         return true;
@@ -104,15 +101,15 @@ struct UserExample : tvgexam::Example
         auto progress = tvgexam::progress(elapsed, 2.5f, true);   //2.5 seconds
 
         //Clear the previously applied effects
-        pScene1->push(tvg::SceneEffect::ClearAll);
+        scene1->push(tvg::SceneEffect::ClearAll);
         //Apply DropShadow post effect (r, g, b, a, angle, distance, sigma of blurness, quality)
-        pScene1->push(tvg::SceneEffect::DropShadow, 0, 0, 0, 125, 120.0f, 20.0f * progress, 3.0f, 100);
+        scene1->push(tvg::SceneEffect::DropShadow, 0, 0, 0, 125, 120.0f, 20.0f * progress, 3.0f, 100);
 
-        pScene2->push(tvg::SceneEffect::ClearAll);
-        pScene2->push(tvg::SceneEffect::DropShadow, 65, 143, 222, (int)(255.0f * progress), 135.0f, 10.0f, 3.0f, 100);
+        scene2->push(tvg::SceneEffect::ClearAll);
+        scene2->push(tvg::SceneEffect::DropShadow, 65, 143, 222, (int)(255.0f * progress), 135.0f, 10.0f, 3.0f, 100);
 
-        pScene3->push(tvg::SceneEffect::ClearAll);
-        pScene3->push(tvg::SceneEffect::DropShadow, 0, 0, 0, 125, 360.0f * progress, 20.0f, 3.0f, 100);
+        scene3->push(tvg::SceneEffect::ClearAll);
+        scene3->push(tvg::SceneEffect::DropShadow, 0, 0, 0, 125, 360.0f * progress, 20.0f, 3.0f, 100);
 
         canvas->update();
 

--- a/examples/EffectGaussianBlur.cpp
+++ b/examples/EffectGaussianBlur.cpp
@@ -28,9 +28,9 @@
 
 struct UserExample : tvgexam::Example
 {
-    tvg::Scene* pScene1 = nullptr;   //direction both
-    tvg::Scene* pScene2 = nullptr;   //direction horizontal
-    tvg::Scene* pScene3 = nullptr;   //direction vertical
+    tvg::Scene* scene1 = nullptr;   //direction both
+    tvg::Scene* scene2 = nullptr;   //direction horizontal
+    tvg::Scene* scene3 = nullptr;   //direction vertical
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
@@ -38,43 +38,40 @@ struct UserExample : tvgexam::Example
 
         //Prepare a scene for post effects (direction both)
         {
-            auto scene = tvg::Scene::gen();
-            pScene1 = scene.get();
+            scene1 = tvg::Scene::gen();
 
             auto picture = tvg::Picture::gen();
             picture->load(EXAMPLE_DIR"/svg/tiger.svg");
             picture->size(w / 2, h / 2);
 
-            scene->push(std::move(picture));
-            canvas->push(std::move(scene));
+            scene1->push(picture);
+            canvas->push(scene1);
         }
 
         //Prepare a scene for post effects (direction horizontal)
         {
-            auto scene = tvg::Scene::gen();
-            pScene2 = scene.get();
+            scene2 = tvg::Scene::gen();
 
             auto picture = tvg::Picture::gen();
             picture->load(EXAMPLE_DIR"/svg/tiger.svg");
             picture->size(w / 2, h / 2);
             picture->translate(w / 2, 0);
 
-            scene->push(std::move(picture));
-            canvas->push(std::move(scene));
+            scene2->push(picture);
+            canvas->push(scene2);
         }
 
         //Prepare a scene for post effects (direction vertical)
         {
-            auto scene = tvg::Scene::gen();
-            pScene3 = scene.get();
+            scene3 = tvg::Scene::gen();
 
             auto picture = tvg::Picture::gen();
             picture->load(EXAMPLE_DIR"/svg/tiger.svg");
             picture->size(w / 2, h / 2);
             picture->translate(0, h / 2);
 
-            scene->push(std::move(picture));
-            canvas->push(std::move(scene));
+            scene3->push(picture);
+            canvas->push(scene3);
         }
 
 
@@ -90,15 +87,15 @@ struct UserExample : tvgexam::Example
         auto progress = tvgexam::progress(elapsed, 2.5f, true);   //2.5 seconds
 
         //Clear the previously applied effects
-        pScene1->push(tvg::SceneEffect::ClearAll);
+        scene1->push(tvg::SceneEffect::ClearAll);
         //Apply GaussianBlur post effect (sigma, direction, border option, quality)
-        pScene1->push(tvg::SceneEffect::GaussianBlur, 10.0f * progress, 0, 0, 100);
+        scene1->push(tvg::SceneEffect::GaussianBlur, 10.0f * progress, 0, 0, 100);
 
-        pScene2->push(tvg::SceneEffect::ClearAll);
-        pScene2->push(tvg::SceneEffect::GaussianBlur, 10.0f * progress, 1, 0, 100);
+        scene2->push(tvg::SceneEffect::ClearAll);
+        scene2->push(tvg::SceneEffect::GaussianBlur, 10.0f * progress, 1, 0, 100);
 
-        pScene3->push(tvg::SceneEffect::ClearAll);
-        pScene3->push(tvg::SceneEffect::GaussianBlur, 10.0f * progress, 2, 0, 100);
+        scene3->push(tvg::SceneEffect::ClearAll);
+        scene3->push(tvg::SceneEffect::GaussianBlur, 10.0f * progress, 2, 0, 100);
 
         canvas->update();
 

--- a/examples/Example.h
+++ b/examples/Example.h
@@ -21,6 +21,7 @@
  */
 #include "config.h"
 
+#include <memory>
 #include <cmath>
 #include <vector>
 #include <fstream>
@@ -156,6 +157,7 @@ struct Window
     virtual ~Window()
     {
         delete(example);
+        delete(canvas);
 
         //Terminate the SDL
         SDL_DestroyWindow(window);
@@ -269,8 +271,6 @@ struct Window
 
 struct SwWindow : Window
 {
-    unique_ptr<tvg::SwCanvas> canvas = nullptr;
-
     SwWindow(Example* example, uint32_t width, uint32_t height, uint32_t threadsCnt) : Window(tvg::CanvasEngine::Sw, example, width, height, threadsCnt)
     {
         if (!initialized) return;
@@ -284,8 +284,6 @@ struct SwWindow : Window
             return;
         }
 
-        Window::canvas = canvas.get();
-
         resize();
     }
 
@@ -295,7 +293,7 @@ struct SwWindow : Window
         if (!surface) return;
 
         //Set the canvas target and draw on it.
-        verify(canvas->target((uint32_t*)surface->pixels, surface->w, surface->pitch / 4, surface->h, tvg::ColorSpace::ARGB8888));
+        verify(static_cast<tvg::SwCanvas*>(canvas)->target((uint32_t*)surface->pixels, surface->w, surface->pitch / 4, surface->h, tvg::ColorSpace::ARGB8888));
     }
 
     void refresh() override
@@ -311,8 +309,6 @@ struct SwWindow : Window
 struct GlWindow : Window
 {
     SDL_GLContext context;
-
-    unique_ptr<tvg::GlCanvas> canvas = nullptr;
 
     GlWindow(Example* example, uint32_t width, uint32_t height, uint32_t threadsCnt) : Window(tvg::CanvasEngine::Gl, example, width, height, threadsCnt)
     {
@@ -337,8 +333,6 @@ struct GlWindow : Window
             return;
         }
 
-        Window::canvas = canvas.get();
-
         resize();
     }
 
@@ -350,7 +344,7 @@ struct GlWindow : Window
     void resize() override
     {
         //Set the canvas target and draw on it.
-        verify(canvas->target(0, width, height));
+        verify(static_cast<tvg::GlCanvas*>(canvas)->target(0, width, height));
     }
 
     void refresh() override
@@ -367,8 +361,6 @@ struct GlWindow : Window
 
 struct WgWindow : Window
 {
-    unique_ptr<tvg::WgCanvas> canvas = nullptr;
-
     WGPUInstance instance;
     WGPUSurface surface;
 
@@ -428,8 +420,6 @@ struct WgWindow : Window
             return;
         }
 
-        Window::canvas = canvas.get();
-
         resize();
     }
 
@@ -442,7 +432,7 @@ struct WgWindow : Window
     void resize() override
     {
         //Set the canvas target and draw on it.
-        verify(canvas->target(instance, surface, width, height));
+        verify(static_cast<tvg::WgCanvas*>(canvas)->target(instance, surface, width, height));
     }
 
     void refresh() override 

--- a/examples/FillRule.cpp
+++ b/examples/FillRule.cpp
@@ -43,7 +43,7 @@ struct UserExample : tvgexam::Example
         shape1->fill(255, 255, 255);
         shape1->fill(tvg::FillRule::Winding);  //Fill all winding shapes
 
-        canvas->push(std::move(shape1));
+        canvas->push(shape1);
 
         //Star 2
         auto shape2 = tvg::Shape::gen();
@@ -56,7 +56,7 @@ struct UserExample : tvgexam::Example
         shape2->fill(255, 255, 255);
         shape2->fill(tvg::FillRule::EvenOdd); //Fill polygons with even odd pattern
 
-        canvas->push(std::move(shape2));
+        canvas->push(shape2);
 
         return true;
     }

--- a/examples/FillSpread.cpp
+++ b/examples/FillSpread.cpp
@@ -52,9 +52,9 @@ struct UserExample : tvgexam::Example
             fill1->radial(x1 + r, y1 + r, 40.0f, x1 + r, y1 + r, 0.0f);
             fill1->colorStops(colorStops, colorCnt);
             fill1->spread(tvg::FillSpread::Pad);
-            shape1->fill(std::move(fill1));
+            shape1->fill(fill1);
 
-            canvas->push(std::move(shape1));
+            canvas->push(shape1);
 
             //Reflect
             x1 = 280.0f;
@@ -65,9 +65,9 @@ struct UserExample : tvgexam::Example
             fill2->radial(x1 + r, y1 + r, 40.0f, x1 + r, y1 + r, 0.0f);
             fill2->colorStops(colorStops, colorCnt);
             fill2->spread(tvg::FillSpread::Reflect);
-            shape2->fill(std::move(fill2));
+            shape2->fill(fill2);
 
-            canvas->push(std::move(shape2));
+            canvas->push(shape2);
 
             //Repeat
             x1 = 540.0f;
@@ -78,9 +78,9 @@ struct UserExample : tvgexam::Example
             fill3->radial(x1 + r, y1 + r, 40.0f, x1 + r, y1 + r, 0.0f);
             fill3->colorStops(colorStops, colorCnt);
             fill3->spread(tvg::FillSpread::Repeat);
-            shape3->fill(std::move(fill3));
+            shape3->fill(fill3);
 
-            canvas->push(std::move(shape3));
+            canvas->push(shape3);
         }
 
         //Linear grad
@@ -96,9 +96,9 @@ struct UserExample : tvgexam::Example
             fill1->linear(x1, y1, x1 + 50.0f, y1 + 50.0f);
             fill1->colorStops(colorStops, colorCnt);
             fill1->spread(tvg::FillSpread::Pad);
-            shape1->fill(std::move(fill1));
+            shape1->fill(fill1);
 
-            canvas->push(std::move(shape1));
+            canvas->push(shape1);
 
             //Reflect
             x1 = 280.0f;
@@ -109,9 +109,9 @@ struct UserExample : tvgexam::Example
             fill2->linear(x1, y1, x1 + 50.0f, y1 + 50.0f);
             fill2->colorStops(colorStops, colorCnt);
             fill2->spread(tvg::FillSpread::Reflect);
-            shape2->fill(std::move(fill2));
+            shape2->fill(fill2);
 
-            canvas->push(std::move(shape2));
+            canvas->push(shape2);
 
             //Repeat
             x1 = 540.0f;
@@ -122,9 +122,9 @@ struct UserExample : tvgexam::Example
             fill3->linear(x1, y1, x1 + 50.0f, y1 + 50.0f);
             fill3->colorStops(colorStops, colorCnt);
             fill3->spread(tvg::FillSpread::Repeat);
-            shape3->fill(std::move(fill3));
+            shape3->fill(fill3);
 
-            canvas->push(std::move(shape3));
+            canvas->push(shape3);
 
             return true;
         }

--- a/examples/GifSaver.cpp
+++ b/examples/GifSaver.cpp
@@ -37,8 +37,8 @@ void exportGif()
 
     picture->size(800, 800);
 
-    auto saver = tvg::Saver::gen();
-    if (!tvgexam::verify(saver->save(std::move(animation), "./test.gif"))) return;
+    auto saver = unique_ptr<tvg::Saver>(tvg::Saver::gen());
+    if (!tvgexam::verify(saver->save(animation, "./test.gif"))) return;
     saver->sync();
 
     cout << "Successfully exported to test.gif." << endl;

--- a/examples/GradientMasking.cpp
+++ b/examples/GradientMasking.cpp
@@ -33,110 +33,112 @@ struct UserExample : tvgexam::Example
         if (!canvas) return false;
 
         //Solid Rectangle
-        auto shape = tvg::Shape::gen();
-        shape->appendRect(0, 0, 400, 400);
+        {
+            auto shape = tvg::Shape::gen();
+            shape->appendRect(0, 0, 400, 400);
 
-        //Mask
-        auto mask = tvg::Shape::gen();
-        mask->appendCircle(200, 200, 125, 125);
-        mask->fill(255, 0, 0);
+            //Mask
+            auto mask = tvg::Shape::gen();
+            mask->appendCircle(200, 200, 125, 125);
+            mask->fill(255, 0, 0);
 
-        auto fill = tvg::LinearGradient::gen();
-        fill->linear(0, 0, 400, 400);
-        tvg::Fill::ColorStop colorStops[2];
-        colorStops[0] = {0,0,0,0,255};
-        colorStops[1] = {1,255,255,255,255};
-        fill->colorStops(colorStops,2);
-        shape->fill(std::move(fill));
+            auto fill = tvg::LinearGradient::gen();
+            fill->linear(0, 0, 400, 400);
+            tvg::Fill::ColorStop colorStops[2];
+            colorStops[0] = {0,0,0,0,255};
+            colorStops[1] = {1,255,255,255,255};
+            fill->colorStops(colorStops,2);
+            shape->fill(fill);
 
-        shape->mask(std::move(mask), tvg::MaskMethod::Alpha);
-        canvas->push(std::move(shape));
-
-    //-------------------------------------------
+            shape->mask(mask, tvg::MaskMethod::Alpha);
+            canvas->push(shape);
+        }
 
         //Star
-        auto shape1 = tvg::Shape::gen();
-        shape1->moveTo(599, 34);
-        shape1->lineTo(653, 143);
-        shape1->lineTo(774, 160);
-        shape1->lineTo(687, 244);
-        shape1->lineTo(707, 365);
-        shape1->lineTo(599, 309);
-        shape1->lineTo(497, 365);
-        shape1->lineTo(512, 245);
-        shape1->lineTo(426, 161);
-        shape1->lineTo(546, 143);
-        shape1->close();
+        {
+            auto shape1 = tvg::Shape::gen();
+            shape1->moveTo(599, 34);
+            shape1->lineTo(653, 143);
+            shape1->lineTo(774, 160);
+            shape1->lineTo(687, 244);
+            shape1->lineTo(707, 365);
+            shape1->lineTo(599, 309);
+            shape1->lineTo(497, 365);
+            shape1->lineTo(512, 245);
+            shape1->lineTo(426, 161);
+            shape1->lineTo(546, 143);
+            shape1->close();
 
-        //Mask
-        auto mask1 = tvg::Shape::gen();
-        mask1->appendCircle(600, 200, 125, 125);
-        mask1->fill(255, 0, 0);
+            //Mask
+            auto mask1 = tvg::Shape::gen();
+            mask1->appendCircle(600, 200, 125, 125);
+            mask1->fill(255, 0, 0);
 
-        auto fill1 = tvg::LinearGradient::gen();
-        fill1->linear(400, 0, 800, 400);
-        tvg::Fill::ColorStop colorStops1[2];
-        colorStops1[0] = {0,0,0,0,255};
-        colorStops1[1] = {1,1,255,255,255};
-        fill1->colorStops(colorStops1,2);
-        shape1->fill(std::move(fill1));
+            auto fill1 = tvg::LinearGradient::gen();
+            fill1->linear(400, 0, 800, 400);
+            tvg::Fill::ColorStop colorStops1[2];
+            colorStops1[0] = {0,0,0,0,255};
+            colorStops1[1] = {1,1,255,255,255};
+            fill1->colorStops(colorStops1,2);
+            shape1->fill(fill1);
 
-        shape1->mask(std::move(mask1), tvg::MaskMethod::Alpha);
-        canvas->push(std::move(shape1));
-
-    //-------------------------------------------
+            shape1->mask(mask1, tvg::MaskMethod::Alpha);
+            canvas->push(shape1);
+        }
 
         //Solid Rectangle
-        auto shape2 = tvg::Shape::gen();
-        shape2->appendRect(0, 400, 400, 400);
+        {
+            auto shape2 = tvg::Shape::gen();
+            shape2->appendRect(0, 400, 400, 400);
 
-        //Mask
-        auto mask2 = tvg::Shape::gen();
-        mask2->appendCircle(200, 600, 125, 125);
-        mask2->fill(255, 0, 0);
+            //Mask
+            auto mask2 = tvg::Shape::gen();
+            mask2->appendCircle(200, 600, 125, 125);
+            mask2->fill(255, 0, 0);
 
-        auto fill2 = tvg::LinearGradient::gen();
-        fill2->linear(0, 400, 400, 800);
-        tvg::Fill::ColorStop colorStops2[2];
-        colorStops2[0] = {0,0,0,0,255};
-        colorStops2[1] = {1,255,255,255,255};
-        fill2->colorStops(colorStops2,2);
-        shape2->fill(std::move(fill2));
+            auto fill2 = tvg::LinearGradient::gen();
+            fill2->linear(0, 400, 400, 800);
+            tvg::Fill::ColorStop colorStops2[2];
+            colorStops2[0] = {0,0,0,0,255};
+            colorStops2[1] = {1,255,255,255,255};
+            fill2->colorStops(colorStops2,2);
+            shape2->fill(fill2);
 
-        shape2->mask(std::move(mask2), tvg::MaskMethod::InvAlpha);
-        canvas->push(std::move(shape2));
-
-    //-------------------------------------------
+            shape2->mask(mask2, tvg::MaskMethod::InvAlpha);
+            canvas->push(shape2);
+        }
 
         // Star
-        auto shape3 = tvg::Shape::gen();
-        shape3->moveTo(599, 434);
-        shape3->lineTo(653, 543);
-        shape3->lineTo(774, 560);
-        shape3->lineTo(687, 644);
-        shape3->lineTo(707, 765);
-        shape3->lineTo(599, 709);
-        shape3->lineTo(497, 765);
-        shape3->lineTo(512, 645);
-        shape3->lineTo(426, 561);
-        shape3->lineTo(546, 543);
-        shape3->close();
+        {
+            auto shape3 = tvg::Shape::gen();
+            shape3->moveTo(599, 434);
+            shape3->lineTo(653, 543);
+            shape3->lineTo(774, 560);
+            shape3->lineTo(687, 644);
+            shape3->lineTo(707, 765);
+            shape3->lineTo(599, 709);
+            shape3->lineTo(497, 765);
+            shape3->lineTo(512, 645);
+            shape3->lineTo(426, 561);
+            shape3->lineTo(546, 543);
+            shape3->close();
 
-        //Mask
-        auto mask3 = tvg::Shape::gen();
-        mask3->appendCircle(600, 600, 125, 125);
-        mask3->fill(255, 0, 0);
+            //Mask
+            auto mask3 = tvg::Shape::gen();
+            mask3->appendCircle(600, 600, 125, 125);
+            mask3->fill(255, 0, 0);
 
-        auto fill3 = tvg::LinearGradient::gen();
-        fill3->linear(400, 400, 800, 800);
-        tvg::Fill::ColorStop colorStops3[2];
-        colorStops3[0] = {0,0,0,0,255};
-        colorStops3[1] = {1,1,255,255,255};
-        fill3->colorStops(colorStops3,2);
-        shape3->fill(std::move(fill3));
+            auto fill3 = tvg::LinearGradient::gen();
+            fill3->linear(400, 400, 800, 800);
+            tvg::Fill::ColorStop colorStops3[2];
+            colorStops3[0] = {0,0,0,0,255};
+            colorStops3[1] = {1,1,255,255,255};
+            fill3->colorStops(colorStops3,2);
+            shape3->fill(fill3);
 
-        shape3->mask(std::move(mask3), tvg::MaskMethod::InvAlpha);
-        canvas->push(std::move(shape3));
+            shape3->mask(mask3, tvg::MaskMethod::InvAlpha);
+            canvas->push(shape3);
+        }
 
         return true;
     }

--- a/examples/GradientStroke.cpp
+++ b/examples/GradientStroke.cpp
@@ -70,14 +70,14 @@ struct UserExample : tvgexam::Example
         auto fillStroke1 = tvg::LinearGradient::gen();
         fillStroke1->linear(100, 100, 250, 250);
         fillStroke1->colorStops(colorStops1, 3);
-        shape1->strokeFill(std::move(fillStroke1));
+        shape1->strokeFill(fillStroke1);
 
         auto fill1 = tvg::LinearGradient::gen();
         fill1->linear(100, 100, 250, 250);
         fill1->colorStops(colorStops1, 3);
-        shape1->fill(std::move(fill1));
+        shape1->fill(fill1);
 
-        canvas->push(std::move(shape1));
+        canvas->push(shape1);
 
         // radial gradient stroke + duplicate
         auto shape2 = tvg::Shape::gen();
@@ -87,22 +87,22 @@ struct UserExample : tvgexam::Example
         auto fillStroke2 = tvg::RadialGradient::gen();
         fillStroke2->radial(600, 175, 100, 600, 175, 0);
         fillStroke2->colorStops(colorStops2, 2);
-        shape2->strokeFill(std::move(fillStroke2));
+        shape2->strokeFill(fillStroke2);
 
-        auto shape3 = tvg::cast<tvg::Shape>(shape2->duplicate());
+        auto shape3 = static_cast<tvg::Shape*>(shape2->duplicate());
         shape3->translate(0, 200);
 
         auto fillStroke3 = tvg::LinearGradient::gen();
         fillStroke3->linear(500, 115, 700, 235);
         fillStroke3->colorStops(colorStops3, 2);
-        shape3->strokeFill(std::move(fillStroke3));
+        shape3->strokeFill(fillStroke3);
 
-        auto shape4 = tvg::cast<tvg::Shape>(shape2->duplicate());
+        auto shape4 = static_cast<tvg::Shape*>(shape2->duplicate());
         shape4->translate(0, 400);
 
-        canvas->push(std::move(shape2));
-        canvas->push(std::move(shape3));
-        canvas->push(std::move(shape4));
+        canvas->push(shape2);
+        canvas->push(shape3);
+        canvas->push(shape4);
 
         // dashed gradient stroke
         auto shape5 = tvg::Shape::gen();
@@ -114,15 +114,15 @@ struct UserExample : tvgexam::Example
         auto fillStroke5 = tvg::LinearGradient::gen();
         fillStroke5->linear(150, 450, 450, 750);
         fillStroke5->colorStops(colorStops3, 2);
-        shape5->strokeFill(std::move(fillStroke5));
+        shape5->strokeFill(fillStroke5);
 
         auto fill5 = tvg::LinearGradient::gen();
         fill5->linear(150, 450, 450, 750);
         fill5->colorStops(colorStops3, 2);
-        shape5->fill(std::move(fill5));
+        shape5->fill(fill5);
         shape5->scale(0.8);
 
-        canvas->push(std::move(shape5));
+        canvas->push(shape5);
 
         return true;
     }

--- a/examples/GradientTransform.cpp
+++ b/examples/GradientTransform.cpp
@@ -59,14 +59,14 @@ struct UserExample : tvgexam::Example
         colorStops[2] = {1, 255, 255, 255, 255};
 
         fill->colorStops(colorStops, 3);
-        shape->fill(std::move(fill));
+        shape->fill(fill);
         shape->translate(385, 400);
 
         //Update Shape1
         shape->scale(1 - 0.75 * progress);
         shape->rotate(360 * progress);
 
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         //Shape2
         auto shape2 = tvg::Shape::gen();
@@ -83,12 +83,12 @@ struct UserExample : tvgexam::Example
         colorStops2[1] = {1, 255, 255, 255, 255};
 
         fill2->colorStops(colorStops2, 2);
-        shape2->fill(std::move(fill2));
+        shape2->fill(fill2);
 
         shape2->rotate(360 * progress);
         shape2->translate(400 + progress * 300, 400);
 
-        canvas->push(std::move(shape2));
+        canvas->push(shape2);
 
         //Shape3
         auto shape3 = tvg::Shape::gen();
@@ -109,14 +109,14 @@ struct UserExample : tvgexam::Example
 
         fill3->colorStops(colorStops3, 4);
 
-        shape3->fill(std::move(fill3));
+        shape3->fill(fill3);
         shape3->translate(400, 400);
 
         //Update Shape3
         shape3->rotate(-360 * progress);
         shape3->scale(0.5 + progress);
 
-        canvas->push(std::move(shape3));
+        canvas->push(shape3);
 
         return true;
     }

--- a/examples/ImageRotation.cpp
+++ b/examples/ImageRotation.cpp
@@ -30,7 +30,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    tvg::Picture* pPicture = nullptr;
+    tvg::Picture* picture = nullptr;
 
     float deg2rad(float degree)
     {
@@ -41,12 +41,11 @@ struct UserExample : tvgexam::Example
     {
         if (!canvas) return false;
 
-        auto picture = tvg::Picture::gen();
-        pPicture = picture.get();
+        picture = tvg::Picture::gen();
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/image/scaledown.jpg"))) return false;
 
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         return true;
     }
@@ -81,7 +80,7 @@ struct UserExample : tvgexam::Example
         m.e13 += (-400 * m.e11 + -400 * m.e12);
         m.e23 += (-400 * m.e21 + -400 * m.e22);
 
-        pPicture->transform(m);
+        picture->transform(m);
 
         canvas->update();
 

--- a/examples/ImageScaleDown.cpp
+++ b/examples/ImageScaleDown.cpp
@@ -28,19 +28,18 @@
 
 struct UserExample : tvgexam::Example
 {
-    tvg::Picture* pPicture = nullptr;
+    tvg::Picture* picture = nullptr;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
         if (!canvas) return false;
 
         //Original
-        auto picture = tvg::Picture::gen();
-        pPicture = picture.get();
+        picture = tvg::Picture::gen();
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/image/scaledown.jpg"))) return false;
 
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         return true;
     }
@@ -53,9 +52,9 @@ struct UserExample : tvgexam::Example
 
         auto progress = tvgexam::progress(elapsed, 7.0f, true);  //play time 7 sec.
 
-        pPicture->scale(1.0f - progress);
+        picture->scale(1.0f - progress);
 
-        canvas->update(pPicture);
+        canvas->update(picture);
 
         return true;
     }

--- a/examples/ImageScaleUp.cpp
+++ b/examples/ImageScaleUp.cpp
@@ -29,19 +29,18 @@
 
 struct UserExample : tvgexam::Example
 {
-    tvg::Picture* pPicture = nullptr;
+    tvg::Picture* picture = nullptr;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
         if (!canvas) return false;
 
         //Original
-        auto picture = tvg::Picture::gen();
-        pPicture = picture.get();
+        picture = tvg::Picture::gen();
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/image/scaleup.jpg"))) return false;
 
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         return true;
     }
@@ -54,9 +53,9 @@ struct UserExample : tvgexam::Example
 
         auto progress = tvgexam::progress(elapsed, 7.0f, true);  //play time 7 sec.
 
-        pPicture->scale(progress * 4.0f);
+        picture->scale(progress * 4.0f);
 
-        canvas->update(pPicture);
+        canvas->update(picture);
 
         return true;
     }

--- a/examples/Interaction.cpp
+++ b/examples/Interaction.cpp
@@ -82,14 +82,14 @@ struct UserExample : tvgexam::Example
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
         //Animation Controller
-        animation = tvg::Animation::gen();
+        animation = unique_ptr<tvg::Animation>(tvg::Animation::gen());
         auto picture = animation->picture();
 
         //Background
         auto shape = tvg::Shape::gen();
         shape->appendRect(0, 0, w, h);
         shape->fill(50, 50, 50);
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/locker.json"))) return false;
 
@@ -110,7 +110,7 @@ struct UserExample : tvgexam::Example
         picture->scale(scale);
         picture->translate(shiftX, shiftY);
 
-        canvas->push(tvg::cast(picture));
+        canvas->push(picture);
 
         //Default is a stopped motion
         animation->segment(0.0f, 0.0f);

--- a/examples/InvLumaMasking.cpp
+++ b/examples/InvLumaMasking.cpp
@@ -47,9 +47,9 @@ struct UserExample : tvgexam::Example
         nMask->appendCircle(220, 220, 125, 125);
         nMask->fill(255, 200, 255);
 
-        mask->mask(std::move(nMask), tvg::MaskMethod::InvLuma);
-        shape->mask(std::move(mask), tvg::MaskMethod::InvLuma);
-        canvas->push(std::move(shape));
+        mask->mask(nMask, tvg::MaskMethod::InvLuma);
+        shape->mask(mask, tvg::MaskMethod::InvLuma);
+        canvas->push(shape);
 
         //SVG
         auto svg = tvg::Picture::gen();
@@ -63,8 +63,8 @@ struct UserExample : tvgexam::Example
         mask2->appendCircle(150, 500, 75, 75);
         mask2->appendRect(150, 500, 200, 200, 30, 30);
         mask2->fill(255, 255, 255);
-        svg->mask(std::move(mask2), tvg::MaskMethod::InvLuma);
-        canvas->push(std::move(svg));
+        svg->mask(mask2, tvg::MaskMethod::InvLuma);
+        canvas->push(svg);
 
         //Star
         auto star = tvg::Shape::gen();
@@ -87,8 +87,8 @@ struct UserExample : tvgexam::Example
         auto mask3 = tvg::Shape::gen();
         mask3->appendCircle(600, 200, 125, 125);
         mask3->fill(0, 255, 255);
-        star->mask(std::move(mask3), tvg::MaskMethod::InvLuma);
-        canvas->push(std::move(star));
+        star->mask(mask3, tvg::MaskMethod::InvLuma);
+        canvas->push(star);
 
         //Image
         ifstream file(EXAMPLE_DIR"/image/rawimage_200x300.raw", ios::binary);
@@ -109,10 +109,10 @@ struct UserExample : tvgexam::Example
         auto mask4_circle = tvg::Shape::gen();
         mask4_circle->appendCircle(600, 550, 125, 125);
         mask4_circle->fill(128, 0, 128);
-        mask4->push(std::move(mask4_rect));
-        mask4->push(std::move(mask4_circle));
-        image->mask(std::move(mask4), tvg::MaskMethod::InvLuma);
-        canvas->push(std::move(image));
+        mask4->push(mask4_rect);
+        mask4->push(mask4_circle);
+        image->mask(mask4, tvg::MaskMethod::InvLuma);
+        canvas->push(image);
 
         free(data);
 

--- a/examples/InvMasking.cpp
+++ b/examples/InvMasking.cpp
@@ -47,9 +47,9 @@ struct UserExample : tvgexam::Example
         nMask->appendCircle(220, 220, 125, 125);
         nMask->fill(255, 255, 255);    //InvAlphaMask RGB channels are unused.
 
-        mask->mask(std::move(nMask), tvg::MaskMethod::InvAlpha);
-        shape->mask(std::move(mask), tvg::MaskMethod::InvAlpha);
-        canvas->push(std::move(shape));
+        mask->mask(nMask, tvg::MaskMethod::InvAlpha);
+        shape->mask(mask, tvg::MaskMethod::InvAlpha);
+        canvas->push(shape);
 
         //SVG
         auto svg = tvg::Picture::gen();
@@ -63,8 +63,8 @@ struct UserExample : tvgexam::Example
         mask2->appendCircle(150, 500, 75, 75);
         mask2->appendRect(150, 500, 200, 200, 30, 30);
         mask2->fill(255, 255, 255);   //InvAlphaMask RGB channels are unused.
-        svg->mask(std::move(mask2), tvg::MaskMethod::InvAlpha);
-        canvas->push(std::move(svg));
+        svg->mask(mask2, tvg::MaskMethod::InvAlpha);
+        canvas->push(svg);
 
         //Star
         auto star = tvg::Shape::gen();
@@ -87,8 +87,8 @@ struct UserExample : tvgexam::Example
         auto mask3 = tvg::Shape::gen();
         mask3->appendCircle(600, 200, 125, 125);
         mask3->fill(255, 255, 255);        //InvAlphaMask RGB channels are unused.
-        star->mask(std::move(mask3), tvg::MaskMethod::InvAlpha);
-        canvas->push(std::move(star));
+        star->mask(mask3, tvg::MaskMethod::InvAlpha);
+        canvas->push(star);
 
         //Image
         ifstream file(EXAMPLE_DIR"/image/rawimage_200x300.raw", ios::binary);
@@ -117,8 +117,8 @@ struct UserExample : tvgexam::Example
         mask4->close();
         mask4->fill(255, 255, 255);      //InvAlphaMask RGB channels are unused.
         mask4->opacity(70);
-        image->mask(std::move(mask4), tvg::MaskMethod::InvAlpha);
-        canvas->push(std::move(image));
+        image->mask(mask4, tvg::MaskMethod::InvAlpha);
+        canvas->push(image);
 
         return true;
     }

--- a/examples/LinearGradient.cpp
+++ b/examples/LinearGradient.cpp
@@ -47,8 +47,8 @@ struct UserExample : tvgexam::Example
 
         fill->colorStops(colorStops, 2);
 
-        shape1->fill(std::move(fill));
-        canvas->push(std::move(shape1));
+        shape1->fill(fill);
+        canvas->push(shape1);
 
         //Prepare Circle
         auto shape2 = tvg::Shape::gen();
@@ -66,8 +66,8 @@ struct UserExample : tvgexam::Example
 
         fill2->colorStops(colorStops2, 3);
 
-        shape2->fill(std::move(fill2));
-        canvas->push(std::move(shape2));
+        shape2->fill(fill2);
+        canvas->push(shape2);
 
         //Prepare Ellipse
         auto shape3 = tvg::Shape::gen();
@@ -86,8 +86,8 @@ struct UserExample : tvgexam::Example
 
         fill3->colorStops(colorStops3, 4);
 
-        shape3->fill(std::move(fill3));
-        canvas->push(std::move(shape3));
+        shape3->fill(fill3);
+        canvas->push(shape3);
 
         return true;
     }

--- a/examples/Lottie.cpp
+++ b/examples/Lottie.cpp
@@ -68,7 +68,7 @@ struct UserExample : tvgexam::Example
         picture->scale(scale);
         picture->translate((counter % NUM_PER_ROW) * size + shiftX, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + shiftY);
 
-        animations.push_back(std::move(animation));
+        animations.push_back(unique_ptr<tvg::Animation>(animation));
 
         cout << "Lottie: " << path << endl;
 
@@ -97,8 +97,7 @@ struct UserExample : tvgexam::Example
         auto shape = tvg::Shape::gen();
         shape->appendRect(0, 0, w, h);
         shape->fill(75, 75, 75);
-
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         this->w = w;
         this->h = h;
@@ -108,7 +107,7 @@ struct UserExample : tvgexam::Example
 
         //Run animation loop
         for (auto& animation : animations) {
-            canvas->push(tvg::cast(animation->picture()));
+            canvas->push(animation->picture());
         }
 
         return true;

--- a/examples/LottieExpressions.cpp
+++ b/examples/LottieExpressions.cpp
@@ -68,7 +68,7 @@ struct UserExample : tvgexam::Example
         picture->scale(scale);
         picture->translate((counter % NUM_PER_ROW) * size + shiftX, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + shiftY);
 
-        animations.push_back(std::move(animation));
+        animations.push_back(unique_ptr<tvg::Animation>(animation));
 
         cout << "Lottie: " << path << endl;
 
@@ -98,7 +98,7 @@ struct UserExample : tvgexam::Example
         shape->appendRect(0, 0, w, h);
         shape->fill(75, 75, 75);
 
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         this->w = w;
         this->h = h;
@@ -108,7 +108,7 @@ struct UserExample : tvgexam::Example
 
         //Run animation loop
         for (auto& animation : animations) {
-            canvas->push(tvg::cast(animation->picture()));
+            canvas->push(animation->picture());
         }
 
         return true;

--- a/examples/LottieExtension.cpp
+++ b/examples/LottieExtension.cpp
@@ -87,11 +87,10 @@ struct UserExample : tvgexam::Example
         if (!canvas) return false;
 
         //Background
-        auto shape = tvg::Shape::gen();
-        shape->appendRect(0, 0, w, h);
-        shape->fill(75, 75, 75);
-
-        canvas->push(std::move(shape));
+        auto bg = tvg::Shape::gen();
+        bg->appendRect(0, 0, w, h);
+        bg->fill(75, 75, 75);
+        canvas->push(bg);
 
         this->w = w;
         this->h = h;
@@ -99,7 +98,7 @@ struct UserExample : tvgexam::Example
 
         //slot (gradient)
         {
-            slot1 = tvg::LottieAnimation::gen();
+            slot1 = std::unique_ptr<tvg::LottieAnimation>(tvg::LottieAnimation::gen());
             auto picture = slot1->picture();
             if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/slotsample.json"))) return false;
 
@@ -108,12 +107,12 @@ struct UserExample : tvgexam::Example
 
             sizing(picture, 0);
 
-            canvas->push(tvg::cast(picture));
+            canvas->push(picture);
         }
 
         //slot (solid fill)
         {
-            slot2 = tvg::LottieAnimation::gen();
+            slot2 = std::unique_ptr<tvg::LottieAnimation>(tvg::LottieAnimation::gen());
             auto picture = slot2->picture();
             if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/slotsample2.json"))) return false;
 
@@ -122,19 +121,19 @@ struct UserExample : tvgexam::Example
 
             sizing(picture, 1);
 
-            canvas->push(tvg::cast(picture));
+            canvas->push(picture);
         }
 
         //marker
         {
-            marker = tvg::LottieAnimation::gen();
+            marker = std::unique_ptr<tvg::LottieAnimation>(tvg::LottieAnimation::gen());
             auto picture = marker->picture();
             if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/marker_sample.json"))) return false;
             if (!tvgexam::verify(marker->segment("sectionC"))) return false;
 
             sizing(picture, 2);
 
-            canvas->push(tvg::cast(picture));
+            canvas->push(picture);
         }
 
         return true;

--- a/examples/LumaMasking.cpp
+++ b/examples/LumaMasking.cpp
@@ -47,9 +47,9 @@ struct UserExample : tvgexam::Example
         nMask->appendCircle(220, 220, 125, 125);
         nMask->fill(255, 200, 255);
 
-        mask->mask(std::move(nMask), tvg::MaskMethod::Luma);
-        shape->mask(std::move(mask), tvg::MaskMethod::Luma);
-        canvas->push(std::move(shape));
+        mask->mask(nMask, tvg::MaskMethod::Luma);
+        shape->mask(mask, tvg::MaskMethod::Luma);
+        canvas->push(shape);
 
         //SVG
         auto svg = tvg::Picture::gen();
@@ -63,8 +63,8 @@ struct UserExample : tvgexam::Example
         mask2->appendCircle(150, 500, 75, 75);
         mask2->appendRect(150, 500, 200, 200, 30, 30);
         mask2->fill(255, 255, 255);
-        svg->mask(std::move(mask2), tvg::MaskMethod::Luma);
-        canvas->push(std::move(svg));
+        svg->mask(mask2, tvg::MaskMethod::Luma);
+        canvas->push(svg);
 
         //Star
         auto star = tvg::Shape::gen();
@@ -87,8 +87,8 @@ struct UserExample : tvgexam::Example
         auto mask3 = tvg::Shape::gen();
         mask3->appendCircle(600, 200, 125, 125);
         mask3->fill(0, 255, 255);
-        star->mask(std::move(mask3), tvg::MaskMethod::Luma);
-        canvas->push(std::move(star));
+        star->mask(mask3, tvg::MaskMethod::Luma);
+        canvas->push(star);
 
         //Image
         ifstream file(EXAMPLE_DIR"/image/rawimage_200x300.raw", ios::binary);
@@ -109,10 +109,10 @@ struct UserExample : tvgexam::Example
         auto mask4_circle = tvg::Shape::gen();
         mask4_circle->appendCircle(600, 550, 125, 125);
         mask4_circle->fill(128, 0, 128);
-        mask4->push(std::move(mask4_rect));
-        mask4->push(std::move(mask4_circle));
-        image->mask(std::move(mask4), tvg::MaskMethod::Luma);
-        canvas->push(std::move(image));
+        mask4->push(mask4_rect);
+        mask4->push(mask4_circle);
+        image->mask(mask4, tvg::MaskMethod::Luma);
+        canvas->push(image);
 
         free(data);
 

--- a/examples/Masking.cpp
+++ b/examples/Masking.cpp
@@ -47,9 +47,9 @@ struct UserExample : tvgexam::Example
         nMask->appendCircle(220, 220, 125, 125);
         nMask->fill(255, 255, 255);       //AlphaMask RGB channels are unused.
 
-        mask->mask(std::move(nMask), tvg::MaskMethod::Alpha);
-        shape->mask(std::move(mask), tvg::MaskMethod::Alpha);
-        canvas->push(std::move(shape));
+        mask->mask(nMask, tvg::MaskMethod::Alpha);
+        shape->mask(mask, tvg::MaskMethod::Alpha);
+        canvas->push(shape);
 
         //SVG
         auto svg = tvg::Picture::gen();
@@ -63,8 +63,8 @@ struct UserExample : tvgexam::Example
         mask2->appendCircle(150, 500, 75, 75);
         mask2->appendRect(150, 500, 200, 200, 30, 30);
         mask2->fill(255, 255, 255);       //AlphaMask RGB channels are unused.
-        svg->mask(std::move(mask2), tvg::MaskMethod::Alpha);
-        canvas->push(std::move(svg));
+        svg->mask(mask2, tvg::MaskMethod::Alpha);
+        canvas->push(svg);
 
         //Star
         auto star = tvg::Shape::gen();
@@ -89,8 +89,8 @@ struct UserExample : tvgexam::Example
         mask3->appendCircle(600, 200, 125, 125);
         mask3->fill(255, 255, 255);       //AlphaMask RGB channels are unused.
         mask3->opacity(200);
-        star->mask(std::move(mask3), tvg::MaskMethod::Alpha);
-        canvas->push(std::move(star));
+        star->mask(mask3, tvg::MaskMethod::Alpha);
+        canvas->push(star);
 
         //Image
         ifstream file(EXAMPLE_DIR"/image/rawimage_200x300.raw", ios::binary);
@@ -118,8 +118,8 @@ struct UserExample : tvgexam::Example
         mask4->close();
         mask4->fill(255, 255, 255);        //AlphaMask RGB channels are unused.
         mask4->opacity(70);
-        image->mask(std::move(mask4), tvg::MaskMethod::Alpha);
-        canvas->push(std::move(image));
+        image->mask(mask4, tvg::MaskMethod::Alpha);
+        canvas->push(image);
 
         free(data);
 

--- a/examples/MaskingMethods.cpp
+++ b/examples/MaskingMethods.cpp
@@ -43,7 +43,7 @@ struct UserExample : tvgexam::Example
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, 625, h);
         bg->fill(50, 50, 50);
-        canvas->push(std::move(bg));
+        canvas->push(bg);
 
         {
             //Shape + Shape Mask Add
@@ -58,9 +58,9 @@ struct UserExample : tvgexam::Example
             auto add = tvg::Shape::gen();
             add->appendCircle(175, 100, 50, 50);
             add->fill(255, 255, 255);
-            mask->mask(std::move(add), tvg::MaskMethod::Add);
-            shape->mask(std::move(mask), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape));
+            mask->mask(add, tvg::MaskMethod::Add);
+            shape->mask(mask, tvg::MaskMethod::Alpha);
+            canvas->push(shape);
 
             //Shape + Shape Mask Subtract
             auto shape2 = tvg::Shape::gen();
@@ -74,9 +74,9 @@ struct UserExample : tvgexam::Example
             auto sub = tvg::Shape::gen();
             sub->appendCircle(400, 100, 50, 50);
             sub->fill(255, 255, 255);
-            mask2->mask(std::move(sub), tvg::MaskMethod::Subtract);
-            shape2->mask(std::move(mask2), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape2));
+            mask2->mask(sub, tvg::MaskMethod::Subtract);
+            shape2->mask(mask2, tvg::MaskMethod::Alpha);
+            canvas->push(shape2);
 
             //Shape + Shape Mask Intersect
             auto shape3 = tvg::Shape::gen();
@@ -90,9 +90,9 @@ struct UserExample : tvgexam::Example
             auto inter = tvg::Shape::gen();
             inter->appendCircle(650, 100, 50, 50);
             inter->fill(255, 255, 255);
-            mask3->mask(std::move(inter), tvg::MaskMethod::Intersect);
-            shape3->mask(std::move(mask3), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape3));
+            mask3->mask(inter, tvg::MaskMethod::Intersect);
+            shape3->mask(mask3, tvg::MaskMethod::Alpha);
+            canvas->push(shape3);
 
             //Shape + Shape Mask Difference
             auto shape4 = tvg::Shape::gen();
@@ -106,9 +106,9 @@ struct UserExample : tvgexam::Example
             auto diff = tvg::Shape::gen();
             diff->appendCircle(900, 100, 50, 50);
             diff->fill(255, 255, 255);
-            mask4->mask(std::move(diff), tvg::MaskMethod::Difference);
-            shape4->mask(std::move(mask4), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape4));
+            mask4->mask(diff, tvg::MaskMethod::Difference);
+            shape4->mask(mask4, tvg::MaskMethod::Alpha);
+            canvas->push(shape4);
 
             //Shape + Shape Mask Lighten
             auto shape5 = tvg::Shape::gen();
@@ -122,9 +122,9 @@ struct UserExample : tvgexam::Example
             auto light = tvg::Shape::gen();
             light->appendCircle(1150, 100, 50, 50);
             light->fill(255, 255, 255);
-            mask5->mask(std::move(light), tvg::MaskMethod::Lighten);
-            shape5->mask(std::move(mask5), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape5));
+            mask5->mask(light, tvg::MaskMethod::Lighten);
+            shape5->mask(mask5, tvg::MaskMethod::Alpha);
+            canvas->push(shape5);
 
             //Shape + Shape Mask Darken
             auto shape6 = tvg::Shape::gen();
@@ -138,9 +138,9 @@ struct UserExample : tvgexam::Example
             auto dark = tvg::Shape::gen();
             dark->appendCircle(1400, 100, 50, 50);
             dark->fill(255, 255, 255);
-            mask6->mask(std::move(dark), tvg::MaskMethod::Darken);
-            shape6->mask(std::move(mask6), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape6));
+            mask6->mask(dark, tvg::MaskMethod::Darken);
+            shape6->mask(mask6, tvg::MaskMethod::Alpha);
+            canvas->push(shape6);
         }
         {
             //Shape + Shape Mask Add
@@ -155,9 +155,9 @@ struct UserExample : tvgexam::Example
             auto add = tvg::Shape::gen();
             add->appendCircle(175, 300, 50, 50);
             add->fill(255, 255, 255);
-            mask->mask(std::move(add), tvg::MaskMethod::Add);
-            shape->mask(std::move(mask), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(shape));
+            mask->mask(add, tvg::MaskMethod::Add);
+            shape->mask(mask, tvg::MaskMethod::InvAlpha);
+            canvas->push(shape);
 
             //Shape + Shape Mask Subtract
             auto shape2 = tvg::Shape::gen();
@@ -171,9 +171,9 @@ struct UserExample : tvgexam::Example
             auto sub = tvg::Shape::gen();
             sub->appendCircle(400, 300, 50, 50);
             sub->fill(255, 255, 255);
-            mask2->mask(std::move(sub), tvg::MaskMethod::Subtract);
-            shape2->mask(std::move(mask2), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(shape2));
+            mask2->mask(sub, tvg::MaskMethod::Subtract);
+            shape2->mask(mask2, tvg::MaskMethod::InvAlpha);
+            canvas->push(shape2);
 
             //Shape + Shape Mask Intersect
             auto shape3 = tvg::Shape::gen();
@@ -187,9 +187,9 @@ struct UserExample : tvgexam::Example
             auto inter = tvg::Shape::gen();
             inter->appendCircle(650, 300, 50, 50);
             inter->fill(255, 255, 255);
-            mask3->mask(std::move(inter), tvg::MaskMethod::Intersect);
-            shape3->mask(std::move(mask3), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(shape3));
+            mask3->mask(inter, tvg::MaskMethod::Intersect);
+            shape3->mask(mask3, tvg::MaskMethod::InvAlpha);
+            canvas->push(shape3);
 
             //Shape + Shape Mask Difference
             auto shape4 = tvg::Shape::gen();
@@ -203,9 +203,9 @@ struct UserExample : tvgexam::Example
             auto diff = tvg::Shape::gen();
             diff->appendCircle(900, 300, 50, 50);
             diff->fill(255, 255, 255);
-            mask4->mask(std::move(diff), tvg::MaskMethod::Difference);
-            shape4->mask(std::move(mask4), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(shape4));
+            mask4->mask(diff, tvg::MaskMethod::Difference);
+            shape4->mask(mask4, tvg::MaskMethod::InvAlpha);
+            canvas->push(shape4);
 
             //Shape + Shape Mask Lighten
             auto shape5 = tvg::Shape::gen();
@@ -219,9 +219,9 @@ struct UserExample : tvgexam::Example
             auto light = tvg::Shape::gen();
             light->appendCircle(1150, 300, 50, 50);
             light->fill(255, 255, 255);
-            mask5->mask(std::move(light), tvg::MaskMethod::Lighten);
-            shape5->mask(std::move(mask5), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(shape5));
+            mask5->mask(light, tvg::MaskMethod::Lighten);
+            shape5->mask(mask5, tvg::MaskMethod::InvAlpha);
+            canvas->push(shape5);
 
             //Shape + Shape Mask Darken
             auto shape6 = tvg::Shape::gen();
@@ -235,9 +235,9 @@ struct UserExample : tvgexam::Example
             auto dark = tvg::Shape::gen();
             dark->appendCircle(1400, 300, 50, 50);
             dark->fill(255, 255, 255);
-            mask6->mask(std::move(dark), tvg::MaskMethod::Darken);
-            shape6->mask(std::move(mask6), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(shape6));
+            mask6->mask(dark, tvg::MaskMethod::Darken);
+            shape6->mask(mask6, tvg::MaskMethod::InvAlpha);
+            canvas->push(shape6);
         }
         {
             //Rect + Rect Mask Add
@@ -252,9 +252,9 @@ struct UserExample : tvgexam::Example
             auto add = tvg::Shape::gen();
             add->appendRect(125, 450, 100, 100);
             add->fill(255, 255, 255);
-            mask->mask(std::move(add), tvg::MaskMethod::Add);
-            shape->mask(std::move(mask), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape));
+            mask->mask(add, tvg::MaskMethod::Add);
+            shape->mask(mask, tvg::MaskMethod::Alpha);
+            canvas->push(shape);
 
             //Rect + Rect Mask Subtract
             auto shape2 = tvg::Shape::gen();
@@ -268,9 +268,9 @@ struct UserExample : tvgexam::Example
             auto sub = tvg::Shape::gen();
             sub->appendRect(375, 450, 100, 100);
             sub->fill(255, 255, 255);
-            mask2->mask(std::move(sub), tvg::MaskMethod::Subtract);
-            shape2->mask(std::move(mask2), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape2));
+            mask2->mask(sub, tvg::MaskMethod::Subtract);
+            shape2->mask(mask2, tvg::MaskMethod::Alpha);
+            canvas->push(shape2);
 
             //Rect + Rect Mask Intersect
             auto shape3 = tvg::Shape::gen();
@@ -284,9 +284,9 @@ struct UserExample : tvgexam::Example
             auto inter = tvg::Shape::gen();
             inter->appendRect(625, 450, 100, 100);
             inter->fill(255, 255, 255);
-            mask3->mask(std::move(inter), tvg::MaskMethod::Intersect);
-            shape3->mask(std::move(mask3), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape3));
+            mask3->mask(inter, tvg::MaskMethod::Intersect);
+            shape3->mask(mask3, tvg::MaskMethod::Alpha);
+            canvas->push(shape3);
 
             //Rect + Rect Mask Difference
             auto shape4 = tvg::Shape::gen();
@@ -300,9 +300,9 @@ struct UserExample : tvgexam::Example
             auto diff = tvg::Shape::gen();
             diff->appendRect(875, 450, 100, 100);
             diff->fill(255, 255, 255);
-            mask4->mask(std::move(diff), tvg::MaskMethod::Difference);
-            shape4->mask(std::move(mask4), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape4));
+            mask4->mask(diff, tvg::MaskMethod::Difference);
+            shape4->mask(mask4, tvg::MaskMethod::Alpha);
+            canvas->push(shape4);
 
             //Rect + Rect Mask Lighten
             auto shape5 = tvg::Shape::gen();
@@ -316,9 +316,9 @@ struct UserExample : tvgexam::Example
             auto light = tvg::Shape::gen();
             light->appendRect(1175, 450, 100, 100);
             light->fill(255, 255, 255);
-            mask5->mask(std::move(light), tvg::MaskMethod::Lighten);
-            shape5->mask(std::move(mask5), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape5));
+            mask5->mask(light, tvg::MaskMethod::Lighten);
+            shape5->mask(mask5, tvg::MaskMethod::Alpha);
+            canvas->push(shape5);
 
             //Rect + Rect Mask Darken
             auto shape6 = tvg::Shape::gen();
@@ -332,9 +332,9 @@ struct UserExample : tvgexam::Example
             auto dark = tvg::Shape::gen();
             dark->appendRect(1400, 450, 100, 100);
             dark->fill(255, 255, 255);
-            mask6->mask(std::move(dark), tvg::MaskMethod::Darken);
-            shape6->mask(std::move(mask6), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(shape6));
+            mask6->mask(dark, tvg::MaskMethod::Darken);
+            shape6->mask(mask6, tvg::MaskMethod::Alpha);
+            canvas->push(shape6);
         }
         {
             //Transformed Image + Shape Mask Add
@@ -351,9 +351,9 @@ struct UserExample : tvgexam::Example
             auto add = tvg::Shape::gen();
             add->appendCircle(150, 750, 50, 50);
             add->fill(255, 255, 255);
-            mask->mask(std::move(add), tvg::MaskMethod::Add);
-            image->mask(std::move(mask), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(image));
+            mask->mask(add, tvg::MaskMethod::Add);
+            image->mask(mask, tvg::MaskMethod::Alpha);
+            canvas->push(image);
 
             //Transformed Image + Shape Mask Subtract
             auto image2 = tvg::Picture::gen();
@@ -369,9 +369,9 @@ struct UserExample : tvgexam::Example
             auto sub = tvg::Shape::gen();
             sub->appendCircle(400, 750, 50, 50);
             sub->fill(255, 255, 255);
-            mask2->mask(std::move(sub), tvg::MaskMethod::Subtract);
-            image2->mask(std::move(mask2), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(image2));
+            mask2->mask(sub, tvg::MaskMethod::Subtract);
+            image2->mask(mask2, tvg::MaskMethod::Alpha);
+            canvas->push(image2);
 
             //Transformed Image + Shape Mask Intersect
             auto image3 = tvg::Picture::gen();
@@ -387,9 +387,9 @@ struct UserExample : tvgexam::Example
             auto inter = tvg::Shape::gen();
             inter->appendCircle(650, 750, 50, 50);
             inter->fill(255, 255, 255, 127);
-            mask3->mask(std::move(inter), tvg::MaskMethod::Intersect);
-            image3->mask(std::move(mask3), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(image3));
+            mask3->mask(inter, tvg::MaskMethod::Intersect);
+            image3->mask(mask3, tvg::MaskMethod::Alpha);
+            canvas->push(image3);
 
             //Transformed Image + Shape Mask Difference
             auto image4 = tvg::Picture::gen();
@@ -405,9 +405,9 @@ struct UserExample : tvgexam::Example
             auto diff = tvg::Shape::gen();
             diff->appendCircle(900, 750, 50, 50);
             diff->fill(255, 255, 255);
-            mask4->mask(std::move(diff), tvg::MaskMethod::Difference);
-            image4->mask(std::move(mask4), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(image4));
+            mask4->mask(diff, tvg::MaskMethod::Difference);
+            image4->mask(mask4, tvg::MaskMethod::Alpha);
+            canvas->push(image4);
 
             //Transformed Image + Shape Mask Lighten
             auto image5 = tvg::Picture::gen();
@@ -423,9 +423,9 @@ struct UserExample : tvgexam::Example
             auto light = tvg::Shape::gen();
             light->appendCircle(1150, 750, 50, 50);
             light->fill(255, 255, 255);
-            mask5->mask(std::move(light), tvg::MaskMethod::Lighten);
-            image5->mask(std::move(mask5), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(image5));
+            mask5->mask(light, tvg::MaskMethod::Lighten);
+            image5->mask(mask5, tvg::MaskMethod::Alpha);
+            canvas->push(image5);
 
             //Transformed Image + Shape Mask Darken
             auto image6 = tvg::Picture::gen();
@@ -441,9 +441,9 @@ struct UserExample : tvgexam::Example
             auto dark = tvg::Shape::gen();
             dark->appendCircle(1400, 750, 50, 50);
             dark->fill(255, 255, 255);
-            mask6->mask(std::move(dark), tvg::MaskMethod::Darken);
-            image6->mask(std::move(mask6), tvg::MaskMethod::Alpha);
-            canvas->push(std::move(image6));
+            mask6->mask(dark, tvg::MaskMethod::Darken);
+            image6->mask(mask6, tvg::MaskMethod::Alpha);
+            canvas->push(image6);
         }
         {
             //Transformed Image + Shape Mask Add
@@ -460,9 +460,9 @@ struct UserExample : tvgexam::Example
             auto add = tvg::Shape::gen();
             add->appendCircle(150, 950, 50, 50);
             add->fill(255, 255, 255);
-            mask->mask(std::move(add), tvg::MaskMethod::Add);
-            image->mask(std::move(mask), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(image));
+            mask->mask(add, tvg::MaskMethod::Add);
+            image->mask(mask, tvg::MaskMethod::InvAlpha);
+            canvas->push(image);
 
             //Transformed Image + Shape Mask Subtract
             auto image2 = tvg::Picture::gen();
@@ -478,9 +478,9 @@ struct UserExample : tvgexam::Example
             auto sub = tvg::Shape::gen();
             sub->appendCircle(400, 950, 50, 50);
             sub->fill(255, 255, 255);
-            mask2->mask(std::move(sub), tvg::MaskMethod::Subtract);
-            image2->mask(std::move(mask2), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(image2));
+            mask2->mask(sub, tvg::MaskMethod::Subtract);
+            image2->mask(mask2, tvg::MaskMethod::InvAlpha);
+            canvas->push(image2);
 
             //Transformed Image + Shape Mask Intersect
             auto image3 = tvg::Picture::gen();
@@ -496,9 +496,9 @@ struct UserExample : tvgexam::Example
             auto inter = tvg::Shape::gen();
             inter->appendCircle(650, 950, 50, 50);
             inter->fill(255, 255, 255, 127);
-            mask3->mask(std::move(inter), tvg::MaskMethod::Intersect);
-            image3->mask(std::move(mask3), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(image3));
+            mask3->mask(inter, tvg::MaskMethod::Intersect);
+            image3->mask(mask3, tvg::MaskMethod::InvAlpha);
+            canvas->push(image3);
 
             //Transformed Image + Shape Mask Difference
             auto image4 = tvg::Picture::gen();
@@ -514,9 +514,9 @@ struct UserExample : tvgexam::Example
             auto diff = tvg::Shape::gen();
             diff->appendCircle(900, 950, 50, 50);
             diff->fill(255, 255, 255);
-            mask4->mask(std::move(diff), tvg::MaskMethod::Difference);
-            image4->mask(std::move(mask4), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(image4));
+            mask4->mask(diff, tvg::MaskMethod::Difference);
+            image4->mask(mask4, tvg::MaskMethod::InvAlpha);
+            canvas->push(image4);
 
             //Transformed Image + Shape Mask Lighten
             auto image5 = tvg::Picture::gen();
@@ -532,9 +532,9 @@ struct UserExample : tvgexam::Example
             auto light = tvg::Shape::gen();
             light->appendCircle(1150, 950, 50, 50);
             light->fill(255, 255, 255);
-            mask5->mask(std::move(light), tvg::MaskMethod::Lighten);
-            image5->mask(std::move(mask5), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(image5));
+            mask5->mask(light, tvg::MaskMethod::Lighten);
+            image5->mask(mask5, tvg::MaskMethod::InvAlpha);
+            canvas->push(image5);
 
             //Transformed Image + Shape Mask Darken
             auto image6 = tvg::Picture::gen();
@@ -550,9 +550,9 @@ struct UserExample : tvgexam::Example
             auto dark = tvg::Shape::gen();
             dark->appendCircle(1400, 950, 50, 50);
             dark->fill(255, 255, 255);
-            mask6->mask(std::move(dark), tvg::MaskMethod::Darken);
-            image6->mask(std::move(mask6), tvg::MaskMethod::InvAlpha);
-            canvas->push(std::move(image6));
+            mask6->mask(dark, tvg::MaskMethod::Darken);
+            image6->mask(mask6, tvg::MaskMethod::InvAlpha);
+            canvas->push(image6);
         }
         free(data);
         return true;

--- a/examples/MultiCanvas.cpp
+++ b/examples/MultiCanvas.cpp
@@ -41,7 +41,7 @@ void content(tvg::Canvas* canvas)
     auto bg = tvg::Shape::gen();
     bg->appendRect(0, 0, SIZE, SIZE);
     bg->fill(255, 255, 255);
-    canvas->push(std::move(bg));
+    canvas->push(bg);
 
     char buf[PATH_MAX];
     snprintf(buf, sizeof(buf), EXAMPLE_DIR"/svg/logo.svg");
@@ -63,7 +63,7 @@ void content(tvg::Canvas* canvas)
     picture->translate(shiftX, shiftY);
     picture->scale(scale);
 
-    canvas->push(std::move(picture));
+    canvas->push(picture);
 }
 
 
@@ -102,7 +102,7 @@ void runSw()
     auto surface = SDL_GetWindowSurface(window);
 
     for (int counter = 0; counter < NUM_PER_LINE * NUM_PER_LINE; ++counter) {
-        auto canvas = tvg::SwCanvas::gen();
+        auto canvas = unique_ptr<tvg::SwCanvas>(tvg::SwCanvas::gen());
         auto offx = (counter % NUM_PER_LINE) * SIZE;
         auto offy = SIZE * (counter / NUM_PER_LINE);
         auto w = surface->w - offx;
@@ -215,7 +215,7 @@ void runGl()
     GLFrameBuffer glFbo{SIZE, SIZE};
     
     for (int counter = 0; counter < NUM_PER_LINE * NUM_PER_LINE; ++counter) {
-        auto canvas = tvg::GlCanvas::gen();
+        auto canvas = unique_ptr<tvg::GlCanvas>(tvg::GlCanvas::gen());
 
         // Pass the framebuffer id to the GlCanvas
         tvgexam::verify(canvas->target(glFbo.fbo, SIZE, SIZE));

--- a/examples/Opacity.cpp
+++ b/examples/Opacity.cpp
@@ -40,7 +40,7 @@ struct UserExample : tvgexam::Example
         auto shape1 = tvg::Shape::gen();
         shape1->appendCircle(400, 400, 250, 250);
         shape1->fill(255, 255, 0);
-        scene->push(std::move(shape1));
+        scene->push(shape1);
 
         //Round rectangle
         auto shape2 = tvg::Shape::gen();
@@ -48,11 +48,10 @@ struct UserExample : tvgexam::Example
         shape2->fill(0, 255, 0);
         shape2->strokeWidth(10);
         shape2->strokeFill(255, 255, 255);
-        scene->push(std::move(shape2));
-
+        scene->push(shape2);
 
         //Draw the Scene onto the Canvas
-        canvas->push(std::move(scene));
+        canvas->push(scene);
 
         //Create a Scene 2
         auto scene2 = tvg::Scene::gen();
@@ -79,7 +78,7 @@ struct UserExample : tvgexam::Example
         shape3->strokeFill(255, 255, 255);
         shape3->opacity(127);
 
-        scene2->push(std::move(shape3));
+        scene2->push(shape3);
 
         //Circle
         auto shape4 = tvg::Shape::gen();
@@ -101,10 +100,10 @@ struct UserExample : tvgexam::Example
         shape4->strokeFill(0, 0, 255);
         shape4->opacity(200);
         shape4->scale(3);
-        scene2->push(std::move(shape4));
+        scene2->push(shape4);
 
         //Draw the Scene onto the Canvas
-        canvas->push(std::move(scene2));
+        canvas->push(scene2);
 
         return true;
     }

--- a/examples/Path.cpp
+++ b/examples/Path.cpp
@@ -50,7 +50,7 @@ struct UserExample : tvgexam::Example
             shape1->lineTo(146, 143);
             shape1->close();
             shape1->fill(0, 0, 255);
-            canvas->push(std::move(shape1));
+            canvas->push(shape1);
 
             //Circle
             auto shape2 = tvg::Shape::gen();
@@ -68,7 +68,7 @@ struct UserExample : tvgexam::Example
             shape2->cubicTo(cx - radius, cy - halfRadius, cx - halfRadius, cy - radius, cx, cy - radius);
             shape2->close();
             shape2->fill(255, 0, 0);
-            canvas->push(std::move(shape2));
+            canvas->push(shape2);
         }
 
         //Commands Copy
@@ -106,7 +106,7 @@ struct UserExample : tvgexam::Example
             shape1->appendPath(cmds, 11, pts, 10);     //copy path data
             shape1->fill(0, 255, 0);
             shape1->translate(400, 0);
-            canvas->push(std::move(shape1));
+            canvas->push(shape1);
 
             /* Circle */
             auto cx = 550.0f;
@@ -147,7 +147,7 @@ struct UserExample : tvgexam::Example
             shape2->appendPath(cmds2, 6, pts2, 13);     //copy path data
             shape2->fill(255, 255, 0);
             shape2->translate(-300, 0);
-            canvas->push(std::move(shape2));
+            canvas->push(shape2);
         }
 
         return true;

--- a/examples/Performance.cpp
+++ b/examples/Performance.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    tvg::Picture* pPicture = nullptr;
+    tvg::Picture* picture = nullptr;
     uint32_t w, h;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
@@ -41,12 +41,11 @@ struct UserExample : tvgexam::Example
         //Use the opacity for a half-translucent mask.
         mask->opacity(125);
 
-        auto picture = tvg::Picture::gen();
+        picture = tvg::Picture::gen();
         picture->load(EXAMPLE_DIR"/svg/tiger.svg");
         picture->size(w, h);
-        picture->mask(std::move(mask), tvg::MaskMethod::Alpha);
-        pPicture = picture.get();
-        canvas->push(std::move(picture));
+        picture->mask(mask, tvg::MaskMethod::Alpha);
+        canvas->push(picture);
 
         this->w = w;
         this->h = h;
@@ -62,7 +61,7 @@ struct UserExample : tvgexam::Example
 
         canvas->clear(false);
 
-        pPicture->translate(w * progress * 0.05f, h * progress * 0.05f);
+        picture->translate(w * progress * 0.05f, h * progress * 0.05f);
 
         canvas->update();
 

--- a/examples/PictureJpg.cpp
+++ b/examples/PictureJpg.cpp
@@ -42,7 +42,7 @@ struct UserExample : tvgexam::Example
             picture->rotate(30 * i);
             picture->size(200, 200);
             picture->opacity(opacity + opacity * i);
-            canvas->push(std::move(picture));
+            canvas->push(picture);
         }
 
         //Open file manually
@@ -62,7 +62,7 @@ struct UserExample : tvgexam::Example
         free(data);
         picture->translate(400, 0);
         picture->scale(0.8);
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         return true;
     }

--- a/examples/PicturePng.cpp
+++ b/examples/PicturePng.cpp
@@ -36,7 +36,7 @@ struct UserExample : tvgexam::Example
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);    //x, y, w, h
         bg->fill(255, 255, 255);                //r, g, b
-        canvas->push(std::move(bg));
+        canvas->push(bg);
 
         //Load png file from path
         auto opacity = 31;
@@ -48,7 +48,7 @@ struct UserExample : tvgexam::Example
             picture->rotate(30 * i);
             picture->size(200, 200);
             picture->opacity(opacity + opacity * i);
-            canvas->push(std::move(picture));
+            canvas->push(picture);
         }
 
         //Open file manually
@@ -67,7 +67,7 @@ struct UserExample : tvgexam::Example
         free(data);
         picture->translate(400, 0);
         picture->scale(0.8);
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         return true;
     }

--- a/examples/PictureRaw.cpp
+++ b/examples/PictureRaw.cpp
@@ -33,11 +33,10 @@ struct UserExample : tvgexam::Example
         if (!canvas) return false;
 
         //Background
-        auto shape = tvg::Shape::gen();
-        shape->appendRect(0, 0, w, h);
-        shape->fill(255, 255, 255);
-
-        canvas->push(std::move(shape));
+        auto bg = tvg::Shape::gen();
+        bg->appendRect(0, 0, w, h);
+        bg->fill(255, 255, 255);
+        canvas->push(bg);
 
         string path(EXAMPLE_DIR"/image/rawimage_200x300.raw");
         ifstream file(path, ios::binary);
@@ -49,7 +48,7 @@ struct UserExample : tvgexam::Example
         auto picture = tvg::Picture::gen();
         if (!tvgexam::verify(picture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         picture->translate(400, 250);
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         auto picture2 = tvg::Picture::gen();
         if (!tvgexam::verify(picture2->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
@@ -62,9 +61,9 @@ struct UserExample : tvgexam::Example
         auto circle = tvg::Shape::gen();
         circle->appendCircle(350, 350, 200, 200);
 
-        picture2->clip(std::move(circle));
+        picture2->clip(circle);
 
-        canvas->push(std::move(picture2));
+        canvas->push(picture2);
 
         free(data);
 

--- a/examples/PictureSvg.cpp
+++ b/examples/PictureSvg.cpp
@@ -36,7 +36,7 @@ struct UserExample : tvgexam::Example
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);    //x, y, w, h
         bg->fill(255, 255, 255);       //r, g, b
-        canvas->push(std::move(bg));
+        canvas->push(bg);
 
         char buf[PATH_MAX];
         snprintf(buf, sizeof(buf), EXAMPLE_DIR"/svg/logo.svg");
@@ -58,7 +58,7 @@ struct UserExample : tvgexam::Example
         picture->translate(shiftX, shiftY);
         picture->scale(scale);
 
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         return true;
     }

--- a/examples/PictureWebp.cpp
+++ b/examples/PictureWebp.cpp
@@ -36,7 +36,7 @@ struct UserExample : tvgexam::Example
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);             //x, y, w, h
         bg->fill(255, 255, 255);                //r, g, b
-        canvas->push(std::move(bg));
+        canvas->push(bg);
 
         //Load webp file from path
         auto opacity = 31;
@@ -48,7 +48,7 @@ struct UserExample : tvgexam::Example
             picture->rotate(30 * i);
             picture->size(200, 200);
             picture->opacity(opacity + opacity * i);
-            canvas->push(std::move(picture));
+            canvas->push(picture);
         }
 
         //Open file manually
@@ -67,7 +67,7 @@ struct UserExample : tvgexam::Example
         free(data);
         picture->translate(400, 0);
         picture->scale(0.8);
-        canvas->push(std::move(picture));
+        canvas->push(picture);
 
         return true;
     }

--- a/examples/RadialGradient.cpp
+++ b/examples/RadialGradient.cpp
@@ -47,8 +47,8 @@ struct UserExample : tvgexam::Example
 
         fill->colorStops(colorStops, 2);
 
-        shape1->fill(std::move(fill));
-        canvas->push(std::move(shape1));
+        shape1->fill(fill);
+        canvas->push(shape1);
 
         //Prepare Circle
         auto shape2 = tvg::Shape::gen();
@@ -66,8 +66,8 @@ struct UserExample : tvgexam::Example
 
         fill2->colorStops(colorStops2, 3);
 
-        shape2->fill(std::move(fill2));
-        canvas->push(std::move(shape2));
+        shape2->fill(fill2);
+        canvas->push(shape2);
 
         //Prepare Ellipse
         auto shape3 = tvg::Shape::gen();
@@ -86,8 +86,8 @@ struct UserExample : tvgexam::Example
 
         fill3->colorStops(colorStops3, 4);
 
-        shape3->fill(std::move(fill3));
-        canvas->push(std::move(shape3));
+        shape3->fill(fill3);
+        canvas->push(shape3);
 
         return true;
     }

--- a/examples/Retaining.cpp
+++ b/examples/Retaining.cpp
@@ -36,19 +36,19 @@ struct UserExample : tvgexam::Example
         auto shape1 = tvg::Shape::gen();
         shape1->appendRect(0, 0, 400, 400, 50, 50);  //x, y, w, h, rx, ry
         shape1->fill(0, 255, 0);                     //r, g, b
-        canvas->push(std::move(shape1));
+        canvas->push(shape1);
 
         //Prepare Round Rectangle2
         auto shape2 = tvg::Shape::gen();
         shape2->appendRect(100, 100, 400, 400, 50, 50);  //x, y, w, h, rx, ry
         shape2->fill(255, 255, 0);                       //r, g, b
-        canvas->push(std::move(shape2));
+        canvas->push(shape2);
 
         //Prepare Round Rectangle3
         auto shape3 = tvg::Shape::gen();
         shape3->appendRect(200, 200, 400, 400, 50, 50);  //x, y, w, h, rx, ry
         shape3->fill(0, 255, 255);                       //r, g, b
-        canvas->push(std::move(shape3));
+        canvas->push(shape3);
 
         //Prepare Scene
         auto scene = tvg::Scene::gen();
@@ -58,16 +58,16 @@ struct UserExample : tvgexam::Example
         shape4->fill(255, 0, 0);
         shape4->strokeWidth(5);
         shape4->strokeFill(255, 255, 255);
-        scene->push(std::move(shape4));
+        scene->push(shape4);
 
         auto shape5 = tvg::Shape::gen();
         shape5->appendCircle(550, 550, 150, 150);
         shape5->fill(255, 0, 255);
         shape5->strokeWidth(5);
         shape5->strokeFill(255, 255, 255);
-        scene->push(std::move(shape5));
+        scene->push(shape5);
 
-        canvas->push(std::move(scene));
+        canvas->push(scene);
 
         return true;
     }

--- a/examples/Scene.cpp
+++ b/examples/Scene.cpp
@@ -39,19 +39,19 @@ struct UserExample : tvgexam::Example
         auto shape1 = tvg::Shape::gen();
         shape1->appendRect(0, 0, 400, 400, 50, 50);  //x, y, w, h, rx, ry
         shape1->fill(0, 255, 0);                     //r, g, b
-        scene->push(std::move(shape1));
+        scene->push(shape1);
 
         //Prepare Circle
         auto shape2 = tvg::Shape::gen();
         shape2->appendCircle(400, 400, 200, 200);    //cx, cy, radiusW, radiusH
         shape2->fill(255, 255, 0);                   //r, g, b
-        scene->push(std::move(shape2));
+        scene->push(shape2);
 
         //Prepare Ellipse
         auto shape3 = tvg::Shape::gen();
         shape3->appendCircle(600, 600, 150, 100);    //cx, cy, radiusW, radiusH
         shape3->fill(0, 255, 255);                   //r, g, b
-        scene->push(std::move(shape3));
+        scene->push(shape3);
 
         //Create another Scene
         auto scene2 = tvg::Scene::gen();
@@ -72,7 +72,7 @@ struct UserExample : tvgexam::Example
         shape4->lineTo(146, 143);
         shape4->close();
         shape4->fill(0, 0, 255);
-        scene2->push(std::move(shape4));
+        scene2->push(shape4);
 
         //Circle
         auto shape5 = tvg::Shape::gen();
@@ -89,13 +89,13 @@ struct UserExample : tvgexam::Example
         shape5->cubicTo(cx - halfRadius, cy + radius, cx - radius, cy + halfRadius, cx - radius, cy);
         shape5->cubicTo(cx - radius, cy - halfRadius, cx - halfRadius, cy - radius, cx, cy - radius);
         shape5->fill(255, 0, 0);
-        scene2->push(std::move(shape5));
+        scene2->push(shape5);
 
         //Push scene2 onto the scene
-        scene->push(std::move(scene2));
+        scene->push(scene2);
 
         //Draw the Scene onto the Canvas
-        canvas->push(std::move(scene));
+        canvas->push(scene);
 
         return true;
     }

--- a/examples/SceneBlending.cpp
+++ b/examples/SceneBlending.cpp
@@ -36,7 +36,7 @@ struct UserExample : tvgexam::Example
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);
         bg->fill(100, 100, 100);
-        canvas->push(std::move(bg));
+        canvas->push(bg);
 
         //Create a Scene
         auto scene = tvg::Scene::gen();
@@ -46,7 +46,7 @@ struct UserExample : tvgexam::Example
         auto shape1 = tvg::Shape::gen();
         shape1->appendCircle(400, 400, 250, 250);
         shape1->fill(255, 255, 0);
-        scene->push(std::move(shape1));
+        scene->push(shape1);
 
         //Round rectangle
         auto shape2 = tvg::Shape::gen();
@@ -54,10 +54,10 @@ struct UserExample : tvgexam::Example
         shape2->fill(0, 255, 0);
         shape2->strokeWidth(10);
         shape2->strokeFill(255, 255, 255);
-        scene->push(std::move(shape2));
+        scene->push(shape2);
 
         //Draw the Scene onto the Canvas
-        canvas->push(std::move(scene));
+        canvas->push(scene);
 
         //Create a Scene 2
         auto scene2 = tvg::Scene::gen();
@@ -85,7 +85,7 @@ struct UserExample : tvgexam::Example
         shape3->strokeFill(255, 255, 255);
         shape3->opacity(127);
 
-        scene2->push(std::move(shape3));
+        scene2->push(shape3);
 
         //Circle
         auto shape4 = tvg::Shape::gen();
@@ -107,10 +107,10 @@ struct UserExample : tvgexam::Example
         shape4->strokeFill(0, 0, 255);
         shape4->opacity(200);
         shape4->scale(3);
-        scene2->push(std::move(shape4));
+        scene2->push(shape4);
 
         //Draw the Scene onto the Canvas
-        canvas->push(std::move(scene2));
+        canvas->push(scene2);
 
         return true;
     }

--- a/examples/SceneTransform.cpp
+++ b/examples/SceneTransform.cpp
@@ -50,19 +50,19 @@ struct UserExample : tvgexam::Example
         shape1->fill(0, 255, 0);                           //r, g, b
         shape1->strokeWidth(5);                            //width
         shape1->strokeFill(255, 255, 255);                 //r, g, b
-        scene->push(std::move(shape1));
+        scene->push(shape1);
 
         //Prepare Circle (Scene1)
         auto shape2 = tvg::Shape::gen();
         shape2->appendCircle(-165, -150, 200, 200);    //cx, cy, radiusW, radiusH
         shape2->fill(255, 255, 0);                     //r, g, b
-        scene->push(std::move(shape2));
+        scene->push(shape2);
 
         //Prepare Ellipse (Scene1)
         auto shape3 = tvg::Shape::gen();
         shape3->appendCircle(265, 250, 150, 100);      //cx, cy, radiusW, radiusH
         shape3->fill(0, 255, 255);                     //r, g, b
-        scene->push(std::move(shape3));
+        scene->push(shape3);
 
         scene->translate(350, 350);
         scene->scale(0.5);
@@ -89,7 +89,7 @@ struct UserExample : tvgexam::Example
         shape4->fill(0, 0, 255, 127);
         shape4->strokeWidth(3);                        //width
         shape4->strokeFill(0, 0, 255);                 //r, g, b
-        scene2->push(std::move(shape4));
+        scene2->push(shape4);
 
         //Circle (Scene2)
         auto shape5 = tvg::Shape::gen();
@@ -107,16 +107,16 @@ struct UserExample : tvgexam::Example
         shape5->cubicTo(cx - radius, cy - halfRadius, cx - halfRadius, cy - radius, cx, cy - radius);
         shape5->close();
         shape5->fill(255, 0, 0, 127);
-        scene2->push(std::move(shape5));
+        scene2->push(shape5);
 
         scene2->translate(500, 350);
         scene2->rotate(360 * progress);
 
         //Push scene2 onto the scene
-        scene->push(std::move(scene2));
+        scene->push(scene2);
 
         //Draw the Scene onto the Canvas
-        canvas->push(std::move(scene));
+        canvas->push(scene);
 
         return true;
     }

--- a/examples/Shapes.cpp
+++ b/examples/Shapes.cpp
@@ -38,25 +38,25 @@ struct UserExample : tvgexam::Example
         shape4->appendCircle(400, 150, 150, 150);       //cx, cy, radiusW, radiusH
         shape4->appendCircle(600, 150, 150, 100);       //cx, cy, radiusW, radiusH
         shape4->fill(255, 255, 0);                      //r, g, b
-        canvas->push(std::move(shape4));
+        canvas->push(shape4);
 
         //Prepare Round Rectangle
         auto shape1 = tvg::Shape::gen();
         shape1->appendRect(0, 450, 300, 300, 50, 50);  //x, y, w, h, rx, ry
         shape1->fill(0, 255, 0);                       //r, g, b
-        canvas->push(std::move(shape1));
+        canvas->push(shape1);
 
         //Prepare Circle
         auto shape2 = tvg::Shape::gen();
         shape2->appendCircle(400, 600, 150, 150);    //cx, cy, radiusW, radiusH
         shape2->fill(255, 255, 0);                   //r, g, b
-        canvas->push(std::move(shape2));
+        canvas->push(shape2);
 
         //Prepare Ellipse
         auto shape3 = tvg::Shape::gen();
         shape3->appendCircle(600, 600, 150, 100);    //cx, cy, radiusW, radiusH
         shape3->fill(0, 255, 255);                   //r, g, b
-        canvas->push(std::move(shape3));
+        canvas->push(shape3);
 
         return true;
     }

--- a/examples/Stroke.cpp
+++ b/examples/Stroke.cpp
@@ -40,7 +40,7 @@ struct UserExample : tvgexam::Example
         shape1->strokeJoin(tvg::StrokeJoin::Bevel);   //default is Bevel
         shape1->strokeWidth(10);                       //width: 10px
 
-        canvas->push(std::move(shape1));
+        canvas->push(shape1);
 
         //Shape 2
         auto shape2 = tvg::Shape::gen();
@@ -50,7 +50,7 @@ struct UserExample : tvgexam::Example
         shape2->strokeJoin(tvg::StrokeJoin::Round);
         shape2->strokeWidth(10);
 
-        canvas->push(std::move(shape2));
+        canvas->push(shape2);
 
         //Shape 3
         auto shape3 = tvg::Shape::gen();
@@ -60,7 +60,7 @@ struct UserExample : tvgexam::Example
         shape3->strokeJoin(tvg::StrokeJoin::Miter);
         shape3->strokeWidth(10);
 
-        canvas->push(std::move(shape3));
+        canvas->push(shape3);
 
         //Shape 4
         auto shape4 = tvg::Shape::gen();
@@ -69,7 +69,7 @@ struct UserExample : tvgexam::Example
         shape4->strokeFill(255, 255, 255);
         shape4->strokeWidth(1);
 
-        canvas->push(std::move(shape4));
+        canvas->push(shape4);
 
         //Shape 5
         auto shape5 = tvg::Shape::gen();
@@ -78,7 +78,7 @@ struct UserExample : tvgexam::Example
         shape5->strokeFill(255, 255, 255);
         shape5->strokeWidth(2);
 
-        canvas->push(std::move(shape5));
+        canvas->push(shape5);
 
         //Shape 6
         auto shape6 = tvg::Shape::gen();
@@ -87,7 +87,7 @@ struct UserExample : tvgexam::Example
         shape6->strokeFill(255, 255, 255);
         shape6->strokeWidth(4);
 
-        canvas->push(std::move(shape6));
+        canvas->push(shape6);
 
         //Stroke width test
         for (int i = 0; i < 10; ++i) {
@@ -97,7 +97,7 @@ struct UserExample : tvgexam::Example
             hline->strokeFill(255, 255, 255);            //color: r, g, b
             hline->strokeWidth(i + 1);                   //stroke width
             hline->strokeCap(tvg::StrokeCap::Round);     //default is Square
-            canvas->push(std::move(hline));
+            canvas->push(hline);
 
             auto vline = tvg::Shape::gen();
             vline->moveTo(500 + (25 * i), 550);
@@ -105,7 +105,7 @@ struct UserExample : tvgexam::Example
             vline->strokeFill(255, 255, 255);            //color: r, g, b
             vline->strokeWidth(i + 1);                   //stroke width
             vline->strokeCap(tvg::StrokeCap::Round);     //default is Square
-            canvas->push(std::move(vline));
+            canvas->push(vline);
         }
 
         //Stroke cap test
@@ -116,17 +116,17 @@ struct UserExample : tvgexam::Example
         line1->strokeWidth(15);
         line1->strokeCap(tvg::StrokeCap::Round);
 
-        auto line2 = tvg::cast<tvg::Shape>(line1->duplicate());
-        auto line3 = tvg::cast<tvg::Shape>(line1->duplicate());
-        canvas->push(std::move(line1));
+        auto line2 = static_cast<tvg::Shape*>(line1->duplicate());
+        auto line3 = static_cast<tvg::Shape*>(line1->duplicate());
+        canvas->push(line1);
 
         line2->strokeCap(tvg::StrokeCap::Square);
         line2->translate(0, 50);
-        canvas->push(std::move(line2));
+        canvas->push(line2);
 
         line3->strokeCap(tvg::StrokeCap::Butt);
         line3->translate(0, 100);
-        canvas->push(std::move(line3));
+        canvas->push(line3);
 
         return true;
     }

--- a/examples/StrokeLine.cpp
+++ b/examples/StrokeLine.cpp
@@ -43,7 +43,7 @@ struct UserExample : tvgexam::Example
         shape1->strokeWidth(10);
         shape1->strokeJoin(tvg::StrokeJoin::Round);
         shape1->strokeCap(tvg::StrokeCap::Round);
-        canvas->push(std::move(shape1));
+        canvas->push(shape1);
 
         auto shape2 = tvg::Shape::gen();
         shape2->moveTo(270, 50);
@@ -55,7 +55,7 @@ struct UserExample : tvgexam::Example
         shape2->strokeWidth(10);
         shape2->strokeJoin(tvg::StrokeJoin::Bevel);
         shape2->strokeCap(tvg::StrokeCap::Square);
-        canvas->push(std::move(shape2));
+        canvas->push(shape2);
 
         auto shape3 = tvg::Shape::gen();
         shape3->moveTo(520, 50);
@@ -67,7 +67,7 @@ struct UserExample : tvgexam::Example
         shape3->strokeWidth(10);
         shape3->strokeJoin(tvg::StrokeJoin::Miter);
         shape3->strokeCap(tvg::StrokeCap::Butt);
-        canvas->push(std::move(shape3));
+        canvas->push(shape3);
 
         //Test for Stroke Dash
         auto shape4 = tvg::Shape::gen();
@@ -83,7 +83,7 @@ struct UserExample : tvgexam::Example
 
         float dashPattern1[2] = {20, 10};
         shape4->strokeDash(dashPattern1, 2);
-        canvas->push(std::move(shape4));
+        canvas->push(shape4);
 
         auto shape5 = tvg::Shape::gen();
         shape5->moveTo(270, 230);
@@ -98,7 +98,7 @@ struct UserExample : tvgexam::Example
 
         float dashPattern2[2] = {10, 10};
         shape5->strokeDash(dashPattern2, 2);
-        canvas->push(std::move(shape5));
+        canvas->push(shape5);
 
         auto shape6 = tvg::Shape::gen();
         shape6->moveTo(520, 230);
@@ -113,7 +113,7 @@ struct UserExample : tvgexam::Example
 
         float dashPattern3[6] = {10, 10, 1, 8, 1, 10};
         shape6->strokeDash(dashPattern3, 6);
-        canvas->push(std::move(shape6));
+        canvas->push(shape6);
 
         //For a comparison with shapes 10-12
         auto shape7 = tvg::Shape::gen();
@@ -125,7 +125,7 @@ struct UserExample : tvgexam::Example
         shape7->strokeWidth(15);
         shape7->strokeJoin(tvg::StrokeJoin::Round);
         shape7->strokeCap(tvg::StrokeCap::Round);
-        canvas->push(std::move(shape7));
+        canvas->push(shape7);
 
         auto shape8 = tvg::Shape::gen();
         shape8->moveTo(320, 440);
@@ -136,7 +136,7 @@ struct UserExample : tvgexam::Example
         shape8->strokeWidth(15);
         shape8->strokeJoin(tvg::StrokeJoin::Bevel);
         shape8->strokeCap(tvg::StrokeCap::Square);
-        canvas->push(std::move(shape8));
+        canvas->push(shape8);
 
         auto shape9 = tvg::Shape::gen();
         shape9->moveTo(570, 440);
@@ -147,7 +147,7 @@ struct UserExample : tvgexam::Example
         shape9->strokeWidth(15);
         shape9->strokeJoin(tvg::StrokeJoin::Miter);
         shape9->strokeCap(tvg::StrokeCap::Butt);
-        canvas->push(std::move(shape9));
+        canvas->push(shape9);
 
         //Test for Stroke Dash for Circle and Rect
         auto shape10 = tvg::Shape::gen();
@@ -158,7 +158,7 @@ struct UserExample : tvgexam::Example
         shape10->strokeJoin(tvg::StrokeJoin::Round);
         shape10->strokeCap(tvg::StrokeCap::Round);
         shape10->strokeDash(dashPattern1, 2);
-        canvas->push(std::move(shape10));
+        canvas->push(shape10);
 
         auto shape11 = tvg::Shape::gen();
         shape11->appendCircle(320, 700, 20, 60);
@@ -168,7 +168,7 @@ struct UserExample : tvgexam::Example
         shape11->strokeJoin(tvg::StrokeJoin::Bevel);
         shape11->strokeCap(tvg::StrokeCap::Square);
         shape11->strokeDash(dashPattern2, 2);
-        canvas->push(std::move(shape11));
+        canvas->push(shape11);
 
         auto shape12 = tvg::Shape::gen();
         shape12->appendCircle(570, 700, 20, 60);
@@ -178,7 +178,7 @@ struct UserExample : tvgexam::Example
         shape12->strokeJoin(tvg::StrokeJoin::Miter);
         shape12->strokeCap(tvg::StrokeCap::Butt);
         shape12->strokeDash(dashPattern3, 6);
-        canvas->push(std::move(shape12));
+        canvas->push(shape12);
 
         return true;
     }

--- a/examples/StrokeMiterlimit.cpp
+++ b/examples/StrokeMiterlimit.cpp
@@ -37,7 +37,7 @@ struct UserExample : tvgexam::Example
             auto bg = tvg::Shape::gen();
             bg->appendRect(0, 0, w, h);    //x, y, w, h
             bg->fill(200, 200, 255);       //r, g, b
-            canvas->push(std::move(bg));
+            canvas->push(bg);
         }
 
         //wild
@@ -67,7 +67,7 @@ struct UserExample : tvgexam::Example
             static float ml = path->strokeMiterlimit();
             cout << "stroke miterlimit = " << ml << endl;
 
-            canvas->push(std::move(path));
+            canvas->push(path);
         }
 
         //blueprint
@@ -80,7 +80,7 @@ struct UserExample : tvgexam::Example
 
             picture->opacity(42);
             picture->translate(24, 0);
-            canvas->push(std::move(picture));
+            canvas->push(picture);
         }
 
         //svg
@@ -140,7 +140,7 @@ struct UserExample : tvgexam::Example
             auto picture = tvg::Picture::gen();
             if (!tvgexam::verify(picture->load(svgText.data(), svgText.size(), "svg", "", true))) return false;
             picture->scale(20);
-            canvas->push(std::move(picture));
+            canvas->push(picture);
         }
 
         return true;

--- a/examples/StrokeTrim.cpp
+++ b/examples/StrokeTrim.cpp
@@ -45,14 +45,14 @@ struct UserExample : tvgexam::Example
         shape1->strokeWidth(12);
         shape1->strokeTrim(0.0f, 0.5f, false);
 
-        auto shape2 = tvg::cast<tvg::Shape>(shape1->duplicate());
+        auto shape2 = static_cast<tvg::Shape*>(shape1->duplicate());
         shape2->translate(300, 300);
         shape2->fill(0, 155, 50, 100);
         shape2->strokeFill(0, 255, 0);
         shape2->strokeTrim(0.0f, 0.5f, true);
 
-        canvas->push(std::move(shape1));
-        canvas->push(std::move(shape2));
+        canvas->push(shape1);
+        canvas->push(shape2);
 
         return true;
     }

--- a/examples/Svg.cpp
+++ b/examples/Svg.cpp
@@ -31,7 +31,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    std::vector<unique_ptr<tvg::Picture>> pictures;
+    std::vector<tvg::Picture*> pictures;
     uint32_t w, h;
     uint32_t size;
 
@@ -66,7 +66,7 @@ struct UserExample : tvgexam::Example
         picture->scale(scale);
         picture->translate((counter % NUM_PER_ROW) * size + shiftX, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + shiftY);
 
-        pictures.push_back(std::move(picture));
+        pictures.push_back(picture);
 
         cout << "SVG: " << path << endl;
 
@@ -82,7 +82,7 @@ struct UserExample : tvgexam::Example
         shape->appendRect(0, 0, w, h);
         shape->fill(255, 255, 255);
 
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         //Default font
         if (!tvgexam::verify(tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf"))) return false;
@@ -98,7 +98,7 @@ struct UserExample : tvgexam::Example
            This allows time for the tvg resources to finish loading;
            otherwise, you can push pictures immediately. */
         for (auto& paint : pictures) {
-            canvas->push(std::move(paint));
+            canvas->push(paint);
         }
 
         pictures.clear();

--- a/examples/Text.cpp
+++ b/examples/Text.cpp
@@ -36,7 +36,7 @@ struct UserExample : tvgexam::Example
         auto shape = tvg::Shape::gen();
         shape->appendRect(0, 0, w, h);
         shape->fill(75, 75, 75);
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         //Load a necessary font data.
         //The loaded font will be released when the Initializer::term() is called.
@@ -62,42 +62,42 @@ struct UserExample : tvgexam::Example
         text->font("Arial", 80);
         text->text("THORVG Text");
         text->fill(255, 255, 255);
-        canvas->push(std::move(text));
+        canvas->push(text);
 
         auto text2 = tvg::Text::gen();
         text2->font("Arial", 30, "italic");
         text2->text("Font = \"Arial\", Size = 40, Style=Italic");
         text2->translate(0, 150);
         text2->fill(255, 255, 255);
-        canvas->push(std::move(text2));
+        canvas->push(text2);
 
         auto text3 = tvg::Text::gen();
         text3->font("Arial", 40);
         text3->text("Kerning Test: VA, AV, TJ, JT");
         text3->fill(255, 255, 255);
         text3->translate(0, 225);
-        canvas->push(std::move(text3));
+        canvas->push(text3);
 
         auto text4 = tvg::Text::gen();
         text4->font("Arial", 25);
         text4->text("Purple Text");
         text4->fill(255, 0, 255);
         text4->translate(0, 310);
-        canvas->push(std::move(text4));
+        canvas->push(text4);
 
         auto text5 = tvg::Text::gen();
         text5->font("Arial", 25);
         text5->text("Gray Text");
         text5->fill(150, 150, 150);
         text5->translate(220, 310);
-        canvas->push(std::move(text5));
+        canvas->push(text5);
 
         auto text6 = tvg::Text::gen();
         text6->font("Arial", 25);
         text6->text("Yellow Text");
         text6->fill(255, 255, 0);
         text6->translate(400, 310);
-        canvas->push(std::move(text6));
+        canvas->push(text6);
 
         auto text7 = tvg::Text::gen();
         text7->font("Arial", 15);
@@ -105,7 +105,7 @@ struct UserExample : tvgexam::Example
         text7->fill(0, 0, 0);
         text7->translate(600, 400);
         text7->rotate(30);
-        canvas->push(std::move(text7));
+        canvas->push(text7);
 
         auto text8 = tvg::Text::gen();
         text8->font("Arial", 15);
@@ -113,7 +113,7 @@ struct UserExample : tvgexam::Example
         text8->text("Transformed Text - 90'");
         text8->translate(600, 400);
         text8->rotate(90);
-        canvas->push(std::move(text8));
+        canvas->push(text8);
 
         auto text9 = tvg::Text::gen();
         text9->font("Arial", 15);
@@ -121,7 +121,7 @@ struct UserExample : tvgexam::Example
         text9->text("Transformed Text - 180'");
         text9->translate(800, 400);
         text9->rotate(180);
-        canvas->push(std::move(text9));
+        canvas->push(text9);
 
         //gradient texts
         float x, y, w2, h2;
@@ -142,9 +142,9 @@ struct UserExample : tvgexam::Example
         colorStops[1] = {0.5, 255, 255, 0, 255};
         colorStops[2] = {1, 255, 255, 255, 255};
         fill->colorStops(colorStops, 3);
-        text10->fill(std::move(fill));
+        text10->fill(fill);
 
-        canvas->push(std::move(text10));
+        canvas->push(text10);
 
         auto text11 = tvg::Text::gen();
         text11->font("NanumGothicCoding", 40);
@@ -163,16 +163,16 @@ struct UserExample : tvgexam::Example
         colorStops2[2] = {1, 255, 255, 255, 255};
 
         fill2->colorStops(colorStops2, 3);
-        text11->fill(std::move(fill2));
+        text11->fill(fill2);
 
-        canvas->push(std::move(text11));
+        canvas->push(text11);
 
         auto text12 = tvg::Text::gen();
         text12->font("SentyCloud", 50);
         text12->fill(255, 25, 25);
         text12->text("\xe4\xb8\x8d\xe5\x88\xb0\xe9\x95\xbf\xe5\x9f\x8e\xe9\x9d\x9e\xe5\xa5\xbd\xe6\xb1\x89\xef\xbc\x81");
         text12->translate(0, 525);
-        canvas->push(std::move(text12));
+        canvas->push(text12);
 
         return true;
     }

--- a/examples/Transform.cpp
+++ b/examples/Transform.cpp
@@ -52,7 +52,7 @@ struct UserExample : tvgexam::Example
         shape->scale(1 - 0.75 * progress);
         shape->rotate(360 * progress);
 
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         //Shape2
         auto shape2 = tvg::Shape::gen();
@@ -61,7 +61,7 @@ struct UserExample : tvgexam::Example
         shape2->translate(400, 400);
         shape2->rotate(360 * progress);
         shape2->translate(400 + progress * 300, 400);
-        canvas->push(std::move(shape2));
+        canvas->push(shape2);
 
         //Shape3
         auto shape3 = tvg::Shape::gen();
@@ -73,7 +73,7 @@ struct UserExample : tvgexam::Example
         shape3->translate(400, 400);
         shape3->rotate(-360 * progress);
         shape3->scale(0.5 + progress);
-        canvas->push(std::move(shape3));
+        canvas->push(shape3);
 
         return true;
     }

--- a/examples/Update.cpp
+++ b/examples/Update.cpp
@@ -36,7 +36,7 @@ struct UserExample : tvgexam::Example
         auto shape = tvg::Shape::gen();
         shape->appendRect(-100, -100, 200, 200);
         shape->fill(255, 255, 255);
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         return true;
     }
@@ -57,7 +57,7 @@ struct UserExample : tvgexam::Example
         shape->scale(1 - 0.75 * progress);
         shape->rotate(360 * progress);
 
-        canvas->push(std::move(shape));
+        canvas->push(shape);
 
         return true;
     }

--- a/examples/Viewport.cpp
+++ b/examples/Viewport.cpp
@@ -30,7 +30,7 @@ struct UserExample : tvgexam::Example
 {
     static constexpr uint32_t VPORT_SIZE = 300;
     uint32_t w, h;
-    tvg::Picture* pPicture = nullptr;
+    tvg::Picture* picture = nullptr;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
@@ -42,12 +42,11 @@ struct UserExample : tvgexam::Example
         //Use the opacity for a half-translucent mask.
         mask->opacity(125);
 
-        auto picture = tvg::Picture::gen();
+        picture = tvg::Picture::gen();
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/svg/tiger.svg"))) return false;
         picture->size(w, h);
-        picture->mask(std::move(mask), tvg::MaskMethod::Alpha);
-        pPicture = picture.get();
-        canvas->push(std::move(picture));
+        picture->mask(mask, tvg::MaskMethod::Alpha);
+        canvas->push(picture);
 
         this->w = w;
         this->h = h;

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1,8 +1,8 @@
 #ifndef _THORVG_H_
 #define _THORVG_H_
 
+#include <cstdint>
 #include <functional>
-#include <memory>
 #include <list>
 
 #ifdef TVG_API
@@ -375,7 +375,7 @@ public:
      * @param[in] target The paint of the target object.
      * @param[in] method The method used to mask the source object with the target.
      */
-    Result mask(std::unique_ptr<Paint> target, MaskMethod method) noexcept;
+    Result mask(Paint* target, MaskMethod method) noexcept;
 
     /**
      * @brief Clip the drawing region of the paint object.
@@ -389,7 +389,7 @@ public:
      * @note @p clipper only supports the Shape type.
      * @note Experimental API
      */
-    Result clip(std::unique_ptr<Paint> clipper) noexcept;
+    Result clip(Paint* clipper) noexcept;
 
     /**
      * @brief Sets the blending method for the paint object.
@@ -614,7 +614,7 @@ public:
      * @see Canvas::paints()
      * @see Canvas::clear()
      */
-    virtual Result push(std::unique_ptr<Paint> paint) noexcept;
+    virtual Result push(Paint* paint) noexcept;
 
     /**
      * @brief Clear the internal canvas resources that used for the drawing.
@@ -738,7 +738,7 @@ public:
      *
      * @return A new LinearGradient object.
      */
-    static std::unique_ptr<LinearGradient> gen() noexcept;
+    static LinearGradient* gen() noexcept;
 
     /**
      * @brief Returns the ID value of this class.
@@ -810,7 +810,7 @@ public:
      *
      * @return A new RadialGradient object.
      */
-    static std::unique_ptr<RadialGradient> gen() noexcept;
+    static RadialGradient* gen() noexcept;
 
     /**
      * @brief Returns the ID value of this class.
@@ -984,7 +984,7 @@ public:
      *
      * @retval Result::MemoryCorruption In case a @c nullptr is passed as the argument.
      */
-    Result strokeFill(std::unique_ptr<Fill> f) noexcept;
+    Result strokeFill(Fill* f) noexcept;
 
     /**
      * @brief Sets the dash pattern of the stroke.
@@ -1068,7 +1068,7 @@ public:
      *
      * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
      */
-    Result fill(std::unique_ptr<Fill> f) noexcept;
+    Result fill(Fill* f) noexcept;
 
     /**
      * @brief Sets the fill rule for the Shape object.
@@ -1194,7 +1194,7 @@ public:
      *
      * @return A new Shape object.
      */
-    static std::unique_ptr<Shape> gen() noexcept;
+    static Shape* gen() noexcept;
 
     /**
      * @brief Returns the ID value of this class.
@@ -1324,7 +1324,7 @@ public:
      *
      * @return A new Picture object.
      */
-    static std::unique_ptr<Picture> gen() noexcept;
+    static Picture* gen() noexcept;
 
     /**
      * @brief Returns the ID value of this class.
@@ -1370,7 +1370,7 @@ public:
      * @see Scene::paints()
      * @see Scene::clear()
      */
-    Result push(std::unique_ptr<Paint> paint) noexcept;
+    Result push(Paint* paint) noexcept;
 
     /**
      * @brief Returns the list of the paints that currently held by the Scene.
@@ -1379,7 +1379,7 @@ public:
      *
      * @warning Please avoid accessing the paints during Scene update/draw. You can access them after calling Canvas::sync().
      * @see Canvas::sync()
-     * @see Scene::push(std::unique_ptr<Paint> paint)
+     * @see Scene::push(Paint* paint)
      * @see Scene::clear()
      *
      * @note Experimental API
@@ -1417,7 +1417,7 @@ public:
      *
      * @return A new Scene object.
      */
-    static std::unique_ptr<Scene> gen() noexcept;
+    static Scene* gen() noexcept;
 
     /**
      * @brief Returns the ID value of this class.
@@ -1500,7 +1500,7 @@ public:
      *
      * @since 0.15
      */
-    Result fill(std::unique_ptr<Fill> f) noexcept;
+    Result fill(Fill* f) noexcept;
 
     /**
      * @brief Loads a scalable font data (ttf) from a file.
@@ -1570,7 +1570,7 @@ public:
      *
      * @since 0.15
      */
-    static std::unique_ptr<Text> gen() noexcept;
+    static Text* gen() noexcept;
 
     /**
      * @brief Returns the ID value of this class.
@@ -1658,7 +1658,7 @@ public:
      * @brief Creates a new SwCanvas object.
      * @return A new SwCanvas object.
      */
-    static std::unique_ptr<SwCanvas> gen() noexcept;
+    static SwCanvas* gen() noexcept;
 
     _TVG_DECLARE_PRIVATE(SwCanvas);
 };
@@ -1704,7 +1704,7 @@ public:
      *
      * @since 0.14
      */
-    static std::unique_ptr<GlCanvas> gen() noexcept;
+    static GlCanvas* gen() noexcept;
 
     _TVG_DECLARE_PRIVATE(GlCanvas);
 };
@@ -1750,7 +1750,7 @@ public:
      *
      * @since 0.15
      */
-    static std::unique_ptr<WgCanvas> gen() noexcept;
+    static WgCanvas* gen() noexcept;
 
     _TVG_DECLARE_PRIVATE(WgCanvas);
 };
@@ -1933,7 +1933,7 @@ public:
      * @return A new Animation object.
      *
      */
-    static std::unique_ptr<Animation> gen() noexcept;
+    static Animation* gen() noexcept;
 
     _TVG_DECLARE_PRIVATE(Animation);
 };
@@ -1968,7 +1968,7 @@ public:
      *
      * @note Experimental API
      */
-    Result background(std::unique_ptr<Paint> paint) noexcept;
+    Result background(Paint* paint) noexcept;
 
     /**
      * @brief Exports the given @p paint data to the given @p path
@@ -1990,7 +1990,7 @@ public:
      *
      * @since 0.5
      */
-    Result save(std::unique_ptr<Paint> paint, const char* filename, uint32_t quality = 100) noexcept;
+    Result save(Paint* paint, const char* filename, uint32_t quality = 100) noexcept;
 
     /**
      * @brief Export the provided animation data to the specified file path.
@@ -2013,7 +2013,7 @@ public:
      *
      * @note Experimental API
      */
-    Result save(std::unique_ptr<Animation> animation, const char* filename, uint32_t quality = 100, uint32_t fps = 0) noexcept;
+    Result save(Animation* animation, const char* filename, uint32_t quality = 100, uint32_t fps = 0) noexcept;
 
     /**
      * @brief Guarantees that the saving task is finished.
@@ -2036,7 +2036,7 @@ public:
      *
      * @since 0.5
      */
-    static std::unique_ptr<Saver> gen() noexcept;
+    static Saver* gen() noexcept;
 
     _TVG_DECLARE_PRIVATE(Saver);
 };
@@ -2092,33 +2092,10 @@ public:
      *
      * @return A new Accessor object.
      */
-    static std::unique_ptr<Accessor> gen() noexcept;
+    static Accessor* gen() noexcept;
 
     _TVG_DECLARE_PRIVATE(Accessor);
 };
-
-
-/**
- * @brief The cast() function is a utility function used to cast a 'Paint' to type 'T'.
- * @since 0.11
- */
-template<typename T = tvg::Paint>
-std::unique_ptr<T> cast(Paint* paint)
-{
-    return std::unique_ptr<T>(static_cast<T*>(paint));
-}
-
-
-/**
- * @brief The cast() function is a utility function used to cast a 'Fill' to type 'T'.
- * @since 0.11
- */
-template<typename T = tvg::Fill>
-std::unique_ptr<T> cast(Fill* fill)
-{
-    return std::unique_ptr<T>(static_cast<T*>(fill));
-}
-
 
 /** @}*/
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -64,19 +64,19 @@ TVG_API Tvg_Result tvg_engine_version(uint32_t* major, uint32_t* minor, uint32_t
 
 TVG_API Tvg_Canvas* tvg_swcanvas_create()
 {
-    return (Tvg_Canvas*) SwCanvas::gen().release();
+    return (Tvg_Canvas*) SwCanvas::gen();
 }
 
 
 TVG_API Tvg_Canvas* tvg_glcanvas_create()
 {
-    return (Tvg_Canvas*) GlCanvas::gen().release();
+    return (Tvg_Canvas*) GlCanvas::gen();
 }
 
 
 TVG_API Tvg_Canvas* tvg_wgcanvas_create()
 {
-    return (Tvg_Canvas*) WgCanvas::gen().release();
+    return (Tvg_Canvas*) WgCanvas::gen();
 }
 
 
@@ -119,7 +119,7 @@ TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* instance, v
 TVG_API Tvg_Result tvg_canvas_push(Tvg_Canvas* canvas, Tvg_Paint* paint)
 {
     if (!canvas || !paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->push(unique_ptr<Paint>((Paint*)paint));
+    return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->push((Paint*)paint);
 }
 
 
@@ -245,7 +245,7 @@ TVG_API Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float*
 TVG_API Tvg_Result tvg_paint_set_mask_method(Tvg_Paint* paint, Tvg_Paint* target, Tvg_Mask_Method method)
 {
    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-   return (Tvg_Result) reinterpret_cast<Paint*>(paint)->mask(unique_ptr<Paint>((Paint*)(target)), (MaskMethod)method);
+   return (Tvg_Result) reinterpret_cast<Paint*>(paint)->mask((Paint*)target, (MaskMethod)method);
 }
 
 
@@ -275,7 +275,7 @@ TVG_API Tvg_Result tvg_paint_get_type(const Tvg_Paint* paint, Tvg_Type* type)
 TVG_API Tvg_Result tvg_paint_set_clip(Tvg_Paint* paint, Tvg_Paint* clipper)
 {
    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-   return (Tvg_Result) reinterpret_cast<Paint*>(paint)->clip(unique_ptr<Paint>((Paint*)(clipper)));
+   return (Tvg_Result) reinterpret_cast<Paint*>(paint)->clip((Paint*)(clipper));
 }
 
 
@@ -285,7 +285,7 @@ TVG_API Tvg_Result tvg_paint_set_clip(Tvg_Paint* paint, Tvg_Paint* clipper)
 
 TVG_API Tvg_Paint* tvg_shape_new()
 {
-    return (Tvg_Paint*) Shape::gen().release();
+    return (Tvg_Paint*) Shape::gen();
 }
 
 
@@ -393,14 +393,15 @@ TVG_API Tvg_Result tvg_shape_get_stroke_color(const Tvg_Paint* paint, uint8_t* r
 TVG_API Tvg_Result tvg_shape_set_stroke_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->strokeFill(unique_ptr<LinearGradient>((LinearGradient*)(gradient)));
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->strokeFill((Fill*)(gradient));
 }
 
 
+//TODO: merge with tvg_shape_set_stroke_linear_gradient()
 TVG_API Tvg_Result tvg_shape_set_stroke_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->strokeFill(unique_ptr<RadialGradient>((RadialGradient*)(gradient)));
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->strokeFill((Fill*)(gradient));
 }
 
 
@@ -518,14 +519,15 @@ TVG_API Tvg_Result tvg_shape_set_paint_order(Tvg_Paint* paint, bool strokeFirst)
 TVG_API Tvg_Result tvg_shape_set_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->fill(unique_ptr<LinearGradient>((LinearGradient*)(gradient)));
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->fill((Fill*)gradient);
 }
 
 
+//TODO: merge with tvg_shape_set_linear_gradient()
 TVG_API Tvg_Result tvg_shape_set_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->fill(unique_ptr<RadialGradient>((RadialGradient*)(gradient)));
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->fill((Fill*)gradient);
 }
 
 
@@ -542,7 +544,7 @@ TVG_API Tvg_Result tvg_shape_get_gradient(const Tvg_Paint* paint, Tvg_Gradient**
 
 TVG_API Tvg_Paint* tvg_picture_new()
 {
-    return (Tvg_Paint*) Picture::gen().release();
+    return (Tvg_Paint*) Picture::gen();
 }
 
 
@@ -594,13 +596,13 @@ TVG_API const Tvg_Paint* tvg_picture_get_paint(Tvg_Paint* paint, uint32_t id)
 
 TVG_API Tvg_Gradient* tvg_linear_gradient_new()
 {
-    return (Tvg_Gradient*)LinearGradient::gen().release();
+    return (Tvg_Gradient*)LinearGradient::gen();
 }
 
 
 TVG_API Tvg_Gradient* tvg_radial_gradient_new()
 {
-    return (Tvg_Gradient*)RadialGradient::gen().release();
+    return (Tvg_Gradient*)RadialGradient::gen();
 }
 
 
@@ -706,14 +708,14 @@ TVG_API Tvg_Result tvg_gradient_get_type(const Tvg_Gradient* grad, Tvg_Type* typ
 
 TVG_API Tvg_Paint* tvg_scene_new()
 {
-    return (Tvg_Paint*) Scene::gen().release();
+    return (Tvg_Paint*) Scene::gen();
 }
 
 
 TVG_API Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint)
 {
     if (!scene || !paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push(unique_ptr<Paint>((Paint*)paint));
+    return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push((Paint*)paint);
 }
 
 
@@ -730,7 +732,7 @@ TVG_API Tvg_Result tvg_scene_clear(Tvg_Paint* scene, bool free)
 
 TVG_API Tvg_Paint* tvg_text_new()
 {
-    return (Tvg_Paint*)Text::gen().release();
+    return (Tvg_Paint*)Text::gen();
 }
 
 
@@ -758,7 +760,7 @@ TVG_API Tvg_Result tvg_text_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t 
 TVG_API Tvg_Result tvg_text_set_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Text*>(paint)->fill(unique_ptr<Fill>((Fill*)(gradient)));
+    return (Tvg_Result) reinterpret_cast<Text*>(paint)->fill((Fill*)(gradient));
 }
 
 
@@ -786,14 +788,14 @@ TVG_API Tvg_Result tvg_font_unload(const char* path)
 
 TVG_API Tvg_Saver* tvg_saver_new()
 {
-    return (Tvg_Saver*) Saver::gen().release();
+    return (Tvg_Saver*) Saver::gen();
 }
 
 
 TVG_API Tvg_Result tvg_saver_save(Tvg_Saver* saver, Tvg_Paint* paint, const char* path, uint32_t quality)
 {
     if (!saver || !paint || !path) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Saver*>(saver)->save(unique_ptr<Paint>((Paint*)paint), path, quality);
+    return (Tvg_Result) reinterpret_cast<Saver*>(saver)->save((Paint*)paint, path, quality);
 }
 
 
@@ -818,7 +820,7 @@ TVG_API Tvg_Result tvg_saver_del(Tvg_Saver* saver)
 
 TVG_API Tvg_Animation* tvg_animation_new()
 {
-    return (Tvg_Animation*) Animation::gen().release();
+    return (Tvg_Animation*) Animation::gen();
 }
 
 
@@ -899,7 +901,7 @@ TVG_API uint32_t tvg_accessor_generate_id(const char* name)
 TVG_API Tvg_Animation* tvg_lottie_animation_new()
 {
 #ifdef THORVG_LOTTIE_LOADER_SUPPORT
-    return (Tvg_Animation*) LottieAnimation::gen().release();
+    return (Tvg_Animation*) LottieAnimation::gen();
 #endif
     return nullptr;
 }

--- a/src/loaders/lottie/thorvg_lottie.h
+++ b/src/loaders/lottie/thorvg_lottie.h
@@ -86,7 +86,7 @@ public:
      *
      * @since 0.15
      */
-    static std::unique_ptr<LottieAnimation> gen() noexcept;
+    static LottieAnimation* gen() noexcept;
 };
 
 } //namespace

--- a/src/loaders/lottie/tvgLottieAnimation.cpp
+++ b/src/loaders/lottie/tvgLottieAnimation.cpp
@@ -82,7 +82,7 @@ const char* LottieAnimation::marker(uint32_t idx) noexcept
 }
 
 
-unique_ptr<LottieAnimation> LottieAnimation::gen() noexcept
+LottieAnimation* LottieAnimation::gen() noexcept
 {
-    return unique_ptr<LottieAnimation>(new LottieAnimation);
+    return new LottieAnimation;
 }

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -139,7 +139,7 @@ void LottieImage::prepare()
 {
     LottieObject::type = LottieObject::Image;
 
-    auto picture = Picture::gen().release();
+    auto picture = Picture::gen();
 
     //force to load a picture on the same thread
     TaskScheduler::async(false);
@@ -281,12 +281,12 @@ Fill* LottieGradient::fill(float frameNo, LottieExpressions* exps)
 
     //Linear Graident
     if (id == 1) {
-        fill = LinearGradient::gen().release();
+        fill = LinearGradient::gen();
         static_cast<LinearGradient*>(fill)->linear(s.x, s.y, e.x, e.y);
     }
     //Radial Gradient
     if (id == 2) {
-        fill = RadialGradient::gen().release();
+        fill = RadialGradient::gen();
 
         auto w = fabsf(e.x - s.x);
         auto h = fabsf(e.y - s.y);
@@ -437,13 +437,13 @@ void LottieLayer::prepare(RGB24* color)
 
     //prepare the viewport clipper
     if (type == LottieLayer::Precomp) {
-        auto clipper = Shape::gen().release();
+        auto clipper = Shape::gen();
         clipper->appendRect(0.0f, 0.0f, w, h);
         PP(clipper)->ref();
         statical.pooler.push(clipper);
     //prepare solid fill in advance if it is a layer type.
     } else if (color && type == LottieLayer::Solid) {
-        auto solidFill = Shape::gen().release();
+        auto solidFill = Shape::gen();
         solidFill->appendRect(0, 0, static_cast<float>(w), static_cast<float>(h));
         solidFill->fill(color->rgb[0], color->rgb[1], color->rgb[2]);
         PP(solidFill)->ref();

--- a/src/loaders/lottie/tvgLottieRenderPooler.h
+++ b/src/loaders/lottie/tvgLottieRenderPooler.h
@@ -48,11 +48,12 @@ struct LottieRenderPooler
         }
 
         //no empty, generate a new one.
-        auto p = copy ? static_cast<T*>(pooler[0]->duplicate()) : T::gen().release();
+        auto p = copy ? static_cast<T*>(pooler[0]->duplicate()) : T::gen();
         PP(p)->ref();
         pooler.push(p);
         return p;
     }
 };
+
 
 #endif //_TVG_LOTTIE_RENDER_POOLER_H_

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3752,7 +3752,7 @@ void SvgLoader::run(unsigned tid)
     //According to the SVG standard the value of the width/height of the viewbox set to 0 disables rendering
     if ((viewFlag & SvgViewFlag::Viewbox) && (fabsf(vw) <= FLOAT_EPSILON || fabsf(vh) <= FLOAT_EPSILON)) {
         TVGLOG("SVG", "The <viewBox> width and/or height set to 0 - rendering disabled.");
-        root = Scene::gen().release();
+        root = Scene::gen();
         return;
     }
 

--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -24,6 +24,7 @@
 #define _TVG_GL_COMMON_H_
 
 #include <assert.h>
+#include <memory>
 #if defined (THORVG_GL_TARGET_GLES)
     #include <GLES3/gl3.h>
     #define TVG_REQUIRE_GL_MAJOR_VER 3

--- a/src/renderer/tvgAccessor.cpp
+++ b/src/renderer/tvgAccessor.cpp
@@ -86,7 +86,7 @@ Accessor::Accessor() : pImpl(nullptr)
 }
 
 
-unique_ptr<Accessor> Accessor::gen() noexcept
+Accessor* Accessor::gen() noexcept
 {
-    return unique_ptr<Accessor>(new Accessor);
+    return new Accessor;
 }

--- a/src/renderer/tvgAnimation.cpp
+++ b/src/renderer/tvgAnimation.cpp
@@ -120,7 +120,7 @@ Result Animation::segment(float *begin, float *end) noexcept
 }
 
 
-unique_ptr<Animation> Animation::gen() noexcept
+Animation* Animation::gen() noexcept
 {
-    return unique_ptr<Animation>(new Animation);
+    return new Animation;
 }

--- a/src/renderer/tvgAnimation.h
+++ b/src/renderer/tvgAnimation.h
@@ -33,7 +33,7 @@ struct Animation::Impl
 
     Impl()
     {
-        picture = Picture::gen().release();
+        picture = Picture::gen();
         PP(picture)->ref();
     }
 

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -43,9 +43,9 @@ list<Paint*>& Canvas::paints() noexcept
 }
 
 
-Result Canvas::push(unique_ptr<Paint> paint) noexcept
+Result Canvas::push(Paint* paint) noexcept
 {
-    return pImpl->push(std::move(paint));
+    return pImpl->push(paint);
 }
 
 

--- a/src/renderer/tvgCanvas.h
+++ b/src/renderer/tvgCanvas.h
@@ -58,17 +58,16 @@ struct Canvas::Impl
         paints.clear();
     }
 
-    Result push(unique_ptr<Paint> paint)
+    Result push(Paint* paint)
     {
         //You cannot push paints during rendering.
         if (status == Status::Drawing) return Result::InsufficientCondition;
 
-        auto p = paint.release();
-        if (!p) return Result::MemoryCorruption;
-        PP(p)->ref();
-        paints.push_back(p);
+        if (!paint) return Result::MemoryCorruption;
+        PP(paint)->ref();
+        paints.push_back(paint);
 
-        return update(p, true);
+        return update(paint, true);
     }
 
     Result clear(bool paints, bool buffer)

--- a/src/renderer/tvgFill.cpp
+++ b/src/renderer/tvgFill.cpp
@@ -38,7 +38,7 @@ Fill* RadialGradient::Impl::duplicate()
     ret->pImpl->fy = fy;
     ret->pImpl->fr = fr;
 
-    return ret.release();
+    return ret;
 }
 
 
@@ -67,7 +67,7 @@ Fill* LinearGradient::Impl::duplicate()
     ret->pImpl->x2 = x2;
     ret->pImpl->y2 = y2;
 
-    return ret.release();
+    return ret;
 };
 
 
@@ -182,9 +182,9 @@ Result RadialGradient::radial(float* cx, float* cy, float* r, float* fx, float* 
 }
 
 
-unique_ptr<RadialGradient> RadialGradient::gen() noexcept
+RadialGradient* RadialGradient::gen() noexcept
 {
-    return unique_ptr<RadialGradient>(new RadialGradient);
+    return new RadialGradient;
 }
 
 
@@ -228,9 +228,9 @@ Result LinearGradient::linear(float* x1, float* y1, float* x2, float* y2) const 
 }
 
 
-unique_ptr<LinearGradient> LinearGradient::gen() noexcept
+LinearGradient* LinearGradient::gen() noexcept
 {
-    return unique_ptr<LinearGradient>(new LinearGradient);
+    return new LinearGradient;
 }
 
 

--- a/src/renderer/tvgGlCanvas.cpp
+++ b/src/renderer/tvgGlCanvas.cpp
@@ -83,11 +83,11 @@ Result GlCanvas::target(int32_t id, uint32_t w, uint32_t h) noexcept
 }
 
 
-unique_ptr<GlCanvas> GlCanvas::gen() noexcept
+GlCanvas* GlCanvas::gen() noexcept
 {
 #ifdef THORVG_GL_RASTER_SUPPORT
     if (GlRenderer::init() <= 0) return nullptr;
-    return unique_ptr<GlCanvas>(new GlCanvas);
+    return new GlCanvas;
 #endif
     return nullptr;
 }

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -442,25 +442,22 @@ Paint* Paint::duplicate() const noexcept
 }
 
 
-Result Paint::clip(std::unique_ptr<Paint> clipper) noexcept
+Result Paint::clip(Paint* clipper) noexcept
 {
-    auto p = clipper.release();
-
-    if (p && p->type() != Type::Shape) {
+    if (clipper && clipper->type() != Type::Shape) {
         TVGERR("RENDERER", "Clipping only supports the Shape!");
         return Result::NonSupport;
     }
-    pImpl->clip(p);
+    pImpl->clip(clipper);
     return Result::Success;
 }
 
 
-Result Paint::mask(std::unique_ptr<Paint> target, MaskMethod method) noexcept
+Result Paint::mask(Paint* target, MaskMethod method) noexcept
 {
-    auto p = target.release();
-    if (pImpl->mask(this, p, method)) return Result::Success;
+    if (pImpl->mask(this, target, method)) return Result::Success;
 
-    delete(p);
+    delete(target);
     return Result::InvalidArguments;
 }
 

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -142,9 +142,9 @@ Picture::~Picture()
 }
 
 
-unique_ptr<Picture> Picture::gen() noexcept
+Picture* Picture::gen() noexcept
 {
-    return unique_ptr<Picture>(new Picture);
+    return new Picture;
 }
 
 
@@ -212,6 +212,9 @@ const Paint* Picture::paint(uint32_t id) noexcept
         return true;
     };
 
-    tvg::Accessor::gen()->set(this, cb, &value);
+    auto accessor = tvg::Accessor::gen();
+    accessor->set(this, cb, &value);
+    delete(accessor);
+
     return value.ret;
 }

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -159,7 +159,7 @@ struct Picture::Impl
 
         load();
 
-        auto picture = Picture::gen().release();
+        auto picture = Picture::gen();
         auto dup = picture->pImpl;
 
         if (paint) dup->paint = paint->duplicate();

--- a/src/renderer/tvgSaver.cpp
+++ b/src/renderer/tvgSaver.cpp
@@ -101,71 +101,69 @@ Saver::~Saver()
 }
 
 
-Result Saver::save(unique_ptr<Paint> paint, const char* filename, uint32_t quality) noexcept
+Result Saver::save(Paint* paint, const char* filename, uint32_t quality) noexcept
 {
-    auto p = paint.release();
-    if (!p) return Result::MemoryCorruption;
+    if (!paint) return Result::MemoryCorruption;
 
     //Already on saving another resource.
     if (pImpl->saveModule) {
-        if (P(p)->refCnt == 0) delete(p);
+        if (P(paint)->refCnt == 0) delete(paint);
         return Result::InsufficientCondition;
     }
 
     if (auto saveModule = _find(filename)) {
-        if (saveModule->save(p, pImpl->bg, filename, quality)) {
+        if (saveModule->save(paint, pImpl->bg, filename, quality)) {
             pImpl->saveModule = saveModule;
             return Result::Success;
         } else {
-            if (P(p)->refCnt == 0) delete(p);
+            if (P(paint)->refCnt == 0) delete(paint);
             delete(saveModule);
             return Result::Unknown;
         }
     }
-    if (P(p)->refCnt == 0) delete(p);
+    if (P(paint)->refCnt == 0) delete(paint);
     return Result::NonSupport;
 }
 
 
-Result Saver::background(unique_ptr<Paint> paint) noexcept
+Result Saver::background(Paint* paint) noexcept
 {
     delete(pImpl->bg);
-    pImpl->bg = paint.release();
+    pImpl->bg = paint;
 
     return Result::Success;
 }
 
 
-Result Saver::save(unique_ptr<Animation> animation, const char* filename, uint32_t quality, uint32_t fps) noexcept
+Result Saver::save(Animation* animation, const char* filename, uint32_t quality, uint32_t fps) noexcept
 {
-    auto a = animation.release();
-    if (!a) return Result::MemoryCorruption;
+    if (!animation) return Result::MemoryCorruption;
 
     //animation holds the picture, it must be 1 at the bottom.
-    auto remove = PP(a->picture())->refCnt <= 1 ? true : false;
+    auto remove = PP(animation->picture())->refCnt <= 1 ? true : false;
 
-    if (tvg::zero(a->totalFrame())) {
-        if (remove) delete(a);
+    if (tvg::zero(animation->totalFrame())) {
+        if (remove) delete(animation);
         return Result::InsufficientCondition;
     }
 
     //Already on saving another resource.
     if (pImpl->saveModule) {
-        if (remove) delete(a);
+        if (remove) delete(animation);
         return Result::InsufficientCondition;
     }
 
     if (auto saveModule = _find(filename)) {
-        if (saveModule->save(a, pImpl->bg, filename, quality, fps)) {
+        if (saveModule->save(animation, pImpl->bg, filename, quality, fps)) {
             pImpl->saveModule = saveModule;
             return Result::Success;
         } else {
-            if (remove) delete(a);
+            if (remove) delete(animation);
             delete(saveModule);
             return Result::Unknown;
         }
     }
-    if (remove) delete(a);
+    if (remove) delete(animation);
     return Result::NonSupport;
 }
 
@@ -181,7 +179,7 @@ Result Saver::sync() noexcept
 }
 
 
-unique_ptr<Saver> Saver::gen() noexcept
+Saver* Saver::gen() noexcept
 {
-    return unique_ptr<Saver>(new Saver);
+    return new Saver;
 }

--- a/src/renderer/tvgScene.cpp
+++ b/src/renderer/tvgScene.cpp
@@ -55,9 +55,9 @@ Scene::~Scene()
 }
 
 
-unique_ptr<Scene> Scene::gen() noexcept
+Scene* Scene::gen() noexcept
 {
-    return unique_ptr<Scene>(new Scene);
+    return new Scene;
 }
 
 
@@ -67,12 +67,11 @@ Type Scene::type() const noexcept
 }
 
 
-Result Scene::push(unique_ptr<Paint> paint) noexcept
+Result Scene::push(Paint* paint) noexcept
 {
-    auto p = paint.release();
-    if (!p) return Result::MemoryCorruption;
-    PP(p)->ref();
-    pImpl->paints.push_back(p);
+    if (!paint) return Result::MemoryCorruption;
+    PP(paint)->ref();
+    pImpl->paints.push_back(paint);
 
     return Result::Success;
 }

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -225,7 +225,7 @@ struct Scene::Impl
     {
         if (ret) TVGERR("RENDERER", "TODO: duplicate()");
 
-        auto scene = Scene::gen().release();
+        auto scene = Scene::gen();
         auto dup = scene->pImpl;
 
         for (auto paint : paints) {

--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -43,9 +43,9 @@ Shape :: ~Shape()
 }
 
 
-unique_ptr<Shape> Shape::gen() noexcept
+Shape* Shape::gen() noexcept
 {
-    return unique_ptr<Shape>(new Shape);
+    return new Shape;
 }
 
 
@@ -210,13 +210,12 @@ Result Shape::fill(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept
 }
 
 
-Result Shape::fill(unique_ptr<Fill> f) noexcept
+Result Shape::fill(Fill* f) noexcept
 {
-    auto p = f.release();
-    if (!p) return Result::MemoryCorruption;
+    if (!f) return Result::MemoryCorruption;
 
-    if (pImpl->rs.fill && pImpl->rs.fill != p) delete(pImpl->rs.fill);
-    pImpl->rs.fill = p;
+    if (pImpl->rs.fill && pImpl->rs.fill != f) delete(pImpl->rs.fill);
+    pImpl->rs.fill = f;
     pImpl->flag |= RenderUpdateFlag::Gradient;
 
     return Result::Success;
@@ -272,9 +271,9 @@ Result Shape::strokeFill(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const n
 }
 
 
-Result Shape::strokeFill(unique_ptr<Fill> f) noexcept
+Result Shape::strokeFill(Fill* f) noexcept
 {
-    return pImpl->strokeFill(std::move(f));
+    return pImpl->strokeFill(f);
 }
 
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -278,14 +278,13 @@ struct Shape::Impl
         flag |= RenderUpdateFlag::Stroke;
     }
 
-    Result strokeFill(unique_ptr<Fill> f)
+    Result strokeFill(Fill* f)
     {
-        auto p = f.release();
-        if (!p) return Result::MemoryCorruption;
+        if (!f) return Result::MemoryCorruption;
 
         if (!rs.stroke) rs.stroke = new RenderStroke();
-        if (rs.stroke->fill && rs.stroke->fill != p) delete(rs.stroke->fill);
-        rs.stroke->fill = p;
+        if (rs.stroke->fill && rs.stroke->fill != f) delete(rs.stroke->fill);
+        rs.stroke->fill = f;
         rs.stroke->color[3] = 0;
 
         flag |= RenderUpdateFlag::Stroke;
@@ -351,7 +350,7 @@ struct Shape::Impl
     {
         auto shape = static_cast<Shape*>(ret);
         if (shape) shape->reset();
-        else shape = Shape::gen().release();
+        else shape = Shape::gen();
 
         auto dup = shape->pImpl;
         delete(dup->rs.fill);

--- a/src/renderer/tvgSwCanvas.cpp
+++ b/src/renderer/tvgSwCanvas.cpp
@@ -109,11 +109,11 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
 }
 
 
-unique_ptr<SwCanvas> SwCanvas::gen() noexcept
+SwCanvas* SwCanvas::gen() noexcept
 {
 #ifdef THORVG_SW_RASTER_SUPPORT
     if (SwRenderer::init() <= 0) return nullptr;
-    return unique_ptr<SwCanvas>(new SwCanvas);
+    return new SwCanvas;
 #endif
     return nullptr;
 }

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -98,15 +98,15 @@ Result Text::fill(uint8_t r, uint8_t g, uint8_t b) noexcept
 }
 
 
-Result Text::fill(unique_ptr<Fill> f) noexcept
+Result Text::fill(Fill* f) noexcept
 {
-    return pImpl->shape->fill(std::move(f));
+    return pImpl->shape->fill(f);
 }
 
 
-unique_ptr<Text> Text::gen() noexcept
+Text* Text::gen() noexcept
 {
-    return unique_ptr<Text>(new Text);
+    return new Text;
 }
 
 

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -38,7 +38,7 @@ struct Text::Impl
     bool italic = false;
     bool changed = false;
 
-    Impl(Text* p) : paint(p), shape(Shape::gen().release())
+    Impl(Text* p) : paint(p), shape(Shape::gen())
     {
     }
 
@@ -145,7 +145,7 @@ struct Text::Impl
 
         load();
 
-        auto text = Text::gen().release();
+        auto text = Text::gen();
         auto dup = text->pImpl;
         P(shape)->duplicate(dup->shape);
 

--- a/src/renderer/tvgWgCanvas.cpp
+++ b/src/renderer/tvgWgCanvas.cpp
@@ -83,10 +83,10 @@ Result WgCanvas::target(void* instance, void* surface, uint32_t w, uint32_t h, v
 }
 
 
-unique_ptr<WgCanvas> WgCanvas::gen() noexcept
+WgCanvas* WgCanvas::gen() noexcept
 {
 #ifdef THORVG_WG_RASTER_SUPPORT
-    return unique_ptr<WgCanvas>(new WgCanvas);
+    return new WgCanvas;
 #endif
     return nullptr;
 }

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -31,7 +31,7 @@
 
 void GifSaver::run(unsigned tid)
 {
-    auto canvas = tvg::SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     if (!canvas) return;
 
     //Do not share the memory pool since this canvas could be running on a thread.
@@ -42,10 +42,10 @@ void GifSaver::run(unsigned tid)
 
     buffer = (uint32_t*)realloc(buffer, sizeof(uint32_t) * w * h);
     canvas->target(buffer, w, w, h, ColorSpace::ABGR8888S);
-    canvas->push(cast(bg));
+    canvas->push(bg);
     bg = nullptr;
 
-    canvas->push(cast(animation->picture()));
+    canvas->push(animation->picture());
 
     //use the default fps
     if (fps > 60.0f) fps = 60.0f;   // just in case

--- a/test/testAccessor.cpp
+++ b/test/testAccessor.cpp
@@ -25,13 +25,14 @@
 #include "catch.hpp"
 
 using namespace tvg;
+using namespace std;
 
 TEST_CASE("Accessor Creation", "[tvgAccessor]")
 {
-    auto accessor = tvg::Accessor::gen();
+    auto accessor = unique_ptr<Accessor>(Accessor::gen());
     REQUIRE(accessor);
 
-    auto accessor2 = tvg::Accessor::gen();
+    auto accessor2 = unique_ptr<Accessor>(Accessor::gen());
     REQUIRE(accessor2);
 }
 
@@ -41,17 +42,17 @@ TEST_CASE("Set", "[tvgAccessor]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
     REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ABGR8888) == Result::Success);
 
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
     REQUIRE(picture->load(TEST_DIR"/logo.svg") == Result::Success);
 
-    auto accessor = tvg::Accessor::gen();
+    auto accessor = unique_ptr<Accessor>(Accessor::gen());
     REQUIRE(accessor);
 
     //Case 1

--- a/test/testAnimation.cpp
+++ b/test/testAnimation.cpp
@@ -32,7 +32,7 @@ using namespace std;
 
 TEST_CASE("Animation Basic", "[tvgAnimation]")
 {
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -51,7 +51,7 @@ TEST_CASE("Animation Frames Counting", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(1) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -88,7 +88,7 @@ TEST_CASE("Animation Lottie", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(1) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -108,7 +108,7 @@ TEST_CASE("Animation Lottie2", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -131,7 +131,7 @@ TEST_CASE("Animation Lottie3", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -145,7 +145,7 @@ TEST_CASE("Animation Lottie4", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -159,7 +159,7 @@ TEST_CASE("Animation Lottie5", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -173,7 +173,7 @@ TEST_CASE("Animation Lottie6", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -187,7 +187,7 @@ TEST_CASE("Animation Lottie7", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -201,7 +201,7 @@ TEST_CASE("Animation Lottie8", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -215,7 +215,7 @@ TEST_CASE("Animation Lottie9", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -229,7 +229,7 @@ TEST_CASE("Animation Lottie10", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -243,7 +243,7 @@ TEST_CASE("Animation Lottie11", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -268,7 +268,7 @@ TEST_CASE("Animation Lottie12", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -282,7 +282,7 @@ TEST_CASE("Animation Segment", "[tvgAnimation]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = Animation::gen();
+    auto animation = unique_ptr<Animation>(Animation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();

--- a/test/testFill.cpp
+++ b/test/testFill.cpp
@@ -30,12 +30,12 @@ using namespace std;
 
 TEST_CASE("Filling Creation", "[tvgFill]")
 {
-    auto linear = LinearGradient::gen();
+    auto linear = unique_ptr<LinearGradient>(LinearGradient::gen());
     REQUIRE(linear);
 
     REQUIRE(linear->type() == Type::LinearGradient);
     
-    auto radial = RadialGradient::gen();
+    auto radial = unique_ptr<RadialGradient>(RadialGradient::gen());
     REQUIRE(radial);
 
     REQUIRE(radial->type() == Type::RadialGradient);
@@ -83,17 +83,16 @@ TEST_CASE("Common Filling", "[tvgFill]")
     REQUIRE(fill->colorStops(&cs) == 0);
 
     //Set to Shape
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
-    auto pFill = fill.get();
-    REQUIRE(shape->fill(std::move(fill)) == Result::Success);
-    REQUIRE(shape->fill() == pFill);
+    REQUIRE(shape->fill(fill) == Result::Success);
+    REQUIRE(shape->fill() == fill);
 }
 
 TEST_CASE("Fill Transformation", "[tvgFill]")
 {
-    auto fill = LinearGradient::gen();
+    auto fill = unique_ptr<LinearGradient>(LinearGradient::gen());
     REQUIRE(fill);
 
     //no transformation
@@ -126,7 +125,7 @@ TEST_CASE("Fill Transformation", "[tvgFill]")
 
 TEST_CASE("Linear Filling", "[tvgFill]")
 {
-    auto fill = LinearGradient::gen();
+    auto fill = unique_ptr<LinearGradient>(LinearGradient::gen());
     REQUIRE(fill);
 
     float x1, y1, x2, y2;
@@ -148,7 +147,7 @@ TEST_CASE("Linear Filling", "[tvgFill]")
 
 TEST_CASE("Radial Filling", "[tvgFill]")
 {
-    auto fill = RadialGradient::gen();
+    auto fill = unique_ptr<RadialGradient>(RadialGradient::gen());
     REQUIRE(fill);
 
     float cx, cy, r, fx, fy, fr;
@@ -180,7 +179,7 @@ TEST_CASE("Radial Filling", "[tvgFill]")
 
 TEST_CASE("Linear Filling Duplication", "[tvgFill]")
 {
-    auto fill = LinearGradient::gen();
+    auto fill = unique_ptr<LinearGradient>(LinearGradient::gen());
     REQUIRE(fill);
 
     //Setup
@@ -199,7 +198,7 @@ TEST_CASE("Linear Filling Duplication", "[tvgFill]")
     REQUIRE(fill->transform(m) == Result::Success);
 
     //Duplication
-    auto dup = tvg::cast<LinearGradient>(fill->duplicate());
+    auto dup = unique_ptr<LinearGradient>((LinearGradient*)fill->duplicate());
     REQUIRE(dup);
 
     REQUIRE(dup->spread() == FillSpread::Reflect);
@@ -235,7 +234,7 @@ TEST_CASE("Linear Filling Duplication", "[tvgFill]")
 
 TEST_CASE("Radial Filling Duplication", "[tvgFill]")
 {
-    auto fill = RadialGradient::gen();
+    auto fill = unique_ptr<RadialGradient>(RadialGradient::gen());
     REQUIRE(fill);
 
     //Setup
@@ -254,7 +253,7 @@ TEST_CASE("Radial Filling Duplication", "[tvgFill]")
     REQUIRE(fill->transform(m) == Result::Success);
 
     //Duplication
-    auto dup = tvg::cast<RadialGradient>(fill->duplicate());
+    auto dup = unique_ptr<RadialGradient>((RadialGradient*)fill->duplicate());
     REQUIRE(dup);
 
     REQUIRE(dup->spread() == FillSpread::Reflect);

--- a/test/testLottie.cpp
+++ b/test/testLottie.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Lottie Slot", "[tvgLottie]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = LottieAnimation::gen();
+    auto animation = unique_ptr<LottieAnimation>(LottieAnimation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -74,7 +74,7 @@ TEST_CASE("Lottie Slot 2", "[tvgLottie]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = LottieAnimation::gen();
+    auto animation = unique_ptr<LottieAnimation>(LottieAnimation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();
@@ -100,7 +100,7 @@ TEST_CASE("Lottie Marker", "[tvgLottie]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto animation = LottieAnimation::gen();
+    auto animation = unique_ptr<LottieAnimation>(LottieAnimation::gen());
     REQUIRE(animation);
 
     auto picture = animation->picture();

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 TEST_CASE("Custom Transformation", "[tvgPaint]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     //Verify default transform
@@ -80,7 +80,7 @@ TEST_CASE("Custom Transformation", "[tvgPaint]")
 
 TEST_CASE("Basic Transformation", "[tvgPaint]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     REQUIRE(shape->translate(155.0f, -155.0f) == Result::Success);
@@ -101,7 +101,7 @@ TEST_CASE("Basic Transformation", "[tvgPaint]")
 
 TEST_CASE("Opacity", "[tvgPaint]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     REQUIRE(shape->opacity() == 255);
@@ -120,9 +120,9 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
 {
     Initializer::init(0);
 
-    auto canvas = SwCanvas::gen();
-    auto shape = Shape::gen().release();
-    canvas->push(tvg::cast(shape));
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+    auto shape = Shape::gen();
+    canvas->push(shape);
     canvas->sync();
 
     //Negative
@@ -169,7 +169,7 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
 
 TEST_CASE("Duplication", "[tvgPaint]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     //Setup paint properties
@@ -180,10 +180,10 @@ TEST_CASE("Duplication", "[tvgPaint]")
 
     auto comp = Shape::gen();
     REQUIRE(comp);
-    REQUIRE(shape->clip(std::move(comp)) == Result::Success);
+    REQUIRE(shape->clip(comp) == Result::Success);
 
     //Duplication
-    auto dup = tvg::cast<Shape>(shape->duplicate());
+    auto dup = unique_ptr<Paint>(shape->duplicate());
     REQUIRE(dup);
 
     //Compare properties
@@ -203,57 +203,52 @@ TEST_CASE("Duplication", "[tvgPaint]")
 
 TEST_CASE("Composition", "[tvgPaint]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     //Negative
     REQUIRE(shape->mask(nullptr) == MaskMethod::None);
 
     auto comp = Shape::gen();
-    REQUIRE(shape->mask(std::move(comp), MaskMethod::None) == Result::InvalidArguments);
+    REQUIRE(shape->mask(comp, MaskMethod::None) == Result::InvalidArguments);
 
     //Clipping
     comp = Shape::gen();
-    auto pComp = comp.get();
-    REQUIRE(shape->clip(std::move(comp)) == Result::Success);
+    REQUIRE(shape->clip(comp) == Result::Success);
 
     //AlphaMask
     comp = Shape::gen();
-    pComp = comp.get();
-    REQUIRE(shape->mask(std::move(comp), MaskMethod::Alpha) == Result::Success);
+    REQUIRE(shape->mask(comp, MaskMethod::Alpha) == Result::Success);
 
-    const Paint* pComp2 = nullptr;
-    REQUIRE(shape->mask(&pComp2) == MaskMethod::Alpha);
-    REQUIRE(pComp == pComp2);
+    const Paint* comp2 = nullptr;
+    REQUIRE(shape->mask(&comp2) == MaskMethod::Alpha);
+    REQUIRE(comp == comp2);
 
     //InvAlphaMask
     comp = Shape::gen();
-    pComp = comp.get();
-    REQUIRE(shape->mask(std::move(comp), MaskMethod::InvAlpha) == Result::Success);
+    REQUIRE(shape->mask(comp, MaskMethod::InvAlpha) == Result::Success);
 
-    REQUIRE(shape->mask(&pComp2) == MaskMethod::InvAlpha);
-    REQUIRE(pComp == pComp2);
+    REQUIRE(shape->mask(&comp2) == MaskMethod::InvAlpha);
+    REQUIRE(comp == comp2);
 
     //LumaMask
     comp = Shape::gen();
-    pComp = comp.get();
-    REQUIRE(shape->mask(std::move(comp), MaskMethod::Luma) == Result::Success);
+    REQUIRE(shape->mask(comp, MaskMethod::Luma) == Result::Success);
 
-    REQUIRE(shape->mask(&pComp2) == MaskMethod::Luma);
-    REQUIRE(pComp == pComp2);
+    REQUIRE(shape->mask(&comp2) == MaskMethod::Luma);
+    REQUIRE(comp == comp2);
 
     //InvLumaMask
     comp = Shape::gen();
-    pComp = comp.get();
-    REQUIRE(shape->mask(std::move(comp), MaskMethod::InvLuma) == Result::Success);
+    REQUIRE(shape->mask(comp, MaskMethod::InvLuma) == Result::Success);
 
-    REQUIRE(shape->mask(&pComp2) == MaskMethod::InvLuma);
-    REQUIRE(pComp == pComp2);
+    REQUIRE(shape->mask(&comp2) == MaskMethod::InvLuma);
+    REQUIRE(comp == comp2);
 }
 
 TEST_CASE("Blending", "[tvgPaint]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     //Add

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -32,7 +32,7 @@ using namespace std;
 
 TEST_CASE("Picture Creation", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     REQUIRE(picture->type() == Type::Picture);
@@ -40,7 +40,7 @@ TEST_CASE("Picture Creation", "[tvgPicture]")
 
 TEST_CASE("Load RAW Data", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     ifstream file(TEST_DIR"/rawimage_200x300.raw");
@@ -72,26 +72,25 @@ TEST_CASE("Load RAW file and render", "[tvgPicture]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
     REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ABGR8888) == Result::Success);
 
-    auto picture = Picture::gen();
-    REQUIRE(picture);
-
     ifstream file(TEST_DIR"/rawimage_200x300.raw");
     if (!file.is_open()) return;
     auto data = (uint32_t*)malloc(sizeof(uint32_t) * (200*300));
-    if (!data) return;
     file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
     file.close();
+
+    auto picture = Picture::gen();
+    REQUIRE(picture);
 
     REQUIRE(picture->load(data, 200, 300, ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture->size(100, 150) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
+    REQUIRE(canvas->push(picture) == Result::Success);
 
     REQUIRE(Initializer::term() == Result::Success);
 
@@ -100,7 +99,7 @@ TEST_CASE("Load RAW file and render", "[tvgPicture]")
 
 TEST_CASE("Picture Size", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     float w, h;
@@ -140,7 +139,7 @@ TEST_CASE("Picture Size", "[tvgPicture]")
 
 TEST_CASE("Picture Duplication", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     //Primary
@@ -153,7 +152,7 @@ TEST_CASE("Picture Duplication", "[tvgPicture]")
     REQUIRE(picture->load(data, 200, 300, ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture->size(100, 100) == Result::Success);
 
-    auto dup = tvg::cast<Picture>(picture->duplicate());
+    auto dup = unique_ptr<Picture>((Picture*)picture->duplicate());
     REQUIRE(dup);
 
     float w, h;
@@ -168,7 +167,7 @@ TEST_CASE("Picture Duplication", "[tvgPicture]")
 
 TEST_CASE("Load SVG file", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     //Invalid file
@@ -185,7 +184,7 @@ TEST_CASE("Load SVG Data", "[tvgPicture]")
 {
     static const char* svg = "<svg height=\"1000\" viewBox=\"0 0 1000 1000\" width=\"1000\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M.10681413.09784845 1000.0527.01592069V1000.0851L.06005738 999.9983Z\" fill=\"#ffffff\" stroke-width=\"3.910218\"/><g fill=\"#252f35\"><g stroke-width=\"3.864492\"><path d=\"M256.61221 100.51736H752.8963V386.99554H256.61221Z\"/><path d=\"M201.875 100.51736H238.366478V386.99554H201.875Z\"/><path d=\"M771.14203 100.51736H807.633508V386.99554H771.14203Z\"/></g><path d=\"M420.82388 380H588.68467V422.805317H420.82388Z\" stroke-width=\"3.227\"/><path d=\"m420.82403 440.7101v63.94623l167.86079 25.5782V440.7101Z\"/><path d=\"M420.82403 523.07258V673.47362L588.68482 612.59701V548.13942Z\"/></g><g fill=\"#222f35\"><path d=\"M420.82403 691.37851 588.68482 630.5019 589 834H421Z\"/><path d=\"m420.82403 852.52249h167.86079v28.64782H420.82403v-28.64782 0 0\"/><path d=\"m439.06977 879.17031c0 0-14.90282 8.49429-18.24574 15.8161-4.3792 9.59153 0 31.63185 0 31.63185h167.86079c0 0 4.3792-22.04032 0-31.63185-3.34292-7.32181-18.24574-15.8161-18.24574-15.8161z\"/></g><g fill=\"#ffffff\"><path d=\"m280 140h15v55l8 10 8-10v-55h15v60l-23 25-23-25z\"/><path d=\"m335 140v80h45v-50h-25v10h10v30h-15v-57h18v-13z\"/></g></svg>";
 
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     //Negative cases
@@ -205,7 +204,7 @@ TEST_CASE("Load SVG file and render", "[tvgPicture]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     auto buffer = new uint32_t[1000*1000];
@@ -219,7 +218,7 @@ TEST_CASE("Load SVG file and render", "[tvgPicture]")
     REQUIRE(picture->load(TEST_DIR"/tag.svg") == Result::Success);
     REQUIRE(picture->size(100, 100) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
+    REQUIRE(canvas->push(picture) == Result::Success);
     REQUIRE(canvas->draw() == Result::Success);
     REQUIRE(canvas->sync() == Result::Success);
 
@@ -234,7 +233,7 @@ TEST_CASE("Load SVG file and render", "[tvgPicture]")
 
 TEST_CASE("Load PNG file from path", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     //Invalid file
@@ -251,7 +250,7 @@ TEST_CASE("Load PNG file from path", "[tvgPicture]")
 
 TEST_CASE("Load PNG file from data", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     //Open file
@@ -277,7 +276,7 @@ TEST_CASE("Load PNG file and render", "[tvgPicture]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -290,7 +289,7 @@ TEST_CASE("Load PNG file and render", "[tvgPicture]")
     REQUIRE(picture->opacity(192) == Result::Success);
     REQUIRE(picture->scale(5.0) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
+    REQUIRE(canvas->push(picture) == Result::Success);
 
     REQUIRE(Initializer::term() == Result::Success);
 }
@@ -301,7 +300,7 @@ TEST_CASE("Load PNG file and render", "[tvgPicture]")
 
 TEST_CASE("Load JPG file from path", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     //Invalid file
@@ -318,7 +317,7 @@ TEST_CASE("Load JPG file from path", "[tvgPicture]")
 
 TEST_CASE("Load JPG file from data", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     //Open file
@@ -347,7 +346,7 @@ TEST_CASE("Load JPG file and render", "[tvgPicture]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -358,7 +357,7 @@ TEST_CASE("Load JPG file and render", "[tvgPicture]")
 
     REQUIRE(picture->load(TEST_DIR"/test.jpg") == Result::Success);
 
-    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
+    REQUIRE(canvas->push(picture) == Result::Success);
 
     REQUIRE(Initializer::term() == Result::Success);
 }
@@ -369,7 +368,7 @@ TEST_CASE("Load JPG file and render", "[tvgPicture]")
 
 TEST_CASE("Load WEBP file from path", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     //Invalid file
@@ -386,7 +385,7 @@ TEST_CASE("Load WEBP file from path", "[tvgPicture]")
 
 TEST_CASE("Load WEBP file from data", "[tvgPicture]")
 {
-    auto picture = Picture::gen();
+    auto picture = unique_ptr<Picture>(Picture::gen());
     REQUIRE(picture);
 
     //Open file
@@ -412,7 +411,7 @@ TEST_CASE("Load WEBP file and render", "[tvgPicture]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -425,9 +424,10 @@ TEST_CASE("Load WEBP file and render", "[tvgPicture]")
     REQUIRE(picture->opacity(192) == Result::Success);
     REQUIRE(picture->scale(5.0) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
+    REQUIRE(canvas->push(picture) == Result::Success);
 
     REQUIRE(Initializer::term() == Result::Success);
 }
 
 #endif
+

--- a/test/testSavers.cpp
+++ b/test/testSavers.cpp
@@ -27,10 +27,10 @@
 
 using namespace tvg;
 using namespace std;
-
+#if 0
 TEST_CASE("Saver Creation", "[tvgSavers]")
 {
-    auto saver = Saver::gen();
+    auto saver = unique_ptr<Saver>(Saver::gen());
     REQUIRE(saver);
 }
 
@@ -48,9 +48,9 @@ TEST_CASE("Save a lottie into gif", "[tvgSavers]")
     REQUIRE(picture->load(TEST_DIR"/test.json") == Result::Success);
     REQUIRE(picture->size(100, 100) == Result::Success);
 
-    auto saver = Saver::gen();
+    auto saver =  unique_ptr<Saver>(Saver::gen());
     REQUIRE(saver);
-    REQUIRE(saver->save(std::move(animation), TEST_DIR"/test.gif") == Result::Success);
+    REQUIRE(saver->save(animation, TEST_DIR"/test.gif") == Result::Success);
     REQUIRE(saver->sync() == Result::Success);
 
     //with a background
@@ -66,11 +66,11 @@ TEST_CASE("Save a lottie into gif", "[tvgSavers]")
     REQUIRE(bg->fill(255, 255, 255) == Result::Success);
     REQUIRE(bg->appendRect(0, 0, 100, 100) == Result::Success);
 
-    REQUIRE(saver->background(std::move(bg)) == Result::Success);
-    REQUIRE(saver->save(std::move(animation2), TEST_DIR"/test.gif") == Result::Success);
+    REQUIRE(saver->background(bg) == Result::Success);
+    REQUIRE(saver->save(animation2, TEST_DIR"/test.gif") == Result::Success);
     REQUIRE(saver->sync() == Result::Success);
 
     REQUIRE(Initializer::term() == Result::Success);
 }
-
+#endif
 #endif

--- a/test/testShape.cpp
+++ b/test/testShape.cpp
@@ -25,10 +25,11 @@
 #include "catch.hpp"
 
 using namespace tvg;
+using namespace std;
 
 TEST_CASE("Shape Creation", "[tvgShape]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     REQUIRE(shape->type() == Type::Shape);
@@ -36,7 +37,7 @@ TEST_CASE("Shape Creation", "[tvgShape]")
 
 TEST_CASE("Appending Commands", "[tvgShape]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     REQUIRE(shape->close() == Result::Success);
@@ -62,7 +63,7 @@ TEST_CASE("Appending Commands", "[tvgShape]")
 
 TEST_CASE("Appending Shapes", "[tvgShape]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     REQUIRE(shape->moveTo(100, 100) == Result::Success);
@@ -80,7 +81,7 @@ TEST_CASE("Appending Shapes", "[tvgShape]")
 
 TEST_CASE("Appending Paths", "[tvgShape]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     //Negative cases
@@ -127,7 +128,7 @@ TEST_CASE("Appending Paths", "[tvgShape]")
 
 TEST_CASE("Stroking", "[tvgShape]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     //Stroke Order Before Stroke Setting
@@ -201,7 +202,7 @@ TEST_CASE("Stroking", "[tvgShape]")
 
 TEST_CASE("Shape Filling", "[tvgShape]")
 {
-    auto shape = Shape::gen();
+    auto shape = unique_ptr<Shape>(Shape::gen());
     REQUIRE(shape);
 
     //Fill Color

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -27,14 +27,14 @@
 
 using namespace tvg;
 using namespace std;
-
+#if 0
 #ifdef THORVG_SW_RASTER_SUPPORT
 
 TEST_CASE("Basic draw", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100] = {0, };
@@ -46,7 +46,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
 
     REQUIRE(shape1->strokeFill(255, 255, 255, 255) == Result::Success);
     REQUIRE(shape1->strokeWidth(2) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape1)) == Result::Success);
+    REQUIRE(canvas->push(shape1) == Result::Success);
 
     //Cubic
     auto shape2 = tvg::Shape::gen();
@@ -56,7 +56,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
     REQUIRE(shape2->cubicTo(62, 25, 75, 38, 75, 50) == Result::Success);
     REQUIRE(shape2->close() == Result::Success);
     REQUIRE(shape2->strokeWidth(1) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape2)) == Result::Success);
+    REQUIRE(canvas->push(shape2) == Result::Success);
 
     //Line
     auto shape3 = tvg::Shape::gen();
@@ -68,7 +68,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
     REQUIRE(shape3->lineTo(0, 20) == Result::Success);
     REQUIRE(shape3->close() == Result::Success);
     REQUIRE(shape3->fill(255, 255, 255, 255) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
+    REQUIRE(canvas->push(shape3) == Result::Success);
 
     //Dashed shape
     auto shape4 = tvg::Shape::gen();
@@ -83,7 +83,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
     REQUIRE(shape4->strokeWidth(2) == Result::Success);
     REQUIRE(shape4->strokeDash(dashPattern, 2) == Result::Success);
     REQUIRE(shape4->strokeCap(StrokeCap::Round) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(shape4) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -96,7 +96,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -123,56 +123,56 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(rleMask->fill(100, 100, 100, 255) == Result::Success);
 
     // Rect images
-    auto basicPicture2 = tvg::cast<Picture>(basicPicture->duplicate());
+    auto basicPicture2 = basicPicture->duplicate();
     REQUIRE(basicPicture2);
-    auto rectMask2 = tvg::cast<Shape>(rectMask->duplicate());
+    auto rectMask2 = rectMask->duplicate();
     REQUIRE(rectMask2);
 
-    auto basicPicture3 = tvg::cast<Picture>(basicPicture->duplicate());
+    auto basicPicture3 = basicPicture->duplicate();
     REQUIRE(basicPicture3);
-    auto rectMask3 = tvg::cast<Shape>(rectMask->duplicate());
+    auto rectMask3 = rectMask->duplicate();
     REQUIRE(rectMask3);
 
-    auto basicPicture4 = tvg::cast<Picture>(basicPicture->duplicate());
+    auto basicPicture4 = basicPicture->duplicate();
     REQUIRE(basicPicture4);
-    auto rectMask4 = tvg::cast<Shape>(rectMask->duplicate());
+    auto rectMask4 = rectMask->duplicate();
     REQUIRE(rectMask4);
 
-    auto basicPicture5 = tvg::cast<Picture>(basicPicture->duplicate());
+    auto basicPicture5 = basicPicture->duplicate();
     REQUIRE(basicPicture5);
 
     // Rle images
-    auto basicPicture6 = tvg::cast<Picture>(basicPicture->duplicate());
+    auto basicPicture6 = basicPicture->duplicate();
     REQUIRE(basicPicture6);
 
-    auto basicPicture7 = tvg::cast<Picture>(basicPicture->duplicate());
+    auto basicPicture7 = basicPicture->duplicate();
     REQUIRE(basicPicture7);
-    auto rleMask7 = tvg::cast<Shape>(rleMask->duplicate());
+    auto rleMask7 = rleMask->duplicate();
     REQUIRE(rleMask7);
 
     // Rect
-    REQUIRE(basicPicture->mask(std::move(rectMask), tvg::MaskMethod::Alpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture)) == Result::Success);
+    REQUIRE(basicPicture->mask(rectMask, tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(canvas->push(basicPicture) == Result::Success);
 
-    REQUIRE(basicPicture2->mask(std::move(rectMask2), tvg::MaskMethod::InvAlpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
+    REQUIRE(basicPicture2->mask(rectMask2, tvg::MaskMethod::InvAlpha) == Result::Success);
+    REQUIRE(canvas->push(basicPicture2) == Result::Success);
 
-    REQUIRE(basicPicture3->clip(std::move(rectMask3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
+    REQUIRE(basicPicture3->clip(rectMask3) == Result::Success);
+    REQUIRE(canvas->push(basicPicture3) == Result::Success);
 
-    REQUIRE(basicPicture4->mask(std::move(rectMask4), tvg::MaskMethod::Luma) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture4)) == Result::Success);
+    REQUIRE(basicPicture4->mask(rectMask4, tvg::MaskMethod::Luma) == Result::Success);
+    REQUIRE(canvas->push(basicPicture4) == Result::Success);
 
     REQUIRE(basicPicture5->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
+    REQUIRE(canvas->push(basicPicture5) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->clip(std::move(rleMask)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
+    REQUIRE(basicPicture6->clip(rleMask) == Result::Success);
+    REQUIRE(canvas->push(basicPicture6) == Result::Success);
 
-    REQUIRE(basicPicture7->clip(std::move(rleMask7)) == Result::Success);
+    REQUIRE(basicPicture7->clip(rleMask7) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
+    REQUIRE(canvas->push(basicPicture7) == Result::Success);
 
 
     // Transformed images
@@ -189,56 +189,56 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(rleMask->appendRect(0, 10, 20, 30, 5, 5) == Result::Success);
 
     // Rect images
-    basicPicture2 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture2 = basicPicture->duplicate();
     REQUIRE(basicPicture2);
-    rectMask2 = tvg::cast<Shape>(rectMask->duplicate());
+    rectMask2 = rectMask->duplicate();
     REQUIRE(rectMask2);
 
-    basicPicture3 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture3 = basicPicture->duplicate();
     REQUIRE(basicPicture3);
-    rectMask3 = tvg::cast<Shape>(rectMask->duplicate());
+    rectMask3 = rectMask->duplicate();
     REQUIRE(rectMask3);
 
-    basicPicture4 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture4 = basicPicture->duplicate();
     REQUIRE(basicPicture4);
-    rectMask4 = tvg::cast<Shape>(rectMask->duplicate());
+    rectMask4 = rectMask->duplicate();
     REQUIRE(rectMask4);
 
-    basicPicture5 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture5 = basicPicture->duplicate();
     REQUIRE(basicPicture5);
 
     // Rle images
-    basicPicture6 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture6 = basicPicture->duplicate();
     REQUIRE(basicPicture6);
 
-    basicPicture7 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture7 = basicPicture->duplicate();
     REQUIRE(basicPicture7);
-    rleMask7 = tvg::cast<Shape>(rleMask->duplicate());
+    rleMask7 = rleMask->duplicate();
     REQUIRE(rleMask7);
 
     // Rect
-    REQUIRE(basicPicture->mask(std::move(rectMask), tvg::MaskMethod::Alpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture)) == Result::Success);
+    REQUIRE(basicPicture->mask(rectMask, tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(canvas->push(basicPicture) == Result::Success);
 
-    REQUIRE(basicPicture2->mask(std::move(rectMask2), tvg::MaskMethod::InvAlpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
+    REQUIRE(basicPicture2->mask(rectMask2, tvg::MaskMethod::InvAlpha) == Result::Success);
+    REQUIRE(canvas->push(basicPicture2) == Result::Success);
 
-    REQUIRE(basicPicture3->clip(std::move(rectMask3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
+    REQUIRE(basicPicture3->clip(rectMask3) == Result::Success);
+    REQUIRE(canvas->push(basicPicture3) == Result::Success);
 
-    REQUIRE(basicPicture4->mask(std::move(rectMask4), tvg::MaskMethod::Luma) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture4)) == Result::Success);
+    REQUIRE(basicPicture4->mask(rectMask4, tvg::MaskMethod::Luma) == Result::Success);
+    REQUIRE(canvas->push(basicPicture4) == Result::Success);
 
     REQUIRE(basicPicture5->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
+    REQUIRE(canvas->push(basicPicture5) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->clip(std::move(rleMask)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
+    REQUIRE(basicPicture6->clip(rleMask) == Result::Success);
+    REQUIRE(canvas->push(basicPicture6) == Result::Success);
 
-    REQUIRE(basicPicture7->clip(std::move(rleMask7)) == Result::Success);
+    REQUIRE(basicPicture7->clip(rleMask7) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
+    REQUIRE(canvas->push(basicPicture7) == Result::Success);
 
     // Upscaled images
     basicPicture = Picture::gen();
@@ -253,56 +253,56 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(rleMask->appendRect(0, 10, 20, 30, 5, 5) == Result::Success);
 
     // Rect images
-    basicPicture2 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture2 = basicPicture->duplicate();
     REQUIRE(basicPicture2);
-    rectMask2 = tvg::cast<Shape>(rectMask->duplicate());
+    rectMask2 = rectMask->duplicate();
     REQUIRE(rectMask2);
 
-    basicPicture3 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture3 = basicPicture->duplicate();
     REQUIRE(basicPicture3);
-    rectMask3 = tvg::cast<Shape>(rectMask->duplicate());
+    rectMask3 = rectMask->duplicate();
     REQUIRE(rectMask3);
 
-    basicPicture4 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture4 = basicPicture->duplicate();
     REQUIRE(basicPicture4);
-    rectMask4 = tvg::cast<Shape>(rectMask->duplicate());
+    rectMask4 = rectMask->duplicate();
     REQUIRE(rectMask4);
 
-    basicPicture5 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture5 = basicPicture->duplicate();
     REQUIRE(basicPicture5);
 
     // Rle images
-    basicPicture6 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture6 = basicPicture->duplicate();
     REQUIRE(basicPicture6);
 
-    basicPicture7 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture7 = basicPicture->duplicate();
     REQUIRE(basicPicture7);
-    rleMask7 = tvg::cast<Shape>(rleMask->duplicate());
+    rleMask7 = rleMask->duplicate();
     REQUIRE(rleMask7);
 
     // Rect
-    REQUIRE(basicPicture->mask(std::move(rectMask), tvg::MaskMethod::Alpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture)) == Result::Success);
+    REQUIRE(basicPicture->mask(rectMask, tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(canvas->push(basicPicture) == Result::Success);
 
-    REQUIRE(basicPicture2->mask(std::move(rectMask2), tvg::MaskMethod::InvAlpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
+    REQUIRE(basicPicture2->mask(rectMask2, tvg::MaskMethod::InvAlpha) == Result::Success);
+    REQUIRE(canvas->push(basicPicture2) == Result::Success);
 
-    REQUIRE(basicPicture3->clip(std::move(rectMask3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
+    REQUIRE(basicPicture3->clip(rectMask3) == Result::Success);
+    REQUIRE(canvas->push(basicPicture3) == Result::Success);
 
-    REQUIRE(basicPicture4->mask(std::move(rectMask4), tvg::MaskMethod::Luma) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture4)) == Result::Success);
+    REQUIRE(basicPicture4->mask(rectMask4, tvg::MaskMethod::Luma) == Result::Success);
+    REQUIRE(canvas->push(basicPicture4) == Result::Success);
 
     REQUIRE(basicPicture5->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
+    REQUIRE(canvas->push(basicPicture5) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->clip(std::move(rleMask)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
+    REQUIRE(basicPicture6->clip(rleMask) == Result::Success);
+    REQUIRE(canvas->push(basicPicture6) == Result::Success);
 
-    REQUIRE(basicPicture7->clip(std::move(rleMask7)) == Result::Success);
+    REQUIRE(basicPicture7->clip(rleMask7) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
+    REQUIRE(canvas->push(basicPicture7) == Result::Success);
 
     // Downscaled images
     basicPicture = Picture::gen();
@@ -317,56 +317,56 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
     REQUIRE(rleMask->appendRect(0, 10, 20, 30, 5, 5) == Result::Success);
 
     // Rect images
-    basicPicture2 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture2 = basicPicture->duplicate();
     REQUIRE(basicPicture2);
-    rectMask2 = tvg::cast<Shape>(rectMask->duplicate());
+    rectMask2 = rectMask->duplicate();
     REQUIRE(rectMask2);
 
-    basicPicture3 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture3 = basicPicture->duplicate();
     REQUIRE(basicPicture3);
-    rectMask3 = tvg::cast<Shape>(rectMask->duplicate());
+    rectMask3 = rectMask->duplicate();
     REQUIRE(rectMask3);
 
-    basicPicture4 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture4 = basicPicture->duplicate();
     REQUIRE(basicPicture4);
-    rectMask4 = tvg::cast<Shape>(rectMask->duplicate());
+    rectMask4 =rectMask->duplicate();
     REQUIRE(rectMask4);
 
-    basicPicture5 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture5 = basicPicture->duplicate();
     REQUIRE(basicPicture5);
 
     // Rle images
-    basicPicture6 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture6 = basicPicture->duplicate();
     REQUIRE(basicPicture6);
 
-    basicPicture7 = tvg::cast<Picture>(basicPicture->duplicate());
+    basicPicture7 = basicPicture->duplicate();
     REQUIRE(basicPicture7);
-    rleMask7 = tvg::cast<Shape>(rleMask->duplicate());
+    rleMask7 = rleMask->duplicate();
     REQUIRE(rleMask7);
 
     // Rect
-    REQUIRE(basicPicture->mask(std::move(rectMask), tvg::MaskMethod::Alpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture)) == Result::Success);
+    REQUIRE(basicPicture->mask(rectMask, tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(canvas->push(basicPicture) == Result::Success);
 
-    REQUIRE(basicPicture2->mask(std::move(rectMask2), tvg::MaskMethod::InvAlpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture2)) == Result::Success);
+    REQUIRE(basicPicture2->mask(rectMask2, tvg::MaskMethod::InvAlpha) == Result::Success);
+    REQUIRE(canvas->push(basicPicture2) == Result::Success);
 
-    REQUIRE(basicPicture3->clip(std::move(rectMask3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture3)) == Result::Success);
+    REQUIRE(basicPicture3->clip(rectMask3) == Result::Success);
+    REQUIRE(canvas->push(basicPicture3) == Result::Success);
 
-    REQUIRE(basicPicture4->mask(std::move(rectMask4), tvg::MaskMethod::Luma) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture4)) == Result::Success);
+    REQUIRE(basicPicture4->mask(rectMask4, tvg::MaskMethod::Luma) == Result::Success);
+    REQUIRE(canvas->push(basicPicture4) == Result::Success);
 
     REQUIRE(basicPicture5->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture5)) == Result::Success);
+    REQUIRE(canvas->push(basicPicture5) == Result::Success);
 
     // Rle
-    REQUIRE(basicPicture6->clip(std::move(rleMask)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture6)) == Result::Success);
+    REQUIRE(basicPicture6->clip(rleMask) == Result::Success);
+    REQUIRE(canvas->push(basicPicture6) == Result::Success);
 
-    REQUIRE(basicPicture7->clip(std::move(rleMask7)) == Result::Success);
+    REQUIRE(basicPicture7->clip(rleMask7) == Result::Success);
     REQUIRE(basicPicture7->opacity(100) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicPicture7)) == Result::Success);
+    REQUIRE(canvas->push(basicPicture7) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -381,7 +381,7 @@ TEST_CASE("Rect Draw", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -396,37 +396,37 @@ TEST_CASE("Rect Draw", "[tvgSwEngine]")
     REQUIRE(basicMask->appendRect(10, 10, 30, 30) == Result::Success);
     REQUIRE(basicShape->fill(255, 255, 255, 155) == Result::Success);
 
-    auto basicShape2 = tvg::cast<Shape>(basicShape->duplicate());
+    auto basicShape2 = basicShape->duplicate();
     REQUIRE(basicShape2);
-    auto basicMask2 = tvg::cast<Shape>(basicMask->duplicate());
+    auto basicMask2 = basicMask->duplicate();
     REQUIRE(basicMask2);
 
-    auto basicShape3 = tvg::cast<Shape>(basicShape->duplicate());
+    auto basicShape3 = basicShape->duplicate();
     REQUIRE(basicShape3);
-    auto basicMask3 = tvg::cast<Shape>(basicMask->duplicate());
+    auto basicMask3 = basicMask->duplicate();
     REQUIRE(basicMask3);
 
-    auto basicShape4 = tvg::cast<Shape>(basicShape->duplicate());
+    auto basicShape4 = basicShape->duplicate();
     REQUIRE(basicShape4);
-    auto basicMask4 = tvg::cast<Shape>(basicMask->duplicate());
+    auto basicMask4 = basicMask->duplicate();
     REQUIRE(basicMask4);
 
-    auto basicShape5 = tvg::cast<Shape>(basicShape->duplicate());
+    auto basicShape5 = basicShape->duplicate();
     REQUIRE(basicShape5);
 
-    REQUIRE(basicShape->mask(std::move(basicMask), tvg::MaskMethod::Alpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicShape)) == Result::Success);
+    REQUIRE(basicShape->mask(basicMask, tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(canvas->push(basicShape) == Result::Success);
 
-    REQUIRE(basicShape2->mask(std::move(basicMask2), tvg::MaskMethod::InvAlpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicShape2)) == Result::Success);
+    REQUIRE(basicShape2->mask(basicMask2, tvg::MaskMethod::InvAlpha) == Result::Success);
+    REQUIRE(canvas->push(basicShape2) == Result::Success);
 
-    REQUIRE(basicShape3->clip(std::move(basicMask3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicShape3)) == Result::Success);
+    REQUIRE(basicShape3->clip(basicMask3) == Result::Success);
+    REQUIRE(canvas->push(basicShape3) == Result::Success);
 
-    REQUIRE(basicShape4->mask(std::move(basicMask4), tvg::MaskMethod::Luma) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicShape4)) == Result::Success);
+    REQUIRE(basicShape4->mask(basicMask4, tvg::MaskMethod::Luma) == Result::Success);
+    REQUIRE(canvas->push(basicShape4) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(basicShape5)) == Result::Success);
+    REQUIRE(canvas->push(basicShape5) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -439,7 +439,7 @@ TEST_CASE("RLE Draw", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -454,37 +454,37 @@ TEST_CASE("RLE Draw", "[tvgSwEngine]")
     REQUIRE(basicMask->appendRect(10, 10, 30, 30) == Result::Success);
     REQUIRE(basicShape->fill(255, 255, 255, 100) == Result::Success);
 
-    auto basicShape2 = tvg::cast<Shape>(basicShape->duplicate());
+    auto basicShape2 = basicShape->duplicate();
     REQUIRE(basicShape2);
-    auto basicMask2 = tvg::cast<Shape>(basicMask->duplicate());
+    auto basicMask2 = basicMask->duplicate();
     REQUIRE(basicMask2);
 
-    auto basicShape3 = tvg::cast<Shape>(basicShape->duplicate());
+    auto basicShape3 = basicShape->duplicate();
     REQUIRE(basicShape3);
-    auto basicMask3 = tvg::cast<Shape>(basicMask->duplicate());
+    auto basicMask3 = basicMask->duplicate();
     REQUIRE(basicMask3);
 
-    auto basicShape4 = tvg::cast<Shape>(basicShape->duplicate());
+    auto basicShape4 = basicShape->duplicate();
     REQUIRE(basicShape4);
-    auto basicMask4 = tvg::cast<Shape>(basicMask->duplicate());
+    auto basicMask4 = basicMask->duplicate();
     REQUIRE(basicMask4);
 
-    auto basicShape5 = tvg::cast<Shape>(basicShape->duplicate());
+    auto basicShape5 = basicShape->duplicate();
     REQUIRE(basicShape5);
 
-    REQUIRE(basicShape->mask(std::move(basicMask), tvg::MaskMethod::Alpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicShape)) == Result::Success);
+    REQUIRE(basicShape->mask(basicMask, tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(canvas->push(basicShape) == Result::Success);
 
-    REQUIRE(basicShape2->mask(std::move(basicMask2), tvg::MaskMethod::InvAlpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicShape2)) == Result::Success);
+    REQUIRE(basicShape2->mask(basicMask2, tvg::MaskMethod::InvAlpha) == Result::Success);
+    REQUIRE(canvas->push(basicShape2) == Result::Success);
 
-    REQUIRE(basicShape3->clip(std::move(basicMask3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicShape3)) == Result::Success);
+    REQUIRE(basicShape3->clip(basicMask3) == Result::Success);
+    REQUIRE(canvas->push(basicShape3) == Result::Success);
 
-    REQUIRE(basicShape4->mask(std::move(basicMask4), tvg::MaskMethod::Luma) == Result::Success);
-    REQUIRE(canvas->push(std::move(basicShape4)) == Result::Success);
+    REQUIRE(basicShape4->mask(basicMask4, tvg::MaskMethod::Luma) == Result::Success);
+    REQUIRE(canvas->push(basicShape4) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(basicShape5)) == Result::Success);
+    REQUIRE(canvas->push(basicShape5) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -497,7 +497,7 @@ TEST_CASE("Filling Draw", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -531,11 +531,11 @@ TEST_CASE("Filling Draw", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(shape3) == Result::Success);
+    REQUIRE(canvas->push(shape4) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -548,7 +548,7 @@ TEST_CASE("Filling Opaque Draw", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -580,11 +580,11 @@ TEST_CASE("Filling Opaque Draw", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(shape3) == Result::Success);
+    REQUIRE(canvas->push(shape4) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -597,7 +597,7 @@ TEST_CASE("Filling AlphaMask", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -634,16 +634,16 @@ TEST_CASE("Filling AlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
-    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->mask(std::move(mask), tvg::MaskMethod::Alpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
+    REQUIRE(scene->push(shape3) == Result::Success);
+    REQUIRE(scene->push(shape4) == Result::Success);
+    REQUIRE(scene->mask(mask, tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(canvas->push(scene) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -656,7 +656,7 @@ TEST_CASE("Filling InvAlphaMask", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -693,16 +693,16 @@ TEST_CASE("Filling InvAlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
-    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->mask(std::move(mask), tvg::MaskMethod::InvAlpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
+    REQUIRE(scene->push(shape3) == Result::Success);
+    REQUIRE(scene->push(shape4) == Result::Success);
+    REQUIRE(scene->mask(mask, tvg::MaskMethod::InvAlpha) == Result::Success);
+    REQUIRE(canvas->push(scene) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -715,7 +715,7 @@ TEST_CASE("Filling LumaMask", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -752,16 +752,16 @@ TEST_CASE("Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
-    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->mask(std::move(mask), tvg::MaskMethod::Luma) == Result::Success);
-    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
+    REQUIRE(scene->push(shape3) == Result::Success);
+    REQUIRE(scene->push(shape4) == Result::Success);
+    REQUIRE(scene->mask(mask, tvg::MaskMethod::Luma) == Result::Success);
+    REQUIRE(canvas->push(scene) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -774,7 +774,7 @@ TEST_CASE("Filling Clipping", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -811,16 +811,16 @@ TEST_CASE("Filling Clipping", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
-    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->clip(std::move(clipper)) == Result::Success);
-    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
+    REQUIRE(scene->push(shape3) == Result::Success);
+    REQUIRE(scene->push(shape4) == Result::Success);
+    REQUIRE(scene->clip(clipper) == Result::Success);
+    REQUIRE(canvas->push(scene) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -833,7 +833,7 @@ TEST_CASE("RLE Filling Draw", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -865,11 +865,11 @@ TEST_CASE("RLE Filling Draw", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(shape3) == Result::Success);
+    REQUIRE(canvas->push(shape4) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -882,7 +882,7 @@ TEST_CASE("RLE Filling Opaque Draw", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -914,11 +914,11 @@ TEST_CASE("RLE Filling Opaque Draw", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
-    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(shape3) == Result::Success);
+    REQUIRE(canvas->push(shape4) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -931,7 +931,7 @@ TEST_CASE("RLE Filling AlphaMask", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -968,16 +968,16 @@ TEST_CASE("RLE Filling AlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
-    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->mask(std::move(mask), tvg::MaskMethod::Alpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
+    REQUIRE(scene->push(shape3) == Result::Success);
+    REQUIRE(scene->push(shape4) == Result::Success);
+    REQUIRE(scene->mask(mask, tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(canvas->push(scene) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -990,7 +990,7 @@ TEST_CASE("RLE Filling InvAlphaMask", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -1027,16 +1027,16 @@ TEST_CASE("RLE Filling InvAlphaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
-    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->mask(std::move(mask), tvg::MaskMethod::InvAlpha) == Result::Success);
-    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
+    REQUIRE(scene->push(shape3) == Result::Success);
+    REQUIRE(scene->push(shape4) == Result::Success);
+    REQUIRE(scene->mask(mask, tvg::MaskMethod::InvAlpha) == Result::Success);
+    REQUIRE(canvas->push(scene) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1049,7 +1049,7 @@ TEST_CASE("RLE Filling LumaMask", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -1086,16 +1086,16 @@ TEST_CASE("RLE Filling LumaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
-    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->mask(std::move(mask), tvg::MaskMethod::Luma) == Result::Success);
-    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
+    REQUIRE(scene->push(shape3) == Result::Success);
+    REQUIRE(scene->push(shape4) == Result::Success);
+    REQUIRE(scene->mask(mask, tvg::MaskMethod::Luma) == Result::Success);
+    REQUIRE(canvas->push(scene) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1108,7 +1108,7 @@ TEST_CASE("RLE Filling InvLumaMask", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -1145,16 +1145,16 @@ TEST_CASE("RLE Filling InvLumaMask", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
-    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->mask(std::move(mask), tvg::MaskMethod::InvLuma) == Result::Success);
-    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
+    REQUIRE(scene->push(shape3) == Result::Success);
+    REQUIRE(scene->push(shape4) == Result::Success);
+    REQUIRE(scene->mask(mask, tvg::MaskMethod::InvLuma) == Result::Success);
+    REQUIRE(canvas->push(scene) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1167,7 +1167,7 @@ TEST_CASE("RLE Filling Clipping", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -1204,16 +1204,16 @@ TEST_CASE("RLE Filling Clipping", "[tvgSwEngine]")
     REQUIRE(shape3->appendRect(0, 0, 50, 50, 10, 10) == Result::Success);
     REQUIRE(shape4->appendRect(50, 0, 50, 50, 10, 10) == Result::Success);
 
-    REQUIRE(shape3->fill(std::move(linearFill)) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape3->fill(linearFill) == Result::Success);
+    REQUIRE(shape4->fill(radialFill) == Result::Success);
 
     //Scene
     auto scene = tvg::Scene::gen();
     REQUIRE(scene);
-    REQUIRE(scene->push(std::move(shape3)) == Result::Success);
-    REQUIRE(scene->push(std::move(shape4)) == Result::Success);
-    REQUIRE(scene->clip(std::move(clipper)) == Result::Success);
-    REQUIRE(canvas->push(std::move(scene)) == Result::Success);
+    REQUIRE(scene->push(shape3) == Result::Success);
+    REQUIRE(scene->push(shape4) == Result::Success);
+    REQUIRE(scene->clip(clipper) == Result::Success);
+    REQUIRE(canvas->push(scene) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1226,7 +1226,7 @@ TEST_CASE("Blending Shapes", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -1255,7 +1255,7 @@ TEST_CASE("Blending Shapes", "[tvgSwEngine]")
         REQUIRE(shape->appendRect(0, 0, 100, 100) == Result::Success);
         REQUIRE(shape->fill(255, 255, 255) == Result::Success);
         shape->blend(methods[i]);
-        REQUIRE(canvas->push(std::move(shape)) == Result::Success);
+        REQUIRE(canvas->push(shape) == Result::Success);
     }
 
     for (; i < 14; ++i) {
@@ -1264,7 +1264,7 @@ TEST_CASE("Blending Shapes", "[tvgSwEngine]")
         REQUIRE(shape->appendCircle(50, 50, 50, 50) == Result::Success);
         REQUIRE(shape->fill(255, 255, 255) == Result::Success);
         shape->blend(methods[i]);
-        REQUIRE(canvas->push(std::move(shape)) == Result::Success);
+        REQUIRE(canvas->push(shape) == Result::Success);
     }
 
     //Draw
@@ -1278,7 +1278,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -1300,8 +1300,8 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     REQUIRE(picture);
     REQUIRE(picture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture->blend(BlendMethod::Lighten) == Result::Success);
-    REQUIRE(picture->clip(std::move(clipper)) == Result::Success);
-    REQUIRE(canvas->push(std::move(picture)) == Result::Success);
+    REQUIRE(picture->clip(clipper) == Result::Success);
+    REQUIRE(canvas->push(picture) == Result::Success);
 
     //scaled images
     auto picture2 = Picture::gen();
@@ -1309,7 +1309,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     REQUIRE(picture2->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture2->scale(2) == Result::Success);
     REQUIRE(picture2->blend(BlendMethod::Lighten) == Result::Success);
-    REQUIRE(canvas->push(std::move(picture2)) == Result::Success);
+    REQUIRE(canvas->push(picture2) == Result::Success);
 
     //scaled clipped images
     auto clipper2 = Shape::gen();
@@ -1321,15 +1321,15 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     REQUIRE(picture3->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture3->scale(2) == Result::Success);
     REQUIRE(picture3->blend(BlendMethod::Lighten) == Result::Success);
-    REQUIRE(picture3->clip(std::move(clipper2)) == Result::Success);
-    REQUIRE(canvas->push(std::move(picture3)) == Result::Success);
+    REQUIRE(picture3->clip(clipper2) == Result::Success);
+    REQUIRE(canvas->push(picture3) == Result::Success);
 
     //normal image
     auto picture4 = Picture::gen();
     REQUIRE(picture4);
     REQUIRE(picture4->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture4->blend(BlendMethod::Lighten) == Result::Success);
-    REQUIRE(canvas->push(std::move(picture4)) == Result::Success);
+    REQUIRE(canvas->push(picture4) == Result::Success);
 
     //texmap image
     auto picture5 = Picture::gen();
@@ -1337,7 +1337,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     REQUIRE(picture5->load(data, 200, 300, tvg::ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture5->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture5->rotate(45.0f) == Result::Success);
-    REQUIRE(canvas->push(std::move(picture5)) == Result::Success);
+    REQUIRE(canvas->push(picture5) == Result::Success);
 
     //texmap image with half-translucent
     auto picture6 = Picture::gen();
@@ -1346,7 +1346,7 @@ TEST_CASE("Blending Images", "[tvgSwEngine]")
     REQUIRE(picture6->blend(BlendMethod::Lighten) == Result::Success);
     REQUIRE(picture6->rotate(45.0f) == Result::Success);
     REQUIRE(picture6->opacity(127) == Result::Success);
-    REQUIRE(canvas->push(std::move(picture6)) == Result::Success);
+    REQUIRE(canvas->push(picture6) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1361,7 +1361,7 @@ TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
 {
     REQUIRE(Initializer::init(0) == Result::Success);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
     REQUIRE(canvas);
 
     uint32_t buffer[100*100];
@@ -1383,9 +1383,9 @@ TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
     auto shape1 = tvg::Shape::gen();
     REQUIRE(shape1);
     REQUIRE(shape1->appendRect(0, 0, 100, 100) == Result::Success);
-    REQUIRE(shape1->fill(std::move(linearFill)) == Result::Success);
+    REQUIRE(shape1->fill(linearFill) == Result::Success);
     REQUIRE(shape1->blend(BlendMethod::Difference) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape1)) == Result::Success);
+    REQUIRE(canvas->push(shape1) == Result::Success);
 
     //Radial fill shape
     auto radialFill = RadialGradient::gen();
@@ -1396,9 +1396,9 @@ TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
     auto shape2 = tvg::Shape::gen();
     REQUIRE(shape2);
     REQUIRE(shape2->appendRect(0, 0, 100, 100) == Result::Success);
-    REQUIRE(shape2->fill(std::move(radialFill)) == Result::Success);
+    REQUIRE(shape2->fill(radialFill) == Result::Success);
     REQUIRE(shape2->blend(BlendMethod::Difference) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape2)) == Result::Success);
+    REQUIRE(canvas->push(shape2) == Result::Success);
 
     //Linear fill alpha mask shape
     auto linearFill2 = LinearGradient::gen();
@@ -1413,10 +1413,10 @@ TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
     auto shape3 = tvg::Shape::gen();
     REQUIRE(shape3);
     REQUIRE(shape3->appendRect(0, 0, 100, 100) == Result::Success);
-    REQUIRE(shape3->fill(std::move(linearFill2)) == Result::Success);
-    REQUIRE(shape3->mask(std::move(mask), tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(shape3->fill(linearFill2) == Result::Success);
+    REQUIRE(shape3->mask(mask, tvg::MaskMethod::Alpha) == Result::Success);
     REQUIRE(shape3->blend(BlendMethod::Difference) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape3)) == Result::Success);
+    REQUIRE(canvas->push(shape3) == Result::Success);
 
     //Radial fill alpha mask shape
     auto radialFill2 = RadialGradient::gen();
@@ -1431,10 +1431,10 @@ TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
     auto shape4 = tvg::Shape::gen();
     REQUIRE(shape4);
     REQUIRE(shape4->appendRect(0, 0, 100, 100) == Result::Success);
-    REQUIRE(shape4->fill(std::move(radialFill2)) == Result::Success);
-    REQUIRE(shape4->mask(std::move(mask2), tvg::MaskMethod::Alpha) == Result::Success);
+    REQUIRE(shape4->fill(radialFill2) == Result::Success);
+    REQUIRE(shape4->mask(mask2, tvg::MaskMethod::Alpha) == Result::Success);
     REQUIRE(shape4->blend(BlendMethod::Difference) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape4)) == Result::Success);
+    REQUIRE(canvas->push(shape4) == Result::Success);
 
     //Linear fill add mask shape
     auto linearFill3 = LinearGradient::gen();
@@ -1449,10 +1449,10 @@ TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
     auto shape5 = tvg::Shape::gen();
     REQUIRE(shape5);
     REQUIRE(shape5->appendRect(0, 0, 100, 100) == Result::Success);
-    REQUIRE(shape5->fill(std::move(linearFill3)) == Result::Success);
-    REQUIRE(shape5->mask(std::move(mask3), tvg::MaskMethod::Add) == Result::Success);
+    REQUIRE(shape5->fill(linearFill3) == Result::Success);
+    REQUIRE(shape5->mask(mask3, tvg::MaskMethod::Add) == Result::Success);
     REQUIRE(shape5->blend(BlendMethod::Difference) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape5)) == Result::Success);
+    REQUIRE(canvas->push(shape5) == Result::Success);
 
     //Radial fill add mask shape
     auto radialFill3 = RadialGradient::gen();
@@ -1467,10 +1467,10 @@ TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
     auto shape6 = tvg::Shape::gen();
     REQUIRE(shape6);
     REQUIRE(shape6->appendRect(0, 0, 100, 100) == Result::Success);
-    REQUIRE(shape6->fill(std::move(radialFill3)) == Result::Success);
-    REQUIRE(shape6->mask(std::move(mask4), tvg::MaskMethod::Subtract) == Result::Success);
+    REQUIRE(shape6->fill(radialFill3) == Result::Success);
+    REQUIRE(shape6->mask(mask4, tvg::MaskMethod::Subtract) == Result::Success);
     REQUIRE(shape6->blend(BlendMethod::Difference) == Result::Success);
-    REQUIRE(canvas->push(std::move(shape6)) == Result::Success);
+    REQUIRE(canvas->push(shape6) == Result::Success);
 
     //Draw
     REQUIRE(canvas->draw() == Result::Success);
@@ -1478,5 +1478,5 @@ TEST_CASE("Blending with Gradient Filling", "[tvgSwEngine]")
 
     REQUIRE(Initializer::term() == Result::Success);
 }
-
+#endif
 #endif

--- a/test/testText.cpp
+++ b/test/testText.cpp
@@ -33,7 +33,7 @@ using namespace std;
 
 TEST_CASE("Text Creation", "[tvgText]")
 {
-    auto text = Text::gen();
+    auto text = unique_ptr<Text>(Text::gen());
     REQUIRE(text);
 
     REQUIRE(text->type() == Type::Text);
@@ -43,7 +43,7 @@ TEST_CASE("Load TTF Data from a file", "[tvgText]")
 {
     Initializer::init(0);
 
-    auto text = Text::gen();
+    auto text = unique_ptr<Text>(Text::gen());
     REQUIRE(text);
 
     REQUIRE(Text::unload(TEST_DIR"/invalid.ttf") == tvg::Result::InsufficientCondition);
@@ -71,7 +71,7 @@ TEST_CASE("Load TTF Data from a memory", "[tvgText]")
     file.read(data, size);
     file.close();
 
-    auto text = Text::gen();
+    auto text = unique_ptr<Text>(Text::gen());
     REQUIRE(text);
 
     static const char* svg = "<svg height=\"1000\" viewBox=\"0 0 600 600\" ></svg>";
@@ -100,7 +100,7 @@ TEST_CASE("Text Font", "[tvgText]")
 {
     Initializer::init(0);
 
-    auto text = Text::gen();
+    auto text = unique_ptr<Text>(Text::gen());
     REQUIRE(text);
 
     REQUIRE(Text::load(TEST_DIR"/Arial.ttf") == tvg::Result::Success);
@@ -118,7 +118,7 @@ TEST_CASE("Text Basic", "[tvgText]")
 {
     Initializer::init(0);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
 
     auto text = Text::gen();
     REQUIRE(text);
@@ -133,7 +133,7 @@ TEST_CASE("Text Basic", "[tvgText]")
 
     REQUIRE(text->fill(255, 255, 255) == tvg::Result::Success);
 
-    REQUIRE(canvas->push(std::move(text)) == Result::Success);
+    REQUIRE(canvas->push(text) == Result::Success);
 
     Initializer::term();
 }
@@ -142,7 +142,7 @@ TEST_CASE("Text with composite glyphs", "[tvgText]")
 {
     Initializer::init(0);
 
-    auto canvas = SwCanvas::gen();
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
 
     auto text = Text::gen();
     REQUIRE(text);
@@ -154,7 +154,7 @@ TEST_CASE("Text with composite glyphs", "[tvgText]")
 
     REQUIRE(text->fill(255, 255, 255) == tvg::Result::Success);
 
-    REQUIRE(canvas->push(std::move(text)) == Result::Success);
+    REQUIRE(canvas->push(text) == Result::Success);
 
     Initializer::term();
 }

--- a/tools/lottie2gif/lottie2gif.cpp
+++ b/tools/lottie2gif/lottie2gif.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <string.h>
 #include <vector>
+#include <memory>
 #include <thorvg.h>
 #ifdef _WIN32
     #define WIN32_LEAN_AND_MEAN
@@ -80,16 +81,16 @@ private:
       float scale =  static_cast<float>(this->width) / width;
       picture->size(width * scale, height * scale);
 
-      auto saver = Saver::gen();
+      auto saver = unique_ptr<Saver>(Saver::gen());
 
       //set a background color
       if (background) {
          auto bg = Shape::gen();
          bg->fill(r, g, b);
          bg->appendRect(0, 0, width * scale, height * scale);
-         saver->background(std::move(bg));
+         saver->background(bg);
       }
-      if (saver->save(std::move(animation), out.c_str(), 100, fps) != Result::Success) return false;
+      if (saver->save(animation, out.c_str(), 100, fps) != Result::Success) return false;
       if (saver->sync() != Result::Success) return false;
 
       if (Initializer::term() != Result::Success) return false;

--- a/tools/svg2png/svg2png.cpp
+++ b/tools/svg2png/svg2png.cpp
@@ -143,11 +143,11 @@ public:
             shape->appendRect(0, 0, static_cast<float>(w), static_cast<float>(h), 0, 0);
             shape->fill(r, g, b);
 
-            if (canvas->push(std::move(shape)) != tvg::Result::Success) return 1;
+            if (canvas->push(shape) != tvg::Result::Success) return 1;
         }
 
         //Drawing
-        canvas->push(std::move(picture));
+        canvas->push(picture);
         canvas->draw();
         canvas->sync();
 
@@ -179,7 +179,7 @@ private:
         }
 
         //Create a Canvas
-        canvas = tvg::SwCanvas::gen();
+        canvas = unique_ptr<tvg::SwCanvas>(tvg::SwCanvas::gen());
     }
 
     void createBuffer(int w, int h)


### PR DESCRIPTION
Remove the requirement for unique_ptr in the function prototypes.
This change will simplify the API usage, making it more streamlined
and user-friendly. However, memory management will now be the
responsibility of the user.

C++ API Modification:
```
- Result Paint::mask(std::unique_ptr<Paint> target, MaskMethod method) -> Result Paint::mask(Paint* target, MaskMethod method)
- Result Paint::clip(std::unique_ptr<Paint> clipper) -> Result Paint::clip(Paint* clipper)
- virtual Result Canvas::push(std::unique_ptr<Paint> paint) -> virtual Result Canvas::push(Paint* paint)
- std::unique_ptr<LinearGradient> LinearGradient::gen() -> LinearGradient* LinearGradient::gen()
- std::unique_ptr<RadialGradient> RadialGradient::gen() -> RadialGradient* RadialGradient::gen()
- Result Shape::strokeFill(std::unique_ptr<Fill> f) -> Result Shape::strokeFill(Fill* f)
- Result Shape::fill(std::unique_ptr<Fill> f) -> Result Shape::fill(Fill* f)
- std::unique_ptr<Shape> Shape::gen() -> Shape* Shape::gen()
- std::unique_ptr<Picture> Picture::gen() -> Result Picture::push(Paint* paint)
- std::unique_ptr<Scene> Scene::gen() -> Scene* Scene::gen()
- Result Text::fill(std::unique_ptr<Fill> f) -> Result Text::fill(Fill* f)
- std::unique_ptr<Text> Text::gen() -> Text* Text::gen()
- std::unique_ptr<SwCanvas> SwCanvas::gen() -> SwCanvas* SwCanvas::gen()
- std::unique_ptr<GlCanvas> GlCanvas::gen() -> GlCanvas* GlCanvas::gen()
- std::unique_ptr<Animation> Animation::gen() -> Animation* Animation::gen()
- Result Saver::background(std::unique_ptr<Paint> paint) -> Result Saver::background(Paint* paint)
- Result Saver::save(std::unique_ptr<Paint> paint, const char* filename, uint32_t quality = 100) -> Result Saver::save(Paint* paint, const char* filename, uint32_t quality = 100)
- std::unique_ptr<Saver> Saver::gen() -> Saver* Saver::gen()
- std::unique_ptr<Accessor> Accessor::gen() -> Accessor* Accessor::gen()
```

C++ API removal:
```
- template<typename T = tvg::Paint> std::unique_ptr<T> cast(Paint* paint)
- template<typename T = tvg::Paint> std::unique_ptr<T> cast(Paint* paint)
```

issue: https://github.com/thorvg/thorvg/issues