### PR TITLE
wg_engine: reset context in examples

### DIFF
--- a/examples/Example.h
+++ b/examples/Example.h
@@ -425,6 +425,8 @@ struct WgWindow : Window
 
     virtual ~WgWindow()
     {
+        //the canvas is tightly relying on the wgpu resource. cut out before rleasing them for safety.
+        static_cast<tvg :: WgCanvas*>(canvas)->target(nullptr, nullptr, nullptr, 0, 0);
         wgpuSurfaceRelease(surface);
         wgpuInstanceRelease(instance);
     }


### PR DESCRIPTION
Fix examples termination process: reset rendering context while window releasing before webgpu instance deleted
Issue https://github.com/thorvg/thorvg/issues/2745