### PR TITLE
renderer: handle trimming cases passing through 0.0 point

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -236,15 +236,16 @@ void LottieTrimpath::segment(float frameNo, float& start, float& end, Tween& twe
         end = 0.0f;
         return;
     }
-    if (tvg::equal(diff, 1.0f) || tvg::equal(diff, 2.0f)) {
+
+    //Even if the start and end values do not cause trimming, an offset > 0 can still affect dashing starting point
+    auto o = fmodf(this->offset(frameNo, tween, exps), 360.0f) / 360.0f;  //0 ~ 1
+    if (tvg::zero(o) && diff >= 1.0f) {
         start = 0.0f;
         end = 1.0f;
         return;
     }
 
     if (start > end) std::swap(start, end);
-
-    auto o = fmodf(this->offset(frameNo, tween, exps), 360.0f) / 360.0f;  //0 ~ 1
     start += o;
     end += o;
 }

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -211,10 +211,8 @@ struct Shape::Impl : Paint::Impl
 
     void strokeTrim(float begin, float end, bool simultaneous)
     {
-        if (fabsf(end - begin) >= 1.0f) {
-            begin = 0.0f;
-            end = 1.0f;
-        }
+        //Even if there is no trimming effect, begin can still affect dashing starting point
+        if (fabsf(end - begin) >= 1.0f) end = begin + 1.0f;
 
         if (!rs.stroke) {
             if (begin == 0.0f && end == 1.0f) return;

--- a/src/renderer/tvgTrimPath.cpp
+++ b/src/renderer/tvgTrimPath.cpp
@@ -240,7 +240,10 @@ static void _trim(const PathCommand* inCmds, uint32_t inCmdsCnt, const Point* in
     auto trimStart = begin * totalLength;
     auto trimEnd = end * totalLength;
 
-    if (trimStart > trimEnd) {
+    if (fabsf(begin - end) < EPSILON) {
+        _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, trimStart, totalLength, out);
+        _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, 0.0f, trimStart, out);
+    } else if (begin > end) {
         _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, trimStart, totalLength, out);
         _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, 0.0f, trimEnd, out);
     } else {
@@ -280,10 +283,10 @@ bool TrimPath::valid() const
 
 bool TrimPath::trim(const RenderPath& in, RenderPath& out) const
 {
+    if (in.pts.count < 2 || tvg::zero(begin - end)) return false;
+
     float begin = this->begin, end = this->end;
     _get(begin, end);
-
-    if (in.pts.count < 2 || tvg::zero(begin - end)) return false;
 
     out.cmds.reserve(in.cmds.count * 2);
     out.pts.reserve(in.pts.count * 2);


### PR DESCRIPTION
Trimming that passes through the curve's start point (like -0.1:0.1) requires passing through the curve twice. The points obtained from both passes must be joined - visible when dashing
Cases for simultaneous = true have been handled.

@Issue: https://github.com/thorvg/thorvg/issues/3192

sample:
```
        if (!canvas) return false;

        float dashPattern[2] = {80, 20};

        auto shape1 = tvg::Shape::gen();
        shape1->appendCircle(200, 200, 150, 150);
        shape1->fill(55, 0, 255, 100);
        shape1->strokeFill(0, 0, 255, 200);
        shape1->strokeJoin(tvg::StrokeJoin::Bevel);
        shape1->strokeCap(tvg::StrokeCap::Butt);
        shape1->strokeWidth(22);
        shape1->strokeTrim(-0.25, 0.25, true);
        shape1->strokeDash(dashPattern, 2, 40);
        canvas->push(shape1);
```

before:
<img width="364" alt="Zrzut ekranu 2025-02-10 o 02 45 01" src="https://github.com/user-attachments/assets/6bad5d35-073f-4c01-9a13-f94de99aa7e6" />

after:
<img width="365" alt="Zrzut ekranu 2025-02-10 o 02 45 16" src="https://github.com/user-attachments/assets/a496e45f-ed3b-437a-9d14-f2f719f4da62" />



note:
now includes also https://github.com/thorvg/thorvg/pull/3198
