### PR TITLE
gl_engine: fix fbo and texture leak

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTarget.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTarget.cpp
@@ -22,6 +22,8 @@
 
 #include "tvgGlRenderTarget.h"
 
+GlRenderTarget::GlRenderTarget(uint32_t width, uint32_t height): mWidth(width), mHeight(height) {}
+
 GlRenderTarget::~GlRenderTarget()
 {
     if (mFbo == 0) return;
@@ -122,9 +124,7 @@ GlRenderTarget* GlRenderTargetPool::getRenderTarget(const RenderRegion& vp, GLui
         }
     }
 
-    auto rt = new GlRenderTarget;
-    rt->mWidth = width;
-    rt->mHeight = height;
+    auto rt = new GlRenderTarget(width, height);
     rt->init(resolveId);
     rt->setViewport(vp);
     mPool.push(rt);

--- a/src/renderer/gl_engine/tvgGlRenderTarget.h
+++ b/src/renderer/gl_engine/tvgGlRenderTarget.h
@@ -28,6 +28,8 @@
 class GlRenderTarget
 {
 public:
+    GlRenderTarget() = default;
+    GlRenderTarget(uint32_t width, uint32_t height);
     ~GlRenderTarget();
 
     void init(GLint resolveId);
@@ -42,10 +44,10 @@ public:
     void setViewport(const RenderRegion& vp) { mViewport = vp; }
     const RenderRegion& getViewport() const { return mViewport; }
 
-    uint32_t mWidth;
-    uint32_t mHeight;
 
 private:
+    uint32_t mWidth = 0;
+    uint32_t mHeight = 0;
     RenderRegion mViewport{};
     GLuint mFbo = 0;
     GLuint mColorBuffer = 0;

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -814,8 +814,7 @@ bool GlRenderer::target(void* context, int32_t id, uint32_t w, uint32_t h)
     mContext = context;
     mTargetFboId = static_cast<GLint>(id);
 
-    mRootTarget.mWidth = surface.w;
-    mRootTarget.mHeight = surface.h;
+    mRootTarget = GlRenderTarget(surface.w, surface.h);
     mRootTarget.setViewport({0, 0, static_cast<int32_t>(surface.w), static_cast<int32_t>(surface.h)});
     mRootTarget.init(mTargetFboId);
 


### PR DESCRIPTION
There is a potential memory leaks when GlCanvas change target to a new framebuffer all change size after https://github.com/thorvg/thorvg/commit/ccf5a8158fc7d02679a3dd0d3b6c6ed718385386

Because GlRenderTarget contains framebuffer and render target objects, these GPU resources need to be released before reusing the structure and calling init with the new size.