### PR TITLE
renderer: reserved colorspace option in target api

### DIFF
--- a/examples/Example.h
+++ b/examples/Example.h
@@ -440,7 +440,7 @@ struct WgWindow : Window
     void resize() override
     {
         //Set the canvas target and draw on it.
-        verify(static_cast<tvg::WgCanvas*>(canvas)->target(nullptr, instance, surface, width, height));
+        verify(static_cast<tvg::WgCanvas*>(canvas)->target(nullptr, instance, surface, width, height, tvg::ColorSpace::ABGR8888S));
     }
 
     void refresh() override 

--- a/examples/MultiCanvas.cpp
+++ b/examples/MultiCanvas.cpp
@@ -365,7 +365,7 @@ void runWg()
         auto canvas = unique_ptr<tvg::WgCanvas>(tvg::WgCanvas::gen());
 
         //Set the canvas target and draw on it.
-        tvgexam::verify(canvas->target(device, instance, renderTarget, SIZE, SIZE, 1));
+        tvgexam::verify(canvas->target(device, instance, renderTarget, SIZE, SIZE, tvg::ColorSpace::ABGR8888S, 1));
 
         content(canvas.get());
         if (tvgexam::verify(canvas->draw())) {

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1776,10 +1776,11 @@ public:
      *
      * @param[in] device WGPUDevice, a desired handle for the wgpu device. If it is @c nullptr, ThorVG will assign an appropriate device internally.
      * @param[in] instance WGPUInstance, context for all other wgpu objects.
-     * @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture
+     * @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture.
      * @param[in] w The width of the target.
      * @param[in] h The height of the target.
-     * @param[in] type 0: surface, 1: texture are used as pesentable target
+     * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it only allows @c ColorSpace::ABGR8888S as @c WGPUTextureFormat_RGBA8Unorm.
+     * @param[in] type @c 0: surface, @c 1: texture are used as pesentable target.
      *
      * @retval Result::InsufficientCondition if the canvas is performing rendering. Please ensure the canvas is synced.
      * @retval Result::NonSupport In case the wg engine is not supported.
@@ -1789,7 +1790,7 @@ public:
      * @see Canvas::viewport()
      * @see Canvas::sync()
      */
-    Result target(void* device, void* instance, void* target, uint32_t w, uint32_t h, int type = 0) noexcept;
+    Result target(void* device, void* instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0) noexcept;
 
     /**
      * @brief Creates a new WgCanvas object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -562,10 +562,11 @@ TVG_API Tvg_Canvas* tvg_wgcanvas_create(void);
 *
 * @param[in] device WGPUDevice, a desired handle for the wgpu device. If it is @c nullptr, ThorVG will assign an appropriate device internally.
 * @param[in] instance WGPUInstance, context for all other wgpu objects.
-* @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture
+* @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture.
 * @param[in] w The width of the target.
 * @param[in] h The height of the target.
-* @param[in] type 0: surface, 1: texture are used as pesentable target
+* @param[in] cs Specifies how the pixel values should be interpreted. Currently, it only allows @c TVG_COLORSPACE_ABGR8888S as @c WGPUTextureFormat_RGBA8Unorm.
+* @param[in] type @c 0: surface, @c 1: texture are used as pesentable target.
 *
 * \return Tvg_Result enumeration.
 * \retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
@@ -573,7 +574,7 @@ TVG_API Tvg_Canvas* tvg_wgcanvas_create(void);
 *
 * \note Experimental API
 */
-TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, int type = 0);
+TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type = 0);
 
 /** \} */   // end defgroup ThorVGCapi_WgCanvas
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -109,10 +109,10 @@ TVG_API Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas* canvas, int32_t id, uint3
 }
 
 
-TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, int type)
+TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type)
 {
     if (!canvas) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<WgCanvas*>(canvas)->target(device, instance, target, w, h, type);
+    return (Tvg_Result) reinterpret_cast<WgCanvas*>(canvas)->target(device, instance, target, w, h, static_cast<ColorSpace>(cs), type);
 }
 
 

--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -150,7 +150,7 @@ struct TvgWgEngine : TvgEngineMethod
     void resize(Canvas* canvas, int w, int h) override
     {
     #ifdef THORVG_WG_RASTER_SUPPORT
-        static_cast<WgCanvas*>(canvas)->target(device, instance, surface, w, h);
+        static_cast<WgCanvas*>(canvas)->target(device, instance, surface, w, h, ColorSpace::ABGR8888S);
     #endif
     }
 };

--- a/src/renderer/tvgWgCanvas.cpp
+++ b/src/renderer/tvgWgCanvas.cpp
@@ -57,9 +57,11 @@ WgCanvas::~WgCanvas()
 }
 
 
-Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, uint32_t h, int type) noexcept
+Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type) noexcept
 {
 #ifdef THORVG_WG_RASTER_SUPPORT
+    if (cs != ColorSpace::ABGR8888S) return Result::NonSupport;
+
     if (Canvas::pImpl->status != Status::Damaged && Canvas::pImpl->status != Status::Synced) {
         return Result::InsufficientCondition;
     }


### PR DESCRIPTION
API Modification:
- Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, uint32_t h, int type = 0) -> Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0)
- Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, int type) -> Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type)