### PR TITLE
lottie/expressions: add temporalWiggle() support

### DIFF
--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -195,7 +195,7 @@ struct LottieProperty
     //TODO: Apply common bodies?
     virtual ~LottieProperty() {}
     virtual uint32_t frameCnt() = 0;
-    virtual uint32_t nearest(float time) = 0;
+    virtual uint32_t nearest(float frameNo) = 0;
     virtual float frameNo(int32_t key) = 0;
 
     bool copy(LottieProperty* rhs, bool shallow)
@@ -966,7 +966,7 @@ struct LottieBitmap : LottieProperty
     }
 
     uint32_t frameCnt() override { return 0; }
-    uint32_t nearest(float time) override { return 0; }
+    uint32_t nearest(float frameNo) override { return 0; }
     float frameNo(int32_t key) override { return 0; }
 
     void copy(LottieBitmap& rhs, bool shallow = true)


### PR DESCRIPTION
usage) temporalWiggle(freq, amp, octaves=1, amp_mult=.5, t=time)

Samples the property at a wiggled time. The freq value is the frequency in wiggles per second, amp is the amplitude in units of the property to which it is applied, octaves is the number of octaves of noise to add together, amp_mult is the amount that amp is multiplied by for each octave, and t is the base start time. For this function to be meaningful, the property it samples must be animated, because the function alters only the time of sampling, not the value.

Note: need to verify this with a practical samples.

issue: https://github.com/thorvg/thorvg/issues/1640