### PR TITLE
lottie: enforce fill clipper over stroke clipper

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1254,6 +1254,7 @@ void LottieBuilder::updateMasks(LottieLayer* layer, float frameNo)
             //Cheaper. Replace the masking with a clipper
             if (layer->masks.count == 1 && compMethod == MaskMethod::Alpha) {
                 layer->scene->opacity(MULTIPLY(layer->scene->opacity(), opacity));
+                pShape->strokeWidth(0.0f); //enforce fill clipper over stroke clipper
                 layer->scene->clip(pShape);
                 fastTrack = true;
             } else {


### PR DESCRIPTION
After the stroke clipper is introduced, using clipping
requires ensuring that clipping is based on fill rather
than on stroke. Fixed now.

regression by: 324bff30d15b3be66144a681a5ffa813b7592143