### PR TITLE
wg_engine: crash for empty clips fix

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -383,8 +383,8 @@ void WgRenderDataShape::updateMeshes(WgContext& context, const RenderShape &rsha
     if ((this->meshGroupShapesBBox.meshes.count > 0 ) ||
         (this->meshGroupStrokesBBox.meshes.count > 0)) {
         updateAABB(tr);
-        meshDataBBox.bbox(context, pMin, pMax);
     } else aabb = {{0, 0}, {0, 0}};
+    meshDataBBox.bbox(context, pMin, pMax);
 
     pool->retVertexBuffer(pbuff);
 }


### PR DESCRIPTION
We must to update bbox even in case, if chape did not have any geometry
issue: https://github.com/thorvg/thorvg/issues/3289