### PR TITLE
renderer: ++wasm build portability

### DIFF
--- a/src/renderer/tvgTaskScheduler.h
+++ b/src/renderer/tvgTaskScheduler.h
@@ -23,15 +23,22 @@
 #ifndef _TVG_TASK_SCHEDULER_H_
 #define _TVG_TASK_SCHEDULER_H_
 
-#include <mutex>
-#include <condition_variable>
-
 #include "tvgCommon.h"
 #include "tvgInlist.h"
 
+#ifdef THORVG_THREAD_SUPPORT
+    #include <atomic>
+    #include <thread>
+    #include <mutex>
+    #include <condition_variable>
+#endif
+
 namespace tvg {
 
+
 #ifdef THORVG_THREAD_SUPPORT
+
+using ThreadID = std::thread::id;
 
 struct Task
 {
@@ -79,6 +86,8 @@ private:
 
 #else  //THORVG_THREAD_SUPPORT
 
+using ThreadID = uint8_t;
+
 struct Task
 {
 public:
@@ -105,6 +114,7 @@ struct TaskScheduler
     static void request(Task* task);
     static void async(bool on);
     static bool onthread();  //figure out whether on worker thread or not
+    static ThreadID tid();
 };
 
 }  //namespace

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -21,7 +21,7 @@
  */
 
 #include <cstring>
-
+#include <memory>
 #include "tvgStr.h"
 #include "tvgGifEncoder.h"
 #include "tvgGifSaver.h"


### PR DESCRIPTION
removed the direct thread inclusion
when those thread features are disabled