### PR TITLE
svg_loader: fix transformation order

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -191,7 +191,7 @@ static bool _appendClipChild(SvgLoaderData& loaderData, SvgNode* node, Shape* sh
         if (node->node.use.x != 0.0f || node->node.use.y != 0.0f) {
             finalTransform *= {1, 0, node->node.use.x, 0, 1, node->node.use.y, 0, 0, 1};
         }
-        if (child->transform) finalTransform = *child->transform * finalTransform;
+        if (child->transform) finalTransform *= *child->transform;
 
         return _appendClipShape(loaderData, child, shape, vBox, svgPath, identity((const Matrix*)(&finalTransform)) ? nullptr : &finalTransform);
     }


### PR DESCRIPTION
If a clip was defined by a use node pointing
to a basic shape subject to transformation, and
the use node itself was translated, the order
of applying these transformations was incorrect.


sample:
```
<svg id="svg1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">

  <defs>
    <circle id="m1" cx="30" cy="50" r="30" transform="matrix(1 0.44 1 1 0 10)"/>
  </defs>
  
<clipPath id="clip">
    <use href="#m1" x="10" y="12"/>
</clipPath>

<rect x="0" y="0" width="100" height="100"  fill="red" clip-path="url(#clip)"
      fill-opacity="0.5"/>

<use href="#m1" x="10" y="12" fill="blue" opacity="0.4"/>

  <rect x="47" y="52" width="20" height="20"  fill="red"
      fill-opacity="0.5"/>
</svg>
```

before:
<img width="322" alt="Zrzut ekranu 2025-01-1 o 18 39 53" src="https://github.com/user-attachments/assets/0c8996fb-4a4d-48af-9180-d03aa18e84d1" />

after:
<img width="312" alt="Zrzut ekranu 2025-01-1 o 18 39 19" src="https://github.com/user-attachments/assets/e4ccd393-d944-4e1e-ac89-324a8a83606f" />