### PR TITLE
gl_engine: fix line join while dashing

### DIFF
--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -139,6 +139,7 @@ private:
     float mCurrLen;
     int32_t mCurrIdx;
     bool mCurOpGap;
+    bool mMove;
     Point mPtStart;
     Point mPtCur;
 };


### PR DESCRIPTION
While dashing, changing the path command each time caused a new 'move to' command to be added, even when dash segments across different path commands should have been connected.

@Issue: https://github.com/thorvg/thorvg/issues/3231

before:
<img width="400" alt="Zrzut ekranu 2025-02-25 o 00 27 29" src="https://github.com/user-attachments/assets/0a6681be-a651-4d52-9521-c2f8fc564b33" />

after:
<img width="400" alt="Zrzut ekranu 2025-02-25 o 00 23 04" src="https://github.com/user-attachments/assets/57bbad13-4388-4d3b-ab9e-41572c73c6a0" />
