### PR TITLE
lottie: more precise culling for inverse mattes

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -142,17 +142,17 @@ private:
 
     void updateStrokeEffect(LottieLayer* layer, LottieFxStroke* effect, float frameNo);
     void updateEffect(LottieLayer* layer, float frameNo);
-    void updateLayer(LottieComposition* comp, Scene* scene, LottieLayer* layer, float frameNo);
+    void updateLayer(LottieComposition* comp, Scene* scene, LottieLayer* layer, float frameNo, uint8_t skip);
     bool updateMatte(LottieComposition* comp, float frameNo, Scene* scene, LottieLayer* layer);
-    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo);
-    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, Tween& tween);
+    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, uint8_t skip);
+    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, Tween& tween, uint8_t skip);
     void updateSolid(LottieLayer* layer);
     void updateImage(LottieGroup* layer);
     void updateText(LottieLayer* layer, float frameNo);
     void updateMasks(LottieLayer* layer, float frameNo);
     void updateTransform(LottieLayer* layer, float frameNo);
-    void updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderContext>& contexts);
-    void updateGroup(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& pcontexts, RenderContext* ctx);
+    void updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderContext>& contexts, uint8_t skip);
+    void updateGroup(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& pcontexts, RenderContext* ctx, uint8_t skip);
     void updateTransform(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updateSolidFill(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updateSolidStroke(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);


### PR DESCRIPTION
don't do rendering further when the inverse mattes has
a fully translucent. This could improve rendering performance
in that case.