### PR TITLE
gl_engine: support cross compile GL backend into WASM

### DIFF
--- a/cross/wasm32_gl.txt
+++ b/cross/wasm32_gl.txt
@@ -1,0 +1,21 @@
+[binaries]
+cpp = 'EMSDK:upstream/emscripten/em++.py'
+ar = 'EMSDK:upstream/emscripten/emar.py'
+strip = '-strip'
+
+[properties]
+root = 'EMSDK:upstream/emscripten/system'
+shared_lib_suffix = 'js'
+static_lib_suffix = 'js'
+shared_module_suffix = 'js'
+exe_suffix = 'js'
+
+[built-in options]
+cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'

--- a/src/renderer/gl_engine/meson.build
+++ b/src/renderer/gl_engine/meson.build
@@ -26,6 +26,9 @@ source_file = [
 if host_machine.system() == 'darwin'
     gl_dep = declare_dependency(link_args: ['-framework', 'OpenGL'])
     compiler_flags += ['-Wno-deprecated']     #for deprecated opengl
+elif cc.get_id() == 'emscripten'
+    target_opengles = true
+    gl_dep = dependency('GLESv3', required: false)
 else
     #find a opengl library with fallbacks
     gl_dep = dependency('GL', required: false)

--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -42,8 +42,11 @@
 #include "tvgCommon.h"
 #include "tvgRender.h"
 
-
-#define GL_CHECK(x) \
+#ifdef __EMSCRIPTEN__
+    // query GL Error on WebGL is very slow, so disable it on WebGL
+    #define GL_CHECK(x) x
+#else
+    #define GL_CHECK(x) \
         x; \
         do { \
           GLenum glError = glGetError(); \
@@ -52,6 +55,7 @@
             assert(0); \
           } \
         } while(0)
+#endif
 
 enum class GlStencilMode {
     None,

--- a/wasm_build.sh
+++ b/wasm_build.sh
@@ -17,6 +17,9 @@ if [ ! -d "./build_wasm" ]; then
     elif [[ "$BACKEND" == "sw" ]]; then
       sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32_sw.txt > /tmp/.wasm_cross.txt
       meson -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" --cross-file /tmp/.wasm_cross.txt build_wasm
+    elif [[ "$BACKEND" == "gl" ]]; then
+      sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32_gl.txt > /tmp/.wasm_cross.txt
+      meson -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="gl" --cross-file /tmp/.wasm_cross.txt build_wasm
     else
       sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32_wg.txt > /tmp/.wasm_cross.txt
       meson -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="wg, sw" --cross-file /tmp/.wasm_cross.txt build_wasm


### PR DESCRIPTION
This PR support cross compile the GL backend code into WASM. The code needs WebGL 2.0 API so, the compile flags contains `MAX_WEBGL_VERSION` and `FULL_ES3` Also add binding code to initialize the WebGL context and GLCanvas.

With this PR, the wasm binary contains WebGL backend rendering, the rest of the work will need to be supported by the thorvg.web project.

issue: #2837 