### PR TITLE
sw_engine: fix grad calculations

### DIFF
--- a/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/src/renderer/sw_engine/tvgSwFill.cpp
@@ -466,6 +466,7 @@ void fillRadial(const SwFill* fill, uint8_t* dst, uint32_t y, uint32_t x, uint32
             auto src = MULTIPLY(A(_pixel(fill, sqrtf(det))), a);
             auto tmp = maskOp(src, *cmp, 0);
             *dst = tmp + MULTIPLY(*dst, ~tmp);
+            det += deltaDet;
             deltaDet += deltaDeltaDet;
             b += deltaB;
         }


### PR DESCRIPTION
Added a term that was omitted during one of the refactorings.

before:
<img width="198" alt="Zrzut ekranu 2024-12-13 o 01 47 25" src="https://github.com/user-attachments/assets/963a60c3-4924-4091-adc5-dfe9762615ab" />

after:
<img width="197" alt="Zrzut ekranu 2024-12-13 o 01 46 07" src="https://github.com/user-attachments/assets/cf8c10db-db07-482c-aad8-653fe2fe551c" />

sample:
```
        auto fill = tvg::RadialGradient::gen();
        fill->radial(200, 200, 200, 200, 200, 0);
        tvg::Fill::ColorStop colorStops[2];
        colorStops[0] = {0, 255, 255, 255, 0};
        colorStops[1] = {1, 0, 0, 0, 255};
        fill->colorStops(colorStops, 2);

        auto shape1 = tvg::Shape::gen();
        shape1->appendRect(0, 0, 400, 400);
        shape1->fill(255,0,0);
        
        auto mask = tvg::Shape::gen();
        mask->appendRect(0, 0, 200, 200);
        mask->fill(fill);

        auto add = tvg::Shape::gen();
        add->appendCircle(200, 100, 50, 50);
        add->fill(255, 255, 255, 125);
        mask->mask(add, tvg::MaskMethod::Subtract);
        shape1->mask(mask, tvg::MaskMethod::Alpha);

        canvas->push(shape1);
```