### PR TITLE
wg_engine: fix a memory violation by a mistake

### DIFF
--- a/src/renderer/wg_engine/tvgWgGeometry.cpp
+++ b/src/renderer/wg_engine/tvgWgGeometry.cpp
@@ -77,6 +77,7 @@ WgGeometryBufferPool* WgGeometryBufferPool::instance()
 
 WgGeometryBufferPool::~WgGeometryBufferPool()
 {
-    ARRAY_FOREACH(p, vbuffers) delete(*p);
+    //The indexed buffer may contain the vertex buffer, so free the memory in reverse order.
     ARRAY_FOREACH(p, ibuffers) delete(*p);
+    ARRAY_FOREACH(p, vbuffers) delete(*p);
 }


### PR DESCRIPTION
regresion by ac08a9d6e716cc76b773eb35ba2badb1f3eebffc

issue: https://github.com/thorvg/thorvg/issues/3241