### PR TITLE
capi: unified the separate linear and gradient fill APIs

### DIFF
--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -62,11 +62,11 @@ void contents()
     Tvg_Gradient* grad1_stroke = tvg_gradient_duplicate(grad1);
 
     //Set a gradient fill
-    tvg_shape_set_linear_gradient(shape1, grad1);
+    tvg_shape_set_gradient(shape1, grad1);
 
     //Set a gradient stroke
     tvg_shape_set_stroke_width(shape1, 20.0f);
-    tvg_shape_set_stroke_linear_gradient(shape1, grad1_stroke);
+    tvg_shape_set_stroke_gradient(shape1, grad1_stroke);
     tvg_shape_set_stroke_join(shape1, TVG_STROKE_JOIN_ROUND);
 
 
@@ -114,7 +114,7 @@ void contents()
     tvg_gradient_set_spread(grad2, TVG_STROKE_FILL_PAD);
 
     //Set a gradient fill
-    tvg_shape_set_radial_gradient(shape3, grad2);
+    tvg_shape_set_gradient(shape3, grad2);
 
     //Prepare a radial gradient for the stroke
     uint32_t cnt;
@@ -131,7 +131,7 @@ void contents()
 
     //Set a gradient stroke
     tvg_shape_set_stroke_width(shape3, 30.0f);
-    tvg_shape_set_stroke_radial_gradient(shape3, grad2_stroke);
+    tvg_shape_set_stroke_gradient(shape3, grad2_stroke);
 
     tvg_paint_set_opacity(shape3, 200);
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1229,10 +1229,10 @@ TVG_API Tvg_Result tvg_shape_get_stroke_color(const Tvg_Paint* paint, uint8_t* r
 
 
 /*!
-* \brief Sets the linear gradient fill of the stroke for all of the figures from the path.
+* \brief Sets the gradient fill of the stroke for all of the figures from the path.
 *
 * \param[in] paint A Tvg_Paint pointer to the shape object.
-* \param[in] grad The linear gradient fill.
+* \param[in] grad The gradient fill.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
@@ -1240,22 +1240,7 @@ TVG_API Tvg_Result tvg_shape_get_stroke_color(const Tvg_Paint* paint, uint8_t* r
 *
 * \note Either a solid color or a gradient fill is applied, depending on what was set as last.
 */
-TVG_API Tvg_Result tvg_shape_set_stroke_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
-
-
-/*!
-* \brief Sets the radial gradient fill of the stroke for all of the figures from the path.
-*
-* \param[in] paint A Tvg_Paint pointer to the shape object.
-* \param[in] grad The radial gradient fill.
-*
-* \return Tvg_Result enumeration.
-* \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-* \retval TVG_RESULT_MEMORY_CORRUPTION An invalid Tvg_Gradient pointer or an error with accessing it.
-*
-* \note Either a solid color or a gradient fill is applied, depending on what was set as last.
-*/
-TVG_API Tvg_Result tvg_shape_set_stroke_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
+TVG_API Tvg_Result tvg_shape_set_stroke_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
 
 
 /*!
@@ -1477,12 +1462,12 @@ TVG_API Tvg_Result tvg_shape_set_paint_order(Tvg_Paint* paint, bool strokeFirst)
 
 
 /*!
-* \brief Sets the linear gradient fill for all of the figures from the path.
+* \brief Sets the gradient fill for all of the figures from the path.
 *
 * The parts of the shape defined as inner are filled.
 *
 * \param[in] paint A Tvg_Paint pointer to the shape object.
-* \param[in] grad The linear gradient fill.
+* \param[in] grad The gradient fill.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
@@ -1491,25 +1476,7 @@ TVG_API Tvg_Result tvg_shape_set_paint_order(Tvg_Paint* paint, bool strokeFirst)
 * \note Either a solid color or a gradient fill is applied, depending on what was set as last.
 * \see tvg_shape_set_fill_rule()
 */
-TVG_API Tvg_Result tvg_shape_set_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
-
-
-/*!
-* \brief Sets the radial gradient fill for all of the figures from the path.
-*
-* The parts of the shape defined as inner are filled.
-*
-* \param[in] paint A Tvg_Paint pointer to the shape object.
-* \param[in] grad The radial gradient fill.
-*
-* \return Tvg_Result enumeration.
-* \retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-* \retval TVG_RESULT_MEMORY_CORRUPTION An invalid Tvg_Gradient pointer.
-*
-* \note Either a solid color or a gradient fill is applied, depending on what was set as last.
-* \see tvg_shape_set_fill_rule()
-*/
-TVG_API Tvg_Result tvg_shape_set_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
+TVG_API Tvg_Result tvg_shape_set_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -390,15 +390,7 @@ TVG_API Tvg_Result tvg_shape_get_stroke_color(const Tvg_Paint* paint, uint8_t* r
 }
 
 
-TVG_API Tvg_Result tvg_shape_set_stroke_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
-{
-    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->strokeFill((Fill*)(gradient));
-}
-
-
-//TODO: merge with tvg_shape_set_stroke_linear_gradient()
-TVG_API Tvg_Result tvg_shape_set_stroke_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
+TVG_API Tvg_Result tvg_shape_set_stroke_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
     return (Tvg_Result) reinterpret_cast<Shape*>(paint)->strokeFill((Fill*)(gradient));
@@ -516,15 +508,7 @@ TVG_API Tvg_Result tvg_shape_set_paint_order(Tvg_Paint* paint, bool strokeFirst)
 }
 
 
