### PR TITLE
lottie: Fixed a regression bug

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -980,7 +980,7 @@ void LottieBuilder::updateSolid(LottieLayer* layer)
 void LottieBuilder::updateImage(LottieGroup* layer)
 {
     auto image = static_cast<LottieImage*>(layer->children.first());
-    layer->scene->push(image->picture);
+    layer->scene->push(image->pooling(true));
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -159,10 +159,7 @@ void LottieImage::prepare()
 {
     LottieObject::type = LottieObject::Image;
 
-    if (!picture) {
-        picture = Picture::gen();
-        PP(picture)->ref();
-    }
+    auto picture = Picture::gen();
 
     //force to load a picture on the same thread
     TaskScheduler::async(false);
@@ -173,6 +170,22 @@ void LottieImage::prepare()
     TaskScheduler::async(true);
 
     picture->size(data.width, data.height);
+    PP(picture)->ref();
+
+    pooler.push(picture);
+}
+
+
+void LottieImage::update()
+{
+    //Update the picture data
+    TaskScheduler::async(false);
+    for (auto p = pooler.begin(); p < pooler.end(); ++p) {
+        if (data.size > 0) (*p)->load((const char*)data.b64Data, data.size, data.mimeType);
+        else (*p)->load(data.path);
+        (*p)->size(data.width, data.height);
+    }
+    TaskScheduler::async(true);
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -672,24 +672,19 @@ struct LottieGradientStroke : LottieGradient, LottieStroke
 };
 
 
-struct LottieImage : LottieObject
+struct LottieImage : LottieObject, LottieRenderPooler<tvg::Picture>
 {
     LottieBitmap data;
-    Picture* picture = nullptr;
-
-    ~LottieImage()
-    {
-        if (PP(picture)->unref() == 0) delete(picture);
-    }
 
     void override(LottieProperty* prop, bool byDefault = false) override
     {
         if (byDefault) data.release();
         data = *static_cast<LottieBitmap*>(prop);
-        prepare();
+        update();
     }
 
     void prepare();
+    void update();
 };
 
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1519,7 +1519,10 @@ bool LottieParser::apply(LottieSlot* slot, bool byDefault)
         default: break;
     }
 
-    if (!obj || Invalid()) return false;
+    if (!obj || Invalid()) {
+        delete(obj);
+        return false;
+    }
 
     slot->assign(obj, byDefault);
 


### PR DESCRIPTION
Reverted commit db800c8d4500cd379238c4ec1c9f6c59e70fe908, which introduced another regression that omitted support for multiple image asset references.

Updated the data of active images in the pooler
within the override() function to resolve the issue.