### PR TITLE
renderer: make the file io configurable.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -116,6 +116,12 @@ if get_option('log')
     config_h.set10('THORVG_LOG_ENABLED', true)
 endif
 
+#File IO
+if get_option('file') == true
+    config_h.set10('THORVG_FILE_IO_SUPPORT', true)
+endif
+
+
 #Extra
 lottie_expressions = lottie_loader and get_option('extra').contains('lottie_expressions')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -58,6 +58,11 @@ option('static',
    value: false,
    description: 'Force to use static linking modules in thorvg')
 
+option('file',
+   type: 'boolean',
+   value: true,
+   description: 'Enable File IO calls in thorvg')
+
 option('extra',
    type: 'array',
    choices: ['', 'lottie_expressions'],

--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -59,6 +59,7 @@ JpgLoader::~JpgLoader()
 
 bool JpgLoader::open(const char* path)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     auto jpegFile = fopen(path, "rb");
     if (!jpegFile) return false;
 
@@ -94,6 +95,9 @@ failure:
 finalize:
     fclose(jpegFile);
     return ret;
+#else
+    return false;
+#endif
 }
 
 

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -67,6 +67,7 @@ bool PngLoader::open(const char* path)
 
 bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     image->opaque = NULL;
 
     if (!png_image_begin_read_from_memory(image, data, size)) return false;
@@ -75,6 +76,9 @@ bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpa
     h = (float)image->height;
 
     return true;
+#else
+    return false;
+#endif
 }
 
 

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -68,6 +68,7 @@ WebpLoader::~WebpLoader()
 
 bool WebpLoader::open(const char* path)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     auto webpFile = fopen(path, "rb");
     if (!webpFile) return false;
 
@@ -96,6 +97,9 @@ bool WebpLoader::open(const char* path)
 finalize:
     fclose(webpFile);
     return ret;
+#else
+    return false;
+#endif
 }
 
 

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -70,6 +70,7 @@ JpgLoader::~JpgLoader()
 
 bool JpgLoader::open(const char* path)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     int width, height;
     decoder = jpgdHeader(path, &width, &height);
     if (!decoder) return false;
@@ -78,6 +79,9 @@ bool JpgLoader::open(const char* path)
     h = static_cast<float>(height);
 
     return true;
+#else
+    return false;
+#endif
 }
 
 

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -220,6 +220,7 @@ bool LottieLoader::open(const char* data, uint32_t size, const char* rpath, bool
 
 bool LottieLoader::open(const char* path)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     auto f = fopen(path, "r");
     if (!f) return false;
 
@@ -247,6 +248,9 @@ bool LottieLoader::open(const char* path)
     this->copy = true;
 
     return header();
+#else
+    return false;
+#endif
 }
 
 

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -70,6 +70,7 @@ PngLoader::~PngLoader()
 
 bool PngLoader::open(const char* path)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     auto pngFile = fopen(path, "rb");
     if (!pngFile) return false;
 
@@ -102,6 +103,9 @@ bool PngLoader::open(const char* path)
 finalize:
     fclose(pngFile);
     return ret;
+#else
+    return false;
+#endif
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3913,6 +3913,7 @@ bool SvgLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpa
 
 bool SvgLoader::open(const char* path)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     clear();
 
     ifstream f;
@@ -3930,6 +3931,9 @@ bool SvgLoader::open(const char* path)
     size = filePath.size();
 
     return header();
+#else
+    return false;
+#endif
 }
 
 

--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -36,6 +36,8 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
+#ifdef THORVG_FILE_IO_SUPPORT
+
 #if defined(_WIN32) && (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)
 
 static bool _map(TtfLoader* loader, const string& path)
@@ -155,6 +157,8 @@ static void _unmap(TtfLoader* loader)
 }
 #endif
 
