### PR TITLE
wg_engine: fix resources disposing on context destroy

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -69,7 +69,7 @@ struct WgImageData {
     WGPUTexture texture{};
     WGPUTextureView textureView{};
 
-    void update(WgContext& context, RenderSurface* surface);
+    void update(WgContext& context, const RenderSurface* surface);
     void release(WgContext& context);
 };
 
@@ -142,7 +142,7 @@ private:
     Array<WgRenderDataShape*> mList;
 public:
     WgRenderDataShape* allocate(WgContext& context);
-    void free(WgContext& context, WgRenderDataShape* dataShape);
+    void free(WgContext& context, WgRenderDataShape* renderData);
     void release(WgContext& context);
 };
 
@@ -152,8 +152,19 @@ struct WgRenderDataPicture: public WgRenderDataPaint
     WgImageData imageData{};
     WgMeshData meshData{};
 
+    void updateSurface(WgContext& context, const RenderSurface* surface);
     void release(WgContext& context) override;
     Type type() override { return Type::Picture; };
+};
+
+class WgRenderDataPicturePool {
+private:
+    Array<WgRenderDataPicture*> mPool;
+    Array<WgRenderDataPicture*> mList;
+public:
+    WgRenderDataPicture* allocate(WgContext& context);
+    void free(WgContext& context, WgRenderDataPicture* dataPicture);
+    void release(WgContext& context);
 };
 
 #endif // _TVG_WG_RENDER_DATA_H_

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -71,12 +71,17 @@ private:
     void clearTargets();
     bool surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height);
 
-    // render tree stacks and pools
-    WgRenderStorage mStorageRoot;
+    // render tree stacks
+    WgRenderStorage mRenderStorageRoot;
     Array<WgCompose*> mCompositorStack;
     Array<WgRenderStorage*> mRenderStorageStack;
+
+    // render storage pool
     WgRenderStoragePool mRenderStoragePool;
+
+    // render data paint pools
     WgRenderDataShapePool mRenderDataShapePool;
+    WgRenderDataPicturePool mRenderDataPicturePool;
 
     // rendering context
     WgContext mContext;


### PR DESCRIPTION
We must to dispose all paints before the context will be destroyed to prevent wegpu handles leak, including Shapes and Pictures by using objects pools as global object registers
see: PicturePng, PictureJpg

PicturePng sanitizer report: Before
![image](https://github.com/user-attachments/assets/6b57ac2a-fe70-4f09-af91-59dad5d17e92)
