### PR TITLE
capi: fix name mismatch

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2493,7 +2493,7 @@ TVG_API Tvg_Result tvg_accessor_del(Tvg_Accessor* accessor);
 *
 * @note Experimental API
 */
-TVG_API Tvg_Result tvg_accessor_set_paint(Tvg_Accessor* accessor, Tvg_Paint* paint, bool (*func)(Tvg_Paint* paint, void* data), void* data);
+TVG_API Tvg_Result tvg_accessor_set(Tvg_Accessor* accessor, Tvg_Paint* paint, bool (*func)(Tvg_Paint* paint, void* data), void* data);
 
 
 /*!


### PR DESCRIPTION
The correct name is `tvg_accessor_set`, not `tvg_accessor_set_paint`.