### PR TITLE
sw_engine: hanndle empty clips

### DIFF
--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -842,6 +842,8 @@ void _replaceClipSpan(SwRle *rle, SwSpan* clippedSpans, uint32_t size)
 
 SwRle* rleRender(SwRle* rle, const SwOutline* outline, const SwBBox& renderRegion, bool antiAlias)
 {
+    if (!outline) return nullptr;
+
     constexpr auto RENDER_POOL_SIZE = 16384L;
     constexpr auto BAND_SIZE = 40;
 


### PR DESCRIPTION
Generating the outline may return false, e.g., if the shape is completely trimmed. If such a shape was used as a clip, an attempt to generate 'rle' will still be made. In such a case, a crash will occur because the outline is nullptr.

```
        auto shape1 = tvg::Shape::gen();
        shape1->appendCircle(400, 400, 350, 350);
        shape1->fill(0, 50, 155);
        shape1->strokeFill(0, 0, 255);
        shape1->strokeWidth(12);

        auto clip = tvg::Shape::gen();
        clip->appendRect(0, 0, 400, 400, 50, 50);
        clip->trimpath(0.5, 0.5, true);
        shape1->clip((clip));

        canvas->push(shape1);
```

```
../src/renderer/sw_engine/tvgSwRle.cpp:694:5: runtime error: member access within null pointer of type 'SwOutline'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/renderer/sw_engine/tvgSwRle.cpp:694:5 in 
AddressSanitizer:DEADLYSIGNAL
=================================================================
==26305==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000010 (pc 0x00010a1e0422 bp 0x70000bc75b40 sp 0x70000bc70960 T1)
==26305==The signal is caused by a READ memory access.
==26305==Hint: address points to the zero page.
    #0 0x10a1e0422 in rleRender(SwRle*, SwOutline const*, SwBBox const&, bool) tvgSwRle.cpp:923
    #1 0x10a1eeb9b in shapeGenRle(SwShape*, tvg::RenderShape const*, bool) tvgSwShape.cpp:447
    #2 0x10a1da71a in SwShapeTask::run(unsigned int) tvgSwRenderer.cpp:143
    #3 0x10a122ca2 in tvg::Task::operator()(unsigned int) tvgTaskScheduler.h:64
    #4 0x10a1220e1 in tvg::TaskSchedulerImpl::run(unsigned int) tvgTaskScheduler.cpp:153
    #5 0x10a12137e in void* std::__1::__thread_proxy[abi:se170006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, tvg::TaskSchedulerImpl::TaskSchedulerImpl(unsigned int)::'lambda'()>>(void*) thread.h:238
    #6 0x7ff80798118a in _pthread_start+0x62 (libsystem_pthread.dylib:x86_64+0x618a)
    #7 0x7ff80797cae2 in thread_start+0xe (libsystem_pthread.dylib:x86_64+0x1ae2)
```