### PR TITLE
renderer: handle edge cases for trimming with dashing

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -236,15 +236,16 @@ void LottieTrimpath::segment(float frameNo, float& start, float& end, Tween& twe
         end = 0.0f;
         return;
     }
-    if (tvg::equal(diff, 1.0f) || tvg::equal(diff, 2.0f)) {
+
+    //Even if the start and end values do not cause trimming, an offset > 0 can still affect dashing starting point
+    auto o = fmodf(this->offset(frameNo, tween, exps), 360.0f) / 360.0f;  //0 ~ 1
+    if (tvg::zero(o) && diff >= 1.0f) {
         start = 0.0f;
         end = 1.0f;
         return;
     }
 
     if (start > end) std::swap(start, end);
-
-    auto o = fmodf(this->offset(frameNo, tween, exps), 360.0f) / 360.0f;  //0 ~ 1
     start += o;
     end += o;
 }

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -211,10 +211,8 @@ struct Shape::Impl : Paint::Impl
 
     void strokeTrim(float begin, float end, bool simultaneous)
     {
-        if (fabsf(end - begin) >= 1.0f) {
-            begin = 0.0f;
-            end = 1.0f;
-        }
+        //Even if there is no trimming effect, begin can still affect dashing starting point
+        if (fabsf(end - begin) >= 1.0f) end = begin + 1.0f;
 
         if (!rs.stroke) {
             if (begin == 0.0f && end == 1.0f) return;

--- a/src/renderer/tvgTrimPath.cpp
+++ b/src/renderer/tvgTrimPath.cpp
@@ -240,7 +240,10 @@ static void _trim(const PathCommand* inCmds, uint32_t inCmdsCnt, const Point* in
     auto trimStart = begin * totalLength;
     auto trimEnd = end * totalLength;
 
-    if (trimStart > trimEnd) {
+    if (fabsf(begin - end) < EPSILON) {
+        _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, trimStart, totalLength, out);
+        _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, 0.0f, trimStart, out);
+    } else if (begin > end) {
         _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, trimStart, totalLength, out);
         _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, 0.0f, trimEnd, out);
     } else {
@@ -280,10 +283,10 @@ bool TrimPath::valid() const
 
 bool TrimPath::trim(const RenderPath& in, RenderPath& out) const
 {
+    if (in.pts.count < 2 || tvg::zero(begin - end)) return false;
+
     float begin = this->begin, end = this->end;
     _get(begin, end);
-
-    if (in.pts.count < 2 || tvg::zero(begin - end)) return false;
 
     out.cmds.reserve(in.cmds.count * 2);
     out.pts.reserve(in.pts.count * 2);


### PR DESCRIPTION
In cases where the begin and end values of trimming did not result in trimming (end - begin > 1), trimming was ignored. However, when the stroke is also dashed, this case affects the shift of the point where the first dash becomes visible.

@Issue: https://github.com/thorvg/thorvg/pull/3192