### PR TITLE
chore(build): exclude webgpu_native for emscripten build

### DIFF
--- a/src/renderer/wg_engine/meson.build
+++ b/src/renderer/wg_engine/meson.build
@@ -21,7 +21,7 @@ source_file = [
 ]
 
 wgpu_dep = []
-if not get_option('bindings').contains('wasm_beta')
+if host_machine.system() != 'emscripten'
     wgpu_dep = dependency('wgpu_native')
 endif
 


### PR DESCRIPTION
- Add platform check to exclude webgpu_native in meson.build
- Avoid requiring -Dbindings=wasm_beta for Emscripten builds