### PR TITLE
infra: prevent warning on windows

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -282,7 +282,7 @@ void LottieParser::getValue(int8_t& val)
         //discard rest
         while (nextArrayValue()) getInt();
     } else {
-        val = getFloat();
+        val = (int8_t)getFloat();
     }
 }
 


### PR DESCRIPTION
"conversion from 'float' to 'int8_t', possible loss of data"