### PR TITLE
renderer: safety++

### DIFF
--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -1993,7 +1993,7 @@ void DashStroke::dashLineTo(const Point& to)
     } else {
         Line curr = {mPtCur, to};
 
-        while (len - mCurrLen > 0.0001f) {
+        while (len - mCurrLen > DASH_PATTERN_THRESHOLD) {
             Line right;
             if (mCurrLen > 0.0f) {
                 Line left;
@@ -2056,7 +2056,7 @@ void DashStroke::dashCubicTo(const Point& cnt1, const Point& cnt2, const Point& 
             this->cubicTo(cnt1, cnt2, end);
         }
     } else {
-        while (len - mCurrLen > 0.0001f) {
+        while (len - mCurrLen > DASH_PATTERN_THRESHOLD) {
             Bezier right;
             if (mCurrLen > 0.0f) {
                 Bezier left;

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -101,7 +101,6 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix& trans
 {
     Line cur = {dash.ptCur, *to};
     auto len = cur.length();
-
     if (tvg::zero(len)) {
         _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
     //draw the current line fully
@@ -116,7 +115,7 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix& trans
         }
     //draw the current line partially
     } else {
-        while (len - dash.curLen > 0.0001f) {
+        while (len - dash.curLen > DASH_PATTERN_THRESHOLD) {
             Line left, right;
             if (dash.curLen > 0) {
                 len -= dash.curLen;
@@ -177,7 +176,7 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
         }
     //draw the current line partially
     } else {
-        while ((len - dash.curLen) > 0.0001f) {
+        while ((len - dash.curLen) > DASH_PATTERN_THRESHOLD) {
             Bezier left, right;
             if (dash.curLen > 0) {
                 len -= dash.curLen;

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -35,6 +35,8 @@ namespace tvg
 using RenderData = void*;
 using pixel_t = uint32_t;
 
+#define DASH_PATTERN_THRESHOLD 0.001f
+
 enum RenderUpdateFlag : uint8_t {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, Blend = 128, All = 255};
 enum CompositionFlag : uint8_t {Invalid = 0, Opacity = 1, Blending = 2, Masking = 4, PostProcessing = 8};  //Composition Purpose
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -301,9 +301,9 @@ struct Shape::Impl : Paint::Impl
             if (!dash.pattern) dash.pattern = tvg::malloc<float*>(sizeof(float) * cnt);
             dash.length = 0.0f;
             for (uint32_t i = 0; i < cnt; ++i) {
-                if (pattern[i] < FLT_EPSILON) {
+                if (pattern[i] < DASH_PATTERN_THRESHOLD) {
                     dash.count = 0;
-                    return Result::InvalidArguments;                    
+                    return Result::InvalidArguments;
                 }
                 dash.pattern[i] = pattern[i];
                 dash.length += dash.pattern[i];


### PR DESCRIPTION
introduced a threshold for the minimum dash size
to prevent excessive fragmentation.

issue: https://github.com/thorvg/thorvg/issues/3332