### PR TITLE
common: replace the strdup() with strDuplicate()

### DIFF
--- a/src/common/tvgStr.cpp
+++ b/src/common/tvgStr.cpp
@@ -212,10 +212,9 @@ char* strDuplicate(const char *str, size_t n)
     if (len < n) n = len;
 
     auto ret = tvg::malloc<char*>(n + 1);
-    if (!ret) return nullptr;
     ret[n] = '\0';
 
-    return (char *) memcpy(ret, str, n);
+    return (char*)memcpy(ret, str, n);
 }
 
 char* strAppend(char* lhs, const char* rhs, size_t n)

--- a/src/common/tvgStr.h
+++ b/src/common/tvgStr.h
@@ -24,15 +24,16 @@
 #define _TVG_STR_H_
 
 #include <cstddef>
+#include <stdint.h>
 
 namespace tvg
 {
 
-float strToFloat(const char *nPtr, char **endPtr);      //convert to float
-char* strDuplicate(const char *str, size_t n);          //copy the string
-char* strAppend(char* lhs, const char* rhs, size_t n);  //append the rhs to the lhs
-char* strDirname(const char* path);                     //return the full directory name
-const char* strExtension(const char* filename);         //return the file extension name
+float strToFloat(const char *nPtr, char **endPtr);                //convert to float
+char* strDuplicate(const char *str, size_t n = SIZE_MAX);         //copy the string
+char* strAppend(char* lhs, const char* rhs, size_t n);            //append the rhs to the lhs
+char* strDirname(const char* path);                               //return the full directory name
+const char* strExtension(const char* filename);                   //return the file extension name
 
 }
 #endif //_TVG_STR_H_

--- a/src/loaders/lottie/tvgLottieInterpolator.cpp
+++ b/src/loaders/lottie/tvgLottieInterpolator.cpp
@@ -24,8 +24,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <string.h>
-#include "tvgCommon.h"
+#include "tvgStr.h"
 #include "tvgMath.h"
 #include "tvgLottieInterpolator.h"
 
@@ -127,7 +126,7 @@ float LottieInterpolator::progress(float t)
 
 void LottieInterpolator::set(const char* key, Point& inTangent, Point& outTangent)
 {
-    if (key) this->key = strdup(key);
+    if (key) this->key = strDuplicate(key);
     this->inTangent = inTangent;
     this->outTangent = outTangent;
 

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -20,11 +20,11 @@
  * SOFTWARE.
  */
 
-#include "tvgLottieLoader.h"
+#include "tvgStr.h"
+ #include "tvgLottieLoader.h"
 #include "tvgLottieModel.h"
 #include "tvgLottieParser.h"
 #include "tvgLottieBuilder.h"
-#include "tvgStr.h"
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -209,8 +209,8 @@ bool LottieLoader::open(const char* data, uint32_t size, const char* rpath, bool
     this->size = size;
     this->copy = copy;
 
-    if (!rpath) this->dirName = strdup(".");
-    else this->dirName = strdup(rpath);
+    if (!rpath) this->dirName = strDuplicate(".");
+    else this->dirName = strDuplicate(rpath);
 
     return header();
 }
@@ -295,7 +295,7 @@ bool LottieLoader::override(const char* slots, bool byDefault)
     //override slots
     if (slots) {
         //Copy the input data because the JSON parser will encode the data immediately.
-        auto temp = byDefault ? slots : strdup(slots);
+        auto temp = byDefault ? slots : strDuplicate(slots);
 
         //parsing slot json
         LottieParser parser(temp, dirName, builder->expressions());

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -466,7 +466,7 @@ void LottieParser::registerSlot(LottieObject* obj, const char* sid)
         (*p)->pairs.push({obj});
         return;
     }
-    comp->slots.push(new LottieSlot(strdup(sid), obj, type));
+    comp->slots.push(new LottieSlot(strDuplicate(sid), obj, type));
 }
 
 

--- a/src/loaders/lottie/tvgLottieParserHandler.cpp
+++ b/src/loaders/lottie/tvgLottieParserHandler.cpp
@@ -42,6 +42,7 @@
  * SOFTWARE.
  */
 
+#include "tvgStr.h"
 #include "tvgLottieParserHandler.h"
 
 
@@ -123,7 +124,7 @@ const char* LookaheadParserHandler::getString()
 char* LookaheadParserHandler::getStringCopy()
 {
     auto str = getString();
-    if (str) return strdup(str);
+    if (str) return strDuplicate(str);
     return nullptr;
 }
 

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include "tvgMath.h"
+#include "tvgStr.h"
 #include "tvgLottieData.h"
 #include "tvgLottieInterpolator.h"
 #include "tvgLottieExpressions.h"
