### PR TITLE
engine: introduce scene effect dispose render method

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -968,6 +968,12 @@ bool GlRenderer::render(TVG_UNUSED RenderCompositor* cmp, TVG_UNUSED const Rende
 }
 
 
+void GlRenderer::dispose(TVG_UNUSED RenderEffect* effect)
+{
+    //TODO: dispose the effect
+}
+
+
 ColorSpace GlRenderer::colorSpace()
 {
     return ColorSpace::Unknown;

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -90,6 +90,7 @@ public:
     void prepare(RenderEffect* effect, const Matrix& transform) override;
     bool region(RenderEffect* effect) override;
     bool render(RenderCompositor* cmp, const RenderEffect* effect, bool direct) override;
+    void dispose(TVG_UNUSED RenderEffect* effect) override;
 
     static GlRenderer* gen();
     static int init(TVG_UNUSED uint32_t threads);

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -691,7 +691,7 @@ bool SwRenderer::render(RenderCompositor* cmp, const RenderEffect* effect, bool 
         TVGERR("SW_ENGINE", "Not supported grayscale Gaussian Blur!");
         return false;
     }
-
+    
     switch (effect->type) {
         case SceneEffect::GaussianBlur: {
             return effectGaussianBlur(p, request(surface->channelSize, true), static_cast<const RenderEffectGaussianBlur*>(effect));
@@ -716,6 +716,13 @@ bool SwRenderer::render(RenderCompositor* cmp, const RenderEffect* effect, bool 
         }
         default: return false;
     }
+}
+
+
+void SwRenderer::dispose(RenderEffect* effect) 
+{
+    free(effect->rd);
+    effect->rd = nullptr;
 }
 
 

--- a/src/renderer/sw_engine/tvgSwRenderer.h
+++ b/src/renderer/sw_engine/tvgSwRenderer.h
@@ -65,6 +65,7 @@ public:
     void prepare(RenderEffect* effect, const Matrix& transform) override;
     bool region(RenderEffect* effect) override;
     bool render(RenderCompositor* cmp, const RenderEffect* effect, bool direct) override;
+    void dispose(RenderEffect* effect) override;
 
     static SwRenderer* gen();
     static bool init(uint32_t threads);

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -263,10 +263,7 @@ struct RenderEffect
     SceneEffect type;
     bool valid = false;
 
-    virtual ~RenderEffect()
-    {
-        free(rd);
-    }
+    virtual ~RenderEffect() {}
 };
 
 struct RenderEffectGaussianBlur : RenderEffect
@@ -409,6 +406,7 @@ public:
     virtual void prepare(RenderEffect* effect, const Matrix& transform) = 0;
     virtual bool region(RenderEffect* effect) = 0;
     virtual bool render(RenderCompositor* cmp, const RenderEffect* effect, bool direct) = 0;
+    virtual void dispose(RenderEffect* effect) = 0;
 };
 
 static inline bool MASK_REGION_MERGING(MaskMethod method)

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -299,7 +299,10 @@ struct Scene::Impl : Paint::Impl
     Result resetEffects()
     {
         if (effects) {
-            ARRAY_FOREACH(p, *effects) delete(*p);
+            ARRAY_FOREACH(p, *effects) {
+                renderer->dispose(*p);
+                delete(*p);
+            }
             delete(effects);
             effects = nullptr;
         }

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -483,6 +483,12 @@ bool WgRenderer::render(TVG_UNUSED RenderCompositor* cmp, TVG_UNUSED const Rende
 }
 
 
+void WgRenderer::dispose(TVG_UNUSED RenderEffect* effect)
+{
+    //TODO: dispose the effect
+}
+
+
 bool WgRenderer::preUpdate()
 {
     return true;

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -56,6 +56,7 @@ public:
     void prepare(TVG_UNUSED RenderEffect* effect, TVG_UNUSED const Matrix& transform) override;
     bool region(RenderEffect* effect) override;
     bool render(RenderCompositor* cmp, const RenderEffect* effect, bool direct) override;
+    void dispose(TVG_UNUSED RenderEffect* effect) override;
 
     static WgRenderer* gen();
     static bool init(uint32_t threads);


### PR DESCRIPTION
to correctly delete RenderData from effects it must be disposed in the renderer 
a new method has been added to the RenderMethod interface

https://github.com/thorvg/thorvg/issues/3054