### PR TITLE
loader: fixed potential memory leaks in font handling

### DIFF
--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -249,7 +249,7 @@ bool LoaderMgr::term()
 {
     //clean up the remained font loaders which is globally used.
     INLIST_SAFE_FOREACH(_activeLoaders, loader) {
-        if (loader->type != FileType::Ttf) break;
+        if (loader->type != FileType::Ttf) continue;
         auto ret = loader->close();
         _activeLoaders.remove(loader);
         if (ret) delete(loader);

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -46,11 +46,14 @@ Result Text::load(const char* filename) noexcept
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     bool invalid; //invalid path
-    if (!LoaderMgr::loader(filename, &invalid)) {
+    auto loader = LoaderMgr::loader(filename, &invalid);
+    if (loader) {
+        if (loader->sharing > 0) --loader->sharing;   //font loading doesn't mean sharing.
+        return Result::Success;
+    } else {
         if (invalid) return Result::InvalidArguments;
         else return Result::NonSupport;
     }
-    return Result::Success;
 #else
     TVGLOG("RENDERER", "FILE IO is disabled!");
     return Result::NonSupport;


### PR DESCRIPTION
Simply loading a font doesn't mean it is in use.
Fixed the loader's reference count to prevent incorrect increments.