### PR TITLE
renderer: revise the Shape rect/circle features

### DIFF
--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -94,9 +94,9 @@ void contents()
 //////3. Radial gradient shape with a radial dashed stroke
     //Set a shape
     Tvg_Paint* shape3 = tvg_shape_new();
-    tvg_shape_append_rect(shape3, 550.0f, 20.0f, 100.0f, 50.0f, 0.0f, 0.0f);
-    tvg_shape_append_circle(shape3, 600.0f, 150.0f, 100.0f, 50.0f);
-    tvg_shape_append_rect(shape3, 550.0f, 230.0f, 100.0f, 100.0f, 20.0f, 40.0f);
+    tvg_shape_append_rect(shape3, 550.0f, 20.0f, 100.0f, 50.0f, 0.0f, 0.0f, true);
+    tvg_shape_append_circle(shape3, 600.0f, 150.0f, 100.0f, 50.0f, true);
+    tvg_shape_append_rect(shape3, 550.0f, 230.0f, 100.0f, 100.0f, 20.0f, 40.0f, true);
 
     //Prepare a radial gradient for the fill
     Tvg_Gradient* grad2 = tvg_radial_gradient_new();
@@ -142,8 +142,8 @@ void contents()
 
     //Set circles
     Tvg_Paint* scene_shape1 = tvg_shape_new();
-    tvg_shape_append_circle(scene_shape1, 80.0f, 650.f, 40.0f, 140.0f);
-    tvg_shape_append_circle(scene_shape1, 180.0f, 600.f, 40.0f, 60.0f);
+    tvg_shape_append_circle(scene_shape1, 80.0f, 650.f, 40.0f, 140.0f, true);
+    tvg_shape_append_circle(scene_shape1, 180.0f, 600.f, 40.0f, 60.0f, true);
     tvg_shape_set_fill_color(scene_shape1, 0, 0, 255, 150);
     tvg_shape_set_stroke_color(scene_shape1, 75, 25, 155, 255);
     tvg_shape_set_stroke_width(scene_shape1, 10.0f);
@@ -189,7 +189,7 @@ void contents()
 
         // Set a composite shape
         Tvg_Paint* comp = tvg_shape_new();
-        tvg_shape_append_circle(comp, 600.0f, 600.0f, 100.0f, 100.0f);
+        tvg_shape_append_circle(comp, 600.0f, 600.0f, 100.0f, 100.0f, true);
         tvg_shape_set_fill_color(comp, 0, 0, 0, 200);
         tvg_paint_set_mask_method(pict, comp, TVG_MASK_METHOD_INVERSE_ALPHA);
 

--- a/examples/StrokeTrim.cpp
+++ b/examples/StrokeTrim.cpp
@@ -43,13 +43,13 @@ struct UserExample : tvgexam::Example
         shape1->strokeJoin(tvg::StrokeJoin::Round);
         shape1->strokeCap(tvg::StrokeCap::Round);
         shape1->strokeWidth(12);
-        shape1->strokeTrim(0.0f, 0.5f, false);
+        shape1->strokeTrim(0.25f, 0.75f, false);
 
         auto shape2 = static_cast<tvg::Shape*>(shape1->duplicate());
         shape2->translate(300, 300);
         shape2->fill(0, 155, 50, 100);
         shape2->strokeFill(0, 255, 0);
-        shape2->strokeTrim(0.0f, 0.5f, true);
+        shape2->strokeTrim(0.25f, 0.75f, true);
 
         canvas->push(shape1);
         canvas->push(shape2);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -983,10 +983,11 @@ public:
      * @param[in] h The height of the rectangle.
      * @param[in] rx The x-axis radius of the ellipse defining the rounded corners of the rectangle.
      * @param[in] ry The y-axis radius of the ellipse defining the rounded corners of the rectangle.
+     * @param[in] cw Specifies the path direction: @c true for clockwise, @c false for counterclockwise.
      *
      * @note For @p rx and @p ry greater than or equal to the half of @p w and the half of @p h, respectively, the shape become an ellipse.
      */
