### PR TITLE
wasm: fix build error

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -201,7 +201,7 @@ struct TvgGLEngine : TvgEngineMethod
     #ifdef THORVG_GL_RASTER_SUPPORT
         emscripten_webgl_make_context_current(context);
 
-        static_cast<GlCanvas*>(canvas)->target(0, w, h);
+        static_cast<GlCanvas*>(canvas)->target(0, w, h, ColorSpace::ABGR8888S);
     #endif
     }
 };


### PR DESCRIPTION
Added missing parameter for `GlCanvas->target`

![CleanShot 2024-11-27 at 15 49 19@2x](https://github.com/user-attachments/assets/e1c84852-f553-439d-8d81-a4a0ca5f9a7f)
