### PR TITLE
sw_engine: fix dash offset

### DIFF
--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -129,6 +129,7 @@ struct RenderStroke
             dashPattern = nullptr;
         }
         dashCnt = rhs.dashCnt;
+        dashOffset = rhs.dashOffset;
         miterlimit = rhs.miterlimit;
         cap = rhs.cap;
         join = rhs.join;


### PR DESCRIPTION
The dash offset value was not copied while
'=' opetator was applied.

@Issue: https://github.com/thorvg/thorvg/issues/1643 (part of the problem)

before:
![before_tdd](https://github.com/user-attachments/assets/8004b7c2-72f4-4d57-a29f-f13a394fcad6)

after:
![after_tdd](https://github.com/user-attachments/assets/3bd0fc3d-03fe-45a0-9c20-c18dd2412110)


