### PR TITLE
common: support c++20 builds

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -101,7 +101,7 @@ static void _skew(Matrix* m, float angleDeg, float axisDeg)
 
 static bool _updateTransform(LottieTransform* transform, float frameNo, Matrix& matrix, uint8_t& opacity, bool autoOrient, Tween& tween, LottieExpressions* exps)
 {
-    identity(&matrix);
+    tvg::identity(&matrix);
 
     if (!transform) {
         opacity = 255;
@@ -151,8 +151,8 @@ void LottieBuilder::updateTransform(LottieLayer* layer, float frameNo)
     _updateTransform(transform, frameNo, matrix, layer->cache.opacity, layer->autoOrient, tween, exps);
 
     if (parent) {
-        if (!identity((const Matrix*) &parent->cache.matrix)) {
-            if (identity((const Matrix*) &matrix)) layer->cache.matrix = parent->cache.matrix;
+        if (!tvg::identity((const Matrix*) &parent->cache.matrix)) {
+            if (tvg::identity((const Matrix*) &matrix)) layer->cache.matrix = parent->cache.matrix;
             else layer->cache.matrix = parent->cache.matrix * matrix;
         }
     }
@@ -363,11 +363,11 @@ static void _repeat(LottieGroup* parent, Shape* path, RenderContext* ctx)
                 auto shape = static_cast<Shape*>((*p)->duplicate());
                 SHAPE(shape)->rs.path = SHAPE(path)->rs.path;
 
-                auto opacity = repeater->interpOpacity ? lerp<uint8_t>(repeater->startOpacity, repeater->endOpacity, static_cast<float>(i + 1) / repeater->cnt) : repeater->startOpacity;
+                auto opacity = repeater->interpOpacity ? tvg::lerp<uint8_t>(repeater->startOpacity, repeater->endOpacity, static_cast<float>(i + 1) / repeater->cnt) : repeater->startOpacity;
                 shape->opacity(opacity);
 
                 Matrix m;
-                identity(&m);
+                tvg::identity(&m);
                 translate(&m, repeater->position * multiplier + repeater->anchor);
                 scale(&m, {powf(repeater->scale.x * 0.01f, multiplier), powf(repeater->scale.y * 0.01f, multiplier)});
                 rotate(&m, repeater->rotation * multiplier);
@@ -702,7 +702,7 @@ void LottieBuilder::updatePolystar(LottieGroup* parent, LottieObject** child, fl
 
     //Optimize: Can we skip the individual coords transform?
     Matrix matrix;
-    identity(&matrix);
+    tvg::identity(&matrix);
     translate(&matrix, star->position(frameNo, tween, exps));
     rotate(&matrix, star->rotation(frameNo, tween, exps));
 
@@ -1089,9 +1089,9 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                         auto rangeColor = range->style.fillColor(frameNo, tween, exps); //TODO: use flag to check whether it was really set
                         if (tvg::equal(f, 1.0f)) color = rangeColor;
                         else {
-                            color.rgb[0] = lerp<uint8_t>(color.rgb[0], rangeColor.rgb[0], f);
-                            color.rgb[1] = lerp<uint8_t>(color.rgb[1], rangeColor.rgb[1], f);
-                            color.rgb[2] = lerp<uint8_t>(color.rgb[2], rangeColor.rgb[2], f);
+                            color.rgb[0] = tvg::lerp<uint8_t>(color.rgb[0], rangeColor.rgb[0], f);
+                            color.rgb[1] = tvg::lerp<uint8_t>(color.rgb[1], rangeColor.rgb[1], f);
+                            color.rgb[2] = tvg::lerp<uint8_t>(color.rgb[2], rangeColor.rgb[2], f);
                         }
                         fillOpacity = (uint8_t)(fillOpacity - f * (fillOpacity - range->style.fillOpacity(frameNo, tween, exps)));
                         shape->fill(color.rgb[0], color.rgb[1], color.rgb[2], fillOpacity);
@@ -1101,9 +1101,9 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                             auto rangeColor = range->style.strokeColor(frameNo, tween, exps); //TODO: use flag to check whether it was really set
                             if (tvg::equal(f, 1.0f)) strokeColor = rangeColor;
                             else {
-                                strokeColor.rgb[0] = lerp<uint8_t>(strokeColor.rgb[0], rangeColor.rgb[0], f);
-                                strokeColor.rgb[1] = lerp<uint8_t>(strokeColor.rgb[1], rangeColor.rgb[1], f);
-                                strokeColor.rgb[2] = lerp<uint8_t>(strokeColor.rgb[2], rangeColor.rgb[2], f);
+                                strokeColor.rgb[0] = tvg::lerp<uint8_t>(strokeColor.rgb[0], rangeColor.rgb[0], f);
+                                strokeColor.rgb[1] = tvg::lerp<uint8_t>(strokeColor.rgb[1], rangeColor.rgb[1], f);
+                                strokeColor.rgb[2] = tvg::lerp<uint8_t>(strokeColor.rgb[2], rangeColor.rgb[2], f);
                             }
                             strokeOpacity = (uint8_t)(strokeOpacity - f * (strokeOpacity - range->style.strokeOpacity(frameNo, tween, exps)));
                             shape->strokeFill(strokeColor.rgb[0], strokeColor.rgb[1], strokeColor.rgb[2], strokeOpacity);
@@ -1117,7 +1117,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
 
                     // TextGroup transformation is performed once
                     if (textGroup->paints().size() == 0 && needGroup) {
-                        identity(&textGroupMatrix);
+                        tvg::identity(&textGroupMatrix);
                         translate(&textGroupMatrix, cursor);
 
                         auto alignment = text->alignOption.anchor(frameNo, tween, exps);
@@ -1137,7 +1137,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                     }
 
                     auto& matrix = shape->transform();
-                    identity(&matrix);
+                    tvg::identity(&matrix);
                     translate(&matrix, (translation / scale + cursor) - Point{textGroupMatrix.e13, textGroupMatrix.e23});
                     tvg::scale(&matrix, scaling * capScale);
                     shape->transform(matrix);

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -451,7 +451,7 @@ static jerry_value_t _interp(float t, const jerry_value_t args[], int argsCnt)
         Point pt1 = {(float)jerry_value_as_number(val1),  (float)jerry_value_as_number(val2)};
         Point pt2 = {(float)jerry_value_as_number(val3),  (float)jerry_value_as_number(val4)};
         Point ret;
-        ret = lerp(pt1, pt2, t);
+        ret = tvg::lerp(pt1, pt2, t);
 
         jerry_value_free(val1);
         jerry_value_free(val2);
@@ -472,7 +472,7 @@ static jerry_value_t _interp(float t, const jerry_value_t args[], int argsCnt)
     //1d
     auto val1 = (float) jerry_value_as_number(args[idx + 1]);
     auto val2 = (float) jerry_value_as_number(args[idx + 2]);
-    return jerry_number(lerp(val1, val2, t));
+    return jerry_number(tvg::lerp(val1, val2, t));
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -292,7 +292,7 @@ uint32_t LottieGradient::populate(ColorStop& color, size_t count)
             //generate alpha value
             if (output.count > 0) {
                 auto p = ((*color.input)[cidx] - output.last().offset) / ((*color.input)[aidx] - output.last().offset);
-                cs.a = lerp<uint8_t>(output.last().a, (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f), p);
+                cs.a = tvg::lerp<uint8_t>(output.last().a, (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f), p);
             } else cs.a = (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f);
             cidx += 4;
         } else {
@@ -301,9 +301,9 @@ uint32_t LottieGradient::populate(ColorStop& color, size_t count)
             //generate color value
             if (output.count > 0) {
                 auto p = ((*color.input)[aidx] - output.last().offset) / ((*color.input)[cidx] - output.last().offset);
-                cs.r = lerp<uint8_t>(output.last().r, (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f), p);
-                cs.g = lerp<uint8_t>(output.last().g, (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f), p);
-                cs.b = lerp<uint8_t>(output.last().b, (uint8_t)nearbyint((*color.input)[cidx + 3] * 255.0f), p);
+                cs.r = tvg::lerp<uint8_t>(output.last().r, (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f), p);
+                cs.g = tvg::lerp<uint8_t>(output.last().g, (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f), p);
+                cs.b = tvg::lerp<uint8_t>(output.last().b, (uint8_t)nearbyint((*color.input)[cidx + 3] * 255.0f), p);
             } else {
                 cs.r = (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f);
                 cs.g = (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f);

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -58,7 +58,7 @@ struct LottieScalarFrame
             if (t < 1.0f) return value;
             else return next->value;
         }
-        return lerp(value, next->value, t);
+        return tvg::lerp(value, next->value, t);
     }
 
     float angle(LottieScalarFrame* next, float frameNo)
@@ -97,7 +97,7 @@ struct LottieVectorFrame
             Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
             return bz.at(bz.atApprox(t * length, length));
         } else {
-            return lerp(value, next->value, t);
+            return tvg::lerp(value, next->value, t);
         }
     }
 
@@ -352,7 +352,7 @@ struct LottieGenericProperty : LottieProperty
     Value operator()(float frameNo, Tween& tween, LottieExpressions* exps)
     {
         if (DEFAULT_COND) return operator()(frameNo, exps);
-        return lerp(operator()(frameNo, exps), operator()(tween.frameNo, exps), tween.progress);
+        return tvg::lerp(operator()(frameNo, exps), operator()(tween.frameNo, exps), tween.progress);
     }
 
     void copy(const LottieGenericProperty<Frame, Value, Scalar>& rhs, bool shallow = true)
@@ -385,7 +385,7 @@ struct LottieGenericProperty : LottieProperty
     float angle(float frameNo, Tween& tween)
     {
         if (DEFAULT_COND) return angle(frameNo);
-        return lerp(angle(frameNo), angle(tween.frameNo), tween.progress);
+        return tvg::lerp(angle(frameNo), angle(tween.frameNo), tween.progress);
     }
 
     void prepare()
@@ -505,7 +505,7 @@ struct LottiePathSet : LottieProperty
         auto p = interpPts;
 
         for (auto i = 0; i < frame->value.ptsCnt; ++i, ++s, ++e, ++p) {
-            *p = lerp(*s, *e, t);
+            *p = tvg::lerp(*s, *e, t);
             if (transform) *p *= *transform;
         }
 
@@ -533,7 +533,7 @@ struct LottiePathSet : LottieProperty
         auto e = (frame + 1)->value.pts;
 
         for (auto i = 0; i < frame->value.ptsCnt; ++i, ++s, ++e) {
-            auto pt = lerp(*s, *e, t);
+            auto pt = tvg::lerp(*s, *e, t);
             if (transform) pt *= *transform;
             out.pts.push(pt);
         }
@@ -552,7 +552,7 @@ struct LottiePathSet : LottieProperty
         if (to.pts.count != out.pts.count - pivot) TVGLOG("LOTTIE", "Tweening has different numbers of points in consecutive frames.");
 
         for (uint32_t i = 0; i < std::min(to.pts.count, (out.pts.count - pivot)); ++i) {
-            from[i] = lerp(from[i], to.pts[i], tween.progress);
+            from[i] = tvg::lerp(from[i], to.pts[i], tween.progress);
         }
 
         if (!modifier) return true;
@@ -681,11 +681,11 @@ struct LottieColorStop : LottieProperty
         if (fromCnt != toCnt) TVGLOG("LOTTIE", "Tweening has different numbers of color data in consecutive frames.");
 
         for (uint32_t i = 0; i < std::min(fromCnt, toCnt); ++i) {
-            const_cast<Fill::ColorStop*>(from)->offset = lerp(from->offset, to->offset, tween.progress);
-            const_cast<Fill::ColorStop*>(from)->r = lerp(from->r, to->r, tween.progress);
-            const_cast<Fill::ColorStop*>(from)->g = lerp(from->g, to->g, tween.progress);
-            const_cast<Fill::ColorStop*>(from)->b = lerp(from->b, to->b, tween.progress);
-            const_cast<Fill::ColorStop*>(from)->a = lerp(from->a, to->a, tween.progress);
+            const_cast<Fill::ColorStop*>(from)->offset = tvg::lerp(from->offset, to->offset, tween.progress);
+            const_cast<Fill::ColorStop*>(from)->r = tvg::lerp(from->r, to->r, tween.progress);
+            const_cast<Fill::ColorStop*>(from)->g = tvg::lerp(from->g, to->g, tween.progress);
+            const_cast<Fill::ColorStop*>(from)->b = tvg::lerp(from->b, to->b, tween.progress);
+            const_cast<Fill::ColorStop*>(from)->a = tvg::lerp(from->a, to->a, tween.progress);
         }
 
         return Result::Success;
@@ -725,11 +725,11 @@ struct LottieColorStop : LottieProperty
         Array<Fill::ColorStop> result;
 
         for (auto i = 0; i < count; ++i, ++s, ++e) {
-            auto offset = lerp(s->offset, e->offset, t);
-            auto r = lerp(s->r, e->r, t);
-            auto g = lerp(s->g, e->g, t);
-            auto b = lerp(s->b, e->b, t);
-            auto a = lerp(s->a, e->a, t);
+            auto offset = tvg::lerp(s->offset, e->offset, t);
+            auto r = tvg::lerp(s->r, e->r, t);
+            auto g = tvg::lerp(s->g, e->g, t);
+            auto b = tvg::lerp(s->b, e->b, t);
+            auto a = tvg::lerp(s->a, e->a, t);
             result.push({offset, r, g, b, a});
         }
         return fill->colorStops(result.data, count);

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -782,7 +782,7 @@ static Matrix* _parseTransformationMatrix(const char* value)
     const int POINT_CNT = 8;
 
     auto matrix = tvg::malloc<Matrix*>(sizeof(Matrix));
-    identity(matrix);
+    tvg::identity(matrix);
 
     float points[POINT_CNT];
     int ptCount = 0;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -226,7 +226,7 @@ static bool _appendClipChild(SvgLoaderData& loaderData, SvgNode* node, Shape* sh
         }
         if (child->transform) finalTransform *= *child->transform;
 
-        return _appendClipShape(loaderData, child, shape, vBox, svgPath, identity((const Matrix*)(&finalTransform)) ? nullptr : &finalTransform);
+        return _appendClipShape(loaderData, child, shape, vBox, svgPath, tvg::identity((const Matrix*)(&finalTransform)) ? nullptr : &finalTransform);
     }
     return _appendClipShape(loaderData, node, shape, vBox, svgPath, nullptr);
 }

