### PR TITLE
wasm: optimize binary size

### DIFF
--- a/cross/wasm32.txt
+++ b/cross/wasm32.txt
@@ -11,8 +11,8 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
-cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sSTACK_SIZE=2MB', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sSTACK_SIZE=2MB', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_gl.txt
+++ b/cross/wasm32_gl.txt
@@ -11,8 +11,8 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
-cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_sw.txt
+++ b/cross/wasm32_sw.txt
@@ -11,8 +11,8 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
-cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS']
+cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_wg.txt
+++ b/cross/wasm32_wg.txt
@@ -11,8 +11,8 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
-cpp_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Os', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sSTACK_SIZE=2MB']
+cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sSTACK_SIZE=2MB']
 
 [host_machine]
 system = 'emscripten'

--- a/wasm_build.sh
+++ b/wasm_build.sh
@@ -27,4 +27,5 @@ if [ ! -d "./build_wasm" ]; then
 fi
 
 ninja -C build_wasm/
+wasm-opt build_wasm/src/bindings/wasm/thorvg-wasm.wasm -Oz --converge -all -o build_wasm/src/bindings/wasm/thorvg-wasm.wasm
 ls -lrt build_wasm/src/bindings/wasm/*.{js,wasm}


### PR DESCRIPTION
- Changed optimization flags to -Oz, reducing the binary size by 120KB.
- Applied wasm-opt convergence as a post-process to ensure the minimum possible size with the given optimization flag.