### PR TITLE
wg_engine: support gradient focal point

### DIFF
--- a/src/renderer/wg_engine/tvgWgShaderTypes.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.cpp
@@ -132,7 +132,7 @@ void WgShaderTypeGradient::update(const RadialGradient* radialGradient)
     auto stopCnt = radialGradient->colorStops(&stops);
     updateTexData(stops, stopCnt);
     // update base points
-    radialGradient->radial(&settings[2], &settings[3], &settings[0]);
+    radialGradient->radial(&settings[0], &settings[1], &settings[2], &settings[4], &settings[5], &settings[6]);
 };
 
 

--- a/src/renderer/wg_engine/tvgWgShaderTypes.h
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.h
@@ -65,7 +65,7 @@ struct WgShaderTypeSolidColor
 #define WG_TEXTURE_GRADIENT_SIZE 512
 struct WgShaderTypeGradient
 {
-    float settings[4]{};
+    float settings[4+4]{}; // WGSL: struct GradSettings { settings: vec4f, focal: vec4f; transform: mat4f };
     uint8_t texData[WG_TEXTURE_GRADIENT_SIZE * 4];
 
     void update(const LinearGradient* linearGradient);


### PR DESCRIPTION
Implemented gradien focal points

Issue https://github.com/thorvg/thorvg/issues/2728 
Issue https://github.com/thorvg/thorvg/issues/2936

See https://skia.org/docs/dev/design/conical/
The implementetion provide general solution for the equation, solved by t
```
Setting Up the Equations
Interpolated Center:
Ct = (1-t) * C0 + t * C1
Interpolated Radius:
rt = (1-t) * r0 + t * r1
Distance from Ct to Pt:
|Pt - Ct| = rt
```

No any impact on performance

Before/After:
![image](https://github.com/user-attachments/assets/6195d84c-54cb-4908-a119-46458305b9eb)

Before/After:
![image](https://github.com/user-attachments/assets/08a7674b-282e-48e7-808e-df035fc92e1c)
