### PR TITLE
wasm: add gl option to combined binary

### DIFF
--- a/cross/wasm32.txt
+++ b/cross/wasm32.txt
@@ -1,0 +1,21 @@
+[binaries]
+cpp = 'EMSDK:upstream/emscripten/em++.py'
+ar = 'EMSDK:upstream/emscripten/emar.py'
+strip = '-strip'
+
+[properties]
+root = 'EMSDK:upstream/emscripten/system'
+shared_lib_suffix = 'js'
+static_lib_suffix = 'js'
+shared_module_suffix = 'js'
+exe_suffix = 'js'
+
+[built-in options]
+cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sASYNCIFY=1', '-sSTACK_SIZE=4MB', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'

--- a/wasm_build.sh
+++ b/wasm_build.sh
@@ -21,8 +21,8 @@ if [ ! -d "./build_wasm" ]; then
       sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32_gl.txt > /tmp/.wasm_cross.txt
       meson -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="gl" --cross-file /tmp/.wasm_cross.txt build_wasm
     else
-      sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32_wg.txt > /tmp/.wasm_cross.txt
-      meson -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="wg, sw" --cross-file /tmp/.wasm_cross.txt build_wasm
+      sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32.txt > /tmp/.wasm_cross.txt
+      meson -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="wg, gl, sw" --cross-file /tmp/.wasm_cross.txt build_wasm
     fi
 fi
 


### PR DESCRIPTION
To seamlessly integrate the GL player into our web player and viewer, the wasm_build command has been updated to generate WASM binaries for SW, WG, and GL.

**[Binary Size Comparison]**

(SW + WG + GL)
![CleanShot 2024-12-02 at 13 34 11@2x](https://github.com/user-attachments/assets/8dff2ec7-2790-491b-9b83-c66516ca0421)

(SW + WG)
![CleanShot 2024-12-02 at 13 35 14@2x](https://github.com/user-attachments/assets/be324891-15fa-40c1-bee4-97137ec202b5)

- Glude Code : 147K -> 179K (+ 17%)
- WASM : 1480595B -> 1562006B (+5%)