### PR TITLE
gl_engine: Fix the wrong bounds cause composition not correct

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -220,7 +220,7 @@ RenderRegion GlGeometry::getBounds() const
             static_cast<int32_t>(ceil(right - floor(left))),
             static_cast<int32_t>(ceil(bottom - floor(top))),
         };
-        if (bounds.x < 0 || bounds.y < 0 || bounds.w < 0 || bounds.h < 0) {
+        if (bounds.w < 0 || bounds.h < 0) {
             return mBounds;
         } else {
             return bounds;


### PR DESCRIPTION
This PR fix some rendering error in **Lottie** example. 
related issue: #2799 

--------
* a_mountain.json
<img width="652" alt="截屏2024-11-28 下午5 39 12" src="https://github.com/user-attachments/assets/9b49d92f-ba7f-4828-a676-753c8d6eacb5">

* balloons_with_string.json
<img width="446" alt="截屏2024-11-28 下午5 39 32" src="https://github.com/user-attachments/assets/949eae92-3348-47d4-a887-a4c443fc0c94">

* water_filling.json
<img width="575" alt="截屏2024-11-28 下午5 41 11" src="https://github.com/user-attachments/assets/2fd8016e-5c01-4a4e-9b42-508296169529">

* card_hover.json
<img width="538" alt="截屏2024-11-28 下午5 45 52" src="https://github.com/user-attachments/assets/48f7e995-0b8b-402e-a696-79cb8a3c996a">

