### PR TITLE
lottie/expressions: Fix incorrect evaluation result check condition

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -1355,7 +1355,7 @@ jerry_value_t LottieExpressions::evaluate(float frameNo, LottieExpression* exp)
     //evaluate the code
     auto eval = jerry_eval((jerry_char_t *) exp->code, strlen(exp->code), JERRY_PARSE_NO_OPTS);
 
-    if (jerry_value_is_exception(eval) || jerry_value_is_undefined(eval)) {
+    if (jerry_value_is_exception(eval)) {
         TVGERR("LOTTIE", "Failed to dispatch the expressions!");
         exp->disabled = true;
         return jerry_undefined();


### PR DESCRIPTION
A JavaScript code line may return undefined, but this should not be treated as an error.

For example, consider the following two lines of code:
- `var $bm_rt = 30` (Statement) → result: `undefined`
- `$bm_rt = 30` (Expression) → result: `30`

Both lines execute the same operation, but the JavaScript interpreter (REPL JS) evaluates them differently.

Therefore, an evaluation result of undefined should not be blocked, as it does not indicate a failed code execution.

---

We can simply proof this in browser console.

![CleanShot 2025-02-20 at 21 15 24@2x](https://github.com/user-attachments/assets/2d501864-4ae3-4df9-b074-560ec1b7cce0)

As a result, single line expressions like `var $bm_rt = time * 360` doesn't work.
[sample.json](https://github.com/user-attachments/files/18887080/sample.json)

![CleanShot 2025-02-20 at 21 17 50@2x](https://github.com/user-attachments/assets/7515c2ba-0765-4928-b4d8-051c34d6a2e2)

