### PR TITLE
wasm: remove ASYNCIFY to reduce binary size

### DIFF
--- a/cross/wasm32.txt
+++ b/cross/wasm32.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sASYNCIFY=1', '-sSTACK_SIZE=2MB', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sSTACK_SIZE=2MB', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_wg.txt
+++ b/cross/wasm32_wg.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sASYNCIFY=1', '-sSTACK_SIZE=2MB']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sSTACK_SIZE=2MB']
 
 [host_machine]
 system = 'emscripten'


### PR DESCRIPTION
The binary size recently increased due to the ASYNCIFY option, which was required for WebGPU initialization. 

To prevent unnecessary binary size growth, ThorVG will no longer depend on asynchronous processes such as `emscripten_sleep` (ASYNCIFY or JSPI).

As a result, the combined WASM binary size has been significantly reduced to less than 1MB.

Size comparison: 1559KB → 998KB (-36%)


![CleanShot 2024-12-09 at 19 59 51@2x](https://github.com/user-attachments/assets/d16c19b8-52d9-420f-96c1-812890b04575)

![CleanShot 2024-12-09 at 19 55 19@2x](https://github.com/user-attachments/assets/45342cd3-020e-4e41-b4fe-dafc71b24369)
