### PR TITLE
wg_engine: fix radial fill anti-aliased drawing

### DIFF
--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -43,9 +43,9 @@ void WgContext::initialize(WGPUInstance instance, WGPUDevice device)
     // create shared webgpu assets
     allocateBufferIndexFan(32768);
     samplerNearestRepeat = createSampler(WGPUFilterMode_Nearest, WGPUMipmapFilterMode_Nearest, WGPUAddressMode_Repeat);
-    samplerLinearRepeat = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_Repeat);
-    samplerLinearMirror = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_MirrorRepeat);
-    samplerLinearClamp = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_ClampToEdge);
+    samplerLinearRepeat = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_Repeat, 4);
+    samplerLinearMirror = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_MirrorRepeat, 4);
+    samplerLinearClamp = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_ClampToEdge, 4);
     assert(samplerNearestRepeat);
     assert(samplerLinearRepeat);
     assert(samplerLinearMirror);
@@ -64,12 +64,12 @@ void WgContext::release()
 }
 
 
-WGPUSampler WgContext::createSampler(WGPUFilterMode filter, WGPUMipmapFilterMode mipmapFilter, WGPUAddressMode addrMode)
+WGPUSampler WgContext::createSampler(WGPUFilterMode filter, WGPUMipmapFilterMode mipmapFilter, WGPUAddressMode addrMode, uint16_t anisotropy)
 {
     const WGPUSamplerDescriptor samplerDesc {
         .addressModeU = addrMode, .addressModeV = addrMode, .addressModeW = addrMode,
         .magFilter = filter, .minFilter = filter, .mipmapFilter = mipmapFilter,
-        .lodMinClamp = 0.0f, .lodMaxClamp = 32.0f, .maxAnisotropy = 1
+        .lodMinClamp = 0.0f, .lodMaxClamp = 32.0f, .maxAnisotropy = anisotropy
     };
     return wgpuDeviceCreateSampler(device, &samplerDesc);
 }

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -52,7 +52,7 @@ struct WgContext {
     void release();
     
     // create common objects
-    WGPUSampler createSampler(WGPUFilterMode filter, WGPUMipmapFilterMode mipmapFilter, WGPUAddressMode addrMode);
+    WGPUSampler createSampler(WGPUFilterMode filter, WGPUMipmapFilterMode mipmapFilter, WGPUAddressMode addrMode, uint16_t anisotropy = 1);
     WGPUTexture createTexture(uint32_t width, uint32_t height, WGPUTextureFormat format);
     WGPUTexture createTexStorage(uint32_t width, uint32_t height, WGPUTextureFormat format);
     WGPUTexture createTexAttachement(uint32_t width, uint32_t height, WGPUTextureFormat format, uint32_t sc);


### PR DESCRIPTION
Use anisotropy filter for gradient fills
Not performance impact
Issue https://github.com/thorvg/thorvg/issues/2931

Before/After
![image](https://github.com/user-attachments/assets/88beef23-09c4-4c87-9152-539b6b3dad17)
![image](https://github.com/user-attachments/assets/66643a76-dcf1-4462-bc52-51c3218cf409)
