### PR TITLE
API: enable users to use an accessor to traverse Scene

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -2131,7 +2131,7 @@ public:
     /**
      * @brief Set the access function for traversing the Picture scene tree nodes.
      *
-     * @param[in] picture The picture node to traverse the internal scene-tree.
+     * @param[in] paint The paint node to traverse the internal scene-tree.
      * @param[in] func The callback function calling for every paint nodes of the Picture.
      * @param[in] data Data passed to the @p func as its argument.
      *
@@ -2139,7 +2139,7 @@ public:
      *
      * @note Experimental API
      */
-    Result set(Picture* picture, std::function<bool(const Paint* paint, void* data)> func, void* data) noexcept;
+    Result set(Paint* paint, std::function<bool(const Paint* paint, void* data)> func, void* data) noexcept;
 
     /**
      * @brief Generate a unique ID (hash key) from a given name.

--- a/src/renderer/tvgAccessor.cpp
+++ b/src/renderer/tvgAccessor.cpp
@@ -50,27 +50,27 @@ static bool accessChildren(Iterator* it, function<bool(const Paint* paint, void*
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Result Accessor::set(Picture* picture, function<bool(const Paint* paint, void* data)> func, void* data) noexcept
+Result Accessor::set(Paint* paint, function<bool(const Paint* paint, void* data)> func, void* data) noexcept
 {
-    if (!picture || !func) return Result::InvalidArguments;
+    if (!paint || !func) return Result::InvalidArguments;
 
     //Use the Preorder Tree-Search
 
-    picture->ref();
+    paint->ref();
 
     //Root
-    if (!func(picture, data)) {
-        picture->unref();
+    if (!func(paint, data)) {
+        paint->unref();
         return Result::Success;
     }
 
     //Children
-    if (auto it = IteratorAccessor::iterator(picture)) {
+    if (auto it = IteratorAccessor::iterator(paint)) {
         accessChildren(it, func, data);
         delete(it);
     }
 
-    picture->unref(false);
+    paint->unref(false);
 
     return Result::Success;
 }


### PR DESCRIPTION
remove the restriction of targeting only Picture.
now, any kind of paints can be adaptable here.