### PR TITLE
capi: removed default argument from C API.

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -574,7 +574,7 @@ TVG_API Tvg_Canvas* tvg_wgcanvas_create(void);
 *
 * \note Experimental API
 */
-TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type = 0);
+TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas* canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type);
 
 /** \} */   // end defgroup ThorVGCapi_WgCanvas
 


### PR DESCRIPTION
C does not support default arguments. For thorvg_capi.h to maintain C compatibility, default arguments must be omitted.