### PR TITLE
wasm: reduce WebGPU stack size

### DIFF
--- a/cross/wasm32.txt
+++ b/cross/wasm32.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sASYNCIFY=1', '-sSTACK_SIZE=4MB', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sASYNCIFY=1', '-sSTACK_SIZE=2MB', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_wg.txt
+++ b/cross/wasm32_wg.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sASYNCIFY=1', '-sSTACK_SIZE=4MB']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sASYNCIFY=1', '-sSTACK_SIZE=2MB']
 
 [host_machine]
 system = 'emscripten'


### PR DESCRIPTION
Reduce stack size to 2MB for optimized memory usage

_Originally posted by @SergeyLebedkin  in https://github.com/thorvg/thorvg/pull/3034#discussion_r1875840029_

![Warp 2024-12-09 21 48 16](https://github.com/user-attachments/assets/6f907a4e-e179-4daf-a6dd-065d7e925093)
