### PR TITLE
wg_engine: fix stroke update

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -89,7 +89,8 @@ struct WgRenderSettings
     WgRenderRasterType rasterType{};
     bool skip{};
 
-    void update(WgContext& context, const Fill* fill, const RenderColor& c, const RenderUpdateFlag flags);
+    void updateFill(WgContext& context, const Fill* fill);
+    void updateColor(WgContext& context, const RenderColor& c);
     void release(WgContext& context);
 };
 

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -160,9 +160,12 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
     // setup fill settings
     renderDataShape->viewport = mViewport;
     renderDataShape->opacity = opacity;
-    renderDataShape->renderSettingsShape.update(mContext, rshape.fill, rshape.color, flags);
-    if (rshape.stroke)
-        renderDataShape->renderSettingsStroke.update(mContext, rshape.stroke->fill, rshape.stroke->color, flags);
+    if (flags & RenderUpdateFlag::Gradient && rshape.fill) renderDataShape->renderSettingsShape.updateFill(mContext, rshape.fill);
+    else if (flags & RenderUpdateFlag::Color) renderDataShape->renderSettingsShape.updateColor(mContext, rshape.color);
+    if (rshape.stroke) {
+        if (flags & RenderUpdateFlag::GradientStroke && rshape.stroke->fill) renderDataShape->renderSettingsStroke.updateFill(mContext, rshape.stroke->fill);
+        else if (flags & RenderUpdateFlag::Stroke) renderDataShape->renderSettingsStroke.updateColor(mContext, rshape.stroke->color);
+    }
 
     // store clips data
     renderDataShape->updateClips(clips);


### PR DESCRIPTION
The stroke was not updated because the update function handled flags related to color/gradient only for the fill, not for the stroke.


before:
<img width="508" alt="Zrzut ekranu 2025-02-17 o 15 15 11" src="https://github.com/user-attachments/assets/7af8bfe2-b9e8-449a-a38a-21193f8a0ce7" />

after:
<img width="501" alt="Zrzut ekranu 2025-02-17 o 15 14 51" src="https://github.com/user-attachments/assets/c0b8c05a-9039-488a-9fd4-deb3e22f36a4" />

sample:
```
        auto x = 0.0f, y = 0.0f;

        // fill + no stroke -> fill + stroke
        {
            //fast track
            {
                x += 100; y += 0;
                auto shape = tvg::Shape::gen();
                shape->appendRect(10, 10, 50, 50);
                shape->fill(0, 255, 0);
                shape->translate(x, y);
                canvas->push(shape);

                shape->strokeFill(0, 0, 255);
                shape->strokeWidth(10);
                canvas->update();
            }

            //rle
            {
                x += 100; y += 0;
                auto shape = tvg::Shape::gen();
                shape->appendRect(10, 10, 50, 50, 1, 1);
                shape->fill(0, 255, 0);
                shape->translate(x, y);
                canvas->push(shape);

                shape->strokeFill(0, 0, 255);
                shape->strokeWidth(10);
                canvas->update();
            }
        }

        // grad + no stroke -> grad + stroke
        {
            //fast track
            {
                x = 0.0f; y += 100;

                auto fill = tvg::LinearGradient::gen();
                fill->linear(0, 0, 50, 50);
                tvg::Fill::ColorStop colorStops[2];
                colorStops[0] = {0, 0, 255, 255, 255};
                colorStops[1] = {1, 255, 0, 255, 255};

                fill->colorStops(colorStops, 2);

                auto shape = tvg::Shape::gen();
                shape->appendRect(10, 10, 50, 50);
                shape->fill(fill);
                shape->strokeFill(255, 0, 0);
                shape->strokeWidth(10);
                shape->translate(x, y);
                canvas->push(shape);

                shape->strokeFill(0, 0, 255);
                canvas->update();
            }

            //rle
            {
                x += 100; y += 0;

                auto fill = tvg::LinearGradient::gen();
                fill->linear(0, 0, 50, 50);

                tvg::Fill::ColorStop colorStops[2];
                colorStops[0] = {0, 0, 255, 255, 255};
                colorStops[1] = {1, 255, 0, 255, 255};

                fill->colorStops(colorStops, 2);

                auto shape = tvg::Shape::gen();
                shape->appendRect(10, 10, 50, 50, 1, 1);
                shape->fill(fill);
                shape->strokeFill(255, 0, 0);
                shape->strokeWidth(10);
                shape->translate(x, y);
                canvas->push(shape);

                shape->strokeFill(0, 0, 255);
                canvas->update();
            }
        }
```