### PR TITLE
lottie: add support for text follow path

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -336,6 +336,29 @@ struct LottieMarker
     }
 };
 
+
+struct LottieTextFollowPath
+{
+private:
+    RenderPath path;
+    PathCommand* cmds;
+    uint32_t cmdsCnt;
+    Point* pts;
+    Point* start;
+    float totalLen;
+    float currentLen;
+    Point split(float dLen, float lenSearched, float& angle);
+
+public:
+    LottieFloat firstMargin = 0.0f;
+    LottieMask* mask;
+    int8_t maskIdx = -1;
+
+    Point position(float lenSearched, float& angle);
+    float prepare(LottieMask* mask, float frameNo, float scale, Tween& tween, LottieExpressions* exps);
+};
+
+
 struct LottieText : LottieObject, LottieRenderPooler<tvg::Shape>
 {
     struct AlignOption
@@ -364,6 +387,7 @@ struct LottieText : LottieObject, LottieRenderPooler<tvg::Shape>
 
     LottieTextDoc doc;
     LottieFont* font;
+    LottieTextFollowPath* followPath = nullptr;
     Array<LottieTextRange*> ranges;
 
     ~LottieText()

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1178,6 +1178,20 @@ void LottieParser::parseTextRange(LottieText* text)
 }
 
 
+void LottieParser::parseTextFollowPath(LottieText* text)
+{
+    enterObject();
+    auto key = nextObjectKey();
+    if (!key) return;
+    if (!text->followPath) text->followPath = new LottieTextFollowPath;
+    do {
+        if (KEY_AS("m")) text->followPath->maskIdx = getInt();
+        else if (KEY_AS("f")) parseProperty<LottieProperty::Type::Float>(text->followPath->firstMargin);
+        else skip();
+    } while ((key = nextObjectKey()));
+}
+
+
 void LottieParser::parseText(Array<LottieObject*>& parent)
 {
     enterObject();
@@ -1188,11 +1202,7 @@ void LottieParser::parseText(Array<LottieObject*>& parent)
         if (KEY_AS("d")) parseProperty<LottieProperty::Type::TextDoc>(text->doc, text);
         else if (KEY_AS("a")) parseTextRange(text);
         else if (KEY_AS("m")) parseTextAlignmentOption(text);
-        else if (KEY_AS("p"))
-        {
-            TVGLOG("LOTTIE", "Text Follow Path (p) is not supported");
-            skip();
-        }
+        else if (KEY_AS("p")) parseTextFollowPath(text);
         else skip();
     }
     parent.push(text);

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -120,6 +120,7 @@ private:
     void parseColorStop(LottieGradient* gradient);
     void parseTextRange(LottieText* text);
     void parseTextAlignmentOption(LottieText* text);
+    void parseTextFollowPath(LottieText* text);
     void parseAssets();
     void parseFonts();
     void parseChars(Array<LottieGlyph*>& glyphs);


### PR DESCRIPTION
Added support for cases without text grouping and range selector.

@Issue: https://github.com/thorvg/thorvg/issues/2888

[tvg.json](https://github.com/user-attachments/files/18877521/tvg.json)

<img width="500" alt="TVG_follow_path" src="https://github.com/user-attachments/assets/b63611c9-5ed3-4ae3-951f-80cfbfc89350" />


[follow_path.json](https://github.com/user-attachments/files/18680823/follow_path.json)

<img width="500" alt="Feb-06-2025 01-08-39" src="https://github.com/user-attachments/assets/78d0ccc4-6b39-4cb0-a786-2888f111957c" />


