### PR TITLE
Support Trintone Effect

### DIFF
--- a/examples/SceneEffects.cpp
+++ b/examples/SceneEffects.cpp
@@ -33,6 +33,7 @@ struct UserExample : tvgexam::Example
     tvg::Scene* blur[3] = {nullptr, nullptr, nullptr};   //(for direction both, horizontal, vertical)
     tvg::Scene* fill = nullptr;
     tvg::Scene* tint = nullptr;
+    tvg::Scene* trintone = nullptr;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
@@ -77,6 +78,20 @@ struct UserExample : tvgexam::Example
             canvas->push(tint);
         }
 
+        //trinton scene
+        {
+            trintone = tvg::Scene::gen();
+
+            auto picture = tvg::Picture::gen();
+            picture->load(EXAMPLE_DIR"/svg/tiger.svg");
+            picture->size(SIZE, SIZE);
+            picture->translate(SIZE * 2, SIZE);
+
+            trintone->push(picture);
+            canvas->push(trintone);
+        }
+
+
         return true;
     }
 
@@ -94,11 +109,15 @@ struct UserExample : tvgexam::Example
 
         //Apply Fill post effect (rgba)
         fill->push(tvg::SceneEffect::ClearAll);
-        fill->push(tvg::SceneEffect::Fill, (int)(progress * 255), 0, 0, (int)(255.0f * progress));
+        fill->push(tvg::SceneEffect::Fill, 0, (int)(progress * 255), 0, (int)(255.0f * progress));
 
         //Apply Tint post effect (black:rgb, white:rgb, intensity)
         tint->push(tvg::SceneEffect::ClearAll);
         tint->push(tvg::SceneEffect::Tint, 0, 0, 0, 0, (int)(progress * 255), 0, progress * 100.0f);
+
+        //Apply Trintone post effect (shadow:rgb, midtone:rgb, highlight:rgb)
+        trintone->push(tvg::SceneEffect::ClearAll);
+        trintone->push(tvg::SceneEffect::Trintone, 0, (int)(progress * 255), 0, 199, 110, 36, 255, 255, 255);
 
         canvas->update();
 

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -232,7 +232,8 @@ enum class SceneEffect : uint8_t
     GaussianBlur,      ///< Apply a blur effect with a Gaussian filter. Param(3) = {sigma(float)[> 0], direction(int)[both: 0 / horizontal: 1 / vertical: 2], border(int)[duplicate: 0 / wrap: 1], quality(int)[0 - 100]}
     DropShadow,        ///< Apply a drop shadow effect with a Gaussian Blur filter. Param(8) = {color_R(int)[0 - 255], color_G(int)[0 - 255], color_B(int)[0 - 255], opacity(int)[0 - 255], angle(float)[0 - 360], distance(float), blur_sigma(float)[> 0], quality(int)[0 - 100]}
     Fill,              ///< Override the scene content color with a given fill information (Experimental API). Param(5) = {color_R(int)[0 - 255], color_G(int)[0 - 255], color_B(int)[0 - 255], opacity(int)[0 - 255]}
