### PR TITLE
sw_engine: increase the rle cell buffer

### DIFF
--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -844,7 +844,7 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const SwBBox& renderRegio
 {
     if (!outline) return nullptr;
 
-    constexpr auto RENDER_POOL_SIZE = 16384L;
+    constexpr auto RENDER_POOL_SIZE = 32768L;
     constexpr auto BAND_SIZE = 40;
 
     //TODO: We can preserve several static workers in advance
@@ -866,7 +866,7 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const SwBBox& renderRegio
     rw.cellXCnt = rw.cellMax.x - rw.cellMin.x;
     rw.cellYCnt = rw.cellMax.y - rw.cellMin.y;
     rw.outline = const_cast<SwOutline*>(outline);
-    rw.bandSize = rw.bufferSize / (sizeof(Cell) * 2);  //bandSize: 256
+    rw.bandSize = rw.bufferSize / (sizeof(Cell) * 4);  //bandSize: 256
     rw.bandShoot = 0;
     rw.antiAlias = antiAlias;
 


### PR DESCRIPTION
During shape's rle generation, a static cell buffer is created. Its size may turn out to be insufficient, for example, in cases of long character sequences or very finely dashed strokes. The buffer size has been doubled to address this issue.

@Issue: https://github.com/thorvg/thorvg/issues/3307

sample with dash:
```
        auto shape = tvg::Shape::gen();
        shape->moveTo(100, 100);
        shape->lineTo(700, 100);
        shape->strokeFill(255, 0, 0);
        shape->strokeWidth(20);
        shape->strokeJoin(tvg::StrokeJoin::Round);
        shape->strokeCap(tvg::StrokeCap::Round);

        float dashPattern[2] = {1, 1};
        shape->strokeDash(dashPattern, 2);
        canvas->push(shape);
```

before:
<img width="400" alt="Zrzut ekranu 2025-03-14 o 01 44 31" src="https://github.com/user-attachments/assets/14ff90db-f73e-4cb5-abba-a5673049bfa4" />

after:
<img width="400" alt="Zrzut ekranu 2025-03-14 o 01 45 35" src="https://github.com/user-attachments/assets/150b24e2-e199-46f3-8c94-0af4a5d51d88" />



