### PR TITLE
wg_engine: fix test build scripts and ambiguous declarations for macos

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,9 +1,11 @@
+examples_compiler_flags = compiler_flags
+
 if lib_type == 'static'
-    compiler_flags += ['-DTVG_STATIC']
+    examples_compiler_flags += ['-DTVG_STATIC']
 endif
 
 if target_opengles
-    compiler_flags += '-DTHORVG_GL_TARGET_GLES=1'
+    examples_compiler_flags += '-DTHORVG_GL_TARGET_GLES=1'
 endif
 
 examples_dep = [dependency('sdl2')]
@@ -13,7 +15,7 @@ if all_engines or get_option('engines').contains('wg')
     if host_machine.system() == 'darwin'
         add_languages('objcpp')
         examples_dep += declare_dependency(link_args: ['-lobjc', '-framework', 'Cocoa', '-framework', 'CoreVideo', '-framework', 'IOKit', '-framework', 'QuartzCore'])
-        compiler_flags += ['-x', 'objective-c++']
+        examples_compiler_flags += ['-x', 'objective-c++']
     endif
 endif
 
@@ -86,7 +88,7 @@ foreach current_file : source_file
     executable(name, current_file,
         include_directories : headers,
         link_with : thorvg_lib,
-        cpp_args : compiler_flags,
+        cpp_args : examples_compiler_flags,
         dependencies : examples_dep)
 endforeach
 
@@ -101,7 +103,7 @@ if get_option('bindings').contains('capi')
         executable(name, current_file,
             include_directories : headers,
             link_with : thorvg_lib,
-            cpp_args : compiler_flags,
+            cpp_args : examples_compiler_flags,
             dependencies : examples_dep)
     endforeach
 endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,5 +1,12 @@
+test_compiler_flags = compiler_flags
+
 if lib_type == 'static'
-    compiler_flags += ['-DTVG_STATIC']
+    test_compiler_flags += ['-DTVG_STATIC']
+endif
+
+test_dep = []
+if host_machine.system() == 'darwin'
+    test_dep += declare_dependency(link_args: ['-framework', 'Cocoa', '-framework', 'IOKit'])
 endif
 
 test_file = [
@@ -23,7 +30,8 @@ tests = executable('tvgUnitTests',
     test_file,
     include_directories : headers,
     link_with : thorvg_lib,
-    cpp_args : compiler_flags)
+    cpp_args : test_compiler_flags,
+    dependencies : test_dep)
 
 test('Unit Tests', tests, args : ['--success'])
 


### PR DESCRIPTION
Fixed conflict with ThorVG and Cocoa framework (required for webgpu on macos): Point is **ambiguous** type in a case of macos usage.

![image](https://github.com/user-attachments/assets/a36cf778-c012-4917-b7a5-6dc26e2f3f09)

Conflics appears only in case of **examples + test + wg** compilation:
`meson setup builddir -Dexamples=true -Dtests=true -Dengines="wg"`

Tests must be compiled before examples, where Cocoa are included

Also fixed **try** issue by adding compilations flags to support exceptions in a case of macos usage
![image](https://github.com/user-attachments/assets/e28e5451-58bf-4f99-8143-3c9098da660c)

Issue https://github.com/thorvg/thorvg/issues/2938

_Alternatively_ we can do not change order of the compilation, but change variable declarations in testShape.cpp from Point to tvg::Point, that also removes ambiguous, f.e.

`const tvg::Point* pts2;`
but not
`const Point* pts2;`