### PR TITLE
wg_engine: separate pipelines ans bind group layouts (refactoring)

### DIFF
--- a/src/renderer/wg_engine/tvgWgBindGroups.h
+++ b/src/renderer/wg_engine/tvgWgBindGroups.h
@@ -23,7 +23,7 @@
 #ifndef _TVG_WG_BIND_GROUPS_H_
 #define _TVG_WG_BIND_GROUPS_H_
 
-#include "tvgWgCommon.h"
+#include <webgpu/webgpu.h>
 
 class WgBindGroupLayouts {
 private:
@@ -53,8 +53,8 @@ public:
     void releaseBindGroup(WGPUBindGroup& bindGroup);
     void releaseBindGroupLayout(WGPUBindGroupLayout& bindGroupLayout);
 public:
-    void initialize(WgContext& context);
-    void release(WgContext& context);
+    void initialize(WGPUDevice device);
+    void release();
 };
 
 #endif // _TVG_WG_BIND_GROUPS_H_

--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -23,6 +23,7 @@
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
+#include <cassert>
 #include "tvgWgCommon.h"
 #include "tvgArray.h"
 
@@ -50,11 +51,15 @@ void WgContext::initialize(WGPUInstance instance, WGPUDevice device)
     assert(samplerLinearRepeat);
     assert(samplerLinearMirror);
     assert(samplerLinearClamp);