-TVG_API Tvg_Result tvg_shape_set_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
-{
-    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->fill((Fill*)gradient);
-}
-
-
-//TODO: merge with tvg_shape_set_linear_gradient()
-TVG_API Tvg_Result tvg_shape_set_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
+TVG_API Tvg_Result tvg_shape_set_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
     return (Tvg_Result) reinterpret_cast<Shape*>(paint)->fill((Fill*)gradient);

--- a/test/capi/capiLinearGradient.cpp
+++ b/test/capi/capiLinearGradient.cpp
@@ -56,22 +56,22 @@ TEST_CASE("Linear Gradient start and end position", "[capiLinearGradient]")
 
 TEST_CASE("Linear Gradient in shape", "[capiLinearGradient]")
 {
-    REQUIRE(tvg_shape_set_linear_gradient(NULL, NULL) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_gradient(NULL, NULL) == TVG_RESULT_INVALID_ARGUMENT);
 
     Tvg_Gradient *gradient = tvg_linear_gradient_new();
     REQUIRE(gradient);
-    REQUIRE(tvg_shape_set_linear_gradient(NULL, gradient) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_gradient(NULL, gradient) == TVG_RESULT_INVALID_ARGUMENT);
 
     Tvg_Paint *shape = tvg_shape_new();
     REQUIRE(shape);
 
-    REQUIRE(tvg_shape_set_linear_gradient(shape, gradient) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_shape_set_gradient(shape, gradient) == TVG_RESULT_SUCCESS);
 
     Tvg_Gradient *gradient_ret = NULL;
     REQUIRE(tvg_shape_get_gradient(shape, &gradient_ret) == TVG_RESULT_SUCCESS);
     REQUIRE(gradient_ret);
 
-    REQUIRE(tvg_shape_set_linear_gradient(shape, NULL) == TVG_RESULT_MEMORY_CORRUPTION);
+    REQUIRE(tvg_shape_set_gradient(shape, NULL) == TVG_RESULT_MEMORY_CORRUPTION);
     REQUIRE(tvg_paint_del(shape) == TVG_RESULT_SUCCESS);
 }
 
@@ -271,9 +271,9 @@ TEST_CASE("Stroke Linear Gradient", "[capiLinearGradient]")
 
     REQUIRE(tvg_gradient_set_color_stops(gradient, color_stops, 2) == TVG_RESULT_SUCCESS);
 
