### PR TITLE
gl_engine: Fix gradient color not correct when shape has opacity

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -300,7 +300,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
         16 * sizeof(float),
     });
 
-    auto alpha = 1.0f;
+    auto alpha = sdata.opacity / 255.f;
 
     if (flag & RenderUpdateFlag::GradientStroke) {
         auto strokeWidth = sdata.rshape->strokeWidth();


### PR DESCRIPTION
This PR fix the color not correct when rendering gradient color in GL backend.

the following issue can be fixed with this patch: #3032, #3030

-----
<img width="560" alt="截屏2024-12-13 下午3 32 09" src="https://github.com/user-attachments/assets/07c79323-1900-49c2-8eaf-3e22cbdbed52" />

<img width="579" alt="截屏2024-12-13 下午3 15 58" src="https://github.com/user-attachments/assets/faf4c858-110c-4af6-908d-7a8de1136c5a" />
