### PR TITLE
sw_engine: fix clipping

### DIFF
--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -172,8 +172,9 @@ struct SwShapeTask : SwTask
         //Clip Path
         for (auto clip = clips.begin(); clip < clips.end(); ++clip) {
             auto clipper = static_cast<SwTask*>(*clip);
-            if (shape.rle && !clipper->clip(shape.rle)) goto err;                 //Clip shape rle
-            if (shape.strokeRle && !clipper->clip(shape.strokeRle)) goto err;     //Clip stroke rle
+            auto clipShapeRle = shape.rle ? clipper->clip(shape.rle) : true;
+            auto clipStrokeRle = shape.strokeRle ? clipper->clip(shape.strokeRle) : true;
+            if (!clipShapeRle && !clipStrokeRle) goto err;
         }
 
         bbox = renderRegion; //sync


### PR DESCRIPTION
A shape with both fill and stroke, where clipping left only a fragment of one (either fill or stroke), was not rendered at all. Now fixed.

sample (modified Clipping.cpp):
```
            auto star1 = tvg::Shape::gen();
            compose(star1); 
            star1->fill(255, 255, 0);
            star1->strokeFill(255 ,0, 0);
            star1->strokeWidth(10);

            auto clip1 = tvg::Shape::gen();
            clip1->appendCircle(200, 230, 110, 110);

            auto scene1 = tvg::Scene::gen();
            scene1->push(star1);
            scene1->clip(clip1);

            auto clip2 = tvg::Shape::gen();
            clip2->appendCircle(200, 230, 80, 50);

            auto scene2 = tvg::Scene::gen();
            scene2->push(scene1);
            scene2->clip((clip2));

            canvas->push(scene2);
```
