### PR TITLE
lottie: handle image data while loaders are inactive

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -977,6 +977,7 @@ void LottieBuilder::updateSolid(LottieLayer* layer)
 
 void LottieBuilder::updateImage(LottieGroup* layer)
 {
+    if (layer->children.empty()) return;
     auto image = static_cast<LottieImage*>(layer->children.first());
     layer->scene->push(image->pooling(true));
 }

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -177,7 +177,7 @@ float LottieTextRange::factor(float frameNo, float totalLen, float idx)
 }
 
 
-void LottieImage::prepare()
+bool LottieImage::prepare()
 {
     LottieObject::type = LottieObject::Image;
 
@@ -186,15 +186,23 @@ void LottieImage::prepare()
     //force to load a picture on the same thread
     TaskScheduler::async(false);
 
-    if (data.size > 0) picture->load((const char*)data.b64Data, data.size, data.mimeType);
-    else picture->load(data.path);
+    auto ret = Result::Success;
+    if (data.size > 0) ret = picture->load((const char*)data.b64Data, data.size, data.mimeType);
+    else ret = picture->load(data.path);
 
     TaskScheduler::async(true);
+
+    if (ret != Result::Success) {
+        TVGLOG("LOTTIE", "Error while loading image data.");
+        delete(picture);
+        return false;
+    }
 
     picture->size(data.width, data.height);
     picture->ref();
 
     pooler.push(picture);
+    return true;
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -683,7 +683,7 @@ struct LottieImage : LottieObject, LottieRenderPooler<tvg::Picture>
         update();
     }
 
-    void prepare();
+    bool prepare();
     void update();
 };
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -925,7 +925,7 @@ void LottieParser::parseObject(Array<LottieObject*>& parent)
 }
 
 
-void LottieParser::parseImage(LottieImage* image, const char* data, const char* subPath, bool embedded, float width, float height)
+bool LottieParser::parseImage(LottieImage* image, const char* data, const char* subPath, bool embedded, float width, float height)
 {
     //embedded image resource. should start with "data:"
     //header look like "data:image/png;base64," so need to skip till ','.
@@ -947,7 +947,7 @@ void LottieParser::parseImage(LottieImage* image, const char* data, const char* 
 
     image->data.width = width;
     image->data.height = height;
-    image->prepare();
+    return image->prepare();
 }
 
 
@@ -986,8 +986,10 @@ LottieObject* LottieParser::parseAsset()
     }
     if (data) {
         obj = new LottieImage;
-        parseImage(static_cast<LottieImage*>(obj), data, subPath, embedded, width, height);
-        if (sid) registerSlot<LottieProperty::Type::Image>(obj, sid);
+        if (!parseImage(static_cast<LottieImage*>(obj), data, subPath, embedded, width, height)) {
+            delete(obj);
+            obj = nullptr;
+        } else if (sid) registerSlot<LottieProperty::Type::Image>(obj, sid);
     }
     if (obj) obj->id = id;
     return obj;

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -77,7 +77,7 @@ private:
 
     LottieObject* parseObject();
     LottieObject* parseAsset();
-    void parseImage(LottieImage* image, const char* data, const char* subPath, bool embedded, float width, float height);
+    bool parseImage(LottieImage* image, const char* data, const char* subPath, bool embedded, float width, float height);
     LottieLayer* parseLayer(LottieLayer* precomp);
     LottieObject* parseGroup();
     LottieRect* parseRect();


### PR DESCRIPTION
Handle cases where the lottie file contains image data, but the appropriate loaders are not active - the image object is removed to exclude it from further rendering process.

Note:
This issue became noticeable after commit 0ebbc61. Previously,  if at least one element of the canvas was successfully rendered (```paint->pImpl->render(renderer)```), the operation returned success. Currently, for the scene to return success (```PP(scene)->render(renderer)```), all its elements must be rendered successfully.