### PR TITLE
gl/wg_engine: fix differences in dashing among engines

### DIFF
--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -2079,7 +2079,7 @@ void DashStroke::dashLineTo(const Point& to)
             this->lineTo(curr.pt2);
         }
 
-        if (mCurrLen < 1) {
+        if (mCurrLen < 0.1f) {
             mCurrIdx = (mCurrIdx + 1) % mDashCount;
             mCurrLen = mDashPattern[mCurrIdx];
             mCurOpGap = !mCurOpGap;
@@ -2131,7 +2131,7 @@ void DashStroke::dashCubicTo(const Point& cnt1, const Point& cnt2, const Point& 
             this->cubicTo(cur.ctrl1, cur.ctrl2, cur.end);
         }
 
-        if (mCurrLen < 1) {
+        if (mCurrLen < 0.1f) {
             mCurrIdx = (mCurrIdx + 1) % mDashCount;
             mCurrLen = mDashPattern[mCurrIdx];
             mCurOpGap = !mCurOpGap;

--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -377,7 +377,7 @@ struct WgIndexedVertexBuffer
         while(dashOffset > dashes_lenth) dashOffset -= dashes_lenth;
         auto gap = false;
         // scip dashes by offset
-        while(len_total < dashOffset) {
+        while(len_total <= dashOffset) {
             index_dash = (index_dash + 1) % dashCnt;
             len_total += dashPattern[index_dash];
             gap = !gap;


### PR DESCRIPTION
The differences resulted from discrepancies between the engines in applying equality or inequality signs and in using different precision levels when determining the dash remainder when transitioning to a new path command.

@Issue: https://github.com/thorvg/thorvg/issues/3265

<img width="600" alt="Zrzut ekranu 2025-02-24 o 23 45 04" src="https://github.com/user-attachments/assets/04366268-d244-4e4a-b70f-d2d4f2207dbd" />
