### PR TITLE
lottie: --compiler warnings

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -57,7 +57,9 @@ struct LottieStroke
         if (dashattr->size + 1 > dashattr->allocated) {
             dashattr->allocated = dashattr->size + 2;
             auto newValues = new LottieFloat[dashattr->allocated];
-            for (uint8_t i = 0; i < dashattr->size; ++i) newValues[i] = LottieFloat(dashattr->values[i]);
+            for (uint8_t i = 0; i < dashattr->size; ++i) {
+                newValues[i].copy(dashattr->values[i]);
+            }
             delete[] dashattr->values;
             dashattr->values = newValues;
         }

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -177,6 +177,9 @@ struct LottieProperty
 
     bool copy(LottieProperty* rhs, bool shallow)
     {
+        type = rhs->type;
+        ix = rhs->ix;
+
         if (!rhs->exp) return false;
         if (shallow) {
             exp = rhs->exp;
@@ -306,8 +309,6 @@ struct LottieGenericProperty : LottieProperty
     LottieGenericProperty(const LottieGenericProperty<Frame, Value>& rhs)
     {
         copy(const_cast<LottieGenericProperty<Frame, Value>&>(rhs));
-        type = rhs.type;
-        ix = rhs.ix;
     }
 
     ~LottieGenericProperty()
@@ -622,8 +623,6 @@ struct LottieColorStop : LottieProperty
     LottieColorStop(const LottieColorStop& rhs)
     {
         copy(const_cast<LottieColorStop&>(rhs));
-        type = rhs.type;
-        ix = rhs.ix;
     }
 
     ~LottieColorStop()
@@ -803,8 +802,6 @@ struct LottieTextDoc : LottieProperty
     LottieTextDoc(const LottieTextDoc& rhs)
     {
         copy(const_cast<LottieTextDoc&>(rhs));
-        type = rhs.type;
-        ix = rhs.ix;
     }
 
     ~LottieTextDoc()
@@ -922,8 +919,6 @@ struct LottieBitmap : LottieProperty
     LottieBitmap(const LottieBitmap& rhs)
     {
         copy(const_cast<LottieBitmap&>(rhs));
-        type = rhs.type;
-        ix = rhs.ix;
     }
 
     ~LottieBitmap()


### PR DESCRIPTION
In member function ‘constexpr LottieGenericProperty<LottieScalarFrame<float>, float>& LottieGenericProperty<LottieScalarFrame<float>, float>::ope>    inlined from ‘LottieFloat& LottieStroke::dashValue()’ at ../src/loaders/lottie/tvgLottieModel.h:60:104,
    inlined from ‘void LottieParser::parseStrokeDash(LottieStroke*)’ at ../src/loaders/lottie/tvgLottieParser.cpp:623:82:
../src/loaders/lottie/tvgLottieProperty.h:297:8: warning: ‘<anonymous>.LottieGenericProperty<LottieScalarFrame<float>, float>::value’ may be used>  297 | struct LottieGenericProperty : LottieProperty
      |        ^~~~~~~~~~~~~~~~~~~~~
../src/loaders/lottie/tvgLottieModel.h: In member function ‘void LottieParser::parseStrokeDash(LottieStroke*)’:
../src/loaders/lottie/tvgLottieModel.h:60:104: note: ‘<anonymous>’ declared here
   60 |             for (uint8_t i = 0; i < dashattr->size; ++i) newValues[i] = LottieFloat(dashattr->values[i]);
      |