### PR TITLE
wg_engine: fix dash offset behavior

### DIFF
--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -295,21 +295,22 @@ struct WgVertexBufferInd
         float len_total = dashPattern[index_dash];
         // get dashes length
         float dashes_lenth{};
-        for (uint32_t i = 0; i < dashCnt; i++) 
-            dashes_lenth += dashPattern[i];
+        for (uint32_t i = 0; i < dashCnt * (dashCnt % 2 + 1); i++)
+            dashes_lenth += dashPattern[i % dashCnt];
         if (dashes_lenth == 0) return;
         // normalize dash offset
         float dashOffset = rstroke->dashOffset;
         while(dashOffset < 0) dashOffset += dashes_lenth;
         while(dashOffset > dashes_lenth) dashOffset -= dashes_lenth;
+        auto gap = false;
         // scip dashes by offset
-        while(len_total < dashOffset) { 
+        while(len_total < dashOffset) {
             index_dash = (index_dash + 1) % dashCnt;
             len_total += dashPattern[index_dash];
+            gap = !gap;
         }
         len_total -= dashOffset;
         // iterate by polyline points
-        auto gap = false;
         for (uint32_t i = 0; i < buff.vcount - 1; i++) {
             // append current polyline point
             if (!gap) dashed.append(buff.vbuff[i]);


### PR DESCRIPTION
For an odd number of dash/gap segments, the offset was handled incorrectly because the non-doubled count of dashes and gaps was used.
Additionally, in ddcbbf7, an error was introduced by overlooking the fact that the offset can shift the dash pattern in such a way that the first segment of the dashed line becomes a gap.

samples:
[s.svg.zip](https://github.com/user-attachments/files/18787916/s.svg.zip)
[837.json](https://github.com/user-attachments/files/18787902/837.1.json)
