### PR TITLE
webgpu_gaussian_optimization

### DIFF
--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -221,8 +221,7 @@ void WgPipelines::initialize(WgContext& context)
     // shader blit
     shader_blit = createShaderModule(context.device, "The shader blit", cShaderSrc_Blit);
     // shader effects
-    shader_gaussian_horz = createShaderModule(context.device, "The shader gaussian horizontal", cShaderSrc_GaussianBlur_Horz);
-    shader_gaussian_vert = createShaderModule(context.device, "The shader gaussian vertical", cShaderSrc_GaussianBlur_Vert);
+    shader_gaussian = createShaderModule(context.device, "The shader gaussian", cShaderSrc_GaussianBlur);
 
     // layouts
     layout_stencil = createPipelineLayout(context.device, bindGroupLayoutsStencil, 2);
@@ -450,10 +449,10 @@ void WgPipelines::initialize(WgContext& context)
     // compute pipeline gaussian blur
     gaussian_horz = createComputePipeline(
         context.device, "The compute pipeline gaussian blur horizontal",
-        shader_gaussian_horz, "cs_main", layout_gaussian);
+        shader_gaussian, "cs_main_horz", layout_gaussian);
     gaussian_vert = createComputePipeline(
         context.device, "The compute pipeline gaussian blur vertical",
-        shader_gaussian_vert, "cs_main", layout_gaussian);
+        shader_gaussian, "cs_main_vert", layout_gaussian);
 }
 
 void WgPipelines::releaseGraphicHandles(WgContext& context)
@@ -505,8 +504,7 @@ void WgPipelines::releaseGraphicHandles(WgContext& context)
     releasePipelineLayout(layout_depth);
     releasePipelineLayout(layout_stencil);
     // shaders
-    releaseShaderModule(shader_gaussian_horz);
-    releaseShaderModule(shader_gaussian_vert);
+    releaseShaderModule(shader_gaussian);
     releaseShaderModule(shader_blit);
     releaseShaderModule(shader_scene_compose);
     releaseShaderModule(shader_scene_blend);

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -47,8 +47,7 @@ private:
     // shader blit
     WGPUShaderModule shader_blit{};
     // shader effects
-    WGPUShaderModule shader_gaussian_horz{};
-    WGPUShaderModule shader_gaussian_vert{};
+    WGPUShaderModule shader_gaussian;
 
     // layouts helpers
     WGPUPipelineLayout layout_stencil{};

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -46,7 +46,6 @@ extern const char* cShaderSrc_Blit;
 
 // compute shader sources: effects
 extern const char* cShaderSrc_MergeMasks;
-extern const char* cShaderSrc_GaussianBlur_Vert;
-extern const char* cShaderSrc_GaussianBlur_Horz;
+extern const char* cShaderSrc_GaussianBlur;
 
 #endif // _TVG_WG_SHEDER_SRC_H_

--- a/src/renderer/wg_engine/tvgWgShaderTypes.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.cpp
@@ -205,8 +205,9 @@ void WgShaderTypeGaussianBlur::update(const RenderEffectGaussianBlur* gaussian, 
     assert(gaussian);
     const float sigma = gaussian->sigma;
     const float scale = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
+    const float kernel = std::min(WG_GAUSSIAN_KERNEL_SIZE_MAX, 2 * sigma * scale); // kernel size
     settings[0] = sigma;
-    settings[1] = scale;
-    settings[2] = 2 * sigma * scale; // kernel size
+    settings[1] = std::min(WG_GAUSSIAN_KERNEL_SIZE_MAX / kernel, scale);
+    settings[2] = kernel;
     extend = settings[2] * 2;
 }

--- a/src/renderer/wg_engine/tvgWgShaderTypes.h
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.h
@@ -68,6 +68,7 @@ struct WgShaderTypeGradient
 };
 
 // gaussian settings: sigma, scale, extend
+#define WG_GAUSSIAN_KERNEL_SIZE_MAX (128.0f)
 struct WgShaderTypeGaussianBlur
 {
     float settings[4]{}; // [0]: sigma, [1]: scale, [2]: kernel size, [3]: unused


### PR DESCRIPTION
wg_engine: optimize gaussian blur effect for webgpu renderer

Issue: https://github.com/thorvg/thorvg/issues/3054

+10-15% FPS expected on hi resolutions

Single shader instance used for vertical and horizontal blur
Local workgroup memory used for caching texture data for local threads group
Threads configuration changed from 2d to 1d topology
before:
![image](https://github.com/user-attachments/assets/86ce740f-6cdb-4560-a0f9-584bb5786418)
after:
![gaussian_line](https://github.com/user-attachments/assets/068a8cd4-a63d-468c-a230-4a473efc3c3f)
