### PR TITLE
lottie/slot: fix potential memory leak when overriding twice

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -61,17 +61,17 @@ void LottieSlot::assign(LottieObject* target, bool byDefault)
         switch (type) {
             case LottieProperty::Type::Position: {
                 if (copy) pair->prop = new LottieVector(static_cast<LottieTransform*>(pair->obj)->position);
-                pair->obj->override(&static_cast<LottieTransform*>(target)->position, shallow, byDefault);
+                pair->obj->override(&static_cast<LottieTransform*>(target)->position, shallow, !copy);
                 break;
             }
             case LottieProperty::Type::Point: {
                 if (copy) pair->prop = new LottieScalar(static_cast<LottieTransform*>(pair->obj)->scale);
-                pair->obj->override(&static_cast<LottieTransform*>(target)->scale, shallow, byDefault);
+                pair->obj->override(&static_cast<LottieTransform*>(target)->scale, shallow, !copy);
                 break;
             }
             case LottieProperty::Type::Float: {
                 if (copy) pair->prop = new LottieFloat(static_cast<LottieTransform*>(pair->obj)->rotation);
-                pair->obj->override(&static_cast<LottieTransform*>(target)->rotation, shallow, byDefault);
+                pair->obj->override(&static_cast<LottieTransform*>(target)->rotation, shallow, !copy);
                 break;
             }
             case LottieProperty::Type::Opacity: {
@@ -79,27 +79,27 @@ void LottieSlot::assign(LottieObject* target, bool byDefault)
                     if (pair->obj->type == LottieObject::Type::Transform) pair->prop = new LottieOpacity(static_cast<LottieTransform*>(pair->obj)->opacity);
                     else pair->prop = new LottieOpacity(static_cast<LottieSolid*>(pair->obj)->opacity);
                 }
-                pair->obj->override(&static_cast<LottieSolid*>(target)->opacity, shallow, byDefault);
+                pair->obj->override(&static_cast<LottieSolid*>(target)->opacity, shallow, !copy);
                 break;
             }
             case LottieProperty::Type::Color: {
                 if (copy) pair->prop = new LottieColor(static_cast<LottieSolid*>(pair->obj)->color);
-                pair->obj->override(&static_cast<LottieSolid*>(target)->color, shallow, byDefault);
+                pair->obj->override(&static_cast<LottieSolid*>(target)->color, shallow, !copy);
                 break;
             }
             case LottieProperty::Type::ColorStop: {
                 if (copy) pair->prop = new LottieColorStop(static_cast<LottieGradient*>(pair->obj)->colorStops);
-                pair->obj->override(&static_cast<LottieGradient*>(target)->colorStops, shallow, byDefault);
+                pair->obj->override(&static_cast<LottieGradient*>(target)->colorStops, shallow, !copy);
                 break;
             }
             case LottieProperty::Type::TextDoc: {
                 if (copy) pair->prop = new LottieTextDoc(static_cast<LottieText*>(pair->obj)->doc);
-                pair->obj->override(&static_cast<LottieText*>(target)->doc, shallow, byDefault);
+                pair->obj->override(&static_cast<LottieText*>(target)->doc, shallow, !copy);
                 break;
             }
             case LottieProperty::Type::Image: {
                 if (copy) pair->prop = new LottieBitmap(static_cast<LottieImage*>(pair->obj)->data);
-                pair->obj->override(&static_cast<LottieImage*>(target)->data, shallow, byDefault);
+                pair->obj->override(&static_cast<LottieImage*>(target)->data, shallow, !copy);
                 break;
             }
             default: break;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -213,7 +213,7 @@ struct LottieObject
     {
     }
 
-    virtual void override(LottieProperty* prop, bool shallow, bool byDefault)
+    virtual void override(LottieProperty* prop, bool shallow, bool release)
     {
         TVGERR("LOTTIE", "Unsupported slot type");
     }
@@ -348,9 +348,9 @@ struct LottieText : LottieObject, LottieRenderPooler<tvg::Shape>
         LottieObject::type = LottieObject::Text;
     }
 
