### PR TITLE
ttf_loader: handling contours starting with OFF_CURVE

### DIFF
--- a/src/loaders/ttf/tvgTtfReader.cpp
+++ b/src/loaders/ttf/tvgTtfReader.cpp
@@ -479,13 +479,13 @@ bool TtfReader::convert(Shape* shape, TtfGlyphMetrics& gmetrics, const Point& of
 
     for (uint32_t i = 0; i < cntrsCnt; ++i) {
         //contour must start with move to
+        bool offCurve = !(flags[begin] & ON_CURVE);
+        Point ptsBegin = offCurve ? (pts[begin] + pts[endPts[i]]) * 0.5f : pts[begin];
         pathCmds.push(PathCommand::MoveTo);
-        pathPts.push(pts[begin]);
+        pathPts.push(ptsBegin);
 
-        bool offCurve = false;
-        auto last = (endPts[i] - begin) + 1;
-
-        for (uint32_t x = 1; x < last; ++x) {
+        auto cnt = endPts[i] - begin + 1;
+        for (uint32_t x = 1; x < cnt; ++x) {
             if (flags[begin + x] & ON_CURVE) {
                 if (offCurve) {
                     pathCmds.push(PathCommand::CubicTo);
@@ -511,9 +511,9 @@ bool TtfReader::convert(Shape* shape, TtfGlyphMetrics& gmetrics, const Point& of
         }
         if (offCurve) {
             pathCmds.push(PathCommand::CubicTo);
-            pathPts.push(pathPts.last() + (2.0f/3.0f) * (pts[begin + last - 1] - pathPts.last()));
-            pathPts.push(pts[begin] + (2.0f/3.0f) * (pts[begin + last - 1] - pts[begin]));
-            pathPts.push(pts[begin]);
+            pathPts.push(pathPts.last() + (2.0f/3.0f) * (pts[begin + cnt - 1] - pathPts.last()));
+            pathPts.push(ptsBegin + (2.0f/3.0f) * (pts[begin + cnt - 1] - ptsBegin));
+            pathPts.push(ptsBegin);
         }
         //contour must end with close
         pathCmds.push(PathCommand::Close);


### PR DESCRIPTION
It might happen that the first point doesn't belong to the contour - such cases were observed as artifacts till now.

@Issue: https://github.com/thorvg/thorvg/issues/3268

before:
<img width="792" alt="Zrzut ekranu 2025-02-24 o 17 40 32" src="https://github.com/user-attachments/assets/917b0788-e961-48a5-861f-d9bd57fefe60" />

after:
<img width="797" alt="Zrzut ekranu 2025-02-24 o 17 36 31" src="https://github.com/user-attachments/assets/6da74116-58b2-40ab-a3ff-f05fbe5598e4" />

sample:
```
        auto shape = tvg::Shape::gen();
        shape->appendRect(0, 0, w, h);
        shape->fill(75, 75, 75);
        canvas->push(shape);

        if (!tvgexam::verify(tvg::Text::load(EXAMPLE_DIR"/font/output.ttf"))) return false;

        auto text4 = tvg::Text::gen();
        text4->font("output", 195);
        text4->text("qwerty");
        text4->fill(255, 0, 255);
        text4->translate(0, 210);
        canvas->push(text4);

        text4 = tvg::Text::gen();
        text4->font("output", 195);
        text4->text("uiop");
        text4->fill(255, 0, 0);
        text4->translate(0, 510);
        canvas->push(text4);

        text4 = tvg::Text::gen();
        text4->font("output", 95);
        text4->text("QWERTYUIOP");
        text4->fill(255, 0, 255);
        text4->translate(0, 470);
        canvas->push(text4);

        if (!tvgexam::verify(tvg::Text::load(EXAMPLE_DIR"/font/chin.ttf"))) return false;

        text4 = tvg::Text::gen();
        text4->font("chin", 300);
        text4->text("测试");
        text4->translate(0, -110);
        text4->fill(255, 0, 255);
        canvas->push(text4);
```
[fonts.zip](https://github.com/user-attachments/files/18951389/Archiwum.zip)
