### PR TITLE
wg_engine/sw_engine: fix color burn/dodge edge cases

### DIFF
--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -671,9 +671,9 @@ const char* COLOR_DODGE_BLEND_FRAG = COMPLEX_BLEND_HEADER R"(
         vec4 dstColor = texture(uDstTexture, vUV);
 
         FragColor = vec4(
-            1.0 - srcColor.r > 0.0 ? dstColor.r / (1.0 - srcColor.r) : dstColor.r,
-            1.0 - srcColor.g > 0.0 ? dstColor.g / (1.0 - srcColor.g) : dstColor.g,
-            1.0 - srcColor.b > 0.0 ? dstColor.b / (1.0 - srcColor.b) : dstColor.b,
+            srcColor.r < 1.0 ? dstColor.r / (1.0 - srcColor.r) : (dstColor.r > 0.0 ? 1.0 : 0.0),
+            srcColor.g < 1.0 ? dstColor.g / (1.0 - srcColor.g) : (dstColor.g > 0.0 ? 1.0 : 0.0),
+            srcColor.b < 1.0 ? dstColor.b / (1.0 - srcColor.b) : (dstColor.b > 0.0 ? 1.0 : 0.0),
             1.0
         );
     }
@@ -686,9 +686,9 @@ const char* COLOR_BURN_BLEND_FRAG = COMPLEX_BLEND_HEADER R"(
         vec4 dstColor = texture(uDstTexture, vUV);
 
         FragColor = vec4(
-            srcColor.r > 0.0 ? (1.0 - (1.0 - dstColor.r) / srcColor.r) : dstColor.r,
-            srcColor.g > 0.0 ? (1.0 - (1.0 - dstColor.g) / srcColor.g) : dstColor.g,
-            srcColor.b > 0.0 ? (1.0 - (1.0 - dstColor.b) / srcColor.b) : dstColor.b,
+            srcColor.r > 0.0 ? (1.0 - (1.0 - dstColor.r) / srcColor.r) : (dstColor.r < 1.0 ? 0.0 : 1.0),
+            srcColor.g > 0.0 ? (1.0 - (1.0 - dstColor.g) / srcColor.g) : (dstColor.g < 1.0 ? 0.0 : 1.0),
+            srcColor.b > 0.0 ? (1.0 - (1.0 - dstColor.b) / srcColor.b) : (dstColor.b < 1.0 ? 0.0 : 1.0),
             1.0
         );
     }

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -448,9 +448,9 @@ static inline uint32_t opBlendColorDodge(uint32_t s, uint32_t d, TVG_UNUSED uint
 {
     // d / (1 - s)
     s = 0xffffffff - s;
-    auto c1 = (C1(s) == 0) ? C1(d) : std::min(C1(d) * 255 / C1(s), 255);
-    auto c2 = (C2(s) == 0) ? C2(d) : std::min(C2(d) * 255 / C2(s), 255);
-    auto c3 = (C3(s) == 0) ? C3(d) : std::min(C3(d) * 255 / C3(s), 255);
+    auto c1 = C1(d) == 0 ? 0 : (C1(s) == 0 ? 255 : std::min(C1(d) * 255 / C1(s), 255));
+    auto c2 = C2(d) == 0 ? 0 : (C2(s) == 0 ? 255 : std::min(C2(d) * 255 / C2(s), 255));
+    auto c3 = C3(d) == 0 ? 0 : (C3(s) == 0 ? 255 : std::min(C3(d) * 255 / C3(s), 255));
     return JOIN(255, c1, c2, c3);
 }
 
@@ -458,9 +458,9 @@ static inline uint32_t opBlendColorBurn(uint32_t s, uint32_t d, TVG_UNUSED uint8
 {
     // 1 - (1 - d) / s
     auto id = 0xffffffff - d;
-    auto c1 = (C1(s) == 0) ? C1(d) : 255 - std::min(C1(id) * 255 / C1(s), 255);
-    auto c2 = (C2(s) == 0) ? C2(d) : 255 - std::min(C2(id) * 255 / C2(s), 255);
-    auto c3 = (C3(s) == 0) ? C3(d) : 255 - std::min(C3(id) * 255 / C3(s), 255);
+    auto c1 = C1(d) == 255 ? 255 : (C1(s) == 0 ? 0 : 255 - std::min(C1(id) * 255 / C1(s), 255));
+    auto c2 = C2(d) == 255 ? 255 : (C2(s) == 0 ? 0 : 255 - std::min(C2(id) * 255 / C2(s), 255));
+    auto c3 = C3(d) == 255 ? 255 : (C3(s) == 0 ? 0 : 255 - std::min(C3(id) * 255 / C3(s), 255));
 
     return JOIN(255, c1, c2, c3);
 }

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -514,9 +514,9 @@ fn fs_main_Lighten(in: VertexOutput) -> @location(0) vec4f {
 fn fs_main_ColorDodge(in: VertexOutput) -> @location(0) vec4f {
     let d: FragData = getFragData(in);
     var Rc: vec3f;
-    Rc.r = select(d.Dc.r, d.Dc.r / (1 - d.Sc.r), d.Sc.r < 1);
-    Rc.g = select(d.Dc.g, d.Dc.g / (1 - d.Sc.g), d.Sc.g < 1);
-    Rc.b = select(d.Dc.b, d.Dc.b / (1 - d.Sc.b), d.Sc.b < 1);
+    Rc.r = select(select(0.0, 1.0, d.Dc.r > 0), d.Dc.r / (1 - d.Sc.r), d.Sc.r < 1);
+    Rc.g = select(select(0.0, 1.0, d.Dc.g > 0), d.Dc.g / (1 - d.Sc.g), d.Sc.g < 1);
+    Rc.b = select(select(0.0, 1.0, d.Dc.b > 0), d.Dc.b / (1 - d.Sc.b), d.Sc.b < 1);
     return postProcess(d, vec4f(Rc, 1.0));
 }
 
@@ -524,9 +524,9 @@ fn fs_main_ColorDodge(in: VertexOutput) -> @location(0) vec4f {
 fn fs_main_ColorBurn(in: VertexOutput) -> @location(0) vec4f {
     let d: FragData = getFragData(in);
     var Rc: vec3f;
-    Rc.r = select(d.Dc.r, 1 - (1 - d.Dc.r) / d.Sc.r, d.Sc.r > 0);
-    Rc.g = select(d.Dc.g, 1 - (1 - d.Dc.g) / d.Sc.g, d.Sc.g > 0);
-    Rc.b = select(d.Dc.b, 1 - (1 - d.Dc.b) / d.Sc.b, d.Sc.b > 0);
+    Rc.r = select(select(1.0, 0.0, d.Dc.r < 1), 1 - (1 - d.Dc.r) / d.Sc.r, d.Sc.r > 0);
+    Rc.g = select(select(1.0, 0.0, d.Dc.g < 1), 1 - (1 - d.Dc.g) / d.Sc.g, d.Sc.g > 0);
+    Rc.b = select(select(1.0, 0.0, d.Dc.b < 1), 1 - (1 - d.Dc.b) / d.Sc.b, d.Sc.b > 0);
     return postProcess(d, vec4f(Rc, 1.0));
 }
 


### PR DESCRIPTION
samples:
[blurColorBurn.json](https://github.com/user-attachments/files/18572504/blurColorBurn.json)
[blurColorDodge.json](https://github.com/user-attachments/files/18572505/blurColorDodge.json)

before:
<img width="600" alt="Zrzut ekranu 2025-01-28 o 12 22 09" src="https://github.com/user-attachments/assets/df31a367-490d-41a1-b822-89a75b683121" />

after:
<img width="600" alt="Zrzut ekranu 2025-01-28 o 12 00 41" src="https://github.com/user-attachments/assets/9eda6e0b-d274-4d9d-9c77-3939d714e3de" />
<img width="600" alt="Zrzut ekranu 2025-01-28 o 12 06 50" src="https://github.com/user-attachments/assets/bba12407-a267-40ae-a5f7-f95d4e9e62eb" />


AE:
<img width="400" alt="Zrzut ekranu 2025-01-28 o 12 20 06" src="https://github.com/user-attachments/assets/95e6a69d-ad8f-40f0-bd87-f5db02c7c80a" />
<img width="400" alt="Zrzut ekranu 2025-01-28 o 12 20 21" src="https://github.com/user-attachments/assets/17f7495f-7b05-480f-b063-4c3220d0382e" />

note: skottie results are as from AE, lottie-web are a bit different