@@ -919,8 +920,8 @@ struct LottieBitmap : LottieProperty
         } else {
             //TODO: optimize here by avoiding data copy
             TVGLOG("LOTTIE", "Shallow copy of the image data!");
-            b64Data = strdup(rhs.b64Data);
-            mimeType = strdup(rhs.mimeType);
+            b64Data = strDuplicate(rhs.b64Data);
+            mimeType = strDuplicate(rhs.mimeType);
         }
         size = rhs.size;
         width = rhs.width;

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include "tvgStr.h"
 #include "tvgSvgCssStyle.h"
 
 /************************************************************************/
@@ -71,7 +72,7 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from)
         to->fill.paint.curColor = from->fill.paint.curColor;
         if (from->fill.paint.url) {
             if (to->fill.paint.url) tvg::free(to->fill.paint.url);
-            to->fill.paint.url = strdup(from->fill.paint.url);
+            to->fill.paint.url = strDuplicate(from->fill.paint.url);
         }
         to->fill.flags = (to->fill.flags | SvgFillFlags::Paint);
         to->flags = (to->flags | SvgStyleFlags::Fill);
@@ -105,7 +106,7 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from)
         to->stroke.paint.curColor = from->stroke.paint.curColor;
         if (from->stroke.paint.url) {
             if (to->stroke.paint.url) tvg::free(to->stroke.paint.url);
-            to->stroke.paint.url = strdup(from->stroke.paint.url);
+            to->stroke.paint.url = strDuplicate(from->stroke.paint.url);
         }
         to->stroke.flags = (to->stroke.flags | SvgStrokeFlags::Paint);
         to->flags = (to->flags | SvgStyleFlags::Stroke);
@@ -196,11 +197,11 @@ void cssCopyStyleAttr(SvgNode* to, const SvgNode* from)
 
     if (from->style->clipPath.url) {
         if (to->style->clipPath.url) tvg::free(to->style->clipPath.url);
-        to->style->clipPath.url = strdup(from->style->clipPath.url);
+        to->style->clipPath.url = strDuplicate(from->style->clipPath.url);
     }
     if (from->style->mask.url) {
         if (to->style->mask.url) tvg::free(to->style->mask.url);
-        to->style->mask.url = strdup(from->style->mask.url);
+        to->style->mask.url = strDuplicate(from->style->mask.url);
     }
 }
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -20,16 +20,14 @@
  * SOFTWARE.
  */
 
-#include <cstring>
 #include <fstream>
-#include <float.h>
+#include "tvgStr.h"
+#include "tvgMath.h"
 #include "tvgLoader.h"
 #include "tvgXmlParser.h"
 #include "tvgSvgLoader.h"
 #include "tvgSvgSceneBuilder.h"
-#include "tvgStr.h"
 #include "tvgSvgCssStyle.h"
-#include "tvgMath.h"
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -65,7 +63,7 @@ static char* _copyId(const char* str)
     if (!str) return nullptr;
     if (strlen(str) == 0) return nullptr;
 
-    return strdup(str);
+    return strDuplicate(str);
 }
 
 
@@ -2011,7 +2009,7 @@ static char* _idFromHref(const char* href)
 {
     href = _skipSpace(href, nullptr);
     if ((*href) == '#') href++;
-    return strdup(href);
+    return strDuplicate(href);
 }
 
 
@@ -2233,7 +2231,7 @@ static bool _attrParseTextNode(void* data, const char* key, const char* value)
     if (STR_AS(key, "font-family")) {
         if (value) {
             tvg::free(text->fontFamily);
-            text->fontFamily = strdup(value);
+            text->fontFamily = strDuplicate(value);
         }
     } else if (STR_AS(key, "style")) {
         return simpleXmlParseW3CAttribute(value, strlen(value), _parseStyleAttr, loader);
@@ -3216,15 +3214,15 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
     to->style->flags = (to->style->flags | from->style->flags);
     if (from->style->clipPath.url) {
         tvg::free(to->style->clipPath.url);
-        to->style->clipPath.url = strdup(from->style->clipPath.url);
+        to->style->clipPath.url = strDuplicate(from->style->clipPath.url);
     }
     if (from->style->mask.url) {
         tvg::free(to->style->mask.url);
-        to->style->mask.url = strdup(from->style->mask.url);
+        to->style->mask.url = strDuplicate(from->style->mask.url);
     }
     if (from->style->filter.url) {
         if (to->style->filter.url) tvg::free(to->style->filter.url);
-        to->style->filter.url = strdup(from->style->filter.url);
+        to->style->filter.url = strDuplicate(from->style->filter.url);
     }
 
     //Copy node attribute
@@ -3248,7 +3246,7 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
         case SvgNodeType::Path: {
             if (from->node.path.path) {
                 tvg::free(to->node.path.path);
-                to->node.path.path = strdup(from->node.path.path);
+                to->node.path.path = strDuplicate(from->node.path.path);
             }
             break;
         }
@@ -3271,7 +3269,7 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             to->node.image.h = from->node.image.h;
             if (from->node.image.href) {
                 tvg::free(to->node.image.href);
-                to->node.image.href = strdup(from->node.image.href);
+                to->node.image.href = strDuplicate(from->node.image.href);
             }
             break;
         }
