### PR TITLE
trimming fill & stroke

### DIFF
--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -149,7 +149,7 @@ void contents()
     tvg_shape_set_stroke_width(scene_shape1, 10.0f);
     tvg_shape_set_stroke_cap(scene_shape1, Tvg_Stroke_Cap::TVG_STROKE_CAP_ROUND);
     tvg_shape_set_stroke_join(scene_shape1, Tvg_Stroke_Join::TVG_STROKE_JOIN_ROUND);
-    tvg_shape_set_stroke_trim(scene_shape1, 0.25f, 0.75f, true);
+    tvg_shape_set_trimpath(scene_shape1, 0.25f, 0.75f, true);
 
     //Set circles with a dashed stroke
     Tvg_Paint* scene_shape2 = tvg_paint_duplicate(scene_shape1);

--- a/examples/StrokeTrim.cpp
+++ b/examples/StrokeTrim.cpp
@@ -43,7 +43,7 @@ struct UserExample : tvgexam::Example
         shape1->strokeJoin(tvg::StrokeJoin::Round);
         shape1->strokeCap(tvg::StrokeCap::Round);
         shape1->strokeWidth(12);
-        shape1->strokeTrim(0.25f, 0.75f, false);
+        shape1->trimpath(0.25f, 0.75f, false);
 
         auto shape2 = static_cast<tvg::Shape*>(shape1->duplicate());
         shape2->translate(300, 300);
@@ -52,7 +52,7 @@ struct UserExample : tvgexam::Example
 
         float dashPatterns[] = {10, 20};
         shape2->strokeDash(dashPatterns, 2, 10);
-        shape2->strokeTrim(0.25f, 0.75f, true);
+        shape2->trimpath(0.25f, 0.75f, true);
 
         canvas->push(shape1);
         canvas->push(shape2);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1097,7 +1097,7 @@ public:
     Result strokeMiterlimit(float miterlimit) noexcept;
 
     /**
-     * @brief Sets the trim of the stroke along the defined path segment, allowing control over which part of the stroke is visible.
+     * @brief Sets the trim of the shape along the defined path segment, allowing control over which part of the shape is visible.
      *
      * If the values of the arguments @p begin and @p end exceed the 0-1 range, they are wrapped around in a manner similar to angle wrapping, effectively treating the range as circular.
      *
@@ -1108,7 +1108,7 @@ public:
      *
      * @note Experimental API
      */
-    Result strokeTrim(float begin, float end, bool simultaneous = true) noexcept;
+    Result trimpath(float begin, float end, bool simultaneous = true) noexcept;
 
     /**
      * @brief Sets the solid color for all of the figures from the path.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1413,7 +1413,7 @@ TVG_API Tvg_Result tvg_shape_get_stroke_miterlimit(const Tvg_Paint* paint, float
 
 
 /*!
-* @brief Sets the trim of the stroke along the defined path segment, allowing control over which part of the stroke is visible.
+* @brief Sets the trim of the shape along the defined path segment, allowing control over which part of the shape is visible.
 *
 * If the values of the arguments @p begin and @p end exceed the 0-1 range, they are wrapped around in a manner similar to angle wrapping, effectively treating the range as circular.
 *
@@ -1428,7 +1428,7 @@ TVG_API Tvg_Result tvg_shape_get_stroke_miterlimit(const Tvg_Paint* paint, float
 *
 * @note Experimental API
 */
-TVG_API Tvg_Result tvg_shape_set_stroke_trim(Tvg_Paint* paint, float begin, float end, bool simultaneous);
+TVG_API Tvg_Result tvg_shape_set_trimpath(Tvg_Paint* paint, float begin, float end, bool simultaneous);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -478,10 +478,10 @@ TVG_API Tvg_Result tvg_shape_get_stroke_miterlimit(const Tvg_Paint* paint, float
 }
 
 
