### PR TITLE
array: use default constructor

### DIFF
--- a/src/common/tvgArray.h
+++ b/src/common/tvgArray.h
@@ -41,7 +41,7 @@ struct Array
     uint32_t count = 0;
     uint32_t reserved = 0;
 
-    Array(){}
+    Array() = default;
 
     Array(int32_t size)
     {


### PR DESCRIPTION
Replaces `Array(){}` with `Array() = default;`

The previous constructor was causing issues with WebGPU support, because it created a user-defined constructor, which changes how the object is treated during global initialization in WebAssembly. The empty constructor was likely causing the interpreter to set up unnecessary stack frames or function calls during global initialization, leading to an index out-of-bounds error when trying to use the Array.

By using `= default`, we tell the compiler "don't generate any actual constructor code" - it can just set up the memory directly without function calls or stack frames, which works better with WebAssembly's initialization model.