### PR TITLE
lottie: parsing embedded fonts data

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -898,6 +898,21 @@ void LottieBuilder::updateImage(LottieGroup* layer)
 }
 
 
+void _fontURLText(LottieText* text, Scene* main, float frameNo, Tween& tween, LottieExpressions* exps)
+{
+    auto& doc = text->doc(frameNo, exps);
+    if (!doc.text) return;
+
+    const float ptPerPx = 0.75f; //1 pt = 1/72; 1 in = 96 px; -> 72/96 = 0.75
+    auto txt = Text::gen();
+    txt->font(doc.name, doc.size * 100.0f * ptPerPx);
+    txt->translate(0.0f, -doc.size * 100.0f);
+    txt->text(doc.text);
+    txt->fill(doc.color.rgb[0], doc.color.rgb[1], doc.color.rgb[2]);
+    main->push(txt);
+}
+
+
 void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
 {
     auto text = static_cast<LottieText*>(layer->children.first());
@@ -906,6 +921,11 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
     auto p = doc.text;
 
     if (!p || !text->font) return;
+
+    if (text->font->origin == LottieFont::Origin::FontURL) {
+        _fontURLText(text, layer->scene, frameNo, tween, exps);
+        return;
+    }
 
     auto scale = doc.size;
     Point cursor{};

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -191,6 +191,16 @@ float LottieTextRange::factor(float frameNo, float totalLen, float idx)
 }
 
 
+void LottieFont::prepare()
+{
+    if (!data.b64src || !name) return;
+
+    TaskScheduler::async(false);
+    Text::load(name, data.b64src, data.size, "ttf", false);
+    TaskScheduler::async(true);
+}
+
+
 void LottieImage::prepare()
 {
     LottieObject::type = LottieObject::Image;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -303,14 +303,23 @@ struct LottieFont
         free(style);
         free(family);
         free(name);
+        free(data.b64src);
     }
+
+    struct {
+        char* b64src = nullptr;
+        uint32_t size = 0;
+    } data;
 
     Array<LottieGlyph*> chars;
     char* name = nullptr;
     char* family = nullptr;
     char* style = nullptr;
+    size_t dataSize = 0;
     float ascent = 0.0f;
     Origin origin = Embedded;
+
+    void prepare();
 };
 
 struct LottieMarker

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -954,6 +954,19 @@ LottieObject* LottieParser::parseAsset()
 }
 
 
+void LottieParser::parseFontData(LottieFont* font, const char* data)
+{
+    if (!data) return;
+    if (strncmp(data, "data:font/ttf;base64,", sizeof("data:font/ttf;base64,") - 1) != 0) {
+        TVGLOG("LOTTIE", "Unsupported embeded font data format");
+        return;
+    }
+
+    auto ttf = data + sizeof("data:font/ttf;base64,") - 1;
+    font->data.size = b64Decode(ttf, strlen(ttf), &font->data.b64src);
+}
+
+
 LottieFont* LottieParser::parseFont()
 {
     enterObject();
@@ -964,10 +977,13 @@ LottieFont* LottieParser::parseFont()
         if (KEY_AS("fName")) font->name = getStringCopy();
         else if (KEY_AS("fFamily")) font->family = getStringCopy();
         else if (KEY_AS("fStyle")) font->style = getStringCopy();
+        else if (KEY_AS("fPath")) parseFontData(font, getString());
         else if (KEY_AS("ascent")) font->ascent = getFloat();
         else if (KEY_AS("origin")) font->origin = (LottieFont::Origin) getInt();
         else skip();
     }
+
+    font->prepare();
     return font;
 }
 

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -96,6 +96,7 @@ private:
     LottieRepeater* parseRepeater();
     LottieOffsetPath* parseOffsetPath();
     LottieFont* parseFont();
+    void parseFontData(LottieFont* font, const char* data);
     LottieMarker* parseMarker();
 
     void parseEffect(LottieEffect* effect, void(LottieParser::*func)(LottieEffect*, int));


### PR DESCRIPTION
Only parsing and font loading is added.
The text update while building the scene
will be handled in a separate commit.

@Issue: https://github.com/thorvg/thorvg/issues/3184

ThorVG
<img width="300" alt="Zrzut ekranu 2025-02-13 o 12 40 13" src="https://github.com/user-attachments/assets/978a14ee-9713-4676-a00b-eab815da6de7" />

lottie-web
<img width="300" alt="Zrzut ekranu 2025-02-13 o 12 37 56" src="https://github.com/user-attachments/assets/cab8f134-44fe-4f84-8fe0-ffdc72e36567" />
