### PR TITLE
wg_engine: introduced global vertexbuffer mempool / ++thread safety

### DIFF
--- a/cross/wasm32.txt
+++ b/cross/wasm32.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sSTACK_SIZE=2MB', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_wg.txt
+++ b/cross/wasm32_wg.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sSTACK_SIZE=2MB']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1']
 
 [host_machine]
 system = 'emscripten'

--- a/src/renderer/wg_engine/meson.build
+++ b/src/renderer/wg_engine/meson.build
@@ -12,6 +12,7 @@ source_file = [
     'tvgWgBindGroups.cpp',
     'tvgWgCommon.cpp',
     'tvgWgCompositor.cpp',
+    'tvgWgGeometry.cpp',
     'tvgWgPipelines.cpp',
     'tvgWgRenderData.cpp',
     'tvgWgRenderer.cpp',

--- a/src/renderer/wg_engine/tvgWgGeometry.cpp
+++ b/src/renderer/wg_engine/tvgWgGeometry.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgGeometry.h"
+
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
+
+static WgGeometryBufferPool _pool;
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
+
+WgVertexBuffer* WgGeometryBufferPool::reqVertexBuffer(float scale)
+{
+    ARRAY_FOREACH(p, vbuffers) {
+        if ((*p)->count == 0) {
+            (*p)->scale = scale;
+            return (*p);
+        }
+    }
+    vbuffers.push(new WgVertexBuffer(scale));
+    return vbuffers.last();
+}
+
+void WgGeometryBufferPool::retVertexBuffer(WgVertexBuffer* buffer)
+{
+    buffer->reset(1.0f);
+}
+
+WgIndexedVertexBuffer* WgGeometryBufferPool::reqIndexedVertexBuffer(float scale)
+{
+    ARRAY_FOREACH(p, ibuffers) {
+        if ((*p)->vcount == 0) {
+            (*p)->scale = scale;
+            return (*p);
+        }
+    }
+    ibuffers.push(new WgIndexedVertexBuffer(this, scale));
+    return ibuffers.last();
+}
+
+void WgGeometryBufferPool::retIndexedVertexBuffer(WgIndexedVertexBuffer* buffer)
+{
+    buffer->reset(1.0f);
+}
+
+
+WgGeometryBufferPool* WgGeometryBufferPool::instance()
+{
+    /* TODO: These could be easily addressed per threads. i.e _pool[thread_cnt]; */
+    return &_pool;
+}
+
+
+WgGeometryBufferPool::~WgGeometryBufferPool()
+{
+    ARRAY_FOREACH(p, vbuffers) delete(*p);
+    ARRAY_FOREACH(p, ibuffers) delete(*p);
+}

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -38,7 +38,7 @@ struct WgMeshData {
     void drawImage(WgContext& context, WGPURenderPassEncoder renderPassEncoder);
 
     void update(WgContext& context, const WgVertexBuffer& vertexBuffer);
-    void update(WgContext& context, const WgVertexBufferInd& vertexBufferInd);
+    void update(WgContext& context, const WgIndexedVertexBuffer& vertexBufferInd);
     void bbox(WgContext& context, const Point pmin, const Point pmax);
     void imageBox(WgContext& context, float w, float h);
     void blitBox(WgContext& context);
@@ -60,7 +60,7 @@ struct WgMeshDataGroup {
     Array<WgMeshData*> meshes{};
     
     void append(WgContext& context, const WgVertexBuffer& vertexBuffer);
-    void append(WgContext& context, const WgVertexBufferInd& vertexBufferInd);
+    void append(WgContext& context, const WgIndexedVertexBuffer& vertexBufferInd);
     void append(WgContext& context, const Point pmin, const Point pmax);
     void release(WgContext& context);
 };
@@ -126,11 +126,11 @@ struct WgRenderDataShape: public WgRenderDataPaint
     FillRule fillRule{};
 
     void appendShape(WgContext& context, const WgVertexBuffer& vertexBuffer);
-    void appendStroke(WgContext& context, const WgVertexBufferInd& vertexBufferInd);
+    void appendStroke(WgContext& context, const WgIndexedVertexBuffer& vertexBufferInd);
     void updateBBox(Point pmin, Point pmax);
     void updateAABB(const Matrix& tr);
-    void updateMeshes(WgContext& context, const RenderShape& rshape, const Matrix& tr);
-    void proceedStrokes(WgContext& context, const RenderStroke* rstroke, const WgVertexBuffer& buff);
+    void updateMeshes(WgContext& context, const RenderShape& rshape, const Matrix& tr, WgGeometryBufferPool* pool);
+    void proceedStrokes(WgContext& context, const RenderStroke* rstroke, const WgVertexBuffer& buff, WgGeometryBufferPool* pool);
     void releaseMeshes(WgContext& context);
     void release(WgContext& context) override;
     Type type() override { return Type::Shape; };

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -106,6 +106,11 @@ private:
     WGPUTexture targetTexture{}; // external handle
     WGPUSurfaceTexture surfaceTexture{};
     WGPUSurface surface{};  // external handle
+
+    struct {
+        WgGeometryBufferPool* pool;   //private buffer pool
+        bool individual = false;      //buffer-pool sharing policy
+    } mBufferPool;
 };
 
 #endif /* _TVG_WG_RENDERER_H_ */


### PR DESCRIPTION
Manage the global buffer memory for vertex and indexed vertex buffers, increase the memory size incrementally twice by default and reduce the default buffer size, which is not suitable for typical scenarios.

This could reduce the a bit stack memory usage and improve the portability across systems where has the stack memory limitation and potentially gaining performance enhancement by avoiding brutal stack memory usage at the many function calls.

added the internal functions:

- WgVertexBuffer* mpoolReqVertexBuffer(float scale = 1.0f);
- WgIndexedVertexBuffer* mpoolReqIndexedVertexBuffer(float scale = 1.0f);
- void mpoolRetVertexBuffer(WgVertexBuffer* buffer);
- void mpoolRetIndexedVertexBuffer(WgIndexedVertexBuffer* buffer);

issue: https://github.com/thorvg/thorvg/issues/3159