-    Result appendRect(float x, float y, float w, float h, float rx = 0, float ry = 0) noexcept;
+    Result appendRect(float x, float y, float w, float h, float rx = 0, float ry = 0, bool cw = true) noexcept;
 
     /**
      * @brief Appends an ellipse to the path.
@@ -1001,9 +1002,10 @@ public:
      * @param[in] cy The vertical coordinate of the center of the ellipse.
      * @param[in] rx The x-axis radius of the ellipse.
      * @param[in] ry The y-axis radius of the ellipse.
+     * @param[in] cw Specifies the path direction: @c true for clockwise, @c false for counterclockwise.
      *
      */
-    Result appendCircle(float cx, float cy, float rx, float ry) noexcept;
+    Result appendCircle(float cx, float cy, float rx, float ry, bool cw = true) noexcept;
 
     /**
      * @brief Appends a given sub-path to the path.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1175,13 +1175,14 @@ TVG_API Tvg_Result tvg_shape_close(Tvg_Paint* paint);
 * @param[in] h The height of the rectangle.
 * @param[in] rx The x-axis radius of the ellipse defining the rounded corners of the rectangle.
 * @param[in] ry The y-axis radius of the ellipse defining the rounded corners of the rectangle.
+* @param[in] cw Specifies the path direction: @c true for clockwise, @c false for counterclockwise.
 *
 * @return Tvg_Result enumeration.
 * @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
 & @note For @p rx and @p ry greater than or equal to the half of @p w and the half of @p h, respectively, the shape become an ellipse.
 */
