### PR TITLE
wg_engine: simplify shader types (refactoring)

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -268,7 +268,7 @@ void WgRenderSettings::update(WgContext& context, const Fill* fill, const Render
         skip = false;
     } else if ((flags & RenderUpdateFlag::Color) && !fill) {
         rasterType = WgRenderRasterType::Solid;
-        WgShaderTypeSolidColor solidColor(c);
+        WgShaderTypeVec4f solidColor(c);
         if (context.allocateBufferUniform(bufferGroupSolid, &solidColor, sizeof(solidColor))) {
             context.layouts.releaseBindGroup(bindGroupSolid);
             bindGroupSolid = context.layouts.createBindGroupBuffer1Un(bufferGroupSolid);
@@ -306,7 +306,7 @@ void WgRenderDataPaint::release(WgContext& context)
 void WgRenderDataPaint::update(WgContext& context, const tvg::Matrix& transform, tvg::ColorSpace cs, uint8_t opacity)
 {
     WgShaderTypeMat4x4f modelMat(transform);
-    WgShaderTypeBlendSettings blendSettings(cs, opacity);
+    WgShaderTypeVec4f blendSettings(cs, opacity);
     bool bufferModelMatChanged = context.allocateBufferUniform(bufferModelMat, &modelMat, sizeof(modelMat));
     bool bufferBlendSettingsChanged = context.allocateBufferUniform(bufferBlendSettings, &blendSettings, sizeof(blendSettings));
     if (bufferModelMatChanged || bufferBlendSettingsChanged) {

--- a/src/renderer/wg_engine/tvgWgShaderTypes.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.cpp
@@ -24,9 +24,9 @@
 #include <cassert>
 #include "tvgMath.h"
 
-///////////////////////////////////////////////////////////////////////////////
-// shader types
-///////////////////////////////////////////////////////////////////////////////
+//************************************************************************
+// WgShaderTypeMat4x4f
+//************************************************************************
 
 WgShaderTypeMat4x4f::WgShaderTypeMat4x4f()
 {
@@ -85,34 +85,40 @@ void WgShaderTypeMat4x4f::update(size_t w, size_t h)
     mat[12] = -1.0f;     mat[13] = +1.0f;     mat[14] = +0.0f; mat[15] = +1.0f;
 }
 
+//************************************************************************
+// WgShaderTypeVec4f
+//************************************************************************
 
-WgShaderTypeBlendSettings::WgShaderTypeBlendSettings(const ColorSpace colorSpace, uint8_t o)
+WgShaderTypeVec4f::WgShaderTypeVec4f(const ColorSpace colorSpace, uint8_t o)
 {
     update(colorSpace, o);
 }
 
 
-void WgShaderTypeBlendSettings::update(const ColorSpace colorSpace, uint8_t o)
-{
-    settings[0] = (uint32_t)colorSpace;
-    settings[3] = o / 255.0f;
-}
-
-
-WgShaderTypeSolidColor::WgShaderTypeSolidColor(const RenderColor& c)
+WgShaderTypeVec4f::WgShaderTypeVec4f(const RenderColor& c)
 {
     update(c);
 }
 
 
-void WgShaderTypeSolidColor::update(const RenderColor& c)
+void WgShaderTypeVec4f::update(const ColorSpace colorSpace, uint8_t o)
 {
-    color[0] = c.r / 255.0f; // red
-    color[1] = c.g / 255.0f; // green
-    color[2] = c.b / 255.0f; // blue
-    color[3] = c.a / 255.0f; // alpha
+    vec[0] = (uint32_t)colorSpace;
+    vec[3] = o / 255.0f;
 }
 
+
+void WgShaderTypeVec4f::update(const RenderColor& c)
+{
+    vec[0] = c.r / 255.0f; // red
+    vec[1] = c.g / 255.0f; // green
+    vec[2] = c.b / 255.0f; // blue
+    vec[3] = c.a / 255.0f; // alpha
+}
+
+//************************************************************************
+// WgShaderTypeGradient
+//************************************************************************
 
 void WgShaderTypeGradient::update(const LinearGradient* linearGradient)
 {

--- a/src/renderer/wg_engine/tvgWgShaderTypes.h
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.h
@@ -43,21 +43,14 @@ struct WgShaderTypeMat4x4f
 };
 
 // vec4f
-struct WgShaderTypeBlendSettings
+struct WgShaderTypeVec4f
 {
-    float settings[4]{};
+    float vec[4]{};
 
-    WgShaderTypeBlendSettings() {};
-    WgShaderTypeBlendSettings(const ColorSpace colorSpace, uint8_t o);
+    WgShaderTypeVec4f() {};
+    WgShaderTypeVec4f(const ColorSpace colorSpace, uint8_t o);
+    WgShaderTypeVec4f(const RenderColor& c);
     void update(const ColorSpace colorSpace, uint8_t o);
-};
-
-// vec4f
-struct WgShaderTypeSolidColor
-{
-    float color[4]{};
-
-    WgShaderTypeSolidColor(const RenderColor& c);
     void update(const RenderColor& c);
 };
 


### PR DESCRIPTION
Use universal vec4f type for blend settings and color to pass data as shader parameter
see: Blending examples