### PR TITLE
wg_engine: remove unnecessary header

### DIFF
--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -20,9 +20,6 @@
  * SOFTWARE.
  */
 
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
 #include <cassert>
 #include "tvgWgCommon.h"
 #include "tvgArray.h"


### PR DESCRIPTION
The Emscripten header was previously used because the WebGPU initialization logic was in WgContext::initialize.

Now, initialization occurs at the binding/application level.