### PR TITLE
lottie/text: added range selector flags

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1082,25 +1082,13 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                         opacity = (uint8_t)(opacity - f * (opacity - range->style.opacity(frameNo, tween, exps)));
                         shape->opacity(opacity);
 
-                        auto rangeColor = range->style.fillColor(frameNo, tween, exps); //TODO: use flag to check whether it was really set
-                        if (tvg::equal(f, 1.0f)) color = rangeColor;
-                        else {
-                            color.rgb[0] = tvg::lerp<uint8_t>(color.rgb[0], rangeColor.rgb[0], f);
-                            color.rgb[1] = tvg::lerp<uint8_t>(color.rgb[1], rangeColor.rgb[1], f);
-                            color.rgb[2] = tvg::lerp<uint8_t>(color.rgb[2], rangeColor.rgb[2], f);
-                        }
+                        range->color(frameNo, color, strokeColor, f, tween, exps);
+
                         fillOpacity = (uint8_t)(fillOpacity - f * (fillOpacity - range->style.fillOpacity(frameNo, tween, exps)));
                         shape->fill(color.rgb[0], color.rgb[1], color.rgb[2], fillOpacity);
 
-                        shape->strokeWidth(f * range->style.strokeWidth(frameNo, tween, exps) / scale);
+                        if (range->style.flags.strokeWidth) shape->strokeWidth(f * range->style.strokeWidth(frameNo, tween, exps) / scale);
                         if (shape->strokeWidth() > 0.0f) {
-                            auto rangeColor = range->style.strokeColor(frameNo, tween, exps); //TODO: use flag to check whether it was really set
-                            if (tvg::equal(f, 1.0f)) strokeColor = rangeColor;
-                            else {
-                                strokeColor.rgb[0] = tvg::lerp<uint8_t>(strokeColor.rgb[0], rangeColor.rgb[0], f);
-                                strokeColor.rgb[1] = tvg::lerp<uint8_t>(strokeColor.rgb[1], rangeColor.rgb[1], f);
-                                strokeColor.rgb[2] = tvg::lerp<uint8_t>(strokeColor.rgb[2], rangeColor.rgb[2], f);
-                            }
                             strokeOpacity = (uint8_t)(strokeOpacity - f * (strokeOpacity - range->style.strokeOpacity(frameNo, tween, exps)));
                             shape->strokeFill(strokeColor.rgb[0], strokeColor.rgb[1], strokeColor.rgb[2], strokeOpacity);
                             shape->order(doc.stroke.below);

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -258,6 +258,13 @@ struct LottieTextRange
     enum Shape : uint8_t { Square = 1, RampUp, RampDown, Triangle, Round, Smooth };
     enum Unit : uint8_t { Percent = 1, Index };
 
+    LottieTextRange()
+    {
+        style.flags.fillColor = 0;
+        style.flags.strokeColor = 0;
+        style.flags.strokeWidth = 0;
+    }
+
     ~LottieTextRange()
     {
         tvg::free(interpolator);
@@ -275,6 +282,11 @@ struct LottieTextRange
         LottieOpacity fillOpacity = 255;
         LottieOpacity strokeOpacity = 255;
         LottieOpacity opacity = 255;
+        struct {
+            bool fillColor : 1;
+            bool strokeColor : 1;
+            bool strokeWidth : 1;
+        } flags;
     } style;
 
     LottieFloat offset = 0.0f;
@@ -292,6 +304,22 @@ struct LottieTextRange
     bool expressible = false;
 
     float factor(float frameNo, float totalLen, float idx);
+
+    void color(float frameNo, RGB24& fillColor, RGB24& strokeColor, float factor, Tween& tween, LottieExpressions* exps)
+    {
+        if (style.flags.fillColor) {
+            auto color = style.fillColor(frameNo, tween, exps);
+            fillColor.rgb[0] = tvg::lerp<uint8_t>(fillColor.rgb[0], color.rgb[0], factor);
+            fillColor.rgb[1] = tvg::lerp<uint8_t>(fillColor.rgb[1], color.rgb[1], factor);
+            fillColor.rgb[2] = tvg::lerp<uint8_t>(fillColor.rgb[2], color.rgb[2], factor);
+        }
+        if (style.flags.strokeColor) {
+            auto color = style.strokeColor(frameNo, tween, exps);
+            strokeColor.rgb[0] = tvg::lerp<uint8_t>(strokeColor.rgb[0], color.rgb[0], factor);
+            strokeColor.rgb[1] = tvg::lerp<uint8_t>(strokeColor.rgb[1], color.rgb[1], factor);
+            strokeColor.rgb[2] = tvg::lerp<uint8_t>(strokeColor.rgb[2], color.rgb[2], factor);
+        }
+    }
 };
 
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1132,7 +1132,8 @@ void LottieParser::parseTextRange(LottieText* text)
                 enterObject();
                 while (auto key = nextObjectKey()) {
                     if (KEY_AS("t")) selector->expressible = (bool) getInt();
-                    else if (KEY_AS("xe")) {
+                    else if (KEY_AS("xe"))
+                    {
                         parseProperty(selector->maxEase);
                         selector->interpolator = tvg::malloc<LottieInterpolator*>(sizeof(LottieInterpolator));
                     }
@@ -1153,10 +1154,22 @@ void LottieParser::parseTextRange(LottieText* text)
                 while (auto key = nextObjectKey()) {
                     if (KEY_AS("t")) parseProperty(selector->style.letterSpacing);
                     else if (KEY_AS("ls")) parseProperty(selector->style.lineSpacing);
-                    else if (KEY_AS("fc")) parseProperty(selector->style.fillColor);
+                    else if (KEY_AS("fc"))
+                    {
+                        parseProperty(selector->style.fillColor);
+                        selector->style.flags.fillColor = true;
+                    }
                     else if (KEY_AS("fo")) parseProperty(selector->style.fillOpacity);
-                    else if (KEY_AS("sw")) parseProperty(selector->style.strokeWidth);
-                    else if (KEY_AS("sc")) parseProperty(selector->style.strokeColor);
+                    else if (KEY_AS("sw"))
+                    {
+                        parseProperty(selector->style.strokeWidth);
+                        selector->style.flags.strokeWidth = true;
+                    }
+                    else if (KEY_AS("sc"))
+                    {
+                        parseProperty(selector->style.strokeColor);
+                        selector->style.flags.strokeColor = true;
+                    }
                     else if (KEY_AS("so")) parseProperty(selector->style.strokeOpacity);
                     else if (KEY_AS("o")) parseProperty(selector->style.opacity);
                     else if (KEY_AS("p")) parseProperty(selector->style.position);


### PR DESCRIPTION
| Text Style | Text Doc |
|------------|--------|
| ![CleanShot 2025-04-03 at 15 39 51@2x](https://github.com/user-attachments/assets/14e909e3-c3ba-4e2d-94f3-b239cde74f1c) | ![CleanShot 2025-04-03 at 15 38 49@2x](https://github.com/user-attachments/assets/601a8206-5aa3-4cba-9138-7139bf446d8a) |

Duplicated text document properties (fill color, stroke color, and stroke width) to the text range.  
If these properties are not defined in the range selector, ThorVG incorrectly overrides them with default values.  
The correct behavior is to preserve the original values. The added flags address this issue.

---

### Stroke Width

| lottie-web | ThorVG (Before) | ThorVG (Patched) |
|------------|------------------|-------------------|
| ![CleanShot 2025-04-03 at 15 42 09@2x](https://github.com/user-attachments/assets/d5c6546f-cbe4-4a92-9a15-a7fdbb3d096c) | ![Warp 2025-04-03 15 29 08](https://github.com/user-attachments/assets/e21ae71a-f0ca-44bc-8c11-25b19ef03747) | ![CleanShot 2025-04-03 at 15 42 42@2x](https://github.com/user-attachments/assets/893770d6-0d32-483b-b250-a975d7d6488c) |

---

### Range Color

| lottie-web | ThorVG (Before) | ThorVG (Patched) |
|------------|------------------|-------------------|
| ![CleanShot 2025-04-03 at 15 45 06@2x](https://github.com/user-attachments/assets/0879751d-66d5-4d8f-a075-e595648edbdb) | ![CleanShot 2025-04-03 at 15 45 47@2x](https://github.com/user-attachments/assets/ff28c954-0a6e-4f6d-8509-6a55225536da) | ![CleanShot 2025-04-03 at 15 45 10@2x](https://github.com/user-attachments/assets/4f0d2885-ee34-4aa0-b89e-2e6686d1abe9) |

---

**[Test Samples]**

- [stroke-width.json](https://github.com/user-attachments/files/19581352/stroke-width.json)  
- [36504.json](https://github.com/user-attachments/files/19581354/36504.json)