+#endif //THORVG_FILE_IO_SUPPORT
+
 
 static uint32_t* _codepoints(const char* text, size_t n)
 {
@@ -199,7 +203,11 @@ void TtfLoader::clear()
         reader.size = 0;
         freeData = false;
         nomap = false;
-    } else _unmap(this);
+    } else {
+#ifdef THORVG_FILE_IO_SUPPORT
+        _unmap(this);
+#endif
+    }
     shape = nullptr;
 }
 
@@ -236,9 +244,13 @@ TtfLoader::~TtfLoader()
 
 bool TtfLoader::open(const char* path)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     clear();
     if (!_map(this, path)) return false;
     return reader.header();
+#else
+    return false;
+#endif
 }
 
 

--- a/src/loaders/webp/tvgWebpLoader.cpp
+++ b/src/loaders/webp/tvgWebpLoader.cpp
@@ -71,6 +71,7 @@ WebpLoader::~WebpLoader()
 
 bool WebpLoader::open(const char* path)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     auto f = fopen(path, "rb");
     if (!f) return false;
 
@@ -101,6 +102,9 @@ bool WebpLoader::open(const char* path)
     freeData = true;
 
     return true;
+#else
+    return false;
+#endif
 }
 
 

--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -159,6 +159,7 @@ static LoadModule* _find(FileType type)
 }
 
 
+#ifdef THORVG_FILE_IO_SUPPORT
 static LoadModule* _findByPath(const char* filename)
 {
     auto ext = strExtension(filename);
@@ -173,6 +174,7 @@ static LoadModule* _findByPath(const char* filename)
     if (!strcmp(ext, "otf") || !strcmp(ext, "otc")) return _find(FileType::Ttf);
     return nullptr;
 }
+#endif
 
 
 static FileType _convert(const char* mimeType)
@@ -281,6 +283,7 @@ bool LoaderMgr::retrieve(LoadModule* loader)
 
 LoadModule* LoaderMgr::loader(const char* filename, bool* invalid)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     *invalid = false;
 
     //TODO: svg & lottie is not sharable.
@@ -324,6 +327,7 @@ LoadModule* LoaderMgr::loader(const char* filename, bool* invalid)
         }
     }
     *invalid = true;
+#endif
     return nullptr;
 }
 

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -156,9 +156,14 @@ Type Picture::type() const noexcept
 
 Result Picture::load(const char* filename) noexcept
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     if (!filename) return Result::InvalidArguments;
 
     return pImpl->load(filename);
+#else
+    TVGLOG("RENDERER", "FILE IO is disabled!");
+    return Result::NonSupport;
+#endif
 }
 
 

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -58,15 +58,19 @@ Result Text::font(const char* name, float size, const char* style) noexcept
 }
 
 
-Result Text::load(const char* path) noexcept
+Result Text::load(const char* filename) noexcept
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     bool invalid; //invalid path
-    if (!LoaderMgr::loader(path, &invalid)) {
+    if (!LoaderMgr::loader(filename, &invalid)) {
         if (invalid) return Result::InvalidArguments;
         else return Result::NonSupport;
     }
-
     return Result::Success;
+#else
+    TVGLOG("RENDERER", "FILE IO is disabled!");
+    return Result::NonSupport;
+#endif
 }
 
 
@@ -87,8 +91,13 @@ Result Text::load(const char* name, const char* data, uint32_t size, const char*
 
 Result Text::unload(const char* filename) noexcept
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     if (LoaderMgr::retrieve(filename)) return Result::Success;
     return Result::InsufficientCondition;
+#else
+    TVGLOG("RENDERER", "FILE IO is disabled!");
+    return Result::NonSupport;
+#endif
 }
 
 


### PR DESCRIPTION
certain systems, may not support file I/O operations. ThorVG should provide users with an option to configure builds according to their requirements.

This ensures that file I/O calls are avoided,
preventing potential crashes.

Please use the meson '-Dfile=true/false' option for this.

issue: https://github.com/thorvg/thorvg/issues/3008