### PR TITLE
gl_engine: correct the stroke alpha calculation

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -53,6 +53,11 @@
           } \
         } while(0)
 
+static inline float getScaleFactor(const Matrix& m)
+{
+    return sqrtf(m.e11 * m.e11 + m.e21 * m.e21);
+}
+
 enum class GlStencilMode {
     None,
     FillWinding,

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -162,7 +162,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdat
     auto a = MULTIPLY(c.a, sdata.opacity);
 
     if (flag & RenderUpdateFlag::Stroke) {
-        float strokeWidth = sdata.rshape->strokeWidth() * sdata.geometry->getTransformMatrix().e11;
+        float strokeWidth = sdata.rshape->strokeWidth() * getScaleFactor(sdata.geometry->getTransformMatrix());
         if (strokeWidth < MIN_GL_STROKE_WIDTH) {
             float alpha = strokeWidth / MIN_GL_STROKE_WIDTH;
             a = MULTIPLY(a, static_cast<uint8_t>(alpha * 255));

--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -1534,7 +1534,7 @@ void Stroker::stroke(const RenderShape *rshape)
     mStrokeWidth = rshape->strokeWidth();
 
     if (isinf(mMatrix.e11)) {
-        auto strokeWidth = rshape->strokeWidth() * mMatrix.e11;
+        auto strokeWidth = rshape->strokeWidth() * getScaleFactor(mMatrix);
         if (strokeWidth <= MIN_GL_STROKE_WIDTH) strokeWidth = MIN_GL_STROKE_WIDTH;
         mStrokeWidth = strokeWidth / mMatrix.e11;
     }


### PR DESCRIPTION
This PR fix the wrong matrix scale factor value caused the stroke alpha to be zero when the matrix contains rotation.

issue: #2997
------
Some case is correct.

1. abstract_circle.json
  
<img width="608" alt="截屏2024-11-26 上午11 26 28" src="https://github.com/user-attachments/assets/67432a9b-bdca-4107-902c-39bc3d4d7a16">

2. anubis.json
<img width="560" alt="截屏2024-11-26 上午11 27 10" src="https://github.com/user-attachments/assets/c90397cc-1d27-4a60-a96c-1ca2ccb26960">

3. kote.json
<img width="604" alt="截屏2024-11-26 上午11 28 00" src="https://github.com/user-attachments/assets/ad1c84f3-1431-44db-84e5-ee7f35a8d1cc">

4. swinging.json
   
<img width="560" alt="截屏2024-11-26 上午11 32 52" src="https://github.com/user-attachments/assets/302516e7-4d0c-4877-937b-ba3394dcf2b0">
