### PR TITLE
lottie: fix viewport clipping issue when resize

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -260,9 +260,8 @@ bool LottieLoader::resize(Paint* paint, float w, float h)
     paint->transform(m);
 
     //apply the scale to the base clipper
-    const Paint* clipper;
-    paint->mask(&clipper);
-    if (clipper) const_cast<Paint*>(clipper)->transform(m);
+    auto clipper = PAINT(paint)->clipper;
+    if (clipper) clipper->transform(m);
 
     return true;
 }


### PR DESCRIPTION
After resizing animation, base clipper for viewport(of root scene) didn't change. This causes issue that animation always clipped by initial psize.

This also brings v1 regression issue after `Result Picture::size(float w, float h)` function called:
Issue: #3039 

### Example:
_psize is 500 by 500, and resized to 700 by 700_



**[v1.0-pre]**

Even if resized to bigger, animations shows in initial size(500 x 500)

![CleanShot 2024-12-27 at 23 22 20@2x](https://github.com/user-attachments/assets/f87a2cb3-a545-497b-a91f-b84728e62a95)

**[v1.0-pre + this patch]**

![CleanShot 2024-12-27 at 23 24 47@2x](https://github.com/user-attachments/assets/8e247620-cb6d-4a3f-b5d8-ba35a1014806)