### PR TITLE
sw_engine: prevent crash while filtering

### DIFF
--- a/src/renderer/sw_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/sw_engine/tvgSwPostEffect.cpp
@@ -175,6 +175,7 @@ bool effectGaussianBlur(SwCompositor* cmp, SwSurface* surface, const RenderEffec
     auto& bbox = cmp->bbox;
     auto w = (bbox.max.x - bbox.min.x);
     auto h = (bbox.max.y - bbox.min.y);
+    if (w == 0 || h == 0) return true;  //off-screen
     auto stride = cmp->image.stride;
     auto front = cmp->image.buf32;
     auto back = buffer.buf32;


### PR DESCRIPTION
In cases where the composition was off-screen,
there was an attempt to access negative array
elements. Fixed by an earlier exit.


sample:
```
        if (!canvas) return false;

        auto shape1 = tvg::Shape::gen();
        shape1->appendRect(0, 0, 800, 800);
        shape1->fill(255, 0, 0);

        auto scene1 = tvg::Scene::gen();
        scene1->push(shape1);
        scene1->push(tvg::SceneEffect::GaussianBlur, 22.0f, 0, 0, 100);

        auto scene2 = tvg::Scene::gen();
        scene2->push(scene1);
        auto clip = tvg::Shape::gen();
        clip->appendRect(0, 0, 400, 400);
        scene2->clip((clip));

        auto scene3 = tvg::Scene::gen();
        scene3->push(scene2);
        scene3->translate(-500,0);

        canvas->push(scene3);

        return true;
```