### PR TITLE
wg/gl_engine: standardize shapes closing precision

### DIFF
--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -1746,7 +1746,7 @@ void Stroker::strokeCubicTo(const Point& cnt1, const Point& cnt2, const Point& e
 
 void Stroker::strokeClose()
 {
-    if (mStrokeState.prevPt != mStrokeState.firstPt) {
+    if (length(mStrokeState.prevPt - mStrokeState.firstPt) > 0.015625f) {
         this->strokeLineTo(mStrokeState.firstPt);
     }
 

--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -148,7 +148,7 @@ struct WgVertexBuffer
     void close()
     {
         // check if last point is not to close to the first point
-        if (!tvg::zero(length2(data[0] - last()))) {
+        if (length(data[0] - last()) > 0.015625f) {
             append(data[0]);
         }
         closed = true;


### PR DESCRIPTION
The sw_engine, when determining the outline, converts floats to ints by multiplying them x64, resulting in a comparison precision of 1/64 = 0.015625.
Both gl_engine and wg_engine operate on floats. Before adding a closing point to a shape, they performed a comparison to check if the point differed from the starting point:
- wg: with a precision of 1e-3 (using length2, i.e., eps = 1e-6
- gl: used direct == comparison. Now, consistency has been ensured by introducing a comparison precision of 1/64 in both wg_engine and gl_engine.

@Issue: https://github.com/thorvg/thorvg/issues/2799
@Issue: https://github.com/thorvg/thorvg/issues/3235

samples to test: polystar.json, starstrips.json

before:
<img width="500" alt="Zrzut ekranu 2025-02-15 o 02 12 52" src="https://github.com/user-attachments/assets/27e60f71-1099-4ce9-b16a-bcf9f9403287" />

after:
<img width="500" alt="Zrzut ekranu 2025-02-15 o 02 24 10" src="https://github.com/user-attachments/assets/210a5607-6b8e-4bda-8125-32a4019cddef" />


after all engine look the same:
<img width="500" alt="Zrzut ekranu 2025-02-15 o 01 53 26" src="https://github.com/user-attachments/assets/afd83491-b575-4ecc-a343-3cb417f4863b" />
<img width="500" alt="Zrzut ekranu 2025-02-15 o 01 53 21" src="https://github.com/user-attachments/assets/7f0680be-2318-44c2-a437-d8a89059b74d" />
<img width="500" alt="Zrzut ekranu 2025-02-15 o 02 13 04" src="https://github.com/user-attachments/assets/fe01575c-ba8c-46d6-8340-33d2502cf773" />

sample:
```
        float a = 0.0f;
        auto shape1 = tvg::Shape::gen();
        shape1->moveTo(100.0 + a, 40.0);
        shape1->lineTo(160.0 + a, 100.0);
        shape1->lineTo(100.0 + a, 160.0);
        shape1->lineTo(40.0 + a, 100.0);
        shape1->lineTo(100.001 + a, 40.0);
        shape1->close();
        shape1->strokeFill(255, 255, 0);
        shape1->strokeWidth(10);
        shape1->strokeJoin(tvg::StrokeJoin::Miter);
        canvas->push(shape1);

        a += 200;
        shape1 = tvg::Shape::gen();
        shape1->moveTo(100.0 + a, 40.0);
        shape1->lineTo(160.0 + a, 100.0);
        shape1->lineTo(100.0 + a, 160.0);
        shape1->lineTo(40.0 + a, 100.0);
        shape1->lineTo(100.0011 + a, 40.0);
        shape1->close();
        shape1->strokeFill(255, 255, 0);
        shape1->strokeWidth(10);
        shape1->strokeJoin(tvg::StrokeJoin::Miter);
        canvas->push(shape1);

        a += 200;
        shape1 = tvg::Shape::gen();
        shape1->moveTo(100.0 + a, 40.0);
        shape1->lineTo(160.0 + a, 100.0);
        shape1->lineTo(100.0 + a, 160.0);
        shape1->lineTo(40.0 + a, 100.0);
        shape1->lineTo(100.015 + a, 40.0);
        shape1->close();
        shape1->strokeFill(255, 255, 0);
        shape1->strokeWidth(10);
        shape1->strokeJoin(tvg::StrokeJoin::Miter);
        canvas->push(shape1);
        
        a += 200;
        shape1 = tvg::Shape::gen();
        shape1->moveTo(100.0 + a, 40.0);
        shape1->lineTo(160.0 + a, 100.0);
        shape1->lineTo(100.0 + a, 160.0);
        shape1->lineTo(40.0 + a, 100.0);
        shape1->lineTo(100.016 + a, 40.0);
        shape1->close();
        shape1->strokeFill(255, 255, 0);
        shape1->strokeWidth(10);
        shape1->strokeJoin(tvg::StrokeJoin::Miter);
        canvas->push(shape1);
```