### PR TITLE
sw/gl/wg: ++threads safety

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include <atomic>
 #include "tvgGlCommon.h"
 #include "tvgGlRenderer.h"
 #include "tvgGlGpuBuffer.h"
@@ -33,8 +34,8 @@
 
 #define NOISE_LEVEL 0.5f
 
-static int32_t initEngineCnt = false;
-static int32_t rendererCnt = 0;
+static atomic<int32_t> initEngineCnt{};
+static atomic<int32_t> rendererCnt{};
 
 
 static void _termEngine()
@@ -1285,7 +1286,7 @@ bool GlRenderer::postUpdate()
 }
 
 
-int GlRenderer::init(uint32_t threads)
+bool GlRenderer::init(uint32_t threads)
 {
     if ((initEngineCnt++) > 0) return true;
 
@@ -1301,7 +1302,7 @@ int32_t GlRenderer::init()
 }
 
 
-int GlRenderer::term()
+bool GlRenderer::term()
 {
     if ((--initEngineCnt) > 0) return true;
 

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -93,9 +93,9 @@ public:
     void dispose(TVG_UNUSED RenderEffect* effect) override;
 
     static GlRenderer* gen();
-    static int init(TVG_UNUSED uint32_t threads);
+    static bool init(TVG_UNUSED uint32_t threads);
     static int32_t init();
-    static int term();
+    static bool term();
 
 private:
     GlRenderer(); 

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -24,6 +24,7 @@
     #include <omp.h>
 #endif
 #include <algorithm>
+#include <atomic>
 #include "tvgMath.h"
 #include "tvgSwCommon.h"
 #include "tvgTaskScheduler.h"
@@ -32,8 +33,8 @@
 /************************************************************************/
 /* Internal Class Implementation                                        */
 /************************************************************************/
-static int32_t initEngineCnt = false;
-static int32_t rendererCnt = 0;
+static atomic<int32_t> initEngineCnt{};
+static atomic<int32_t> rendererCnt{};
 static SwMpool* globalMpool = nullptr;
 static uint32_t threadsCnt = 0;
 

--- a/src/renderer/tvgSwCanvas.cpp
+++ b/src/renderer/tvgSwCanvas.cpp
@@ -76,7 +76,7 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     auto renderer = static_cast<SwRenderer*>(pImpl->renderer);
     if (!renderer) return Result::MemoryCorruption;
 
-    if (!renderer->target(buffer, stride, w, h, static_cast<ColorSpace>(cs))) return Result::InvalidArguments;
+    if (!renderer->target(buffer, stride, w, h, cs)) return Result::InvalidArguments;
     pImpl->vport = {0, 0, (int32_t)w, (int32_t)h};
     renderer->viewport(pImpl->vport);
 

--- a/src/renderer/tvgWgCanvas.cpp
+++ b/src/renderer/tvgWgCanvas.cpp
@@ -74,6 +74,7 @@ Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, 
 WgCanvas* WgCanvas::gen() noexcept
 {
 #ifdef THORVG_WG_RASTER_SUPPORT
+    if (WgRenderer::init() <= 0) return nullptr;
     return new WgCanvas;
 #endif
     return nullptr;

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -60,12 +60,12 @@ public:
 
     static WgRenderer* gen();
     static bool init(uint32_t threads);
+    static int32_t init();
     static bool term();
 
 private:
     WgRenderer();
     ~WgRenderer();
-    void initialize();
     void release();
     void disposeObjects();
     void releaseSurfaceTexture();


### PR DESCRIPTION
Considered global engine initialization and termination. Engines could be used among multiple worker threads.