### PR TITLE
portability: fix file size check on Windows

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -234,11 +234,7 @@ bool LottieLoader::open(const char* path)
 
     auto content = (char*)(malloc(sizeof(char) * size + 1));
     fseek(f, 0, SEEK_SET);
-    auto ret = fread(content, sizeof(char), size, f);
-    if (ret < size) {
-        fclose(f);
-        return false;
-    }
+    size = fread(content, sizeof(char), size, f);
     content[size] = '\0';
 
     fclose(f);


### PR DESCRIPTION
Resolved an issue where parsing failed due to mismatch between file size obtained via `ftell` and the actual bytes read by `fread`. This occurred because newline translation (`\r\n` to `\n`) in text mode altered the byte count, leading to incorrect assumptions about the data size.