### PR TITLE
common: add missing condition while trimming

### DIFF
--- a/src/renderer/tvgTrimPath.cpp
+++ b/src/renderer/tvgTrimPath.cpp
@@ -224,8 +224,8 @@ static void _trimPath(const PathCommand* inCmds, uint32_t inCmdsCnt, const Point
             if (len + dLen > trimEnd) {
                 _trimAt(cmds, pts, moveTo, 0.0f, trimEnd - len, start, out);
                 start = true;
-                //add the whole segment
-            } else _add(cmds, pts, moveTo, start, out);
+            //add the whole segment
+            } else if (len + dLen > trimStart + EPSILON) _add(cmds, pts, moveTo, start, out);
         }
 
         len += dLen;


### PR DESCRIPTION
The idea of introducing epsilon during trimming was to eliminate the occurrence of short segments whose length would be zero when higher computational accuracy was used. By mistake, during the refactor of 8ed4c2f302aa54f15b8f2ca2a09f95c143e3c2e1, one of the conditions was lost. Fixed.

@Issue: https://github.com/thorvg/thorvg/issues/3053