### PR TITLE
gl_engine: Fix repeated clip drawing causes performance degradation

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -1207,7 +1207,10 @@ RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matr
 
     sdata->geometry->tesselate(image, flags);
 
-    if (!clips.empty()) sdata->clips.push(clips);
+    if (!clips.empty()) {
+        sdata->clips.clear();
+        sdata->clips.push(clips);
+    }
 
     return sdata;
 }
@@ -1263,7 +1266,10 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
         if (!sdata->geometry->tesselate(rshape, sdata->updateFlag)) return sdata;
     }
 
-    if (!clipper && !clips.empty()) sdata->clips.push(clips);
+    if (!clipper && !clips.empty()) {
+        sdata->clips.clear();
+        sdata->clips.push(clips);
+    }
 
     return sdata;
 }


### PR DESCRIPTION
This PR fix the Lottie example becoming slower with each frame

It is caused by the clip tasks with the GlShape.
The clips need to be cleared every time when shape update. Otherwise, the increasing number of clips will hurt the performance.
