### PR TITLE
sw_engine: Fix buffer overflow in texture mapping rasterizer

### DIFF
--- a/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -85,9 +85,8 @@ static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage
     float _xa = xa, _xb = xb, _ua = ua, _va = va;
     auto sbuf = image->buf32;
     auto dbuf = surface->buf32;
-    int32_t sw = static_cast<int32_t>(image->stride);
-    int32_t sh = image->h;
-    int32_t dw = surface->stride;
+    int32_t sw = static_cast<int32_t>(image->w);
+    int32_t sh = static_cast<int32_t>(image->h);
     int32_t x1, x2, x, y, ar, ab, iru, irv, px, ay;
     int32_t vv = 0, uu = 0;
     int32_t minx = INT32_MAX, maxx = 0;
@@ -144,7 +143,7 @@ static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage
             u = _ua + dx * _dudx;
             v = _va + dx * _dvdx;
 
-            buf = dbuf + ((y * dw) + x1);
+            buf = dbuf + ((y * surface->stride) + x1);
 
             x = x1;
 
@@ -152,32 +151,32 @@ static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage
                 //Draw horizontal line
                 while (x++ < x2) {
                     uu = (int) u;
-                    if (uu >= sw) continue;
                     vv = (int) v;
-                    if (vv >= sh) continue;
+
+                    if ((uint32_t) uu >= image->w || (uint32_t) vv >= image->h) continue;
 
                     ar = (int)(255 * (1 - modff(u, &iptr)));
                     ab = (int)(255 * (1 - modff(v, &iptr)));
                     iru = uu + 1;
                     irv = vv + 1;
 
-                    px = *(sbuf + (vv * sw) + uu);
+                    px = *(sbuf + (vv * image->stride) + uu);
 
                     /* horizontal interpolate */
                     if (iru < sw) {
                         /* right pixel */
-                        int px2 = *(sbuf + (vv * sw) + iru);
+                        int px2 = *(sbuf + (vv * image->stride) + iru);
                         px = INTERPOLATE(px, px2, ar);
                     }
                     /* vertical interpolate */
                     if (irv < sh) {
                         /* bottom pixel */
-                        int px2 = *(sbuf + (irv * sw) + uu);
+                        int px2 = *(sbuf + (irv * image->stride) + uu);
 
                         /* horizontal interpolate */
                         if (iru < sw) {
                             /* bottom right pixel */
-                            int px3 = *(sbuf + (irv * sw) + iru);
+                            int px3 = *(sbuf + (irv * image->stride) + iru);
                             px2 = INTERPOLATE(px2, px3, ar);
                         }
                         px = INTERPOLATE(px, px2, ab);
@@ -188,39 +187,37 @@ static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage
                     //Step UV horizontally
                     u += _dudx;
                     v += _dvdx;
-                    //range over?
-                    if ((uint32_t)(int32_t)v >= image->h) break;
                 }
             } else {
                 //Draw horizontal line
                 while (x++ < x2) {
                     uu = (int) u;
-                    if (uu >= sw) continue;
                     vv = (int) v;
-                    if (vv >= sh) continue;
+
+                    if ((uint32_t) uu >= image->w || (uint32_t) vv >= image->h) continue;
 
                     ar = (int)(255 * (1 - modff(u, &iptr)));
                     ab = (int)(255 * (1 - modff(v, &iptr)));
                     iru = uu + 1;
                     irv = vv + 1;
 
-                    px = *(sbuf + (vv * sw) + uu);
+                    px = *(sbuf + (vv * image->stride) + uu);
 
                     /* horizontal interpolate */
                     if (iru < sw) {
                         /* right pixel */
-                        int px2 = *(sbuf + (vv * sw) + iru);
+                        int px2 = *(sbuf + (vv * image->stride) + iru);
                         px = INTERPOLATE(px, px2, ar);
                     }
                     /* vertical interpolate */
                     if (irv < sh) {
                         /* bottom pixel */
-                        int px2 = *(sbuf + (irv * sw) + uu);
+                        int px2 = *(sbuf + (irv * image->stride) + uu);
 
                         /* horizontal interpolate */
                         if (iru < sw) {
                             /* bottom right pixel */
-                            int px3 = *(sbuf + (irv * sw) + iru);
+                            int px3 = *(sbuf + (irv * image->stride) + iru);
                             px2 = INTERPOLATE(px2, px3, ar);
                         }
                         px = INTERPOLATE(px, px2, ab);
@@ -232,8 +229,6 @@ static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage
                     //Step UV horizontally
                     u += _dudx;
                     v += _dvdx;
-                    //range over?
-                    if ((uint32_t)(int32_t)v >= image->h) break;
                 }
             }
         }
@@ -262,9 +257,8 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
     float _xa = xa, _xb = xb, _ua = ua, _va = va;
     auto sbuf = image->buf32;
     auto dbuf = surface->buf32;
