### PR TITLE
wasm: fix build error when WebGPU is disabled (SW/GL only)

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -191,7 +191,9 @@ struct TvgWgEngine : TvgEngineMethod
 
     void resize(Canvas* canvas, int w, int h) override
     {
+    #ifdef THORVG_WG_RASTER_SUPPORT
         if (canvas) static_cast<WgCanvas*>(canvas)->target(device, instance, surface, w, h, ColorSpace::ABGR8888S);
+    #endif
     }
 };
 


### PR DESCRIPTION
Fixed a build error that occurred when the WebGPU feature was disabled due to a missing feature check condition. The issue affected building with the software and OpenGL only backends.

issue: #3356