### PR TITLE
renderer: fixing cached font selection

### DIFF
--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -232,6 +232,22 @@ static LoadModule* _findFromCache(const char* data, uint32_t size, const char* m
 }
 
 
+static bool _match(const char* path, const char* fontName)
+{
+    auto name = (const char*)strrchr(path, '/');
+#ifdef _WIN32
+    if (name) {
+        if (auto c = (const char*)strrchr(path, '\\')) name = c;
+    } else name = strrchr(path, '\\');
+#endif
+    name = name ? name + 1 : path;
+
+    auto ext = (const char*)strrchr(name, '.');
+    auto len = ext ? ext - name : 0;
+
+    return len > 0 ? !strncmp(name, fontName, len) : !strcmp(name, fontName);
+}
+
 /************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
@@ -330,7 +346,7 @@ bool LoaderMgr::retrieve(const char* filename)
 LoadModule* LoaderMgr::loader(const char* key)
 {
     INLIST_FOREACH(_activeLoaders, loader) {
-        if (loader->pathcache && strstr(loader->hashpath, key)) {
+        if (loader->pathcache && _match(loader->hashpath, key)) {
             ++loader->sharing;
             return loader;
         }


### PR DESCRIPTION
Using a function (strstr) to check if a given font name appeared as a substring in the list of existing names caused errors when similar font names were used.
Fixed by switching to an exact comparison.


samples - problem observed when drawn using Lottie.cpp sample
[text_embeded_fontName1.json](https://github.com/user-attachments/files/18933545/text_embeded_myPath1.json)
[text_embeded_fontName2.json](https://github.com/user-attachments/files/18933546/text_embeded_myPath2.json)

expected:
<img width="400" alt="Zrzut ekranu 2025-02-23 o 22 33 45" src="https://github.com/user-attachments/assets/c276ea75-a920-42d2-9fae-34c0fa9a2525" />
