### PR TITLE
wasm: fix webgl context switching issue in multi-canvas

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -83,6 +83,7 @@ struct TvgEngineMethod
     virtual ~TvgEngineMethod() {}
     virtual Canvas* init(string&) = 0;
     virtual void resize(Canvas* canvas, int w, int h) = 0;
+    virtual void update() = 0;
     virtual val output(int w, int h)
     {
         return val(typed_memory_view<uint8_t>(0, nullptr));
@@ -116,6 +117,8 @@ struct TvgSwEngine : TvgEngineMethod
     {
         return val(typed_memory_view(w * h * 4, buffer));
     }
+
+    void update() override {}
 };
 
 
@@ -156,6 +159,8 @@ struct TvgWgEngine : TvgEngineMethod
         static_cast<WgCanvas*>(canvas)->target(device, instance, surface, w, h, ColorSpace::ABGR8888S);
     #endif
     }
+
+    void update() override {}
 };
 
 struct TvgGLEngine : TvgEngineMethod
@@ -202,6 +207,12 @@ struct TvgGLEngine : TvgEngineMethod
         emscripten_webgl_make_context_current(context);
 
         static_cast<GlCanvas*>(canvas)->target(0, w, h, ColorSpace::ABGR8888S);
+    #endif
+    }
+
+    void update() override {
+    #ifdef THORVG_GL_RASTER_SUPPORT
+        emscripten_webgl_make_context_current(context);
     #endif
     }
 };
@@ -340,6 +351,8 @@ public:
         if (!updated) return true;
 
         errorMsg = NoError;
+
+        engine->update();
 
         this->canvas->clear(false);
 


### PR DESCRIPTION
Previously, rendering multiple canvases with separate WebGL contexts caused unexpected errors due to incorrect context activation. This patch ensures that `emscripten_webgl_make_context_current` is called before every draw operation.


[Main]
There are a few issues in rendering due to invalid context.

![CleanShot 2024-12-04 at 03 16 06](https://github.com/user-attachments/assets/1313e68b-3d15-42c5-9bec-2e0aa2242020)
![CleanShot 2024-12-04 at 03 16 14](https://github.com/user-attachments/assets/9fce9001-a785-4b98-96e2-74a6075ff088)

[Patched]
![CleanShot 2024-12-04 at 03 06 22](https://github.com/user-attachments/assets/9fda764f-22bf-41b1-83de-cbcb44b02df2)