-TVG_API Tvg_Result tvg_shape_set_stroke_trim(Tvg_Paint* paint, float begin, float end, bool simultaneous)
+TVG_API Tvg_Result tvg_shape_set_trimpath(Tvg_Paint* paint, float begin, float end, bool simultaneous)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->strokeTrim(begin, end, simultaneous);
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->trimpath(begin, end, simultaneous);
 }
 
 

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1177,14 +1177,10 @@ void LottieBuilder::updateMasks(LottieLayer* layer, float frameNo)
         //the first mask
         if (!pShape) {
             pShape = layer->pooling();
-            pShape->reset();
-            pShape->fill(255, 255, 255, opacity);
-            pShape->transform(layer->cache.matrix);
             auto compMethod = (method == MaskMethod::Subtract || method == MaskMethod::InvAlpha) ? MaskMethod::InvAlpha : MaskMethod::Alpha;
             //Cheaper. Replace the masking with a clipper
             if (layer->masks.count == 1 && compMethod == MaskMethod::Alpha) {
                 layer->scene->opacity(MULTIPLY(layer->scene->opacity(), opacity));
-                pShape->strokeWidth(0.0f); //enforce fill clipper over stroke clipper
                 layer->scene->clip(pShape);
                 fastTrack = true;
             } else {
@@ -1193,12 +1189,15 @@ void LottieBuilder::updateMasks(LottieLayer* layer, float frameNo)
         //Chain mask composition
         } else if (pMethod != method || pOpacity != opacity || (method != MaskMethod::Subtract && method != MaskMethod::Difference)) {
             auto shape = layer->pooling();
-            shape->reset();
-            shape->fill(255, 255, 255, opacity);
-            shape->transform(layer->cache.matrix);
             pShape->mask(shape, method);
             pShape = shape;
         }
+
+        pShape->reset();
+        pShape->trimpath(0.0f, 1.0f);
+        pShape->strokeWidth(0.0f);
+        pShape->fill(255, 255, 255, opacity);
+        pShape->transform(layer->cache.matrix);
 
         //Default Masking
         if (expand == 0.0f) {

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -764,7 +764,7 @@ void LottieBuilder::updateTrimpath(TVG_UNUSED LottieGroup* parent, LottieObject*
         end = (length * end) + pbegin;
     }
 
-    ctx->propagator->strokeTrim(begin, end, trimpath->type == LottieTrimpath::Type::Simultaneous);
+    ctx->propagator->trimpath(begin, end, trimpath->type == LottieTrimpath::Type::Simultaneous);
     ctx->merging = nullptr;
 }
 
@@ -1257,7 +1257,7 @@ void LottieBuilder::updateStrokeEffect(LottieLayer* layer, LottieFxStroke* effec
     }
 
     shape->transform(layer->cache.matrix);
-    shape->strokeTrim(effect->begin(frameNo) * 0.01f, effect->end(frameNo) * 0.01f);
+    shape->trimpath(effect->begin(frameNo) * 0.01f, effect->end(frameNo) * 0.01f);
     shape->strokeFill(255, 255, 255, (int)(effect->opacity(frameNo) * 255.0f));
     shape->strokeJoin(StrokeJoin::Round);
     shape->strokeCap(StrokeCap::Round);

--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -28,11 +28,18 @@
 
 bool GlGeometry::tesselate(const RenderShape& rshape, RenderUpdateFlag flag)
 {
+    const RenderPath* path = nullptr;
+    RenderPath trimmedPath;
+    if (rshape.trimpath()) {
+        if (!rshape.stroke->trim.trim(rshape.path, trimmedPath)) return true;
+        path = &trimmedPath;
+    } else path = &rshape.path;
+
     if (flag & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
         fill.clear();
 
         BWTessellator bwTess{&fill};
-        bwTess.tessellate(&rshape, matrix);
+        bwTess.tessellate(*path, matrix);
         fillRule = rshape.rule;
         bounds = bwTess.bounds();
     }
@@ -41,7 +48,7 @@ bool GlGeometry::tesselate(const RenderShape& rshape, RenderUpdateFlag flag)
         stroke.clear();
 
         Stroker stroker{&stroke, matrix};
-        stroker.stroke(&rshape);
+        stroker.stroke(&rshape, *path);
         bounds = stroker.bounds();
     }
 

--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -1544,7 +1544,7 @@ void Stroker::stroke(const RenderShape *rshape)
     Point *pts, *trimmedPts = nullptr;
     uint32_t cmdCnt = 0, ptsCnt = 0;
 
-    if (rshape->strokeTrim()) {
+    if (rshape->trimpath()) {
         RenderPath trimmedPath;
         if (!rshape->stroke->trim.trim(rshape->path, trimmedPath)) return;
 

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -43,7 +43,7 @@ class Tessellator final
 public:
     Tessellator(GlGeometryBuffer* buffer);
     ~Tessellator();
-    bool tessellate(const RenderShape *rshape, bool antialias = false);
+    bool tessellate(const RenderShape *rshape, const RenderPath& path, bool antialias = false);
     void tessellate(const Array<const RenderShape*> &shapes);
 
 private:
@@ -81,7 +81,7 @@ class Stroker
 public:
     Stroker(GlGeometryBuffer* buffer, const Matrix& matrix);
     ~Stroker() = default;
-    void stroke(const RenderShape *rshape);
+    void stroke(const RenderShape *rshape, const RenderPath& path);
     RenderRegion bounds() const;
 
 private:
@@ -148,7 +148,7 @@ class BWTessellator
 public:
     BWTessellator(GlGeometryBuffer* buffer);
     ~BWTessellator() = default;
-    void tessellate(const RenderShape *rshape, const Matrix& matrix);
+    void tessellate(const RenderPath& path, const Matrix& matrix);
     RenderRegion bounds() const;
 
 private:

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -288,7 +288,7 @@ struct SwMpool
 {
     SwOutline* outline;
     SwOutline* strokeOutline;
-    SwOutline* dashOutline; //Trimming treated as a special case of dashing
+    SwOutline* dashOutline;
     unsigned allocSize;
 };
 

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -85,7 +85,7 @@ struct SwShapeTask : SwTask
        Additionally, the stroke style should not be dashed. */
     bool antialiasing(float strokeWidth)
     {
-        return strokeWidth < 2.0f || rshape->stroke->dashCnt > 0 || rshape->stroke->strokeFirst || rshape->strokeTrim() || rshape->stroke->color.a < 255;
+        return strokeWidth < 2.0f || rshape->stroke->dashCnt > 0 || rshape->stroke->strokeFirst || rshape->trimpath() || rshape->stroke->color.a < 255;
     }
 
     float validStrokeWidth(bool clipper)

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -510,7 +510,7 @@ bool shapeGenStrokeRle(SwShape* shape, const RenderShape* rshape, const Matrix& 
     auto ret = true;
 
     //Dash style with/without trimming
-    auto trimmed = rshape->strokeTrim();
+    auto trimmed = rshape->trimpath();
     if (rshape->stroke->dashCnt > 0) {
         shapeOutline = _genDashOutline(rshape, transform, mpool, tid, trimmed);
         if (!shapeOutline) return false;

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -175,16 +175,16 @@ struct RenderShape
         if (a) *a = color.a;
     }
 
+    bool trimpath() const
+    {
+        if (!stroke) return false;
+        return stroke->trim.valid();
+    }
+
     float strokeWidth() const
     {
         if (!stroke) return 0;
         return stroke->width;
-    }
-
-    bool strokeTrim() const
-    {
-        if (!stroke) return false;
-        return stroke->trim.valid();
     }
 
     bool strokeFill(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const

--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -231,9 +231,9 @@ float Shape::strokeMiterlimit() const noexcept
 }
 
 
-Result Shape::strokeTrim(float begin, float end, bool simultaneous) noexcept
+Result Shape::trimpath(float begin, float end, bool simultaneous) noexcept
 {
-    SHAPE(this)->strokeTrim(begin, end, simultaneous);
+    SHAPE(this)->trimpath({begin, end, simultaneous});
     return Result::Success;
 }
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -209,25 +209,20 @@ struct Shape::Impl : Paint::Impl
         renderFlag |= RenderUpdateFlag::Stroke;
     }
 
-    void strokeTrim(float begin, float end, bool simultaneous)
+    void trimpath(const TrimPath& trim)
     {
-        //Even if there is no trimming effect, begin can still affect dashing starting point
-        if (fabsf(end - begin) >= 1.0f) end = begin + 1.0f;
-
         if (!rs.stroke) {
-            if (begin == 0.0f && end == 1.0f) return;
+            if (trim.begin == 0.0f && trim.end == 1.0f) return;
             rs.stroke = new RenderStroke();
         }
 
-        if (tvg::equal(rs.stroke->trim.begin, begin) && tvg::equal(rs.stroke->trim.end, end) && rs.stroke->trim.simultaneous == simultaneous) return;
+        if (tvg::equal(rs.stroke->trim.begin, trim.begin) && tvg::equal(rs.stroke->trim.end, trim.end) && rs.stroke->trim.simultaneous == trim.simultaneous) return;
 
-        rs.stroke->trim.begin = begin;
-        rs.stroke->trim.end = end;
-        rs.stroke->trim.simultaneous = simultaneous;
-        renderFlag |= RenderUpdateFlag::Stroke;
+        rs.stroke->trim = trim;
+        renderFlag |= RenderUpdateFlag::Path;
     }
 
-    bool strokeTrim(float* begin, float* end)
+    bool trimpath(float* begin, float* end)
     {
         if (rs.stroke) {
             if (begin) *begin = rs.stroke->trim.begin;

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -374,7 +374,7 @@ void WgRenderDataShape::updateMeshes(WgContext& context, const RenderShape &rsha
     // path decoded vertex buffer
     auto pbuff = pool->reqVertexBuffer(scale);
 
-    if (rshape.strokeTrim()) {
+    if (rshape.trimpath()) {
         auto trimbuff =  pool->reqVertexBuffer(scale);
         pbuff->decodePath(rshape, true, [&](const WgVertexBuffer& path_buff) {
             appendShape(context, path_buff);

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -374,22 +374,11 @@ void WgRenderDataShape::updateMeshes(WgContext& context, const RenderShape &rsha
     // path decoded vertex buffer
     auto pbuff = pool->reqVertexBuffer(scale);
 
-    if (rshape.trimpath()) {
-        auto trimbuff =  pool->reqVertexBuffer(scale);
-        pbuff->decodePath(rshape, true, [&](const WgVertexBuffer& path_buff) {
-            appendShape(context, path_buff);
-        });
-        trimbuff->decodePath(rshape, true, [&](const WgVertexBuffer& path_buff) {
-            appendShape(context, path_buff);
-            proceedStrokes(context, rshape.stroke, path_buff, pool);
-        }, true);
-        pool->retVertexBuffer(trimbuff);
-    } else {
-        pbuff->decodePath(rshape, true, [&](const WgVertexBuffer& path_buff) {
-            appendShape(context, path_buff);
-            if (rshape.stroke) proceedStrokes(context, rshape.stroke, path_buff, pool);
-        });
-    }
+    pbuff->decodePath(rshape, true, [&](const WgVertexBuffer& path_buff) {
+        appendShape(context, path_buff);
+        if (rshape.stroke) proceedStrokes(context, rshape.stroke, path_buff, pool);
+    }, rshape.trimpath());
+
     // update shapes bbox (with empty path handling)
     if ((this->meshGroupShapesBBox.meshes.count > 0 ) ||
         (this->meshGroupStrokesBBox.meshes.count > 0)) {

--- a/test/testShape.cpp
+++ b/test/testShape.cpp
@@ -196,7 +196,7 @@ TEST_CASE("Stroking", "[tvgShape]")
     REQUIRE(shape->strokeMiterlimit() == 1000.0f);
     REQUIRE(shape->strokeMiterlimit(-0.001f) == Result::InvalidArguments);
 
-    REQUIRE(shape->strokeTrim(0.3f, 0.88f, false) == Result::Success);
+    REQUIRE(shape->trimpath(0.3f, 0.88f, false) == Result::Success);
 
     //Stroke Order After Stroke Setting
     REQUIRE(shape->order(true) == Result::Success);


### PR DESCRIPTION
support added for all engines

@issue: https://github.com/thorvg/thorvg/issues/3118 

before:
<img width="500" alt="Zrzut ekranu 2025-02-12 o 21 48 28" src="https://github.com/user-attachments/assets/462b4866-c1e0-4259-92a9-584d32a7cff7" />

after:
<img width="500" alt="Zrzut ekranu 2025-02-12 o 21 46 27" src="https://github.com/user-attachments/assets/2263ddff-bb96-4754-887a-a18858f01f6f" />

sample:
```
        float dashPattern1[2] = {20, 10};

        //Dashed stroke + fill
        auto shape1 = tvg::Shape::gen();
        shape1->appendCircle(120, 120, 75, 75);
        shape1->appendRect(200, 50, 150, 150);
        shape1->fill(0, 50, 155, 100);
        shape1->strokeFill(0, 0, 255);
        shape1->strokeJoin(tvg::StrokeJoin::Round);
        shape1->strokeCap(tvg::StrokeCap::Round);
        shape1->strokeDash(dashPattern1, 2);
        shape1->strokeWidth(12);
        shape1->trimpath(0.2f, 0.8f, false);

        canvas->push(shape1);

        //Dashed stroke only
        shape1 = tvg::Shape::gen();
        shape1->appendCircle(120, 120, 75, 75);
        shape1->appendRect(200, 50, 150, 150);
        shape1->strokeFill(0, 0, 255);
        shape1->strokeJoin(tvg::StrokeJoin::Round);
        shape1->strokeCap(tvg::StrokeCap::Round);
        shape1->strokeDash(dashPattern1, 2);
        shape1->strokeWidth(12);
        shape1->trimpath(0.2f, 0.8f, false);
        shape1->translate(400, 0);

        canvas->push(shape1);

        //stroke + fill
        shape1 = tvg::Shape::gen();
        shape1->appendCircle(120, 120, 75, 75);
        shape1->appendRect(200, 50, 150, 150);
        shape1->fill(0, 50, 155, 100);
        shape1->strokeFill(0, 0, 255);
        shape1->strokeJoin(tvg::StrokeJoin::Round);
        shape1->strokeCap(tvg::StrokeCap::Round);
        shape1->strokeWidth(12);
        shape1->trimpath(0.2f, 0.8f, false);
        shape1->translate(0, 300);

        canvas->push(shape1);

        //stroke only
        shape1 = tvg::Shape::gen();
        shape1->appendCircle(120, 120, 75, 75);
        shape1->appendRect(200, 50, 150, 150);
        shape1->strokeFill(0, 0, 255);
        shape1->strokeJoin(tvg::StrokeJoin::Round);
        shape1->strokeCap(tvg::StrokeCap::Round);
        shape1->strokeWidth(12);
        shape1->trimpath(0.2f, 0.8f, false);
        shape1->translate(400, 300);

        canvas->push(shape1);

        //fill only
        shape1 = tvg::Shape::gen();
        shape1->appendCircle(120, 120, 75, 75);
        shape1->appendRect(200, 50, 150, 150);
        shape1->fill(0, 50, 155, 100);
        shape1->trimpath(0.2f, 0.8f, false);
        shape1->translate(0, 600);

        canvas->push(shape1);
```