### PR TITLE
lottie: handle parsing error

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1242,6 +1242,8 @@ void LottieParser::parseTint(LottieFxTint* effect)
                 ++idx;
             } else skip();
         }
+        //handle extra AE-generated "Ignored" effect value
+        if (idx > 2) skip();
     }
 }
 


### PR DESCRIPTION
Exporting from After Effects adds an extra array element to the tint effect: object with the effect value of type "Ignored". All other object types support animated values, meaning they are enclosed in parentheses. The "Ignored" object, however, expects a single number as a value. This caused a parsing error, which has been fixed by skipping all other objects after reading the expected 3.

sample:
[tint_effect_swapted.json](https://github.com/user-attachments/files/18528107/tint_effect_swapted.json)
[tint_effect.json](https://github.com/user-attachments/files/18528108/tint_effect.json)

before:
<img width="800" alt="Zrzut ekranu 2025-01-24 o 00 05 45" src="https://github.com/user-attachments/assets/31415530-e206-4afa-b67d-9cba8a3c7500" />

after:
<img width="400" alt="Zrzut ekranu 2025-01-24 o 00 06 11" src="https://github.com/user-attachments/assets/26f4f924-13b2-461e-856b-a32d88346230" />

note:
lotti-web and skottie are ignoring this extra segment. Importing a lottie file into AE ignores all effects, so no way to check the expected behavior.  