### PR TITLE
gl_engine: Fix calculation error in path triming

### DIFF
--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -88,6 +88,7 @@ public:
     RenderRegion bounds() const;
 
 private:
+    void doTrimStroke(const PathCommand* cmds, uint32_t cmd_count, const Point* pts, uint32_t pts_count, bool simultaneous, float start, float end);
     void doStroke(const PathCommand* cmds, uint32_t cmd_count, const Point* pts, uint32_t pts_count);
     void doDashStroke(const PathCommand* cmds, uint32_t cmd_count, const Point* pts, uint32_t pts_count, uint32_t dash_count, const float* dash_pattern);
 


### PR DESCRIPTION
This PR rewrite the PathTrim code and fixed almost all the issue caused by PathTrim inside GL backend.

related issue: #2799 

-------
The following cases is correct with this Patch.
* birth_stone_logo
* fly_in_beaker
* frog_vr
* cat_loader
* happy_holidays
* holdanimation
* isometric
* skullboy
* threads
* lolo
* seawalk
* expressions/10151
* expressions/world_locations
* expressions/jolly_walker // This animation is rendered same as Software raster, but I am not sure it is correct


Please check if I am wrong 