-    Tint               ///< Tinting the current scene color with a given black, white color paramters (Experimental API). Param(7) = {black_R(int)[0 - 255], black_G(int)[0 - 255], black_B(int)[0 - 255], white_R(int)[0 - 255], white_G(int)[0 - 255], white_B(int)[0 - 255], intensity(float)[0 - 100]}
+    Tint,              ///< Tinting the current scene color with a given black, white color paramters (Experimental API). Param(7) = {black_R(int)[0 - 255], black_G(int)[0 - 255], black_B(int)[0 - 255], white_R(int)[0 - 255], white_G(int)[0 - 255], white_B(int)[0 - 255], intensity(float)[0 - 100]}
+    Trintone           ///< Apply a tritone color effect to the scene using three color parameters for shadows, midtones, and highlights (Experimental API). Param(9) = {Shadow_R(int)[0 - 255], Shadow_G(int)[0 - 255], Shadow_B(int)[0 - 255], Midtone_R(int)[0 - 255], Midtone_G(int)[0 - 255], Midtone_B(int)[0 - 255], Highlight_R(int)[0 - 255], Highlight_G(int)[0 - 255], Highlight_B(int)[0 - 255]}
 };
 
 

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1314,28 +1314,36 @@ void LottieBuilder::updateEffect(LottieLayer* layer, float frameNo)
     for (auto ef = layer->effects.begin(); ef < layer->effects.end(); ++ef) {
         if (!(*ef)->enable) continue;
         switch ((*ef)->type) {
-            case LottieEffect::Tint: {
+            case SceneEffect::GaussianBlur: {
+                auto effect = static_cast<LottieFxGaussianBlur*>(*ef);
+                layer->scene->push(SceneEffect::GaussianBlur, effect->blurness(frameNo) * BLUR_TO_SIGMA, effect->direction(frameNo) - 1, effect->wrap(frameNo), QUALITY);
+                break;
+            }
+            case SceneEffect::DropShadow: {
+                auto effect = static_cast<LottieFxDropShadow*>(*ef);
+                auto color = effect->color(frameNo);
+                layer->scene->push(SceneEffect::DropShadow, color.rgb[0], color.rgb[1], color.rgb[2], (int)effect->opacity(frameNo), effect->angle(frameNo), effect->distance(frameNo), effect->blurness(frameNo) * BLUR_TO_SIGMA, QUALITY);
+                break;
+            }
+            case SceneEffect::Fill: {
+                auto effect = static_cast<LottieFxFill*>(*ef);
+                auto color = effect->color(frameNo);
+                layer->scene->push(SceneEffect::Fill, color.rgb[0], color.rgb[1], color.rgb[2], (int)(255.0f *effect->opacity(frameNo)));
+                break;
+            }
+            case SceneEffect::Tint: {
                 auto effect = static_cast<LottieFxTint*>(*ef);
                 auto black = effect->black(frameNo);
                 auto white = effect->white(frameNo);
                 layer->scene->push(SceneEffect::Tint, black.rgb[0], black.rgb[1], black.rgb[2], white.rgb[0], white.rgb[1], white.rgb[2], effect->intensity(frameNo));
                 break;
             }
-            case LottieEffect::Fill: {
-                auto effect = static_cast<LottieFxFill*>(*ef);
-                auto color = effect->color(frameNo);
-                layer->scene->push(SceneEffect::Fill, color.rgb[0], color.rgb[1], color.rgb[2], (int)(255.0f *effect->opacity(frameNo)));
-                break;
-            }
-            case LottieEffect::DropShadow: {
-                auto effect = static_cast<LottieFxDropShadow*>(*ef);
-                auto color = effect->color(frameNo);
-                layer->scene->push(SceneEffect::DropShadow, color.rgb[0], color.rgb[1], color.rgb[2], (int)effect->opacity(frameNo), effect->angle(frameNo), effect->distance(frameNo), effect->blurness(frameNo) * BLUR_TO_SIGMA, QUALITY);
-                break;
-            }
-            case LottieEffect::GaussianBlur: {
-                auto effect = static_cast<LottieFxGaussianBlur*>(*ef);
-                layer->scene->push(SceneEffect::GaussianBlur, effect->blurness(frameNo) * BLUR_TO_SIGMA, effect->direction(frameNo) - 1, effect->wrap(frameNo), QUALITY);
+            case SceneEffect::Trintone: {
+                auto effect = static_cast<LottieFxTrintone*>(*ef);
+                auto dark = effect->dark(frameNo);
+                auto midtone = effect->midtone(frameNo);
+                auto bright = effect->bright(frameNo);
+                layer->scene->push(SceneEffect::Trintone, dark.rgb[0], dark.rgb[1], dark.rgb[2], midtone.rgb[0], midtone.rgb[1], midtone.rgb[2], bright.rgb[0], bright.rgb[1], bright.rgb[2]);
                 break;
             }
             default: break;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -79,17 +79,8 @@ struct LottieStroke
 
 struct LottieEffect
 {
-    enum Type : uint8_t
-    {
-        DropShadow = 0,
-        GaussianBlur,
-        Fill,
-        Tint
-    };
-
     virtual ~LottieEffect() {}
-
-    Type type;
+    SceneEffect type;
     bool enable = false;
 };
 
@@ -106,7 +97,7 @@ struct LottieFxFill : LottieEffect
 
     LottieFxFill()
     {
-        type = Fill;
+        type = SceneEffect::Fill;
     }
 };
 
@@ -118,7 +109,19 @@ struct LottieFxTint : LottieEffect
 
     LottieFxTint()
     {
-        type = Tint;
+        type = SceneEffect::Tint;
+    }
+};
+
+struct LottieFxTrintone : LottieEffect
+{
+    LottieColor bright;
+    LottieColor midtone;
+    LottieColor dark;
+
+    LottieFxTrintone()
+    {
+        type = SceneEffect::Trintone;
     }
 };
 
@@ -132,10 +135,9 @@ struct LottieFxDropShadow : LottieEffect
 
     LottieFxDropShadow()
     {
-        type = DropShadow;
+        type = SceneEffect::DropShadow;
     }
 };
-
 
 struct LottieFxGaussianBlur : LottieEffect
 {
@@ -145,7 +147,7 @@ struct LottieFxGaussianBlur : LottieEffect
 
     LottieFxGaussianBlur()
     {
-        type = GaussianBlur;
+        type = SceneEffect::GaussianBlur;
     }
 };
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -62,6 +62,7 @@ LottieEffect* LottieParser::getEffect(int type)
     switch (type) {
         case 20: return new LottieFxTint;
         case 21: return new LottieFxFill;
+        case 23: return new LottieFxTrintone;
         case 25: return new LottieFxDropShadow;
         case 29: return new LottieFxGaussianBlur;
         default: return nullptr;
@@ -1294,6 +1295,31 @@ void LottieParser::parseTint(LottieFxTint* effect)
 }
 
 
+void LottieParser::parseTrintone(LottieFxTrintone* effect)
+{
+    int idx = 0;  //bright, midtone, dark
+    enterArray();
+    while (nextArrayValue()) {
+        enterObject();
+        while (auto key = nextObjectKey()) {
+            if (KEY_AS("v")) {
+                enterObject();
+                while (auto key = nextObjectKey()) {
+                    if (KEY_AS("k")) {
+                        if (idx == 0) parsePropertyInternal(effect->bright);
+                        else if (idx == 1) parsePropertyInternal(effect->midtone);
+                        else if (idx == 2) parsePropertyInternal(effect->dark);
+                        else skip();
+                    } else skip();
+                }
+                ++idx;
+            } else skip();
+        }
+    }
+}
+
+
+
 void LottieParser::parseFill(LottieFxFill* effect)
 {
     int idx = 0;  //fill mask -> all mask -> color -> invert -> h feather -> v feather -> opacity
@@ -1370,20 +1396,24 @@ void LottieParser::parseDropShadow(LottieFxDropShadow* effect)
 void LottieParser::parseEffect(LottieEffect* effect)
 {
     switch (effect->type) {
-        case LottieEffect::Tint: {
+        case SceneEffect::GaussianBlur: {
             parseTint(static_cast<LottieFxTint*>(effect));
             break;
         }
-        case LottieEffect::Fill: {
-            parseFill(static_cast<LottieFxFill*>(effect));
+        case SceneEffect::DropShadow: {
+            parseDropShadow(static_cast<LottieFxDropShadow*>(effect));
             break;
         }
-        case LottieEffect::GaussianBlur: {
+        case SceneEffect::Fill: {
             parseGaussianBlur(static_cast<LottieFxGaussianBlur*>(effect));
             break;
         }
-        case LottieEffect::DropShadow: {
-            parseDropShadow(static_cast<LottieFxDropShadow*>(effect));
+        case SceneEffect::Tint: {
+            parseFill(static_cast<LottieFxFill*>(effect));
+            break;
+        }
+        case SceneEffect::Trintone: {
+            parseTrintone(static_cast<LottieFxTrintone*>(effect));
             break;
         }
         default: break;

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -98,6 +98,7 @@ private:
     LottieFont* parseFont();
     LottieMarker* parseMarker();
 
+    void parseTrintone(LottieFxTrintone* effect);
     void parseTint(LottieFxTint* effect);
     void parseFill(LottieFxFill* effect);
     void parseGaussianBlur(LottieFxGaussianBlur* effect);

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -581,6 +581,7 @@ bool effectFillPrepare(RenderEffectFill* effect);
 bool effectFill(SwCompositor* cmp, const RenderEffectFill* params, bool direct);
 bool effectTintPrepare(RenderEffectTint* effect);
 bool effectTint(SwCompositor* cmp, const RenderEffectTint* params, bool direct);
-
+bool effectTrintonePrepare(RenderEffectTrintone* effect);
+bool effectTrintone(SwCompositor* cmp, const RenderEffectTrintone* params, bool direct);
 
 #endif /* _TVG_SW_COMMON_H_ */

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -656,6 +656,7 @@ bool SwRenderer::prepare(RenderEffect* effect)
         case SceneEffect::DropShadow: return effectDropShadowPrepare(static_cast<RenderEffectDropShadow*>(effect));
         case SceneEffect::Fill: return effectFillPrepare(static_cast<RenderEffectFill*>(effect));
         case SceneEffect::Tint: return effectTintPrepare(static_cast<RenderEffectTint*>(effect));
+        case SceneEffect::Trintone: return effectTrintonePrepare(static_cast<RenderEffectTrintone*>(effect));
         default: return false;
     }
 }
@@ -690,6 +691,9 @@ bool SwRenderer::effect(RenderCompositor* cmp, const RenderEffect* effect, bool 
         }
         case SceneEffect::Tint: {
             return effectTint(p, static_cast<const RenderEffectTint*>(effect), direct);
+        }
+        case SceneEffect::Trintone: {
+            return effectTrintone(p, static_cast<const RenderEffectTrintone*>(effect), direct);
         }
         default: return false;
     }

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -348,6 +348,29 @@ struct RenderEffectTint : RenderEffect
     }
 };
 
+struct RenderEffectTrintone : RenderEffect
+{
+    uint8_t shadow[3];       //rgb
+    uint8_t midtone[3];      //rgb
+    uint8_t highlight[3];    //rgb
+
+    static RenderEffectTrintone* gen(va_list& args)
+    {
+        auto inst = new RenderEffectTrintone;
+        inst->shadow[0] = va_arg(args, int);
+        inst->shadow[1] = va_arg(args, int);
+        inst->shadow[2] = va_arg(args, int);
+        inst->midtone[0] = va_arg(args, int);
+        inst->midtone[1] = va_arg(args, int);
+        inst->midtone[2] = va_arg(args, int);
+        inst->highlight[0] = va_arg(args, int);
+        inst->highlight[1] = va_arg(args, int);
+        inst->highlight[2] = va_arg(args, int);
+        inst->type = SceneEffect::Trintone;
+        return inst;
+    }
+};
+
 class RenderMethod
 {
 private:

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -330,6 +330,10 @@ struct Scene::Impl : Paint::Impl
                 re = RenderEffectTint::gen(args);
                 break;
             }
+            case SceneEffect::Trintone: {
+                re = RenderEffectTrintone::gen(args);
+                break;
+            }
             default: break;
         }
 


### PR DESCRIPTION
The Trintone effect maps the scene's shadows, midtones, and highlights
 to three specific colors, allowing for more complex and artistic color grading.

 Applied Trintone Formula:
```
if (L < 0.5) Result = (1 - 2L) * Shadow + 2L * Midtone
else Result = (1 - 2(L - 0.5)) * Midtone + (2(L - 0.5)) * Highlight
Where the L is Luminance.
```

https://github.com/user-attachments/assets/cd08810a-4bd0-44ca-8599-c42648d5f7ca

https://github.com/user-attachments/assets/ecdd36c5-d1f8-493c-96c0-87720a9b470c

issue: https://github.com/thorvg/thorvg/issues/2718
