### PR TITLE
api: object oriented bounding box support

### DIFF
--- a/examples/BoundingBox.cpp
+++ b/examples/BoundingBox.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+
+#include "Example.h"
+
+/************************************************************************/
+/* ThorVG Drawing Contents                                              */
+/************************************************************************/
+
+struct UserExample : tvgexam::Example
+{
+    void bbox(tvg::Canvas* canvas, tvg::Paint* paint)
+    {
+        tvg::Point pts[4];
+        paint->bounds(pts);
+
+        auto bound = tvg::Shape::gen();
+        bound->moveTo(pts[0].x, pts[0].y);
+        bound->lineTo(pts[1].x, pts[1].y);
+        bound->lineTo(pts[2].x, pts[2].y);
+        bound->lineTo(pts[3].x, pts[3].y);
+        bound->close();
+        bound->strokeWidth(2.0f);
+        bound->strokeFill(255, 255, 0);
+
+        canvas->push(bound);
+    }
+
+    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    {
+        if (!canvas) return false;
+
+        {
+            auto shape = tvg::Shape::gen();
+            shape->appendCircle(50, 100, 40, 100);
+            shape->fill(0, 30, 255);
+            canvas->push(shape);
+            bbox(canvas, shape);
+        }
+
+        {
+            auto shape = tvg::Shape::gen();
+            shape->appendRect(120, 70, 100, 20);
+            shape->fill(100, 250, 155);
+            canvas->push(shape);
+            bbox(canvas, shape);
+        }
+
+        {
+            auto shape = tvg::Shape::gen();
+            shape->appendRect(120, 170, 100, 20);
+            shape->fill(200, 150, 55);
+            shape->rotate(30);
+            canvas->push(shape);
+            bbox(canvas, shape);
+        }
+
+        {
+            auto shape = tvg::Shape::gen();
+            shape->appendRect(450, 50, 150, 100, 40, 50);
+            shape->appendCircle(550, 300, 200, 100);
+            shape->fill(50, 50, 155);
+            canvas->push(shape);
+            bbox(canvas, shape);
+        }
+
+        {
+            auto svg = tvg::Picture::gen();
+            svg->load(EXAMPLE_DIR"/svg/tiger.svg");
+            svg->scale(0.3f);
+            svg->translate(500, 500);
+            canvas->push(svg);
+            bbox(canvas, svg);
+        }
+
+        {
+            auto svg = tvg::Picture::gen();
+            svg->load(EXAMPLE_DIR"/svg/tiger.svg");
+            svg->scale(0.2f);
+            svg->translate(170, 300);
+            svg->rotate(45);
+            canvas->push(svg);
+            bbox(canvas, svg);
+
+        }
+
+        {
+            auto img = tvg::Picture::gen();
+            img->load(EXAMPLE_DIR"/image/test.png");
+            img->scale(0.3f);
+            img->translate(150, 100);
+            canvas->push(img);
+            bbox(canvas, img);
+        }
+
+        {
+            auto img = tvg::Picture::gen();
+            img->load(EXAMPLE_DIR"/image/test.jpg");
+            img->scale(0.3f);
+            img->rotate(80);
+            img->translate(200, 600);
+            canvas->push(img);
+            bbox(canvas, img);
+        }
+
+        {
+            auto line = tvg::Shape::gen();            
+            line->moveTo(400, 450);
+            line->lineTo(700, 450);
+            line->strokeWidth(20);
+            line->strokeFill(55, 55, 0);
+            canvas->push(line);
+            bbox(canvas, line);
+        }
+
+        {
+            auto curve = tvg::Shape::gen();            
+            curve->moveTo(0, 0);
+            curve->cubicTo(40.0f, -10.0f, 120.0f, -150.0f, 80.0f, 0.0f);
+            curve->translate(250, 700);
+            curve->strokeWidth(2.0f);
+            curve->strokeFill(255, 255, 255);
+            canvas->push(curve);
+            bbox(canvas, curve);
+        }
+
+        {
+            auto curve = tvg::Shape::gen();            
+            curve->moveTo(0, 0);
+            curve->cubicTo(40.0f, -10.0f, 120.0f, -150.0f, 80.0f, 0.0f);
+            curve->translate(350, 700);
+            curve->rotate(20.0f);
+            curve->strokeWidth(2.0f);
+            curve->strokeFill(255, 0, 255);
+            canvas->push(curve);
+            bbox(canvas, curve);
+        }
+
+        return true;
+    }
+};
+
+
+/************************************************************************/
+/* Entry Point                                                          */
+/************************************************************************/
+
+int main(int argc, char **argv)
+{
+    return tvgexam::main(new UserExample, argc, argv);
+}

