### PR TITLE
wasm: update canvas API usage from clear() to remove()

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -282,7 +282,7 @@ public:
             return false;
         }
 
-        canvas->clear(true);
+        canvas->remove();
 
         delete(animation);
         animation = Animation::gen();
@@ -323,7 +323,7 @@ public:
 
         if (!updated) return engine->output(width, height);
 
-        if (canvas->draw() != Result::Success) {
+        if (canvas->draw(true) != Result::Success) {
             errorMsg = "draw() fail";
             return val(typed_memory_view<uint8_t>(0, nullptr));
         }
@@ -340,8 +340,6 @@ public:
         if (!updated) return true;
 
         errorMsg = NoError;
-
-        this->canvas->clear(false);
 
         if (canvas->update() != Result::Success) {
             errorMsg = "update() fail";


### PR DESCRIPTION
Following ThorVG API changes (#1372), updated the canvas handling:
- Replaced Canvas::clear() calls with Canvas::remove()

![CleanShot 2024-12-11 at 11 03 05@2x](https://github.com/user-attachments/assets/79fa1acb-d206-48ff-a43c-623d5c2a2fea)