@@ -3291,11 +3289,11 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             to->node.text.fontSize = from->node.text.fontSize;
             if (from->node.text.text) {
                 tvg::free(to->node.text.text);
-                to->node.text.text = strdup(from->node.text.text);
+                to->node.text.text = strDuplicate(from->node.text.text);
             }
             if (from->node.text.fontFamily) {
                 tvg::free(to->node.text.fontFamily);
-                to->node.text.fontFamily = strdup(from->node.text.fontFamily);
+                to->node.text.fontFamily = strDuplicate(from->node.text.fontFamily);
             }
             break;
         }

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -21,8 +21,9 @@
  */
 
 #include <ctype.h>
-#include "tvgXmlParser.h"
 #include "tvgStr.h"
+#include "tvgXmlParser.h"
+
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -550,7 +551,7 @@ const char* simpleXmlParseCSSAttribute(const char* buf, unsigned bufLength, char
         if (*p == '.') break;
     }
 
-    if (p == itr) *tag = strdup("all");
+    if (p == itr) *tag = strDuplicate("all");
     else *tag = strDuplicate(itr, p - itr);
 
     if (p == itrEnd) *name = nullptr;

--- a/src/renderer/tvgCommon.h
+++ b/src/renderer/tvgCommon.h
@@ -62,7 +62,6 @@ using namespace tvg;
 
 #if defined(_MSC_VER) && defined(__clang__)
     #define strncpy strncpy_s
-    #define strdup _strdup
 #endif
 
 void* operator new(std::size_t size);

--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -20,8 +20,6 @@
  * SOFTWARE.
  */
 
-#include <string.h>
-
 #include "tvgInlist.h"
 #include "tvgStr.h"
 #include "tvgLoader.h"
@@ -289,7 +287,7 @@ LoadModule* LoaderMgr::loader(const char* filename, bool* invalid)
     if (auto loader = _findByPath(filename)) {
         if (loader->open(filename)) {
             if (allowCache) {
-                loader->hashpath = strdup(filename);
+                loader->hashpath = strDuplicate(filename);
                 loader->pathcache = true;
                 {
                     ScopedLock lock(key);
@@ -305,7 +303,7 @@ LoadModule* LoaderMgr::loader(const char* filename, bool* invalid)
         if (auto loader = _find(static_cast<FileType>(i))) {
             if (loader->open(filename)) {
                 if (allowCache) {
-                    loader->hashpath = strdup(filename);
+                    loader->hashpath = strDuplicate(filename);
                     loader->pathcache = true;
                     {
                         ScopedLock lock(key);
@@ -438,7 +436,7 @@ LoadModule* LoaderMgr::loader(const char* name, const char* data, uint32_t size,
     //function is dedicated for ttf loader (the only supported font loader)
     auto loader = new TtfLoader;
     if (loader->open(data, size, "", copy)) {
-        loader->hashpath = strdup(name);
+        loader->hashpath = strDuplicate(name);
         loader->pathcache = true;
         ScopedLock lock(key);
         _activeLoaders.back(loader);

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -23,7 +23,7 @@
 #ifndef _TVG_TEXT_H
 #define _TVG_TEXT_H
 
-#include "tvgCommon.h"
+#include "tvgStr.h"
 #include "tvgShape.h"
 #include "tvgFill.h"
 #include "tvgLoader.h"
@@ -53,7 +53,7 @@ struct Text::Impl : Paint::Impl
     Result text(const char* utf8)
     {
         tvg::free(this->utf8);
-        if (utf8) this->utf8 = strdup(utf8);
+        if (utf8) this->utf8 = strDuplicate(utf8);
         else this->utf8 = nullptr;
         changed = true;
 
@@ -156,7 +156,7 @@ struct Text::Impl : Paint::Impl
             ++dup->loader->sharing;
         }
 
-        dup->utf8 = strdup(utf8);
+        dup->utf8 = strDuplicate(utf8);
         dup->italic = italic;
         dup->fontSize = fontSize;
 

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -22,6 +22,7 @@
 
 #include <cstring>
 
+#include "tvgStr.h"
 #include "tvgGifEncoder.h"
 #include "tvgGifSaver.h"
 
@@ -135,7 +136,7 @@ bool GifSaver::save(Animation* animation, Paint* bg, const char* filename, TVG_U
     }
 
     if (!filename) return false;
-    this->path = strdup(filename);
+    this->path = strDuplicate(filename);
 
     this->animation = animation;
 


### PR DESCRIPTION
tvg expects the coherent memory allocator usage,
while strdup() is out of the control. so replaced it.