### PR TITLE
lottie/slot: fix image deep copy logic

### DIFF
--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -946,18 +946,19 @@ struct LottieBitmap : LottieProperty
         if (shallow) {
             b64Data = rhs.b64Data;
             mimeType = rhs.mimeType;
+
+            rhs.b64Data = nullptr;
+            rhs.mimeType = nullptr;
         } else {
             //TODO: optimize here by avoiding data copy
             TVGLOG("LOTTIE", "Shallow copy of the image data!");
             b64Data = duplicate(rhs.b64Data);
-            mimeType = duplicate(rhs.mimeType);
+            if (rhs.mimeType) mimeType = duplicate(rhs.mimeType);
         }
+
         size = rhs.size;
         width = rhs.width;
         height = rhs.height;
-
-        rhs.b64Data = nullptr;
-        rhs.mimeType = nullptr;
     }
 };
 


### PR DESCRIPTION
When the datas are copied with deep copy, memory issue caused (SEGV on unknown address) due to these reasons:

1. `mimeType` is nullptr when it's not embedded(base64) data

2. datas(b64Data, mimeType) should not be clear, it's used for next slot copy in same pair.

---

![CleanShot 2025-03-17 at 10 28 31@2x](https://github.com/user-attachments/assets/acd26b96-8bef-40be-bf02-645e0dba3329)

Test sample:
[slotsample3.json](https://github.com/user-attachments/files/19277100/slotsample3.json)
