### PR TITLE
common: more accurate clipped viewport rounding

### DIFF
--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -119,10 +119,10 @@ static Result _compFastTrack(RenderMethod* renderer, Paint* cmpTarget, const Mat
         if (v1.x > v2.x) std::swap(v1.x, v2.x);
         if (v1.y > v2.y) std::swap(v1.y, v2.y);
 
-        after.x = static_cast<int32_t>(v1.x);
-        after.y = static_cast<int32_t>(v1.y);
-        after.w = static_cast<int32_t>(ceil(v2.x - after.x));
-        after.h = static_cast<int32_t>(ceil(v2.y - after.y));
+        after.x = static_cast<int32_t>(nearbyint(v1.x));
+        after.y = static_cast<int32_t>(nearbyint(v1.y));
+        after.w = static_cast<int32_t>(nearbyint(v2.x)) - after.x;
+        after.h = static_cast<int32_t>(nearbyint(v2.y)) - after.y;
 
         if (after.w < 0) after.w = 0;
         if (after.h < 0) after.h = 0;


### PR DESCRIPTION
Replaced ceil and direct casts with nearbyint to improve viewport size calculation. This ensures consistent approach with the fastTrack case in sw_engine.

@Issue: https://github.com/thorvg/thorvg/issues/3148