### PR TITLE
renderer: fix trimmed stroke blinking

### DIFF
--- a/src/renderer/tvgTrimPath.cpp
+++ b/src/renderer/tvgTrimPath.cpp
@@ -240,10 +240,7 @@ static void _trim(const PathCommand* inCmds, uint32_t inCmdsCnt, const Point* in
     auto trimStart = begin * totalLength;
     auto trimEnd = end * totalLength;
 
-    if (fabsf(begin - end) < EPSILON) {
-        _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, trimStart, totalLength, out);
-        _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, 0.0f, trimStart, out, connect);
-    } else if (begin > end) {
+    if (begin >= end) {
         _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, trimStart, totalLength, out);
         _trimPath(inCmds, inCmdsCnt, inPts, inPtsCnt, 0.0f, trimEnd, out, connect);
     } else {


### PR DESCRIPTION
Bug introduced as part of a7e7bbc.
After recalculating begin and end to the 0-1 range, an extra check was added to handle cases when begin is very close to end. However, this was a bad approach since, even for very close values, their relationship remains important. What should have been done in the mentioned commit is properly handling  the case begin == end, which was incorrectly treated as trimming from begin to end. Instead, it should be handled as trimming from begin to 1.0 and from 0.0 to end.

@Issue: https://github.com/thorvg/thorvg/issues/3204

note:
This extra check for whether `begin - end < epsilon` was added because [18859.json](https://github.com/user-attachments/files/18758198/18859.json) was flickering. However, it was not the correct fix - now it's properly handled.

