### PR TITLE
lottie/expressions: text document support

### DIFF
--- a/src/common/tvgStr.cpp
+++ b/src/common/tvgStr.cpp
@@ -265,4 +265,14 @@ const char* fileext(const char* path)
     return ext;
 }
 
+
+char* concat(const char* a, const char* b)
+{
+    auto len = strlen(a) + strlen(b) + 1;
+    auto ret = tvg::malloc<char*>(len * sizeof(char));
+    strcpy(ret, a);
+    strcat(ret, b);
+    return ret;
+}
+
 }

--- a/src/common/tvgStr.h
+++ b/src/common/tvgStr.h
@@ -33,6 +33,7 @@ static inline bool equal(const char* a, const char* b)
     return !strcmp(a, b) && strlen(a) == strlen(b);
 }
 
+char* concat(const char* a, const char* b);
 float toFloat(const char *str, char **end);                    //convert to float
 char* duplicate(const char *str, size_t n = SIZE_MAX);         //copy the string
 char* append(char* lhs, const char* rhs, size_t n);            //append the rhs to the lhs

--- a/src/loaders/lottie/jerryscript/jerry-core/api/jerryscript.cpp
+++ b/src/loaders/lottie/jerryscript/jerry-core/api/jerryscript.cpp
@@ -217,6 +217,18 @@ jerry_value_is_object (const jerry_value_t value) /**< api value */
 } /* jerry_value_is_object */
 
 /**
+ * Check if the specified value is string.
+ *
+ * @return true  - if the specified value is string,
+ *         false - otherwise
+ */
+bool
+jerry_value_is_string (const jerry_value_t value) /**< api value */
+{
+  return ecma_is_value_string (value);
+} /* jerry_value_is_string */
+
+/**
  * Check if the specified value is undefined.
  *
  * @return true  - if the specified value is undefined,

--- a/src/loaders/lottie/jerryscript/jerry-core/include/jerryscript-core.h
+++ b/src/loaders/lottie/jerryscript/jerry-core/include/jerryscript-core.h
@@ -29,6 +29,7 @@ jerry_value_t jerry_run (const jerry_value_t script);
 bool jerry_value_is_undefined (const jerry_value_t value);
 bool jerry_value_is_number (const jerry_value_t value);
 bool jerry_value_is_object (const jerry_value_t value);
+bool jerry_value_is_string (const jerry_value_t value);
 bool jerry_value_is_exception (const jerry_value_t value);
 jerry_value_t jerry_value_to_object (const jerry_value_t value);
 jerry_value_t jerry_value_to_string (const jerry_value_t value);

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -336,6 +336,19 @@ static void _buildLayer(jerry_value_t context, float frameNo, LottieLayer* layer
 
 static jerry_value_t _addsub(const jerry_value_t args[], float addsub)
 {
+    //string + string
+    if (jerry_value_is_string(args[0]) || jerry_value_is_string(args[1])) {
+        auto a = _name(args[0]);
+        auto b = _name(args[1]);
+        auto ret = tvg::concat(a, b);
+        auto val = jerry_string_sz(ret);
+        tvg::free(ret);
+        tvg::free(a);
+        tvg::free(b);
+        return val;
+    }
+
+    //number + number
     auto n1 = jerry_value_is_number(args[0]);
     auto n2 = jerry_value_is_number(args[1]);
 

--- a/src/loaders/lottie/tvgLottieExpressions.h
+++ b/src/loaders/lottie/tvgLottieExpressions.h
@@ -123,6 +123,21 @@ public:
         return true;
     }
 
+    bool result(float frameNo, TextDocument& doc, LottieExpression* exp)
+    {
+        auto bm_rt = evaluate(frameNo, exp);
+        if (jerry_value_is_undefined(bm_rt)) return false;
+
+        if (jerry_value_is_string(bm_rt)) {
+            auto len = jerry_string_length(bm_rt);
+            doc.text = tvg::realloc<char*>(doc.text, (len + 1) * sizeof(jerry_char_t));
+            jerry_string_to_buffer(bm_rt, JERRY_ENCODING_UTF8, (jerry_char_t*)doc.text, len);
+            doc.text[len] = '\0';
+        }
+        jerry_value_free(bm_rt);
+        return true;
+    }
+
     void update(float curTime);
 
     //singleton (no thread safety)
@@ -157,6 +172,7 @@ struct LottieExpressions
     template<typename Property> bool result(TVG_UNUSED float, TVG_UNUSED RGB24&, TVG_UNUSED LottieExpression*) { return false; }
     template<typename Property> bool result(TVG_UNUSED float, TVG_UNUSED Fill*, TVG_UNUSED LottieExpression*) { return false; }
     template<typename Property> bool result(TVG_UNUSED float, TVG_UNUSED RenderPath&, TVG_UNUSED Matrix*, TVG_UNUSED LottieModifier*, TVG_UNUSED LottieExpression*) { return false; }
+    bool result(TVG_UNUSED float, TVG_UNUSED TextDocument& doc, TVG_UNUSED LottieExpression*) { return false; }
     void update(TVG_UNUSED float) {}
     static LottieExpressions* instance() { return nullptr; }
     static void retrieve(TVG_UNUSED LottieExpressions* instance) {}

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -867,17 +867,27 @@ struct LottieTextDoc : LottieProperty
         return (*frames)[frames->count];
     }
 
-    TextDocument& operator()(float frameNo, LottieExpressions* exps = nullptr)
+    TextDocument& operator()(float frameNo)
     {
-        //overriding with expressions
-        if (exps && exp) TVGERR("LOTTIE", "Not support TextDocument expressions?");
-
         if (!frames) return value;
         if (frames->count == 1 || frameNo <= frames->first().no) return frames->first().value;
         if (frameNo >= frames->last().no) return frames->last().value;
 
         auto frame = frames->data + _bsearch(frames, frameNo);
         return frame->value;
+    }
+
+    TextDocument& operator()(float frameNo, LottieExpressions* exps)
+    {
+        auto& out = operator()(frameNo);
+
+        //overriding with expressions
+        if (exps && exp) {
+            frameNo = _loop(frames, frameNo, exp);
+            exps->result(frameNo, out, exp);
+        }
+
+        return out;
     }
 
     void copy(LottieTextDoc& rhs, bool shallow = true)


### PR DESCRIPTION
- Handle text value of text document.
- Expand `add()` for string concatenation.

issue: #3303


![CleanShot 2025-03-21 at 16 39 23](https://github.com/user-attachments/assets/25d05256-7626-4bc1-82bd-7971caaaa76f)

![CleanShot 2025-03-21 at 16 38 35](https://github.com/user-attachments/assets/427a538e-0c7e-40bb-8015-9c86246f2f23)
