### PR TITLE
lottie: clean up code for maintenance

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -111,7 +111,7 @@ static jerry_value_t _value(float frameNo, LottieProperty* property)
     switch (property->type) {
         case LottieProperty::Type::Point: {
             auto value = jerry_object();
-            auto pos = (*static_cast<LottiePoint*>(property))(frameNo);
+            auto pos = (*static_cast<LottieScalar*>(property))(frameNo);
             auto val1 = jerry_number(pos.x);
             auto val2 = jerry_number(pos.y);
             jerry_object_set_index(value, 0, val1);
@@ -133,7 +133,7 @@ static jerry_value_t _value(float frameNo, LottieProperty* property)
         }
         case LottieProperty::Type::Position: {
             auto value = jerry_object();
-            auto pos = (*static_cast<LottiePosition*>(property))(frameNo);
+            auto pos = (*static_cast<LottieVector*>(property))(frameNo);
             auto val1 = jerry_number(pos.x);
             auto val2 = jerry_number(pos.y);
             jerry_object_set_index(value, 0, val1);
@@ -764,13 +764,13 @@ static jerry_value_t _velocityAtTime(const jerry_call_info_t* info, const jerry_
     //compute the velocity
     switch (exp->property->type) {
         case LottieProperty::Type::Point: {
-            auto prv = (*static_cast<LottiePoint*>(exp->property))(pframe);
-            auto cur = (*static_cast<LottiePoint*>(exp->property))(cframe);
+            auto prv = (*static_cast<LottieScalar*>(exp->property))(pframe);
+            auto cur = (*static_cast<LottieScalar*>(exp->property))(cframe);
             return _velocity(prv.x, cur.x, prv.y, cur.y, elapsed);
         }
         case LottieProperty::Type::Position: {
-            auto prv = (*static_cast<LottiePosition*>(exp->property))(pframe);
-            auto cur = (*static_cast<LottiePosition*>(exp->property))(cframe);
+            auto prv = (*static_cast<LottieVector*>(exp->property))(pframe);
+            auto cur = (*static_cast<LottieVector*>(exp->property))(cframe);
             return _velocity(prv.x, cur.x, prv.y, cur.y, elapsed);
         }
         case LottieProperty::Type::Float: {
@@ -800,13 +800,13 @@ static jerry_value_t _speedAtTime(const jerry_call_info_t* info, const jerry_val
     //compute the velocity
     switch (exp->property->type) {
         case LottieProperty::Type::Point: {
-            prv = (*static_cast<LottiePoint*>(exp->property))(pframe);
-            cur = (*static_cast<LottiePoint*>(exp->property))(cframe);
+            prv = (*static_cast<LottieScalar*>(exp->property))(pframe);
+            cur = (*static_cast<LottieScalar*>(exp->property))(cframe);
             break;
         }
         case LottieProperty::Type::Position: {
-            prv = (*static_cast<LottiePosition*>(exp->property))(pframe);
-            cur = (*static_cast<LottiePosition*>(exp->property))(cframe);
+            prv = (*static_cast<LottieVector*>(exp->property))(pframe);
+            cur = (*static_cast<LottieVector*>(exp->property))(cframe);
             break;
         }
         default: {

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -60,12 +60,12 @@ void LottieSlot::assign(LottieObject* target, bool byDefault)
         //backup the original properties before overwriting
         switch (type) {
             case LottieProperty::Type::Position: {
-                if (copy) pair->prop = new LottiePosition(static_cast<LottieTransform*>(pair->obj)->position);
+                if (copy) pair->prop = new LottieVector(static_cast<LottieTransform*>(pair->obj)->position);
                 pair->obj->override(&static_cast<LottieTransform*>(target)->position, shallow, byDefault);
                 break;
             }
             case LottieProperty::Type::Point: {
-                if (copy) pair->prop = new LottiePoint(static_cast<LottieTransform*>(pair->obj)->scale);
+                if (copy) pair->prop = new LottieScalar(static_cast<LottieTransform*>(pair->obj)->scale);
                 pair->obj->override(&static_cast<LottieTransform*>(target)->scale, shallow, byDefault);
                 break;
             }

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -261,8 +261,8 @@ struct LottieTextRange
     struct {
         LottieColor fillColor = RGB24{255, 255, 255};
         LottieColor strokeColor = RGB24{255, 255, 255};
-        LottiePosition position = Point{0, 0};
-        LottiePoint scale = Point{100, 100};
+        LottieVector position = Point{0, 0};
+        LottieScalar scale = Point{100, 100};
         LottieFloat letterSpacing = 0.0f;
         LottieFloat lineSpacing = 0.0f;
         LottieFloat strokeWidth = 0.0f;
@@ -328,7 +328,7 @@ struct LottieText : LottieObject, LottieRenderPooler<tvg::Shape>
     {
         enum Group : uint8_t { Chars = 1, Word = 2, Line = 3, All = 4 };
         Group grouping = Chars;
-        LottiePoint anchor{};
+        LottieScalar anchor{};
     } alignOption;
 
     LottieText()
@@ -452,8 +452,8 @@ struct LottieRect : LottieShape
         return nullptr;
     }
 
-    LottiePosition position = Point{0.0f, 0.0f};
-    LottiePoint size = Point{0.0f, 0.0f};
+    LottieVector position = Point{0.0f, 0.0f};
+    LottieScalar size = Point{0.0f, 0.0f};
     LottieFloat radius = 0.0f;       //rounded corner radius
 };
 
@@ -476,7 +476,7 @@ struct LottiePolyStar : LottieShape
         return nullptr;
     }
 
-    LottiePosition position = Point{0.0f, 0.0f};
+    LottieVector position = Point{0.0f, 0.0f};
     LottieFloat innerRadius = 0.0f;
     LottieFloat outerRadius = 0.0f;
     LottieFloat innerRoundness = 0.0f;
@@ -498,8 +498,8 @@ struct LottieEllipse : LottieShape
         return nullptr;
     }
 
-    LottiePosition position = Point{0.0f, 0.0f};
-    LottiePoint size = Point{0.0f, 0.0f};
+    LottieVector position = Point{0.0f, 0.0f};
+    LottieScalar size = Point{0.0f, 0.0f};
 };
 
 
@@ -555,7 +555,7 @@ struct LottieTransform : LottieObject
         switch (prop->type) {
             case LottieProperty::Type::Position: {
                 if (byDefault) position.release();
-                position.copy(*static_cast<LottiePosition*>(prop), shallow);
+                position.copy(*static_cast<LottieVector*>(prop), shallow);
                 break;
             }
             case LottieProperty::Type::Float: {
@@ -565,7 +565,7 @@ struct LottieTransform : LottieObject
             }
             case LottieProperty::Type::Point: {
                 if (byDefault) scale.release();
-                scale.copy(*static_cast<LottiePoint*>(prop), shallow);
+                scale.copy(*static_cast<LottieScalar*>(prop), shallow);
                 break;
             }
             case LottieProperty::Type::Opacity: {
@@ -577,10 +577,10 @@ struct LottieTransform : LottieObject
         }
     }
 
-    LottiePosition position = Point{0.0f, 0.0f};
+    LottieVector position = Point{0.0f, 0.0f};
     LottieFloat rotation = 0.0f;           //z rotation
-    LottiePoint scale = Point{100.0f, 100.0f};
-    LottiePoint anchor = Point{0.0f, 0.0f};
+    LottieScalar scale = Point{100.0f, 100.0f};
+    LottieScalar anchor = Point{0.0f, 0.0f};
     LottieOpacity opacity = 255;
     LottieFloat skewAngle = 0.0f;
     LottieFloat skewAxis = 0.0f;
@@ -692,8 +692,8 @@ struct LottieGradient : LottieObject
     uint32_t populate(ColorStop& color, size_t count);
     Fill* fill(float frameNo, LottieExpressions* exps);
 
-    LottiePoint start = Point{0.0f, 0.0f};
-    LottiePoint end = Point{0.0f, 0.0f};
+    LottieScalar start = Point{0.0f, 0.0f};
+    LottieScalar end = Point{0.0f, 0.0f};
     LottieFloat height = 0.0f;
     LottieFloat angle = 0.0f;
     LottieOpacity opacity = 255;
@@ -773,10 +773,10 @@ struct LottieRepeater : LottieObject
     LottieFloat offset = 0.0f;
 
     //Transform
-    LottiePosition position = Point{0.0f, 0.0f};
+    LottieVector position = Point{0.0f, 0.0f};
     LottieFloat rotation = 0.0f;
-    LottiePoint scale = Point{100.0f, 100.0f};
-    LottiePoint anchor = Point{0.0f, 0.0f};
+    LottieScalar scale = Point{100.0f, 100.0f};
+    LottieScalar anchor = Point{0.0f, 0.0f};
     LottieOpacity startOpacity = 255;
     LottieOpacity endOpacity = 255;
     bool inorder = true;        //true: higher,  false: lower


### PR DESCRIPTION
Point/Position is too ambuguous to classify,
Renamed them to LottieScalar and LottieVector,
and unify the duplicate logic among them.