### PR TITLE
lottie/text: fix justification in embedded font rendering

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -923,9 +923,20 @@ static void _fontText(LottieText* text, Scene* scene, float frameNo, LottieExpre
         //fallback to any available font
         txt->font(nullptr, size);
     }
-    txt->translate(0.0f, -doc.size * 100.0f);
     txt->text(doc.text);
     txt->fill(doc.color.rgb[0], doc.color.rgb[1], doc.color.rgb[2]);
+
+    float width;
+    txt->bounds(nullptr, nullptr, &width, nullptr, false);
+
+    float cursorX = 0.0f;
+    if (doc.justify == 1) {
+        cursorX = width * -1;
+    } else if (doc.justify == 2) {
+        cursorX = width * -0.5f;
+    }
+
+    txt->translate(cursorX, -doc.size * 100.0f);
     scene->push(txt);
 }
 


### PR DESCRIPTION
issue: #3266

Embedded font rendering was recently introduced but lacked support for text justification.  This adds the necessary justification logic to ensure proper alignment.



| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/e2537bb5-fd2b-4371-9266-da2f0307f2f8) | ![After](https://github.com/user-attachments/assets/929bea2f-bfc8-46bf-91da-caa1a6833337) |
| ![Before](https://github.com/user-attachments/assets/57bd0756-8c2a-425c-b13b-1fa2d0db0ae0) | ![After](https://github.com/user-attachments/assets/55b8b194-5104-4c66-bb5d-d766ce036454) |