### PR TITLE
renderer: Fix paint transformation after scene change

### DIFF
--- a/src/renderer/tvgScene.cpp
+++ b/src/renderer/tvgScene.cpp
@@ -70,7 +70,9 @@ Type Scene::type() const noexcept
 Result Scene::push(Paint* paint) noexcept
 {
     if (!paint) return Result::MemoryCorruption;
-    PP(paint)->ref();
+    auto pPaint = PP(paint);
+    pPaint->ref();
+    pPaint->renderFlag |= RenderUpdateFlag::Transform;
     pImpl->paints.push_back(paint);
 
     return Result::Success;


### PR DESCRIPTION
This PR fixes a bug when paint was moved between scenes and its transformations wasn't updated.

Resolve: #2958
