### PR TITLE
lottie/slot: fix default slot behavior

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -46,6 +46,14 @@ void LottieLoader::run(unsigned tid)
         if (parser.slots) {
             override(parser.slots, false);
             parser.slots = nullptr;
+            for (auto s = comp->slots.begin(); s < comp->slots.end(); ++s) {
+                if ((*s)->overridden) {
+                    (*s)->overridden = false;
+                    for (auto pair = (*s)->pairs.begin(); pair < (*s)->pairs.end(); ++pair) {
+                        delete(pair->prop);
+                    }
+                }
+            }
         }
         builder->build(comp);
 


### PR DESCRIPTION
Release the `overridden` status and backup property from the slot object to ensure the default slot behaves correctly.

The default slot is not reversible and should not interfere with subsequent slot overrides triggered by the user.

Issue: #2953

---

### 1. Overriding with same sid after default slot overriden

This patch overrides correctly at same sid where default slot passed

```cpp
const char* slotJson = R"({"bg_color":{"p":{"a":0,"k":[1,0.8196,0.2275]}},"check_color":{"p":{"a":0,"k":[0.0078,0.0078,0.0078]}}})";
animation->override(slotJson);
```

![CleanShot 2024-11-13 at 20 12 11@2x](https://github.com/user-attachments/assets/5a0bc77c-d221-4af1-8b91-8b30c797fb50)

### 2. Reverting default slot's sid case

Keep overridden output from default slot, `override(nullptr)` wouldn't reset back.

```cpp
animation->override(nullptr);
```

![CleanShot 2024-11-13 at 20 12 26@2x](https://github.com/user-attachments/assets/d4980f51-6e92-47ea-b10c-570994ace9f5)

