### PR TITLE
sw_engine: handle clips beyond the render region

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -490,11 +490,11 @@ SwFixed mathLength(const SwPoint& pt);
 int mathCubicAngle(const SwPoint* base, SwFixed& angleIn, SwFixed& angleMid, SwFixed& angleOut);
 SwFixed mathMean(SwFixed angle1, SwFixed angle2);
 SwPoint mathTransform(const Point* to, const Matrix& transform);
-bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, bool fastTrack);
-bool mathClipBBox(const SwBBox& clipper, SwBBox& clippee);
+bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, uint8_t* clipperType, bool fastTrack);
+bool mathClipBBox(const SwBBox& clipper, SwBBox& clippee, uint8_t* clipperType);
 
 void shapeReset(SwShape* shape);
-bool shapePrepare(SwShape* shape, const RenderShape* rshape, const Matrix& transform, const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid, bool hasComposite);
+bool shapePrepare(SwShape* shape, const RenderShape* rshape, const Matrix& transform, const SwBBox& clipRegion, SwBBox& renderRegion, uint8_t* clipperType, SwMpool* mpool, unsigned tid, bool hasComposite);
 bool shapePrepared(const SwShape* shape);
 bool shapeGenRle(SwShape* shape, const RenderShape* rshape, bool antiAlias);
 void shapeDelOutline(SwShape* shape, SwMpool* mpool, uint32_t tid);
@@ -543,7 +543,7 @@ SwRle* rleRender(const SwBBox* bbox);
 void rleFree(SwRle* rle);
 void rleReset(SwRle* rle);
 void rleMerge(SwRle* rle, SwRle* clip1, SwRle* clip2);
-void rleClip(SwRle* rle, const SwRle* clip);
+void rleClip(SwRle* rle, const SwRle* clip, uint8_t clipperType);
 void rleClip(SwRle* rle, const SwBBox* clip);
 
 SwMpool* mpoolInit(uint32_t threads);

--- a/src/renderer/sw_engine/tvgSwImage.cpp
+++ b/src/renderer/sw_engine/tvgSwImage.cpp
@@ -91,7 +91,7 @@ bool imagePrepare(SwImage* image, const Matrix& transform, const SwBBox& clipReg
     }
 
     if (!_genOutline(image, transform, mpool, tid)) return false;
-    return mathUpdateOutlineBBox(image->outline, clipRegion, renderRegion, image->direct);
+    return mathUpdateOutlineBBox(image->outline, clipRegion, renderRegion, nullptr, image->direct);
 }
 
 

--- a/src/renderer/sw_engine/tvgSwMath.cpp
+++ b/src/renderer/sw_engine/tvgSwMath.cpp
@@ -272,7 +272,7 @@ SwPoint mathTransform(const Point* to, const Matrix& transform)
 }
 
 
-bool mathClipBBox(const SwBBox& clipper, SwBBox& clippee)
+bool mathClipBBox(const SwBBox& clipper, SwBBox& clippee, uint8_t* clipperType)
 {
     clippee.max.x = (clippee.max.x < clipper.max.x) ? clippee.max.x : clipper.max.x;
     clippee.max.y = (clippee.max.y < clipper.max.y) ? clippee.max.y : clipper.max.y;
@@ -280,17 +280,23 @@ bool mathClipBBox(const SwBBox& clipper, SwBBox& clippee)
     clippee.min.y = (clippee.min.y > clipper.min.y) ? clippee.min.y : clipper.min.y;
 
     //Check valid region
-    if (clippee.max.x - clippee.min.x < 1 && clippee.max.y - clippee.min.y < 1) return false;
+    if (clippee.max.x - clippee.min.x < 1 && clippee.max.y - clippee.min.y < 1) {
+        if (clipperType) *clipperType = 2;
+        return false;
+    }
 
     //Check boundary
     if (clippee.min.x >= clipper.max.x || clippee.min.y >= clipper.max.y ||
-        clippee.max.x <= clipper.min.x || clippee.max.y <= clipper.min.y) return false;
+        clippee.max.x <= clipper.min.x || clippee.max.y <= clipper.min.y) {
+        if (clipperType) *clipperType = 2;
+        return false;
+    }
 
     return true;
 }
 
 
-bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, bool fastTrack)
+bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, SwBBox& renderRegion, uint8_t* clipperType, bool fastTrack)
 {
     if (!outline) return false;
 
@@ -324,5 +330,5 @@ bool mathUpdateOutlineBBox(const SwOutline* outline, const SwBBox& clipRegion, S
         renderRegion.min.y = yMin >> 6;
         renderRegion.max.y = (yMax + 63) >> 6;
     }
-    return mathClipBBox(clipRegion, renderRegion);
+    return mathClipBBox(clipRegion, renderRegion, clipperType);
 }

--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -1020,9 +1020,12 @@ void rleFree(SwRle* rle)
 }
 
 
-void rleClip(SwRle *rle, const SwRle *clip)
+void rleClip(SwRle *rle, const SwRle *clip, uint8_t clipperType)
 {
-    if (rle->size == 0 || clip->size == 0) return;
+    if (rle->size == 0 || clip->size == 0) {
+        if (clipperType == 2) _replaceClipSpan(rle, nullptr, 0);
+        return;
+    }
     auto spanCnt = rle->size > clip->size ? rle->size : clip->size;
     auto spans = static_cast<SwSpan*>(malloc(sizeof(SwSpan) * (spanCnt)));
     auto spansEnd = _intersectSpansRegion(clip, rle, spans, spanCnt);

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -493,10 +493,10 @@ static bool _genOutline(SwShape* shape, const RenderShape* rshape, const Matrix&
 /* External Class Implementation                                        */
 /************************************************************************/
 
-bool shapePrepare(SwShape* shape, const RenderShape* rshape, const Matrix& transform,  const SwBBox& clipRegion, SwBBox& renderRegion, SwMpool* mpool, unsigned tid, bool hasComposite)
+bool shapePrepare(SwShape* shape, const RenderShape* rshape, const Matrix& transform, const SwBBox& clipRegion, SwBBox& renderRegion, uint8_t* clipperType, SwMpool* mpool, unsigned tid, bool hasComposite)
 {
     if (!_genOutline(shape, rshape, transform, mpool, tid, hasComposite)) return false;
-    if (!mathUpdateOutlineBBox(shape->outline, clipRegion, renderRegion, shape->fastTrack)) return false;
+    if (!mathUpdateOutlineBBox(shape->outline, clipRegion, renderRegion, clipperType, shape->fastTrack)) return false;
 
     shape->bbox = renderRegion;
 
@@ -614,7 +614,7 @@ bool shapeGenStrokeRle(SwShape* shape, const RenderShape* rshape, const Matrix& 
 
     strokeOutline = strokeExportOutline(shape->stroke, mpool, tid);
 
-    if (!mathUpdateOutlineBBox(strokeOutline, clipRegion, renderRegion, false)) {
+    if (!mathUpdateOutlineBBox(strokeOutline, clipRegion, renderRegion, nullptr, false)) {
         ret = false;
         goto clear;
     }


### PR DESCRIPTION
before:
![before_frog](https://github.com/user-attachments/assets/7bdcfebe-fddc-4feb-8aca-197506cfdd35)

after:
![after_frog](https://github.com/user-attachments/assets/4bf26c4d-ef86-4afb-bd47-071aa4da1182)

issue: https://github.com/thorvg/thorvg/issues/3003, https://github.com/thorvg/thorvg/issues/2684
