### PR TITLE
renderer: added parent scene query api

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -310,6 +310,21 @@ public:
     virtual ~Paint();
 
     /**
+     * @brief Retrieves the parent paint object.
+     *
+     * This function returns a pointer to the parent object if the current paint
+     * belongs to one. Otherwise, it returns @c nullptr.
+     *
+     * @return A pointer to the parent object if available, otherwise @c nullptr.
+     *
+     * @see Scene::push()
+     * @see Canvas::push()
+     *
+     * @since 1.0
+    */
+    const Paint* parent() const noexcept;
+
+    /**
      * @brief Sets the angle by which the object is rotated.
      *
      * The angle in measured clockwise from the horizontal axis.
@@ -381,6 +396,8 @@ public:
      *
      * @param[in] target The paint of the target object.
      * @param[in] method The method used to mask the source object with the target.
+     *
+     * @retval Result::InsufficientCondition if the target has already belonged to another paint.
      */
     Result mask(Paint* target, MaskMethod method) noexcept;
 
@@ -392,6 +409,7 @@ public:
      * @param[in] clipper The shape object as the clipper.
      *
      * @retval Result::NonSupport If the @p clipper type is not Shape.
+     * @retval Result::InsufficientCondition if the target has already belonged to another paint.
      *
      * @note @p clipper only supports the Shape type.
      * @since 1.0

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -715,7 +715,6 @@ TVG_API Tvg_Result tvg_canvas_set_viewport(Tvg_Canvas* canvas, int32_t x, int32_
 
 /** \} */   // end defgroup ThorVGCapi_Canvas
 
-
 /**
 * @defgroup ThorVGCapi_Paint Paint
 * @brief A module for managing graphical elements. It enables duplication, transformation and composition.
@@ -964,6 +963,8 @@ TVG_API Tvg_Result tvg_paint_get_obb(const Tvg_Paint* paint, Tvg_Point* pt4);
 * @param[in] target The target object of the masking.
 * @param[in] method The method used to mask the source object with the target.
 *
+* @retval TVG_RESULT_INSUFFICIENT_CONDITION if the target has already belonged to another paint.
+*
 * @return Tvg_Result enumeration.
 
 */
@@ -993,11 +994,30 @@ TVG_API Tvg_Result tvg_paint_get_mask_method(const Tvg_Paint* paint, const Tvg_P
 *
 * @return Tvg_Result enumeration.
 * @retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
+* @retval TVG_RESULT_INSUFFICIENT_CONDITION if the target has already belonged to another paint.
 * @retval TVG_RESULT_NOT_SUPPORTED If the @p clipper type is not Shape.
 *
 * @since 1.0
 */
 TVG_API Tvg_Result tvg_paint_clip(Tvg_Paint* paint, Tvg_Paint* clipper);
+
+
+/**
+ * @brief Retrieves the parent paint object.
+ *
+ * This function returns a pointer to the parent object if the current paint
+ * belongs to one. Otherwise, it returns @c nullptr.
+ *
+ * @param[in] paint The Tvg_Paint object of which to get the scene.
+ *
+ * @return A pointer to the parent object if available, otherwise @c nullptr.
+ *
+ * @see tvg_scene_push()
+ * @see tvg_canvas_push()
+ *
+ * @since 1.0
+*/
+TVG_API const Tvg_Paint* tvg_paint_get_parent(const Tvg_Paint* paint);
 
 
 /**

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -169,6 +169,12 @@ TVG_API Tvg_Result tvg_canvas_set_viewport(Tvg_Canvas* canvas, int32_t x, int32_
 /* Paint API                                                            */
 /************************************************************************/
 
+TVG_API const Tvg_Paint* tvg_paint_get_parent(const Tvg_Paint* paint)
+{
+    return (const Tvg_Paint*) reinterpret_cast<const Paint*>(paint)->parent();
+}
+
+
 TVG_API Tvg_Result tvg_paint_del(Tvg_Paint* paint)
 {
     if (!paint) return TVG_RESULT_INVALID_ARGUMENT;

--- a/src/renderer/tvgCanvas.h
+++ b/src/renderer/tvgCanvas.h
@@ -51,10 +51,7 @@ struct Canvas::Impl
     Result push(Paint* target, Paint* at)
     {
         //You cannot push paints during rendering.
-        if (status == Status::Drawing) {
-            TVG_DELETE(target);
-            return Result::InsufficientCondition;
-        }
+        if (status == Status::Drawing) return Result::InsufficientCondition;
 
         auto ret = scene->push(target, at);
         if (ret != Result::Success) return ret;

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -392,19 +392,15 @@ Result Paint::clip(Paint* clipper) noexcept
 {
     if (clipper && clipper->type() != Type::Shape) {
         TVGERR("RENDERER", "Clipping only supports the Shape!");
-        TVG_DELETE(clipper);
         return Result::NonSupport;
     }
-    pImpl->clip(clipper);
-    return Result::Success;
+    return pImpl->clip(clipper);
 }
 
 
 Result Paint::mask(Paint* target, MaskMethod method) noexcept
 {
-    if (pImpl->mask(target, method)) return Result::Success;
-    if (target) TVG_DELETE(target);
-    return Result::InvalidArguments;
+    return pImpl->mask(target, method);
 }
 
 
@@ -448,11 +444,17 @@ uint8_t Paint::ref() noexcept
 
 uint8_t Paint::unref(bool free) noexcept
 {
-    return pImpl->unref(free);
+    return pImpl->unrefx(free);
 }
 
 
 uint8_t Paint::refCnt() const noexcept
 {
     return pImpl->refCnt;
+}
+
+
+const Paint* Paint::parent() const noexcept
+{
+    return pImpl->parent;
 }

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -59,7 +59,6 @@ namespace tvg
 
         struct {
             Matrix m;                 //input matrix
-            Matrix cm;                //multipled parents matrix
             float degree;             //rotation degree
             float scale;              //scale factor
             bool overriding;          //user transform?
@@ -148,7 +147,6 @@ namespace tvg
         {
             //update transform
             if (renderFlag & RenderUpdateFlag::Transform) tr.update();
-            if (origin) return tr.cm;
             return tr.m;
         }
 

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -165,7 +165,10 @@ struct Picture::Impl : Paint::Impl
         auto picture = Picture::gen();
         auto dup = PICTURE(picture);
 
-        if (vector) dup->vector = vector->duplicate();
+        if (vector) {
+            dup->vector = vector->duplicate();
+            PAINT(dup->vector)->parent = picture;
+        }
 
         if (loader) {
             dup->loader = loader;
@@ -211,6 +214,7 @@ struct Picture::Impl : Paint::Impl
             } else {
                 vector = loader->paint();
                 if (vector) {
+                    PAINT(vector)->parent = paint;
                     if (w != loader->w || h != loader->h) {
                         if (!resizing) {
                             w = loader->w;

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -138,7 +138,7 @@ struct Text::Impl : Paint::Impl
     bool bounds(Point* pt4, TVG_UNUSED bool stroking)
     {
         if (!load()) return false;
-        PAINT(shape)->bounds(pt4, true, true, false);
+        PAINT(shape)->bounds(pt4, true, true);
         return true;
     }
 

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -41,6 +41,7 @@ struct Text::Impl : Paint::Impl
 
     Impl(Text* p) : Paint::Impl(p), shape(Shape::gen())
     {
+        PAINT(shape)->parent = p;
     }
 
     ~Impl()
@@ -149,6 +150,8 @@ struct Text::Impl : Paint::Impl
 
         auto text = Text::gen();
         auto dup = TEXT(text);
+        dup->parent = text;
+
         SHAPE(shape)->duplicate(dup->shape);
 
         if (loader) {

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -218,11 +218,8 @@ TEST_CASE("Composition", "[tvgPaint]")
     //Negative
     REQUIRE(shape->mask(nullptr) == MaskMethod::None);
 
-    auto comp = Shape::gen();
-    REQUIRE(shape->mask(comp, MaskMethod::None) == Result::InvalidArguments);
-
     //Clipping
-    comp = Shape::gen();
+    auto comp = Shape::gen();
     REQUIRE(shape->clip(comp) == Result::Success);
 
     //AlphaMask

--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -39,18 +39,25 @@ TEST_CASE("Pushing Paints Into Scene", "[tvgScene]")
 {
     auto scene = unique_ptr<Scene>(Scene::gen());
     REQUIRE(scene);
+    REQUIRE(scene->parent() == nullptr);
 
     Paint* paints[3];
 
     //Pushing Paints
     paints[0] = Shape::gen();
+    REQUIRE(paints[0]->parent() == nullptr);
     REQUIRE(scene->push(paints[0]) == Result::Success);
+    REQUIRE(paints[0]->parent() == scene.get());
 
     paints[1] = Picture::gen();
+    REQUIRE(paints[1]->parent() == nullptr);
     REQUIRE(scene->push(paints[1]) == Result::Success);
+    REQUIRE(paints[1]->parent() == scene.get());
 
     paints[2] = Picture::gen();
+    REQUIRE(paints[2]->parent() == nullptr);
     REQUIRE(scene->push(paints[2]) == Result::Success);
+    REQUIRE(paints[2]->parent() == scene.get());
 
     //Pushing Null Pointer
     REQUIRE(scene->push(nullptr) == Result::InvalidArguments);


### PR DESCRIPTION
added 2 more APIs for user convenience to allow backtracking tree traversal.

API Additions:
- const Paint* Paint::scene() const;
- const Tvg_Paint* tvg_paint_get_scene(const Tvg_Paint* paint)