--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -155,7 +155,7 @@ GlStencilMode GlGeometry::getStencilMode(RenderUpdateFlag flag)
 
 RenderRegion GlGeometry::getBounds() const
 {
-    if (identity(&matrix)) {
+    if (tvg::identity(&matrix)) {
         return bounds;
     } else {
         Point lt{static_cast<float>(bounds.x), static_cast<float>(bounds.y)};

--- a/src/renderer/gl_engine/tvgGlRenderPass.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderPass.cpp
@@ -55,7 +55,7 @@ void GlRenderPass::getMatrix(float *dst, const Matrix &matrix) const
     const auto& vp = getViewport();
 
     Matrix postMatrix{};
-    identity(&postMatrix);
+    tvg::identity(&postMatrix);
     translate(&postMatrix, {(float)-vp.x, (float)-vp.y});
 
     auto m = postMatrix * matrix;

--- a/src/renderer/wg_engine/tvgWgShaderTypes.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.cpp
@@ -178,10 +178,10 @@ void WgShaderTypeGradient::updateTexData(const Fill::ColorStop* stops, uint32_t 
         float delta = 1.0f/(range_e - range_s);
         for (uint32_t ti = range_s; (ti < range_e) && (ti < WG_TEXTURE_GRADIENT_SIZE); ti++) {
             float t = (ti - range_s) * delta;
-            texData[ti * 4 + 0] = lerp(sstops[di-1].r, sstops[di].r, t);
-            texData[ti * 4 + 1] = lerp(sstops[di-1].g, sstops[di].g, t);
-            texData[ti * 4 + 2] = lerp(sstops[di-1].b, sstops[di].b, t);
-            texData[ti * 4 + 3] = lerp(sstops[di-1].a, sstops[di].a, t);
+            texData[ti * 4 + 0] = tvg::lerp(sstops[di-1].r, sstops[di].r, t);
+            texData[ti * 4 + 1] = tvg::lerp(sstops[di-1].g, sstops[di].g, t);
+            texData[ti * 4 + 2] = tvg::lerp(sstops[di-1].b, sstops[di].b, t);
+            texData[ti * 4 + 3] = tvg::lerp(sstops[di-1].a, sstops[di].a, t);
         }
     }
     // tail


### PR DESCRIPTION
Ensures that the project compiles and all tests pass as expected if set to c++20. This was in the form of explicit qualifiers for `identity` and `lerp`, both of which are part of the standard namespace starting in c++20. The former failed compilation outright when unqualified, while the latter silently prioritized `std::lerp` instead.