-    REQUIRE(tvg_shape_set_stroke_linear_gradient(NULL, NULL) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_shape_set_stroke_linear_gradient(NULL, gradient) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_shape_set_stroke_linear_gradient(shape, gradient) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_shape_set_stroke_gradient(NULL, NULL) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_stroke_gradient(NULL, gradient) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_stroke_gradient(shape, gradient) == TVG_RESULT_SUCCESS);
 
     REQUIRE(tvg_shape_get_stroke_gradient(shape, &gradient_ret) == TVG_RESULT_SUCCESS);
     REQUIRE(gradient_ret);

--- a/test/capi/capiRadialGradient.cpp
+++ b/test/capi/capiRadialGradient.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Set gradient center point and radius", "[capiRadialGradient]")
 
 TEST_CASE("Set gradient in shape", "[capiRadialGradient]")
 {
-    REQUIRE(tvg_shape_set_radial_gradient(NULL, NULL) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_gradient(NULL, NULL) == TVG_RESULT_INVALID_ARGUMENT);
 
     Tvg_Gradient *gradient = tvg_radial_gradient_new();
     REQUIRE(gradient);
@@ -65,14 +65,14 @@ TEST_CASE("Set gradient in shape", "[capiRadialGradient]")
     Tvg_Paint *shape = tvg_shape_new();
     REQUIRE(shape);
 
-    REQUIRE(tvg_shape_set_radial_gradient(NULL, gradient) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_shape_set_radial_gradient(shape, gradient) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_shape_set_gradient(NULL, gradient) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_gradient(shape, gradient) == TVG_RESULT_SUCCESS);
 
     Tvg_Gradient *gradient_ret = NULL;
     REQUIRE(tvg_shape_get_gradient(shape, &gradient_ret) == TVG_RESULT_SUCCESS);
     REQUIRE(gradient_ret);
 
-    REQUIRE(tvg_shape_set_radial_gradient(shape, NULL) == TVG_RESULT_MEMORY_CORRUPTION);
+    REQUIRE(tvg_shape_set_gradient(shape, NULL) == TVG_RESULT_MEMORY_CORRUPTION);
     REQUIRE(tvg_paint_del(shape) == TVG_RESULT_SUCCESS);
 }
 
@@ -210,9 +210,9 @@ TEST_CASE("Stroke Radial Gradient", "[capiRadialGradient]")
 
     REQUIRE(tvg_gradient_set_color_stops(gradient, color_stops, 2) == TVG_RESULT_SUCCESS);
 
-    REQUIRE(tvg_shape_set_stroke_radial_gradient(NULL, NULL) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_shape_set_stroke_radial_gradient(NULL, gradient) == TVG_RESULT_INVALID_ARGUMENT);
-    REQUIRE(tvg_shape_set_stroke_radial_gradient(shape, gradient) == TVG_RESULT_SUCCESS);
+    REQUIRE(tvg_shape_set_stroke_gradient(NULL, NULL) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_stroke_gradient(NULL, gradient) == TVG_RESULT_INVALID_ARGUMENT);
+    REQUIRE(tvg_shape_set_stroke_gradient(shape, gradient) == TVG_RESULT_SUCCESS);
 
     REQUIRE(tvg_shape_get_stroke_gradient(shape, &gradient_ret) == TVG_RESULT_SUCCESS);
     REQUIRE(gradient_ret);


### PR DESCRIPTION
API Removal:
- Tvg_Result tvg_shape_set_stroke_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* grad)
- Tvg_Result tvg_shape_set_stroke_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* grad)
- Tvg_Result tvg_shape_set_shape_linear_gradient(Tvg_Paint* paint, Tvg_Gradient* grad)
- Tvg_Result tvg_shape_set_shape_radial_gradient(Tvg_Paint* paint, Tvg_Gradient* grad)

API Addition:
- Tvg_Result tvg_shape_set_stroke_gradient(Tvg_Paint* paint, Tvg_Gradient* grad)
- Tvg_Result tvg_shape_set_shape_gradient(Tvg_Paint* paint, Tvg_Gradient* grad)