-    int32_t sw = static_cast<int32_t>(image->stride);
-    int32_t sh = image->h;
-    int32_t dw = surface->stride;
+    int32_t sw = static_cast<int32_t>(image->w);
+    int32_t sh = static_cast<int32_t>(image->h);
     int32_t x1, x2, x, y, ar, ab, iru, irv, px, ay;
     int32_t vv = 0, uu = 0;
     int32_t minx = INT32_MAX, maxx = 0;
@@ -326,7 +320,7 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
             u = _ua + dx * _dudx;
             v = _va + dx * _dvdx;
 
-            buf = dbuf + ((y * dw) + x1);
+            buf = dbuf + ((y * surface->stride) + x1);
 
             x = x1;
 
@@ -336,32 +330,32 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
                 //Draw horizontal line
                 while (x++ < x2) {
                     uu = (int) u;
-                    if (uu >= sw) continue;
                     vv = (int) v;
-                    if (vv >= sh) continue;
+
+                    if ((uint32_t) uu >= image->w || (uint32_t) vv >= image->h) continue;
 
                     ar = (int)(255.0f * (1.0f - modff(u, &iptr)));
                     ab = (int)(255.0f * (1.0f - modff(v, &iptr)));
                     iru = uu + 1;
                     irv = vv + 1;
 
-                    px = *(sbuf + (vv * sw) + uu);
+                    px = *(sbuf + (vv * image->stride) + uu);
 
                     /* horizontal interpolate */
                     if (iru < sw) {
                         /* right pixel */
-                        int px2 = *(sbuf + (vv * sw) + iru);
+                        int px2 = *(sbuf + (vv * image->stride) + iru);
                         px = INTERPOLATE(px, px2, ar);
                     }
                     /* vertical interpolate */
                     if (irv < sh) {
                         /* bottom pixel */
-                        int px2 = *(sbuf + (irv * sw) + uu);
+                        int px2 = *(sbuf + (irv * image->stride) + uu);
 
                         /* horizontal interpolate */
                         if (iru < sw) {
                             /* bottom right pixel */
-                            int px3 = *(sbuf + (irv * sw) + iru);
+                            int px3 = *(sbuf + (irv * image->stride) + iru);
                             px2 = INTERPOLATE(px2, px3, ar);
                         }
                         px = INTERPOLATE(px, px2, ab);
@@ -379,8 +373,6 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
                     //Step UV horizontally
                     u += _dudx;
                     v += _dvdx;
-                    //range over?
-                    if ((uint32_t)(int32_t)v >= image->h) break;
                 }
             } else {
                 //Draw horizontal line
@@ -388,30 +380,30 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
                     uu = (int) u;
                     vv = (int) v;
 
+                    if ((uint32_t) uu >= image->w || (uint32_t) vv >= image->h) continue;
+
                     ar = (int)(255.0f * (1.0f - modff(u, &iptr)));
                     ab = (int)(255.0f * (1.0f - modff(v, &iptr)));
                     iru = uu + 1;
                     irv = vv + 1;
-
-                    if (vv >= sh) continue;
 
                     px = *(sbuf + (vv * sw) + uu);
 
                     /* horizontal interpolate */
                     if (iru < sw) {
                         /* right pixel */
-                        int px2 = *(sbuf + (vv * sw) + iru);
+                        int px2 = *(sbuf + (vv * image->stride) + iru);
                         px = INTERPOLATE(px, px2, ar);
                     }
                     /* vertical interpolate */
                     if (irv < sh) {
                         /* bottom pixel */
-                        int px2 = *(sbuf + (irv * sw) + uu);
+                        int px2 = *(sbuf + (irv * image->stride) + uu);
 
                         /* horizontal interpolate */
                         if (iru < sw) {
                             /* bottom right pixel */
-                            int px3 = *(sbuf + (irv * sw) + iru);
+                            int px3 = *(sbuf + (irv * image->stride) + iru);
                             px2 = INTERPOLATE(px2, px3, ar);
                         }
                         px = INTERPOLATE(px, px2, ab);
@@ -429,8 +421,6 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
                     //Step UV horizontally
                     u += _dudx;
                     v += _dvdx;
-                    //range over?
-                    if ((uint32_t)(int32_t)v >= image->h) break;
                 }
             }
         }


### PR DESCRIPTION
Fix heap buffer overflow in texture mapping rasterizer by adding proper bounds checking for texture coordinates. This prevents accessing memory outside of the allocated image buffer during texture sampling and interpolation.

---

**Situation:**
At the ` _rasterPolygonImageSegment`, `vv` value gets `-1` then crahses.


![image](https://github.com/user-attachments/assets/67924be3-4592-475e-aa72-b21360f94e1d)



**Sample file:** 
[Lottie Runtime Crash Issue 3102.json](https://github.com/user-attachments/files/18373071/Lottie.Runtime.Crash.Issue.3102.json)

**Crash Point:**
Drawing `image_0`

![image](https://github.com/user-attachments/assets/e2f3e351-603c-41ad-86f6-b87d12b109f8)


**Fixes**

Added a defense logic for preventing the values get negative value, but this need to be reviewed properly.


Issues: #3102 