### PR TITLE
renderer: fix rectangular stroke clipping

### DIFF
--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -250,7 +250,7 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
         viewport = renderer->viewport();
         /* TODO: Intersect the clipper's clipper, if both are FastTrack.
            Update the subsequent clipper first and check its ctxFlag. */
-        if (!PAINT(this->clipper)->clipper && _compFastTrack(renderer, this->clipper, pm, viewport) == Result::Success) {
+        if (!PAINT(this->clipper)->clipper && SHAPE(this->clipper)->rs.strokeWidth() == 0.0f && _compFastTrack(renderer, this->clipper, pm, viewport) == Result::Success) {
             PAINT(this->clipper)->ctxFlag |= ContextFlag::FastTrack;
             compFastTrack = Result::Success;
         } else {

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -250,12 +250,13 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
         viewport = renderer->viewport();
         /* TODO: Intersect the clipper's clipper, if both are FastTrack.
            Update the subsequent clipper first and check its ctxFlag. */
-        if (!PAINT(this->clipper)->clipper && (compFastTrack = _compFastTrack(renderer, this->clipper, pm, viewport)) == Result::Success) {
+        if (!PAINT(this->clipper)->clipper && _compFastTrack(renderer, this->clipper, pm, viewport) == Result::Success) {
             PAINT(this->clipper)->ctxFlag |= ContextFlag::FastTrack;
-        }
-        if (compFastTrack == Result::InsufficientCondition) {
+            compFastTrack = Result::Success;
+        } else {
             trd = PAINT(this->clipper)->update(renderer, pm, clips, 255, pFlag, true);
             clips.push(trd);
+            compFastTrack = Result::InsufficientCondition;
         }
     }
 


### PR DESCRIPTION
For rectangular stroke clipping, clipping was happening in the fastTrack mode, resulting in regular clipping instead of stroke clipping.

1. first commit:
before:
<img width="300" alt="Zrzut ekranu 2025-03-4 o 11 43 26" src="https://github.com/user-attachments/assets/2ec01669-9daa-461d-86b2-a5957eedd176" />

after:
<img width="300" alt="Zrzut ekranu 2025-03-4 o 11 43 12" src="https://github.com/user-attachments/assets/0b77a00a-dc54-476d-a2fe-82f502d065b6" />

sample:
```
        auto rect = tvg::Shape::gen();
        rect->appendRect(0, 0, 800, 800);
        rect->fill(255, 0, 0);

        auto mask = tvg::Shape::gen();
        mask->appendRect(10, 10, 780, 780);
        mask->fill(255, 255, 255);
        rect->mask(mask, tvg::MaskMethod::Alpha);

        auto clipRect = tvg::Shape::gen();
        clipRect->appendRect(100, 100, 600, 600, 100, 100);
        //clipRect->strokeWidth(60);

        auto clip = tvg::Shape::gen();
        clip->appendRect(100, 100, 600, 600, 100, 100);
        clipRect->clip(clip);

        rect->clip(clipRect);
        canvas->push(rect);
```

2. second commit:

before:
<img width="300" alt="Zrzut ekranu 2025-03-3 o 23 57 27" src="https://github.com/user-attachments/assets/d90f574f-c93e-4d9a-a399-06731e6800ac" />

after:
<img width="300" alt="Zrzut ekranu 2025-03-3 o 23 57 12" src="https://github.com/user-attachments/assets/56ff13e4-39f7-438c-ae32-5c90e12b20c6" />

sample:
```
        auto rect = tvg::Shape::gen();
        rect->appendRect(0, 0, 800, 800);
        rect->fill(255, 0, 0);

        auto clipRect = tvg::Shape::gen();
        clipRect->appendRect(100, 100, 600, 600);
        clipRect->strokeWidth(60);

        rect->clip(clipRect);
        canvas->push(rect);
```