### PR TITLE
lottie: fixed a memory leak

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -980,7 +980,7 @@ void LottieBuilder::updateSolid(LottieLayer* layer)
 void LottieBuilder::updateImage(LottieGroup* layer)
 {
     auto image = static_cast<LottieImage*>(layer->children.first());
-    layer->scene->push(image->pooling(true));
+    layer->scene->push(image->picture);
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -159,7 +159,10 @@ void LottieImage::prepare()
 {
     LottieObject::type = LottieObject::Image;
 
-    auto picture = Picture::gen();
+    if (!picture) {
+        picture = Picture::gen();
+        PP(picture)->ref();
+    }
 
     //force to load a picture on the same thread
     TaskScheduler::async(false);
@@ -170,10 +173,6 @@ void LottieImage::prepare()
     TaskScheduler::async(true);
 
     picture->size(data.width, data.height);
-    PP(picture)->ref();
-
-    pooler.reset();
-    pooler.push(picture);
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -672,9 +672,15 @@ struct LottieGradientStroke : LottieGradient, LottieStroke
 };
 
 
-struct LottieImage : LottieObject, LottieRenderPooler<tvg::Picture>
+struct LottieImage : LottieObject
 {
     LottieBitmap data;
+    Picture* picture = nullptr;
+
+    ~LottieImage()
+    {
+        if (PP(picture)->unref() == 0) delete(picture);
+    }
 
     void override(LottieProperty* prop, bool byDefault = false) override
     {


### PR DESCRIPTION
A regression bug by efe7440fa0e38f00e1235fb57f56717914e6000c

To address this, removed the non-essential image pooling mechanism.

issue: https://github.com/thorvg/thorvg/issues/2959