### PR TITLE
lottie: Fixed a regression in masking logic

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1224,6 +1224,13 @@ void LottieBuilder::updateMaskings(LottieLayer* layer, float frameNo)
 {
     if (layer->masks.count == 0) return;
 
+    //Introduce an intermediate scene for embracing the matte + masking
+    if (layer->matteTarget) {
+        auto scene = Scene::gen();
+        scene->push(layer->scene);
+        layer->scene = scene;
+    }
+
     Shape* pShape = nullptr;
     MaskMethod pMethod;
     uint8_t pOpacity;
@@ -1276,13 +1283,6 @@ void LottieBuilder::updateMaskings(LottieLayer* layer, float frameNo)
 
         pOpacity = opacity;
         pMethod = method;
-    }
-
-    //Introduce an intermediate scene for embracing the matte + masking
-    if (layer->matteTarget) {
-        auto scene = Scene::gen();
-        scene->push(layer->scene);
-        layer->scene = scene;
     }
 }
 


### PR DESCRIPTION
The scene tree should be arranged prior to appending the masking. This was caused by 838785d75a79f0dbdb12273b4406b3f650855bbf