### PR TITLE
svg_loader: handle embedded fonts

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -377,6 +377,27 @@ static char* _idFromUrl(const char* url)
 }
 
 
+static char* _srcFromUrl(const char* url)
+{
+    auto open = strchr(url, '(');
+    auto close = strchr(url, ')');
+    if (!open || !close || open >= close) return nullptr;
+
+    open = strchr(open, '\'');
+    if (!open || open >= close) return nullptr;
+    ++open;
+
+    close = strchr(open, '\'');
+    if (!close || close == open) return nullptr;
+    --close;
+
+    while (open < close && *open == ' ') ++open;
+    while (open < close && *close == ' ') --close;
+
+    return strDuplicate(open, (close - open + 1));
+}
+
+
 static unsigned char _parseColor(const char* value, char** end)
 {
     float r;
@@ -2084,6 +2105,35 @@ static SvgNode* _createImageNode(SvgLoaderData* loader, SvgNode* parent, const c
 }
 
 
+static bool _attrParseFontFace(void* data, const char* key, const char* value)
+{
+    if (!key || !value) return false;
+
+    key = _skipSpace(key, nullptr);
+    value = _skipSpace(value, nullptr);
+
+    auto loader = (SvgLoaderData*)data;
+    auto& embeddedFont = loader->fonts.last();
+
+    if (!strcmp(key, "font-family")) {
+        if (embeddedFont.name) tvg::free(embeddedFont.name);
+        embeddedFont.name = strdup(value);
+    } else if (!strcmp(key, "src")) {
+        if (embeddedFont.src) tvg::free(embeddedFont.src);
+        embeddedFont.src = _srcFromUrl(value);
+    }
+
+    return true;
+}
+
+
+static void _createEmbeddedFont(SvgLoaderData* loader, const char* buf, unsigned bufLength, parseAttributes func)
+{
+    loader->fonts.push(EmbeddedFont());
+    func(buf, bufLength, _attrParseFontFace, loader);
+}
+
+
 static SvgNode* _getDefsNode(SvgNode* node)
 {
     if (!node) return nullptr;
@@ -3517,6 +3567,8 @@ static void _svgLoaderParserXmlCssStyle(SvgLoaderData* loader, const char* conte
             TVGLOG("SVG", "Unsupported elements used in the internal CSS style sheets [Elements: %s]", tag);
         } else if (STR_AS(tag, "all")) {
             if ((node = _createCssStyleNode(loader, loader->cssStyle, attrs, attrsLength, simpleXmlParseW3CAttribute))) node->id = _copyId(name);
+        } else if (!strcmp(tag, "@font-face")) { //css at-rule specifying font
+            _createEmbeddedFont(loader, attrs, attrsLength, simpleXmlParseW3CAttribute);
         } else if (!isIgnoreUnsupportedLogElements(tag)) {
             TVGLOG("SVG", "Unsupported elements used in the internal CSS style sheets [Elements: %s]", tag);
         }
@@ -3869,6 +3921,12 @@ void SvgLoader::clear(bool all)
 
     ARRAY_FOREACH(p, loaderData.images) tvg::free(*p);
     loaderData.images.reset();
+
+    ARRAY_FOREACH(p, loaderData.fonts) {
+        Text::unload(p->name);
+        tvg::free(p->name); //p->src is freed right after loading the font
+    }
+    loaderData.fonts.reset();
 
     if (copy) tvg::free((char*)content);
 

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -568,6 +568,12 @@ struct SvgNodeIdPair
     char *id;
 };
 
+struct EmbeddedFont
+{
+    char* name;
+    char* src;
+};
+
 enum class OpenedTagType : uint8_t
 {
     Other = 0,
@@ -587,6 +593,7 @@ struct SvgLoaderData
     Array<SvgNodeIdPair> cloneNodes;
     Array<SvgNodeIdPair> nodesToStyle;
     Array<char*> images;        //embedded images
+    Array<EmbeddedFont> fonts;
     int level = 0;
     bool result = false;
     OpenedTagType openedTag = OpenedTagType::Other;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -961,6 +961,41 @@ static void _updateInvalidViewSize(const Scene* scene, Box& vBox, float& w, floa
     if (!validHeight) h *= vBox.h;
 }
 
+
+static void _loadFonts(Array<EmbeddedFont>& fonts)
+{
+    if (fonts.empty()) return;
+
+    TaskScheduler::async(false);
+    for (auto font = fonts.begin(); font < fonts.end(); ++font) {
+        if (!font->src || !font->name) return;
+
+        auto src = font->src;
+        if (strncmp(src, "data:", sizeof("data:") - 1)) continue;
+        src += sizeof("data:") - 1;
+
+        //handling: 1) data:font/ttf;base64, 2) data:application/font-ttf;base64,
+        src = strstr(src, "ttf;base64,");
+        if (!src) {
+            TVGLOG("SVG", "The embedded font named \"%s\" not loaded properly.", font->name);
+            tvg::free(font->src);
+            font->src = nullptr;
+            continue;
+        }
+        src += sizeof("ttf;base64,") - 1;
+
+        char *decoded = nullptr;
+        auto size = b64Decode(src, strlen(src), &decoded);
+        if (Text::load(font->name, decoded, size) != Result::Success)
+            TVGERR("SVG", "Error while loading the ttf font named %s.", font->name);
+
+        tvg::free(font->src);
+        font->src = nullptr;
+    }
+
+    TaskScheduler::async(true);
+}
+
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
@@ -970,6 +1005,8 @@ Scene* svgSceneBuild(SvgLoaderData& loaderData, Box vBox, float w, float h, Aspe
     //TODO: aspect ratio is valid only if viewBox was set
 
     if (!loaderData.doc || (loaderData.doc->type != SvgNodeType::Doc)) return nullptr;
+
+    _loadFonts(loaderData.fonts);
 
     auto docNode = _sceneBuildHelper(loaderData, loaderData.doc, vBox, svgPath, false, 0);
 

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -472,6 +472,14 @@ bool simpleXmlParseW3CAttribute(const char* buf, unsigned bufLength, simpleXMLAt
     do {
         char* sep = (char*)strchr(buf, ':');
         next = (char*)strchr(buf, ';');
+
+        if (auto src = strstr(buf, "src")) {//src tag from css font-face contains extra semicolon
+            if (src < sep) {
+                if (next + 1 < end) next = (char*)strchr(next + 1, ';');
+                else return true;
+            }
+        }
+
         if (sep >= end) {
             next = nullptr;
             sep = nullptr;


### PR DESCRIPTION
It is possible to embed fonts directly into an SVG file. Support for parsing and loading embedded fonts has been added.

@Issue: https://github.com/thorvg/thorvg/issues/1897