-TVG_API Tvg_Result tvg_shape_append_rect(Tvg_Paint* paint, float x, float y, float w, float h, float rx, float ry);
+TVG_API Tvg_Result tvg_shape_append_rect(Tvg_Paint* paint, float x, float y, float w, float h, float rx, float ry, bool cw);
 
 
 /*!
@@ -1198,11 +1199,12 @@ TVG_API Tvg_Result tvg_shape_append_rect(Tvg_Paint* paint, float x, float y, flo
 * @param[in] cy The vertical coordinate of the center of the ellipse.
 * @param[in] rx The x-axis radius of the ellipse.
 * @param[in] ry The y-axis radius of the ellipse.
+* @param[in] cw Specifies the path direction: @c true for clockwise, @c false for counterclockwise.
 *
 * @return Tvg_Result enumeration.
 * @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
-TVG_API Tvg_Result tvg_shape_append_circle(Tvg_Paint* paint, float cx, float cy, float rx, float ry);
+TVG_API Tvg_Result tvg_shape_append_circle(Tvg_Paint* paint, float cx, float cy, float rx, float ry, bool cw);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -352,17 +352,17 @@ TVG_API Tvg_Result tvg_shape_close(Tvg_Paint* paint)
 }
 
 
-TVG_API Tvg_Result tvg_shape_append_rect(Tvg_Paint* paint, float x, float y, float w, float h, float rx, float ry)
+TVG_API Tvg_Result tvg_shape_append_rect(Tvg_Paint* paint, float x, float y, float w, float h, float rx, float ry, bool cw)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->appendRect(x, y, w, h, rx, ry);
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->appendRect(x, y, w, h, rx, ry, cw);
 }
 
 
-TVG_API Tvg_Result tvg_shape_append_circle(Tvg_Paint* paint, float cx, float cy, float rx, float ry)
+TVG_API Tvg_Result tvg_shape_append_circle(Tvg_Paint* paint, float cx, float cy, float rx, float ry, bool cw)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->appendCircle(cx, cy, rx, ry);
+    return (Tvg_Result) reinterpret_cast<Shape*>(paint)->appendCircle(cx, cy, rx, ry, cw);
 }
 
 

--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -95,16 +95,16 @@ Result Shape::close() noexcept
 }
 
 
-Result Shape::appendCircle(float cx, float cy, float rx, float ry) noexcept
+Result Shape::appendCircle(float cx, float cy, float rx, float ry, bool cw) noexcept
 {
-    SHAPE(this)->appendCircle(cx, cy, rx, ry);
+    SHAPE(this)->appendCircle(cx, cy, rx, ry, cw);
     return Result::Success;
 }
 
 
-Result Shape::appendRect(float x, float y, float w, float h, float rx, float ry) noexcept
+Result Shape::appendRect(float x, float y, float w, float h, float rx, float ry, bool cw) noexcept
 {
-    SHAPE(this)->appendRect(x, y, w, h, rx, ry);
+    SHAPE(this)->appendRect(x, y, w, h, rx, ry, cw);
     return Result::Success;
 }
 

--- a/test/testShape.cpp
+++ b/test/testShape.cpp
@@ -70,13 +70,14 @@ TEST_CASE("Appending Shapes", "[tvgShape]")
     REQUIRE(shape->lineTo(120, 140) == Result::Success);
 
     REQUIRE(shape->appendRect(0, 0, 0, 0, 0, 0) == Result::Success);
-    REQUIRE(shape->appendRect(0, 0,99999999.0f, -99999999.0f, 0, 0) == Result::Success);
-    REQUIRE(shape->appendRect(0, 0, 0, 0, -99999999.0f, 99999999.0f) == Result::Success);
-    REQUIRE(shape->appendRect(99999999.0f, -99999999.0f, 99999999.0f, -99999999.0f, 99999999.0f, -99999999.0f) == Result::Success);
+    REQUIRE(shape->appendRect(0, 0,99999999.0f, -99999999.0f, 0, 0, true) == Result::Success);
+    REQUIRE(shape->appendRect(0, 0, 0, 0, -99999999.0f, 99999999.0f, false) == Result::Success);
+    REQUIRE(shape->appendRect(99999999.0f, -99999999.0f, 99999999.0f, -99999999.0f, 99999999.0f, -99999999.0f, true) == Result::Success);
+    REQUIRE(shape->appendRect(99999999.0f, -99999999.0f, 99999999.0f, -99999999.0f, 99999999.0f, -99999999.0f, false) == Result::Success);
 
     REQUIRE(shape->appendCircle(0, 0, 0, 0) == Result::Success);
-    REQUIRE(shape->appendCircle(-99999999.0f, 99999999.0f, 0, 0) == Result::Success);
-    REQUIRE(shape->appendCircle(-99999999.0f, 99999999.0f, -99999999.0f, 99999999.0f) == Result::Success);
+    REQUIRE(shape->appendCircle(-99999999.0f, 99999999.0f, 0, 0, true) == Result::Success);
+    REQUIRE(shape->appendCircle(-99999999.0f, 99999999.0f, -99999999.0f, 99999999.0f, false) == Result::Success);
 }
 
 TEST_CASE("Appending Paths", "[tvgShape]")


### PR DESCRIPTION
The path direction of shapes is now functional for path trimming. Replace the main logic with Lottie's by default
to align the spec, migrate the original logic to svg loader side.

This revision helps to reduce the binary size by 2–3 KB for lottie loader.

API Modifications:

- Result Shape::appendRect(float x, float y, float w, float h, float rx = 0, float ry = 0) 
 -> Result Shape::appendRect(float x, float y, float w, float h, float rx = 0, float ry = 0, bool cw = true)
- Result Shape::appendCircle(float cx, float cy, float rx, float ry)
 -> Result Shape::appendCircle(float cx, float cy, float rx, float ry, bool cw = true)
- TVG_API Tvg_Result tvg_shape_append_circle(Tvg_Paint* paint, float cx, float cy, float rx, float ry)
 -> TVG_API Tvg_Result tvg_shape_append_circle(Tvg_Paint* paint, float cx, float cy, float rx, float ry, bool cw)
- Tvg_Result tvg_shape_append_rect(Tvg_Paint* paint, float x, float y, float w, float h, float rx, float ry)
 -> Tvg_Result tvg_shape_append_rect(Tvg_Paint* paint, float x, float y, float w, float h, float rx, float ry, bool cw)

issue: https://github.com/thorvg/thorvg/issues/3179