### PR TITLE
renderer: improved the paint bounding box accuracy

### DIFF
--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -344,6 +344,7 @@ struct Bezier
     float atApprox(float at, float length) const;
     Point at(float t) const;
     float angle(float t) const;
+    void bounds(Point& min, Point& max) const;
 };
 
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -104,6 +104,7 @@ struct RenderPath
         cmds.clear();
     }
 
+    bool bounds(float* x, float* y, float* w, float* h);
 };
 
 struct RenderTrimPath

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -118,24 +118,7 @@ struct Shape::Impl : Paint::Impl
 
     bool bounds(float* x, float* y, float* w, float* h, bool stroking)
     {
-        //Path bounding size
-        if (rs.path.pts.count > 0 ) {
-            auto pts = rs.path.pts.begin();
-            Point min = { pts->x, pts->y };
-            Point max = { pts->x, pts->y };
-
-            for (auto pts2 = pts + 1; pts2 < rs.path.pts.end(); ++pts2) {
-                if (pts2->x < min.x) min.x = pts2->x;
-                if (pts2->y < min.y) min.y = pts2->y;
-                if (pts2->x > max.x) max.x = pts2->x;
-                if (pts2->y > max.y) max.y = pts2->y;
-            }
-
-            if (x) *x = min.x;
-            if (y) *y = min.y;
-            if (w) *w = max.x - min.x;
-            if (h) *h = max.y - min.y;
-        }
+        if (!rs.path.bounds(x, y, w, h)) return false;
 
         //Stroke feathering
         if (stroking && rs.stroke) {
@@ -144,7 +127,7 @@ struct Shape::Impl : Paint::Impl
             if (w) *w += rs.stroke->width;
             if (h) *h += rs.stroke->width;
         }
-        return rs.path.pts.count > 0 ? true : false;
+        return true;
     }
 
     void reserveCmd(uint32_t cmdCnt)


### PR DESCRIPTION
previously, the bounding box calculation was simply determined by comparing all the points, which led to incorrect sizing due to Bezier control points.

Now, it accurately computes the curve boundary,
properly addressing this issue.

before -> after:
![image](https://github.com/user-attachments/assets/6318a50c-de2b-48ab-9c39-cd2d2de2adb9)