### PR TITLE
renderer: fix trimmed rect clippers

### DIFF
--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -78,6 +78,9 @@ static Result _compFastTrack(RenderMethod* renderer, Paint* cmpTarget, const Mat
     /* Access Shape class by Paint is bad... but it's ok still it's an internal usage. */
     auto shape = static_cast<Shape*>(cmpTarget);
 
+    //Trimming likely makes the shape non-rectangular
+    if (SHAPE(shape)->rs.trimpath()) return Result::InsufficientCondition;
+
     //Rectangle Candidates?
     const Point* pts;
     uint32_t ptsCnt;


### PR DESCRIPTION
Rectangular clippers followed the 'fastTrack' path, which caused their trimming to be ignored. Fixed.

```
        auto shape1 = tvg::Shape::gen();
        shape1->appendCircle(400, 400, 350, 350);
        shape1->fill(0, 50, 155);
        shape1->strokeFill(0, 0, 255);
        shape1->strokeWidth(12);

        auto clip = tvg::Shape::gen();
        clip->appendRect(0, 0, 400, 400);
        clip->trimpath(0.0, 0.5, true);
        shape1->clip((clip));

        canvas->push(shape1);
```

before:
<img width="421" alt="trim_fasttr_before" src="https://github.com/user-attachments/assets/d841d58d-8f8d-4d46-9bc0-dac90783db96" />

after
<img width="413" alt="trim_fasttr_after" src="https://github.com/user-attachments/assets/317b4617-3535-400b-a28c-f8e7daee813f" />