-    void override(LottieProperty* prop, bool shallow, bool byDefault = false) override
+    void override(LottieProperty* prop, bool shallow, bool release = false) override
     {
-        if (byDefault) doc.release();
+        if (release) doc.release();
         doc.copy(*static_cast<LottieTextDoc*>(prop), shallow);
     }
 
@@ -562,26 +562,26 @@ struct LottieTransform : LottieObject
         return nullptr;
     }
 
-    void override(LottieProperty* prop, bool shallow, bool byDefault) override
+    void override(LottieProperty* prop, bool shallow, bool release) override
     {
         switch (prop->type) {
             case LottieProperty::Type::Position: {
-                if (byDefault) position.release();
+                if (release) position.release();
                 position.copy(*static_cast<LottieVector*>(prop), shallow);
                 break;
             }
             case LottieProperty::Type::Float: {
-                if (byDefault) rotation.release();
+                if (release) rotation.release();
                 rotation.copy(*static_cast<LottieFloat*>(prop), shallow);
                 break;
             }
             case LottieProperty::Type::Point: {
-                if (byDefault) scale.release();
+                if (release) scale.release();
                 scale.copy(*static_cast<LottieScalar*>(prop), shallow);
                 break;
             }
             case LottieProperty::Type::Opacity: {
-                if (byDefault) opacity.release();
+                if (release) opacity.release();
                 opacity.copy(*static_cast<LottieOpacity*>(prop), shallow);
                 break;
             }
@@ -633,9 +633,9 @@ struct LottieSolidStroke : LottieSolid, LottieStroke
         return LottieSolid::property(ix);
     }
 
-    void override(LottieProperty* prop, bool shallow, bool byDefault) override
+    void override(LottieProperty* prop, bool shallow, bool release) override
     {
-        if (byDefault) color.release();
+        if (release) color.release();
         color.copy(*static_cast<LottieColor*>(prop), shallow);
     }
 };
@@ -648,13 +648,13 @@ struct LottieSolidFill : LottieSolid
         LottieObject::type = LottieObject::SolidFill;
     }
 
-    void override(LottieProperty* prop, bool shallow, bool byDefault) override
+    void override(LottieProperty* prop, bool shallow, bool release) override
     {
         if (prop->type == LottieProperty::Type::Opacity) {
-            if (byDefault) opacity.release();
+            if (release) opacity.release();
             opacity.copy(*static_cast<LottieOpacity*>(prop), shallow);
         } else if (prop->type == LottieProperty::Type::Color) {
-            if (byDefault) color.release();
+            if (release) color.release();
             color.copy(*static_cast<LottieColor*>(prop), shallow);
         }
     }
@@ -693,9 +693,9 @@ struct LottieGradient : LottieObject
         return nullptr;
     }
 
-    void override(LottieProperty* prop, bool shallow, bool byDefault = false) override
+    void override(LottieProperty* prop, bool shallow, bool release = false) override
     {
-        if (byDefault) colorStops.release();
+        if (release) colorStops.release();
         colorStops.copy(*static_cast<LottieColorStop*>(prop), shallow);
         prepare();
     }
@@ -748,9 +748,9 @@ struct LottieImage : LottieObject, LottieRenderPooler<tvg::Picture>
 {
     LottieBitmap data;
 
-    void override(LottieProperty* prop, bool shallow, bool byDefault = false) override
+    void override(LottieProperty* prop, bool shallow, bool release = false) override
     {
-        if (byDefault) data.release();
+        if (release) data.release();
         data.copy(*static_cast<LottieBitmap*>(prop), shallow);
         update();
     }


### PR DESCRIPTION
_Originally issued by @mgrudzinska in https://github.com/thorvg/thorvg/pull/3269#discussion_r1974502080_

---

At second overriding for same sid(Lottie Slot), current property(applied from first override) is no longer memory-managed, is just replaced with new value, then system loses pointer.

Thus, if the LottieSlot has already been overridden and doesn't need to back-up for Slot resetting, `release()` should be called before next overriding.

---

![Warp 2025-03-05 15 27 59](https://github.com/user-attachments/assets/2a4201f3-aabe-4def-91ea-a503f5cbf421)

![Warp 2025-03-05 15 28 21](https://github.com/user-attachments/assets/bed1b189-45f6-48c9-9bd9-6277f90979c4)
