### PR TITLE
sw_engine: fix bug introduced in 07e73a9

### DIFF
--- a/src/renderer/sw_engine/tvgSwStroke.cpp
+++ b/src/renderer/sw_engine/tvgSwStroke.cpp
@@ -844,6 +844,7 @@ bool strokeParseOutline(SwStroke* stroke, const SwOutline& outline)
     ARRAY_FOREACH(p, outline.cntrs) {
         auto last = *p;           //index of last point in contour
         auto limit = outline.pts.data + last;
+        ++i;
 
         //Skip empty points
         if (last <= first) {
@@ -860,7 +861,7 @@ bool strokeParseOutline(SwStroke* stroke, const SwOutline& outline)
         if (type == SW_CURVE_TYPE_CUBIC) return false;
         ++types;
 
-        auto closed =  outline.closed.data ? outline.closed.data[i]: false;
+        auto closed =  outline.closed.data ? outline.closed.data[i - 1]: false;
 
         _beginSubPath(*stroke, start, closed);
 


### PR DESCRIPTION
The value of the variable 'i' was not modified
after the refactor, resulting in a reference to
an incorrect array element.


from svg samples:
before:
<img width="400" alt="Zrzut ekranu 2025-01-17 o 02 08 52" src="https://github.com/user-attachments/assets/45eb3ce4-0cee-459f-9de5-ca13d99e952a" />

after:
<img width="400" alt="Zrzut ekranu 2025-01-17 o 02 14 21" src="https://github.com/user-attachments/assets/944d064d-86da-48f1-b2df-2ea14c5ead00" />
