### PR TITLE
sw_engine: fix update issue

### DIFF
--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -123,8 +123,7 @@ struct SwShapeTask : SwTask
         auto visibleFill = false;
 
         //This checks also for the case, if the invisible shape turned to visible by alpha.
-        auto prepareShape = false;
-        if (!shapePrepared(&shape) && (flags & RenderUpdateFlag::Color)) prepareShape = true;
+        auto prepareShape = !shapePrepared(&shape) && flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient);
 
         //Shape
         if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform) || prepareShape) {
@@ -185,6 +184,7 @@ struct SwShapeTask : SwTask
     err:
         bbox.reset();
         shapeReset(&shape);
+        rleReset(shape.strokeRle);
         shapeDelOutline(&shape, mpool, tid);
     }
 

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -461,7 +461,6 @@ void shapeDelOutline(SwShape* shape, SwMpool* mpool, uint32_t tid)
 void shapeReset(SwShape* shape)
 {
     rleReset(shape->rle);
-    rleReset(shape->strokeRle);
     shape->fastTrack = false;
     shape->bbox.reset();
 }


### PR DESCRIPTION
In cases where the fill was changed while the stroke existed but remained unchanged, the stroke would disappear because it was being reset during the shape preparing (shapeReset). Fixed by disabling the reset of stroke rle from shape reseting.

Also the shape should be prepared not only when the RenderUpdateFlag is set to Color, but also when it is set to Gradient.

@Issue: https://github.com/thorvg/thorvg/issues/3237


before:
<img width="573" alt="Zrzut ekranu 2025-02-17 o 02 54 01" src="https://github.com/user-attachments/assets/f97bd7cc-13f6-43e4-8b91-7806759af1af" />


after:
<img width="600" alt="Zrzut ekranu 2025-02-17 o 02 53 43" src="https://github.com/user-attachments/assets/3ef17374-0cb2-45c7-b0fc-1356d4f4acb8" />

sample (changed FillRule.cpp)
[FillRule.cpp.zip](https://github.com/user-attachments/files/18817350/FillRule.cpp.zip)
