### PR TITLE
lottie: fix text stroke's 'of' property

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1092,10 +1092,11 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                 shape->translate(cursor.x - textGroupMatrix.e13, cursor.y - textGroupMatrix.e23);
                 shape->opacity(255);
 
-                if (doc.stroke.render) {
+                if (doc.stroke.width > 0.0f) {
                     shape->strokeJoin(StrokeJoin::Round);
                     shape->strokeWidth(doc.stroke.width / scale);
                     shape->strokeFill(doc.stroke.color.rgb[0], doc.stroke.color.rgb[1], doc.stroke.color.rgb[2]);
+                    shape->order(doc.stroke.below);
                 }
 
                 auto needGroup = false;
@@ -1137,8 +1138,8 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                         fillOpacity = (uint8_t)(fillOpacity - f * (fillOpacity - (*s)->style.fillOpacity(frameNo)));
                         shape->fill(color.rgb[0], color.rgb[1], color.rgb[2], fillOpacity);
 
-                        if (doc.stroke.render) {
-                            shape->strokeWidth(f * (*s)->style.strokeWidth(frameNo) / scale);
+                        shape->strokeWidth(f * (*s)->style.strokeWidth(frameNo) / scale);
+                        if (shape->strokeWidth() > 0.0f) {
                             auto rangeColor = (*s)->style.strokeColor(frameNo); //TODO: use flag to check whether it was really set
                             if (tvg::equal(f, 1.0f)) strokeColor = rangeColor;
                             else {
@@ -1148,6 +1149,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                             }
                             strokeOpacity = (uint8_t)(strokeOpacity - f * (strokeOpacity - (*s)->style.strokeOpacity(frameNo)));
                             shape->strokeFill(strokeColor.rgb[0], strokeColor.rgb[1], strokeColor.rgb[2], strokeOpacity);
+                            shape->order(doc.stroke.below);
                         }
 
                         cursor.x += f * (*s)->style.letterSpacing(frameNo);

--- a/src/loaders/lottie/tvgLottieData.h
+++ b/src/loaders/lottie/tvgLottieData.h
@@ -62,7 +62,7 @@ struct TextDocument
     struct {
         RGB24 color;
         float width;
-        bool render = false;
+        bool below = false;
     } stroke;
     char* name = nullptr;
     float size;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -136,7 +136,7 @@ bool LottieParser::getValue(TextDocument& doc)
         else if (KEY_AS("sz")) getValue(doc.bbox.size);
         else if (KEY_AS("sc")) getValue(doc.stroke.color);
         else if (KEY_AS("sw")) doc.stroke.width = getFloat();
-        else if (KEY_AS("of")) doc.stroke.render = getBool();
+        else if (KEY_AS("of")) doc.stroke.below = !getBool();
         else skip();
     }
     return false;


### PR DESCRIPTION
The text stroke's 'of' property determines whether the stroke appears above (true) or below (false)
the fill.
Previously, it was incorrectly used to decide whether the stroke would render.

@Issue: https://github.com/thorvg/thorvg/issues/3126

before:
<img width="500" alt="Zrzut ekranu 2025-01-14 o 12 39 28" src="https://github.com/user-attachments/assets/202bbdb2-5bfd-44e0-9a9d-e1d4610e6ed3" />

after:
<img width="500" alt="Zrzut ekranu 2025-01-14 o 12 31 29" src="https://github.com/user-attachments/assets/698b7bf8-da5d-4551-9ef9-e06d895255e1" />

samples:
[fill_over_stroke_orange.json](https://github.com/user-attachments/files/18409831/fill_over_stroke_orange.json)
[stroke_over_fill_blue.json](https://github.com/user-attachments/files/18409833/stroke_over_fill_blue.json)