--- a/examples/LottieTweening.cpp
+++ b/examples/LottieTweening.cpp
@@ -97,13 +97,30 @@ struct UserExample : tvgexam::Example
 
     bool clicked(tvg::Canvas* canvas, int32_t x, int32_t y) override
     {
+        auto intersect = [&](float x, float y, tvg::Point* obb) -> bool {
+            //compute edge vectors
+            tvg::Point e1 = {obb[1].x - obb[0].x, obb[1].y - obb[0].y};  // Edge from obb[0] to obb[1]
+            tvg::Point e2 = {obb[3].x - obb[0].x, obb[3].y - obb[0].y};  // Edge from obb[0] to obb[3]
+
+            //compute vectors from obb[0] to the test point
+            tvg::Point o = {x - obb[0].x, y - obb[0].y};
+
+            /* compute dot products to express `o` in terms of edge1 and edge2
+               and then compute barycentric coordinates (u, v) within the box space */
+            auto u = (o.x * e1.x + o.y * e1.y) / (e1.x * e1.x + e1.y * e1.y);
+            auto v = (o.x * e2.x + o.y * e2.y) / (e2.x * e2.x + e2.y * e2.y);
+
+            // Check if point is inside the OBB
+            return (u >= 0.0f && u <= 1.0f && v >= 0.0f && v <= 1.0f);
+        };
+
         int i = 0;
         for (auto& state : states) {
             if (auto paint = lottie->picture()->paint(tvg::Accessor::id(state.name.c_str()))) {
-                float px, py, pw, ph;
-                paint->bounds(&px, &py, &pw, &ph, true);
+                tvg::Point obb[4];
+                paint->bounds(obb);
                 //hit a emoji layer!
-                if (x >= px && x <= px + pw && y >= py && y <= py + ph) {
+                if (intersect(x, y, obb)) {
                     tweening(i);
                     return true;
                 }

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -24,6 +24,7 @@ source_file = [
     'AnimateMasking.cpp',
     'Animation.cpp',
     'Blending.cpp',
+    'BoundingBox.cpp',
     'Clipping.cpp',
     'CustomTransform.cpp',
     'DataLoad.cpp',

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -412,20 +412,42 @@ public:
     Result blend(BlendMethod method) noexcept;
 
     /**
-     * @brief Gets the axis-aligned bounding box of the paint object.
+     * @brief Retrieves the object-oriented bounding box (OBB) of the paint object in canvas space.
+     * 
+     * This function returns the bounding box of the paint, as an oriented bounding box (OBB) after transformations are applied.
      *
-     * @param[out] x The x-coordinate of the upper-left corner of the object.
-     * @param[out] y The y-coordinate of the upper-left corner of the object.
-     * @param[out] w The width of the object.
-     * @param[out] h The height of the object.
-     * @param[in] transformed If @c true, the paint's transformations are taken into account in the scene it belongs to. Otherwise they aren't.
+     * @param[out] pt4 An array of four points representing the bounding box. The array size must be 4.
      *
-     * @note This is useful when you need to figure out the bounding box of the paint in the canvas space.
-     * @note The bounding box doesn't indicate the actual drawing region. It's the smallest rectangle that encloses the object.
-     * @note If @p transformed is @c true, the paint needs to be pushed into a canvas and updated before this api is called.
+     * @retval Result::InvalidArguments @p pt4 is @c nullptr.
+     * @retval Result::InsufficientCondition If it failed to compute the bounding box (mostly due to invalid path information).
+     * 
+     * @note The paint must be pushed into a canvas and updated before calling this function.
+     *
+     * @see Paint::bounds(float* x, float* y, folat* w, float* h)
+     * @see Canvas::update()
+     *
+     * @since 1.0
+     */
+    Result bounds(Point* pt4) const noexcept;
+
+    /**
+     * @brief Retrieves the axis-aligned bounding box (AABB) of the paint object in local space.
+     *
+     * This function returns the bounding box of the paint object relative to its local coordinate system, without applying any transformations.
+     *
+     * @param[out] x The x-coordinate of the upper-left corner of the bounding box.
+     * @param[out] y The y-coordinate of the upper-left corner of the bounding box.
+     * @param[out] w The width of the bounding box.
+     * @param[out] h The height of the bounding box.
+     *
+     * @retval Result::InsufficientCondition If it failed to compute the bounding box (mostly due to invalid path information).
+     *
+     * @note The bounding box is calculated in the object's local space, meaning transformations such as scaling, rotation, or translation are not applied.
+     *
+     * @see Paint::bounds(Point* pt4)
      * @see Canvas::update()
      */
-    Result bounds(float* x, float* y, float* w, float* h, bool transformed = false) const noexcept;
+    Result bounds(float* x, float* y, float* w, float* h) const noexcept;
 
     /**
      * @brief Duplicates the object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -912,25 +912,49 @@ TVG_API Tvg_Result tvg_paint_get_opacity(const Tvg_Paint* paint, uint8_t* opacit
 TVG_API Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint);
 
 
-/*!
-* @brief Gets the axis-aligned bounding box of the Tvg_Paint object.
-*
-* @param[in] paint The Tvg_Paint object of which to get the bounds.
-* @param[out] x The x-coordinate of the upper-left corner of the object.
-* @param[out] y The y-coordinate of the upper-left corner of the object.
-* @param[out] w The width of the object.
-* @param[out] h The height of the object.
-* @param[in] transformed If @c true, the paint's transformations are taken into account in the scene it belongs to. Otherwise they aren't.
-*
-* @return Tvg_Result enumeration.
-* @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-*
-* @note This is useful when you need to figure out the bounding box of the paint in the canvas space.
-* @note The bounding box doesn't indicate the actual drawing region. It's the smallest rectangle that encloses the object.
-* @note If @p transformed is @c true, the paint needs to be pushed into a canvas and updated before this api is called.
-* @see tvg_canvas_update_paint()
-*/
-TVG_API Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h, bool transformed);
+/**
+ * @brief Retrieves the axis-aligned bounding box (AABB) of the paint object in local space.
+ *
+ * This function returns the bounding box of the paint object relative to its local coordinate system, without applying any transformations.
+ *
+ * @param[in] paint The Tvg_Paint object of which to get the bounds.
+ * @param[out] x The x-coordinate of the upper-left corner of the bounding box.
+ * @param[out] y The y-coordinate of the upper-left corner of the bounding box.
+ * @param[out] w The width of the bounding box.
+ * @param[out] h The height of the bounding box.
+ *
+ * @return Tvg_Result enumeration.
+ * @retval TVG_RESULT_INVALID_ARGUMENT An invalid @p paint.
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If it failed to compute the bounding box (mostly due to invalid path information).
+ *  
+ * @note The bounding box is calculated in the object's local space, meaning transformations such as scaling, rotation, or translation are not applied.
+ *
+ * @see tvg_paint_get_obb()
+ * @see tvg_canvas_update_paint()
+ */
+TVG_API Tvg_Result tvg_paint_get_aabb(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
+
+
+/**
+ * @brief Retrieves the object-oriented bounding box (OBB) of the paint object in canvas space.
+ * 
+ * This function returns the bounding box of the paint, as an oriented bounding box (OBB) after transformations are applied.
+ *
+ * @param[in] paint The Tvg_Paint object of which to get the bounds.
+ * @param[out] pt4 An array of four points representing the bounding box. The array size must be 4.
+ *
+ * @return Tvg_Result enumeration.
+ * @retval TVG_RESULT_INVALID_ARGUMENT @p paint or @p pt4 is invalid.
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If it failed to compute the bounding box (mostly due to invalid path information).
+ * 
+ * @note The paint must be pushed into a canvas and updated before calling this function.
+ *
+ * @see tvg_paint_get_aabb()
+ * @see tvg_canvas_update_paint()
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_paint_get_obb(const Tvg_Paint* paint, Tvg_Point* pt4);
 
 
 /*!
@@ -941,7 +965,7 @@ TVG_API Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float*
 * @param[in] method The method used to mask the source object with the target.
 *
 * @return Tvg_Result enumeration.
-* @retval TVG_RESULT_INVALID_ARGUMENT An invalid @p paint or @p target object or the @p method equal to TVG_MASK_METHOD_NONE.
+
 */
 TVG_API Tvg_Result tvg_paint_set_mask_method(Tvg_Paint* paint, Tvg_Paint* target, Tvg_Mask_Method method);
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -256,12 +256,17 @@ TVG_API Tvg_Result tvg_paint_get_opacity(const Tvg_Paint* paint, uint8_t* opacit
 }
 
 
-TVG_API Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h, bool transformed)
+TVG_API Tvg_Result tvg_paint_get_aabb(const Tvg_Paint* paint, float* x, float* y, float* w, float* h)
 {
    if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
-   return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->bounds(x, y, w, h, transformed);
+   return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->bounds(x, y, w, h);
 }
 
+TVG_API Tvg_Result tvg_paint_get_obb(const Tvg_Paint* paint, Tvg_Point* pt4)
+{
+   if (!paint) return TVG_RESULT_INVALID_ARGUMENT;
+   return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->bounds((Point*)pt4);
+}
 
 TVG_API Tvg_Result tvg_paint_set_mask_method(Tvg_Paint* paint, Tvg_Paint* target, Tvg_Mask_Method method)
 {

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -927,7 +927,7 @@ static void _fontText(LottieText* text, Scene* scene, float frameNo, LottieExpre
     txt->fill(doc.color.rgb[0], doc.color.rgb[1], doc.color.rgb[2]);
 
     float width;
-    txt->bounds(nullptr, nullptr, &width, nullptr, false);
+    txt->bounds(nullptr, nullptr, &width, nullptr);
 
     auto cursorX = width * doc.justify;
     txt->translate(cursorX, -doc.size * 100.0f);

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -47,26 +47,10 @@ static inline bool _isGroupType(SvgNodeType type)
 
 //According to: https://www.w3.org/TR/SVG11/coords.html#ObjectBoundingBoxUnits (the last paragraph)
 //a stroke width should be ignored for bounding box calculations
-static Box _boundingBox(const Shape* shape)
+static Box _boundingBox(Paint* shape)
 {
     float x, y, w, h;
-    shape->bounds(&x, &y, &w, &h, false);
-
-    if (auto strokeW = shape->strokeWidth()) {
-        x += 0.5f * strokeW;
-        y += 0.5f * strokeW;
-        w -= strokeW;
-        h -= strokeW;
-    }
-
-    return {x, y, w, h};
-}
-
-
-static Box _boundingBox(const Text* text)
-{
-    float x, y, w, h;
-    text->bounds(&x, &y, &w, &h, false);
+    PAINT(shape)->bounds(&x, &y, &w, &h, false);
     return {x, y, w, h};
 }
 
@@ -260,7 +244,7 @@ static Matrix _compositionTransform(Paint* paint, const SvgNode* node, const Svg
     }
     if (!compNode->node.clip.userSpace) {
         float x, y, w, h;
-        PAINT(paint)->bounds(&x, &y, &w, &h, false, false);
+        PAINT(paint)->bounds(&x, &y, &w, &h, false);
         m *= {w, 0, x, 0, h, y, 0, 0, 1};
     }
     return m;
@@ -346,7 +330,7 @@ static Paint* _applyFilter(SvgLoaderData& loaderData, Paint* paint, const SvgNod
     auto scene = Scene::gen();
 
     Box bbox{};
-    paint->bounds(&bbox.x, &bbox.y, &bbox.w, &bbox.h, false);
+    paint->bounds(&bbox.x, &bbox.y, &bbox.w, &bbox.h);
     Box clipBox = filter.filterUserSpace ? filter.box : Box{bbox.x + filter.box.x * bbox.w, bbox.y + filter.box.y * bbox.h, filter.box.w * bbox.w, filter.box.h * bbox.h};
     auto primitiveUserSpace = filter.primitiveUserSpace;
     auto sx = paint->transform().e11;
@@ -943,13 +927,13 @@ static Scene* _sceneBuildHelper(SvgLoaderData& loaderData, const SvgNode* node, 
 }
 
 
-static void _updateInvalidViewSize(const Scene* scene, Box& vBox, float& w, float& h, SvgViewFlag viewFlag)
+static void _updateInvalidViewSize(Scene* scene, Box& vBox, float& w, float& h, SvgViewFlag viewFlag)
 {
     bool validWidth = (viewFlag & SvgViewFlag::Width);
     bool validHeight = (viewFlag & SvgViewFlag::Height);
 
     float x, y;
-    scene->bounds(&x, &y, &vBox.w, &vBox.h, false);
+    scene->bounds(&x, &y, &vBox.w, &vBox.h);
     if (!validWidth && !validHeight) {
         vBox.x = x;
         vBox.y = y;

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -256,7 +256,8 @@ namespace tvg
 
         RenderRegion bounds(RenderMethod* renderer) const;
         Iterator* iterator();
-        bool bounds(float* x, float* y, float* w, float* h, bool transformed, bool stroking, bool origin = false);
+        bool bounds(float* x, float* y, float* w, float* h, bool stroking);
+        bool bounds(Point* pt4, bool transformed, bool stroking, bool origin = false);
         RenderData update(RenderMethod* renderer, const Matrix& pm, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper = false);
         bool render(RenderMethod* renderer);
         Paint* duplicate(Paint* ret = nullptr);

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -114,13 +114,12 @@ struct Picture::Impl : Paint::Impl
         return Result::Success;
     }
 
-
-    bool bounds(float* x, float* y, float* w, float* h, bool stroking)
+    bool bounds(Point* pt4, bool stroking)
     {
-        if (x) *x = 0;
-        if (y) *y = 0;
-        if (w) *w = this->w;
-        if (h) *h = this->h;
+        pt4[0] = {0.0f, 0.0f};
+        pt4[1] = {w, 0.0f};
+        pt4[2] = {w, h};
+        pt4[3] = {0.0f, h};
         return true;
     }
 

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -194,34 +194,28 @@ struct Scene::Impl : Paint::Impl
         return ret;
     }
 
-    bool bounds(float* px, float* py, float* pw, float* ph, bool stroking)
+    bool bounds(Point* pt4, bool stroking)
     {
         if (paints.empty()) return false;
 
-        auto x1 = FLT_MAX;
-        auto y1 = FLT_MAX;
-        auto x2 = -FLT_MAX;
-        auto y2 = -FLT_MAX;
+        Point min = {FLT_MAX, FLT_MAX};
+        Point max = {-FLT_MAX, -FLT_MAX};
 
         for (auto paint : paints) {
-            auto x = FLT_MAX;
-            auto y = FLT_MAX;
-            auto w = 0.0f;
-            auto h = 0.0f;
-
-            if (!PAINT(paint)->bounds(&x, &y, &w, &h, true, stroking)) continue;
-
+            Point tmp[4];
+            if (!PAINT(paint)->bounds(tmp, true, stroking)) continue;
             //Merge regions
-            if (x < x1) x1 = x;
-            if (x2 < x + w) x2 = (x + w);
-            if (y < y1) y1 = y;
-            if (y2 < y + h) y2 = (y + h);
+            for (int i = 0; i < 4; ++i) {
+                if (tmp[i].x < min.x) min.x = tmp[i].x;
+                if (tmp[i].x > max.x) max.x = tmp[i].x;
+                if (tmp[i].y < min.y) min.y = tmp[i].y;
+                if (tmp[i].y > max.y) max.y = tmp[i].y;
+            }
         }
-
-        if (px) *px = x1;
-        if (py) *py = y1;
-        if (pw) *pw = (x2 - x1);
-        if (ph) *ph = (y2 - y1);
+        pt4[0] = min;
+        pt4[1] = {max.x, min.y};
+        pt4[2] = max;
+        pt4[3] = {min.x, max.y};
 
         return true;
     }

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -116,17 +116,24 @@ struct Shape::Impl : Paint::Impl
         return renderer->region(rd);
     }
 
-    bool bounds(float* x, float* y, float* w, float* h, bool stroking)
+    bool bounds(Point* pt4, bool stroking)
     {
-        if (!rs.path.bounds(x, y, w, h)) return false;
+        float x, y, w, h;
+        if (!rs.path.bounds(&x, &y, &w, &h)) return false;
 
         //Stroke feathering
         if (stroking && rs.stroke) {
-            if (x) *x -= rs.stroke->width * 0.5f;
-            if (y) *y -= rs.stroke->width * 0.5f;
-            if (w) *w += rs.stroke->width;
-            if (h) *h += rs.stroke->width;
+            x -= rs.stroke->width * 0.5f;
+            y -= rs.stroke->width * 0.5f;
+            w += rs.stroke->width;
+            h += rs.stroke->width;
         }
+
+        pt4[0] = {x, y};
+        pt4[1] = {x + w, y};
+        pt4[2] = {x + w, y + h};
+        pt4[3] = {x, y + h};
+
         return true;
     }
 

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -134,10 +134,10 @@ struct Text::Impl : Paint::Impl
         return PAINT(shape)->update(renderer, transform, clips, opacity, pFlag, false);
     }
 
-    bool bounds(float* x, float* y, float* w, float* h, TVG_UNUSED bool stroking)
+    bool bounds(Point* pt4, TVG_UNUSED bool stroking)
     {
         if (!load()) return false;
-        PAINT(shape)->bounds(x, y, w, h, true, true, false);
+        PAINT(shape)->bounds(pt4, true, true, false);
         return true;
     }
 

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -124,7 +124,7 @@ bool GifSaver::save(Animation* animation, Paint* bg, const char* filename, TVG_U
     auto picture = animation->picture();
     float x, y;
     x = y = 0;
-    picture->bounds(&x, &y, &vsize[0], &vsize[1], false);
+    picture->bounds(&x, &y, &vsize[0], &vsize[1]);
 
     //cut off the negative space
     if (x < 0) vsize[0] += x;

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -127,23 +127,28 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
 
     //Negative
     float x = 0, y = 0, w = 0, h = 0;
-    REQUIRE(shape->bounds(&x, &y, &w, &h, false) == Result::InsufficientCondition);
+    REQUIRE(shape->bounds(&x, &y, &w, &h) == Result::InsufficientCondition);
 
     //Case 1
     REQUIRE(shape->appendRect(0.0f, 10.0f, 20.0f, 100.0f, 50.0f, 50.0f) == Result::Success);
     REQUIRE(shape->translate(100.0f, 111.0f) == Result::Success);
-    REQUIRE(shape->bounds(&x, &y, &w, &h, false) == Result::Success);
+    REQUIRE(shape->bounds(&x, &y, &w, &h) == Result::Success);
     REQUIRE(x == 0.0f);
     REQUIRE(y == 10.0f);
     REQUIRE(w == 20.0f);
     REQUIRE(h == 100.0f);
 
     REQUIRE(canvas->update(shape) == Result::Success);
-    REQUIRE(shape->bounds(&x, &y, &w, &h, true) == Result::Success);
-    REQUIRE(x == 100.0f);
-    REQUIRE(y == 121.0f);
-    REQUIRE(w == 20.0f);
-    REQUIRE(h == 100.0f);
+    Point pts[4];
+    REQUIRE(shape->bounds(pts) == Result::Success);
+    REQUIRE(pts[0].x == 100.0f);
+    REQUIRE(pts[3].x == 100.0f);
+    REQUIRE(pts[0].y == 121.0f);
+    REQUIRE(pts[1].y == 121.0f);
+    REQUIRE(pts[1].x == 120.0f);
+    REQUIRE(pts[2].x == 120.0f);
+    REQUIRE(pts[2].y == 221.0f);
+    REQUIRE(pts[3].y == 221.0f);
 
     //Case 2
     REQUIRE(shape->reset() == Result::Success);
@@ -151,18 +156,22 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
     REQUIRE(shape->lineTo(20.0f, 210.0f) == Result::Success);
     auto identity = Matrix{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
     REQUIRE(shape->transform(identity) == Result::Success);
-    REQUIRE(shape->bounds(&x, &y, &w, &h, false) == Result::Success);
+    REQUIRE(shape->bounds(&x, &y, &w, &h) == Result::Success);
     REQUIRE(x == 0.0f);
     REQUIRE(y == 10.0f);
     REQUIRE(w == 20.0f);
     REQUIRE(h == 200.0f);
 
     REQUIRE(canvas->update(shape) == Result::Success);
-    REQUIRE(shape->bounds(&x, &y, &w, &h, true) == Result::Success);
-    REQUIRE(x == 0.0f);
-    REQUIRE(y == 10.0f);
-    REQUIRE(w == 20.0f);
-    REQUIRE(h == 200.0f);
+    REQUIRE(shape->bounds(pts) == Result::Success);
+    REQUIRE(pts[0].x == 0.0f);
+    REQUIRE(pts[3].x == 0.0f);
+    REQUIRE(pts[0].y == 10.0f);
+    REQUIRE(pts[1].y == 10.0f);
+    REQUIRE(pts[1].x == 20.0f);
+    REQUIRE(pts[2].x == 20.0f);
+    REQUIRE(pts[2].y == 210.0f);
+    REQUIRE(pts[3].y == 210.0f);
 
     Initializer::term();
 }


### PR DESCRIPTION
C++ API Modificaiton:
 - Result Paint::bounds(float* x, float* y, float* w, float* h, bool transform = false) const
  -> Result Paint::bounds(float* x, float* y, float* w, float* h) const

C++ API Addition:
 - Result Paint::bounds(Point* pt4) const

C API Modification:
- Tvg_Result tvg_paint_get_bounds(const Tvg_Paint* paint, float* x, float* y, float* w, float* h, bool transformed);
 -> Tvg_Result tvg_paint_get_aabb(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);

C API Addition:
- Tvg_Result tvg_paint_get_obb(const Tvg_Paint* paint, Tvg_Point* pt4);

![image](https://github.com/user-attachments/assets/c854e869-128e-40ed-9720-f8386bdfdf8d)

issue: https://github.com/thorvg/thorvg/issues/3290