+
+    // initialize bind group layouts
+    layouts.initialize(device);
 }
 
 
 void WgContext::release()
 {
+    layouts.release();
     releaseSampler(samplerLinearClamp);
     releaseSampler(samplerLinearMirror);
     releaseSampler(samplerLinearRepeat);

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -23,13 +23,10 @@
 #ifndef _TVG_WG_COMMON_H_
 #define _TVG_WG_COMMON_H_
 
-#include <cassert>
-#include <webgpu/webgpu.h>
+#include "tvgWgBindGroups.h"
 
 #define WG_VERTEX_BUFFER_MIN_SIZE 2048
 #define WG_INDEX_BUFFER_MIN_SIZE 2048
-
-class WgPipelines;
 
 struct WgContext {
     // external webgpu handles
@@ -39,14 +36,14 @@ struct WgContext {
     // common webgpu handles
     WGPUQueue queue{};
     WGPUTextureFormat preferredFormat{};
-    // external handles (do not release)
-    WgPipelines* pipelines{};
     // shared webgpu assets
     WGPUBuffer bufferIndexFan{};
     WGPUSampler samplerNearestRepeat{};
     WGPUSampler samplerLinearRepeat{};
     WGPUSampler samplerLinearMirror{};
     WGPUSampler samplerLinearClamp{};
+    // bind groups layouts
+    WgBindGroupLayouts layouts;
 
     void initialize(WGPUInstance instance, WGPUDevice device);
     void release();

--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -35,8 +35,8 @@ struct WgCompose: RenderCompositor
 class WgCompositor
 {
 private:
-    // pipelines (external handle, do not release)
-    WgPipelines* pipelines{};
+    // pipelines
+    WgPipelines pipelines{};
     // global stencil/depth buffer handles
     WGPUTexture texDepthStencil{};
     WGPUTextureView texViewDepthStencil{};

--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -23,6 +23,7 @@
 #include "tvgWgPipelines.h"
 #include "tvgWgShaderSrc.h"
 #include <cstring>
+#include <cassert>
 
 WGPUShaderModule WgPipelines::createShaderModule(WGPUDevice device, const char* label, const char* code)
 {
@@ -130,13 +131,6 @@ void WgPipelines::releaseShaderModule(WGPUShaderModule& shaderModule)
 
 void WgPipelines::initialize(WgContext& context)
 {
-    // share pipelines to context
-    assert(!context.pipelines);
-    context.pipelines = this;
-
-    // initialize bind group layouts
-    layouts.initialize(context);
-
     // common pipeline settings
     const WGPUVertexAttribute vertexAttributePos { .format = WGPUVertexFormat_Float32x2, .offset = 0, .shaderLocation = 0 };
     const WGPUVertexAttribute vertexAttributeTex { .format = WGPUVertexFormat_Float32x2, .offset = 0, .shaderLocation = 1 };
@@ -160,6 +154,7 @@ void WgPipelines::initialize(WgContext& context)
         .alpha = { .operation = WGPUBlendOperation_Add, .srcFactor = WGPUBlendFactor_One, .dstFactor = WGPUBlendFactor_OneMinusSrcAlpha }
     };
 
+    const WgBindGroupLayouts& layouts = context.layouts;
     // bind group layouts helpers
     const WGPUBindGroupLayout bindGroupLayoutsStencil[] = { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un };
     const WGPUBindGroupLayout bindGroupLayoutsDepth[] = { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un, layouts.layoutBuffer1Un };
@@ -521,5 +516,4 @@ void WgPipelines::releaseGraphicHandles(WgContext& context)
 void WgPipelines::release(WgContext& context)
 {
     releaseGraphicHandles(context);
-    layouts.release(context);
 }

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -23,7 +23,7 @@
 #ifndef _TVG_WG_PIPELINES_H_
 #define _TVG_WG_PIPELINES_H_
 
-#include "tvgWgBindGroups.h"
+#include "tvgWgCommon.h"
 
 class WgPipelines {
 private:
@@ -91,9 +91,6 @@ public:
     WGPURenderPipeline scene_compose[11]{};
     // pipeline blit
     WGPURenderPipeline blit{};
-public:
-    // layouts
-    WgBindGroupLayouts layouts;
 private:
     void releaseGraphicHandles(WgContext& context);
 private:

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -261,8 +261,8 @@ void WgRenderSettings::update(WgContext& context, const Fill* fill, const Render
             if (fill->spread() == FillSpread::Reflect) sampler = context.samplerLinearMirror;
             if (fill->spread() == FillSpread::Repeat) sampler = context.samplerLinearRepeat;
             // update bind group
-            context.pipelines->layouts.releaseBindGroup(bindGroupGradient);
-            bindGroupGradient = context.pipelines->layouts.createBindGroupTexSampledBuff2Un(
+            context.layouts.releaseBindGroup(bindGroupGradient);
+            bindGroupGradient = context.layouts.createBindGroupTexSampledBuff2Un(
                 sampler, texViewGradient, bufferGroupGradient, bufferGroupTransfromGrad);
         }
         skip = false;
@@ -270,8 +270,8 @@ void WgRenderSettings::update(WgContext& context, const Fill* fill, const Render
         rasterType = WgRenderRasterType::Solid;
         WgShaderTypeSolidColor solidColor(c);
         if (context.allocateBufferUniform(bufferGroupSolid, &solidColor, sizeof(solidColor))) {
-            context.pipelines->layouts.releaseBindGroup(bindGroupSolid);
-            bindGroupSolid = context.pipelines->layouts.createBindGroupBuffer1Un(bufferGroupSolid);
+            context.layouts.releaseBindGroup(bindGroupSolid);
+            bindGroupSolid = context.layouts.createBindGroupBuffer1Un(bufferGroupSolid);
         }
         fillType = WgRenderSettingsType::Solid;
         skip = (c.a == 0);
@@ -281,8 +281,8 @@ void WgRenderSettings::update(WgContext& context, const Fill* fill, const Render
 
 void WgRenderSettings::release(WgContext& context)
 {
-    context.pipelines->layouts.releaseBindGroup(bindGroupSolid);
-    context.pipelines->layouts.releaseBindGroup(bindGroupGradient);
+    context.layouts.releaseBindGroup(bindGroupSolid);
+    context.layouts.releaseBindGroup(bindGroupGradient);
     context.releaseBuffer(bufferGroupSolid);
     context.releaseBuffer(bufferGroupGradient);
     context.releaseBuffer(bufferGroupTransfromGrad);
@@ -296,7 +296,7 @@ void WgRenderSettings::release(WgContext& context)
 
 void WgRenderDataPaint::release(WgContext& context)
 {
-    context.pipelines->layouts.releaseBindGroup(bindGroupPaint);
+    context.layouts.releaseBindGroup(bindGroupPaint);
     context.releaseBuffer(bufferModelMat);
     context.releaseBuffer(bufferBlendSettings);
     clips.clear();
@@ -310,8 +310,8 @@ void WgRenderDataPaint::update(WgContext& context, const tvg::Matrix& transform,
     bool bufferModelMatChanged = context.allocateBufferUniform(bufferModelMat, &modelMat, sizeof(modelMat));
     bool bufferBlendSettingsChanged = context.allocateBufferUniform(bufferBlendSettings, &blendSettings, sizeof(blendSettings));
     if (bufferModelMatChanged || bufferBlendSettingsChanged) {
-        context.pipelines->layouts.releaseBindGroup(bindGroupPaint);
-        bindGroupPaint = context.pipelines->layouts.createBindGroupBuffer2Un(bufferModelMat, bufferBlendSettings);
+        context.layouts.releaseBindGroup(bindGroupPaint);
+        bindGroupPaint = context.layouts.createBindGroupBuffer2Un(bufferModelMat, bufferBlendSettings);
     }
 }
 
@@ -545,8 +545,8 @@ void WgRenderDataPicture::updateSurface(WgContext& context, const RenderSurface*
     // update texture data
     imageData.update(context, surface);
     // update texture bind group
-    context.pipelines->layouts.releaseBindGroup(bindGroupPicture);
-    bindGroupPicture = context.pipelines->layouts.createBindGroupTexSampled(
+    context.layouts.releaseBindGroup(bindGroupPicture);
+    bindGroupPicture = context.layouts.createBindGroupTexSampled(
         context.samplerLinearRepeat, imageData.textureView
     );
 }
@@ -554,7 +554,7 @@ void WgRenderDataPicture::updateSurface(WgContext& context, const RenderSurface*
 
 void WgRenderDataPicture::release(WgContext& context)
 {
-    context.pipelines->layouts.releaseBindGroup(bindGroupPicture);
+    context.layouts.releaseBindGroup(bindGroupPicture);
     imageData.release(context);
     meshData.release(context);
     WgRenderDataPaint::release(context);

--- a/src/renderer/wg_engine/tvgWgRenderTarget.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.cpp
@@ -30,17 +30,17 @@ void WgRenderStorage::initialize(WgContext& context, uint32_t width, uint32_t he
     textureMS = context.createTexAttachement(width, height, WGPUTextureFormat_RGBA8Unorm, 4);
     texView = context.createTextureView(texture);
     texViewMS = context.createTextureView(textureMS);
-    bindGroupRead = context.pipelines->layouts.createBindGroupStrorage1RO(texView);
-    bindGroupWrite = context.pipelines->layouts.createBindGroupStrorage1WO(texView);
-    bindGroupTexure = context.pipelines->layouts.createBindGroupTexSampled(context.samplerNearestRepeat, texView);
+    bindGroupRead = context.layouts.createBindGroupStrorage1RO(texView);
+    bindGroupWrite = context.layouts.createBindGroupStrorage1WO(texView);
+    bindGroupTexure = context.layouts.createBindGroupTexSampled(context.samplerNearestRepeat, texView);
 }
 
 
 void WgRenderStorage::release(WgContext& context)
 {
-    context.pipelines->layouts.releaseBindGroup(bindGroupTexure);
-    context.pipelines->layouts.releaseBindGroup(bindGroupWrite);
-    context.pipelines->layouts.releaseBindGroup(bindGroupRead);
+    context.layouts.releaseBindGroup(bindGroupTexure);
+    context.layouts.releaseBindGroup(bindGroupWrite);
+    context.layouts.releaseBindGroup(bindGroupRead);
     context.releaseTextureView(texViewMS);
     context.releaseTexture(textureMS);
     context.releaseTextureView(texView);

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -61,7 +61,6 @@ void WgRenderer::release()
 
     // release context handles
     mCompositor.release(mContext);
-    mPipelines.release(mContext);
     mContext.release();
 
     // release gpu handles
@@ -312,7 +311,6 @@ bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, 
 
     // initialize rendering context
     mContext.initialize(instance, this->device);
-    mPipelines.initialize(mContext);
 
     // initialize render tree instances
     mRenderStoragePool.initialize(mContext, width, height);

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -85,7 +85,6 @@ private:
 
     // rendering context
     WgContext mContext;
-    WgPipelines mPipelines;
     WgCompositor mCompositor;
 
     // rendering states


### PR DESCRIPTION
The main reason of refactoring is to separate bind group sets and pipelines, and change owning of pipelines to compositor
It will be helpfull for resizing (intermidiate changes)
Should not impact to performance and web player
see: Svg example
