### PR TITLE
sw_engine: Fix for rendering short paths

### DIFF
--- a/examples/StrokeShort.cpp
+++ b/examples/StrokeShort.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 - 2024 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "Example.h"
+
+/************************************************************************/
+/* ThorVG Drawing Contents                                              */
+/************************************************************************/
+
+struct UserExample : tvgexam::Example
+{
+    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    {
+        if (!canvas) return false;
+
+        //Line 1 (0 length and available stroke width - draw circle 25x25)
+        auto line1 = tvg::Shape::gen();
+        line1->moveTo(150, 150);
+        line1->lineTo(150, 150);
+        line1->strokeFill(255, 255, 255);
+        line1->strokeWidth(25);
+        line1->strokeCap(tvg::StrokeCap::Round);
+
+        canvas->push(line1);
+
+        //Line 2 (10 length and available stroke width - draw ellipse 35x25)
+        auto line2 = tvg::Shape::gen();
+        line2->moveTo(200, 150);
+        line2->lineTo(210, 150);
+        line2->strokeFill(255, 255, 255);
+        line2->strokeWidth(25);
+        line2->strokeCap(tvg::StrokeCap::Round);
+
+        canvas->push(line2);
+
+        //Line 3 (0 length and available stroke width - draw rectangle 25x25)
+        auto line3 = tvg::Shape::gen();
+        line3->moveTo(150, 200);
+        line3->lineTo(150, 200);
+        line3->strokeFill(255, 255, 255);
+        line3->strokeWidth(25);
+        line3->strokeCap(tvg::StrokeCap::Square);
+
+        canvas->push(line3);
+
+        //Line 4 (10 length and available stroke width - draw rectangle 35x25)
+        auto line4 = tvg::Shape::gen();
+        line4->moveTo(200, 200);
+        line4->lineTo(210, 200);
+        line4->strokeFill(255, 255, 255);
+        line4->strokeWidth(25);
+        line4->strokeCap(tvg::StrokeCap::Square);
+
+        canvas->push(line4);
+
+        //Line 5 (0 length and available stroke width - don't draw anything)
+        auto line5 = tvg::Shape::gen();
+        line5->moveTo(150, 250);
+        line5->lineTo(150, 250);
+        line5->strokeFill(255, 255, 255);
+        line5->strokeWidth(25);
+        line5->strokeCap(tvg::StrokeCap::Butt);
+
+        canvas->push(line5);
+
+        //Line 6 (10 length and available stroke width - draw rectangle 10x25)
+        auto line6 = tvg::Shape::gen();
+        line6->moveTo(200, 250);
+        line6->lineTo(210, 250);
+        line6->strokeFill(255, 255, 255);
+        line6->strokeWidth(25);
+        line6->strokeCap(tvg::StrokeCap::Butt);
+
+        canvas->push(line6);
+
+        return true;
+    }
+};
+
+
+/************************************************************************/
+/* Entry Point                                                          */
+/************************************************************************/
+
+int main(int argc, char **argv)
+{
+    return tvgexam::main(new UserExample, argc, argv);
+}

--- a/examples/Svg.cpp
+++ b/examples/Svg.cpp
@@ -26,7 +26,7 @@
 /* ThorVG Drawing Contents                                              */
 /************************************************************************/
 
-#define NUM_PER_ROW 9
+#define NUM_PER_ROW 10
 #define NUM_PER_COL 9
 
 struct UserExample : tvgexam::Example

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -66,6 +66,7 @@ source_file = [
     'Stroke.cpp',
     'StrokeLine.cpp',
     'StrokeMiterlimit.cpp',
+    'StrokeShort.cpp',
     'StrokeTrim.cpp',
     'Svg.cpp',
     'Text.cpp',

--- a/examples/resources/svg/stroke-short.svg
+++ b/examples/resources/svg/stroke-short.svg
@@ -1,0 +1,1 @@
+<svg width="21.6" height="34.01" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="12" stroke="red" d="M15.6 28.01H6M10.8 6h0" fill="none"/></svg>

--- a/src/renderer/sw_engine/tvgSwStroke.cpp
+++ b/src/renderer/sw_engine/tvgSwStroke.cpp
@@ -374,8 +374,8 @@ static void _lineTo(SwStroke& stroke, const SwPoint& to)
 {
     auto delta = to - stroke.center;
 
-    //a zero-length lineto is a no-op; avoid creating a spurious corner
-    if (delta.zero()) return;
+    //a zero-length lineto is a no-op if stroke width is 0; avoid creating a spurious corner
+    if (delta.zero() && stroke.width == 0) return;
 
     /* The lineLength is used to determine the intersection of strokes outlines.
        The scale needs to be reverted since the stroke width has not been scaled.
@@ -451,8 +451,8 @@ static void _cubicTo(SwStroke& stroke, const SwPoint& ctrl1, const SwPoint& ctrl
             continue;
         }
 
-        //ignoreable size
-        if (valid < 0 && arc == bezStack) {
+        //ignoreable size if stroke width is 0
+        if (valid < 0 && arc == bezStack && stroke.width == 0) {
             stroke.center = to;
             return;
         }


### PR DESCRIPTION
I updated ```tvgSwStroke.cpp``` to ensure it does not terminate prematurely for paths with a step of 0 or exceptionally small values when a valid stroke-width is present.

As part of the examples, I introduced a program called ```./StrokeShort```, which demonstrates the correct rendering of lines in such cases with various ```stroke-cap``` settings.

![image](https://github.com/user-attachments/assets/623db8b7-2e90-4ec7-b5c9-46254c1fa656)

I also added an SVG file (stroke-short.svg) to the resources, which can be viewed using the ```./Svg``` program. It now renders correctly.

Issues: https://github.com/thorvg/thorvg/issues/3065

