### PR TITLE
webp: --compiler warning

### DIFF
--- a/src/loaders/webp/dsp/dec.cpp
+++ b/src/loaders/webp/dsp/dec.cpp
@@ -242,6 +242,7 @@ VP8PredFunc VP8PredLuma16[NUM_B_DC_MODES];
 #define AVG2(a, b) (((a) + (b) + 1) >> 1)
 
 static void VE4(uint8_t* dst) {    // vertical
+  if (!dst) return;
   const uint8_t* top = dst - BPS;
   const uint8_t vals[4] = {
     (uint8_t)AVG3(top[-1], top[0], top[1]),


### PR DESCRIPTION
warning: writing 4 bytes into a region of size 0 [-Wstringop-overflow=]