### PR TITLE
jerryscript: fix warnings on masOS (intel)

### DIFF
--- a/src/loaders/lottie/jerryscript/jerry-core/ecma/base/ecma-helpers-conversion.cpp
+++ b/src/loaders/lottie/jerryscript/jerry-core/ecma/base/ecma-helpers-conversion.cpp
@@ -704,7 +704,7 @@ ecma_number_to_uint32 (ecma_number_t num) /**< ecma-number */
   /* 2 ^ 32 */
   const uint64_t uint64_2_pow_32 = (1ull << 32);
 
-  const ecma_number_t num_2_pow_32 = (float) uint64_2_pow_32;
+  const ecma_number_t num_2_pow_32 = uint64_2_pow_32;
 
   ecma_number_t num_in_uint32_range;
 

--- a/src/loaders/lottie/jerryscript/jerry-core/ecma/base/ecma-helpers-number.cpp
+++ b/src/loaders/lottie/jerryscript/jerry-core/ecma/base/ecma-helpers-number.cpp
@@ -259,7 +259,7 @@ ecma_number_t JERRY_ATTR_CONST
 ecma_number_get_prev (ecma_number_t num) /**< ecma-number */
 {
 #if defined(__GNUC__) || defined(__clang__)
-  return __builtin_nextafter (num, -INFINITY);
+  return __builtin_nextafter ((double)num, (double)-INFINITY);
 #else /* !defined (__GNUC__) && !defined (__clang__) */
   JERRY_ASSERT (!ecma_number_is_nan (num));
   ecma_binary_num_t binary = ecma_number_to_binary (num);
@@ -294,7 +294,7 @@ ecma_number_t JERRY_ATTR_CONST
 ecma_number_get_next (ecma_number_t num) /**< ecma-number */
 {
 #if defined(__GNUC__) || defined(__clang__)
-  return __builtin_nextafter (num, INFINITY);
+  return __builtin_nextafter ((double)num, (double)INFINITY);
 #else /* !defined (__GNUC__) && !defined (__clang__) */
   JERRY_ASSERT (!ecma_number_is_nan (num));
   ecma_binary_num_t binary = ecma_number_to_binary (num);

--- a/src/loaders/lottie/jerryscript/jerry-core/ecma/builtin-objects/ecma-builtin-math.cpp
+++ b/src/loaders/lottie/jerryscript/jerry-core/ecma/builtin-objects/ecma-builtin-math.cpp
@@ -523,7 +523,6 @@ ecma_builtin_math_dispatch_routine (uint8_t builtin_routine_id, /**< built-in wi
       }
       case ECMA_MATH_OBJECT_FROUND:
       {
-        x = (float) x;
         break;
       }
       case ECMA_MATH_OBJECT_IMUL:

--- a/src/loaders/lottie/jerryscript/jerry-core/ecma/operations/ecma-typedarray-object.cpp
+++ b/src/loaders/lottie/jerryscript/jerry-core/ecma/operations/ecma-typedarray-object.cpp
@@ -149,7 +149,7 @@ ecma_typedarray_get_float_element (lit_utf8_byte_t *src) /**< the location in th
 {
   float num;
   ECMA_TYPEDARRAY_GET_ELEMENT (src, num, float);
-  return ecma_make_number_value (num);
+  return ecma_make_number_value ((ecma_value_t)num);
 } /* ecma_typedarray_get_float_element */
 
 /**


### PR DESCRIPTION
warning: implicit conversion increases floating-point precision