### PR TITLE
lottie: revert "lottie: more precise culling for inverse mattes"

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -148,17 +148,17 @@ private:
 
     void updateStrokeEffect(LottieLayer* layer, LottieFxStroke* effect, float frameNo);
     void updateEffect(LottieLayer* layer, float frameNo);
-    void updateLayer(LottieComposition* comp, Scene* scene, LottieLayer* layer, float frameNo, uint8_t skip);
+    void updateLayer(LottieComposition* comp, Scene* scene, LottieLayer* layer, float frameNo);
     bool updateMatte(LottieComposition* comp, float frameNo, Scene* scene, LottieLayer* layer);
-    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, uint8_t skip);
-    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, Tween& tween, uint8_t skip);
+    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo);
+    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, Tween& tween);
     void updateSolid(LottieLayer* layer);
     void updateImage(LottieGroup* layer);
     void updateText(LottieLayer* layer, float frameNo);
     void updateMasks(LottieLayer* layer, float frameNo);
     void updateTransform(LottieLayer* layer, float frameNo);
-    void updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderContext>& contexts, uint8_t skip);
-    void updateGroup(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& pcontexts, RenderContext* ctx, uint8_t skip);
+    void updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderContext>& contexts);
+    void updateGroup(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& pcontexts, RenderContext* ctx);
     void updateTransform(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     bool updateSolidFill(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     bool updateSolidStroke(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);


### PR DESCRIPTION
This reverts commit 7ef3352efa5852037c0441db4b055b791958bec3.

For mattes of type 'InvAlpha' or 'InvLuma', the matted layer can still be visible regardless of the matte's opacity (unlike 'Alpha' and 'Luma' masks, which cut out the entire layer when opacity = 0). The previously introduced optimization incorrectly assumed that with opacity = 255, the image would not be visible.

@Issue: https://github.com/thorvg/thorvg/issues/3375
@Issue: https://github.com/thorvg/thorvg/issues/3380
@Issue: https://github.com/thorvg/thorvg/issues/3381
@Issue: https://github.com/thorvg/thorvg/issues/3382


sample:
[matte_anim.json](https://github.com/user-attachments/files/19622977/matte_anim.json)

before:
![before](https://github.com/user-attachments/assets/44ddc152-121f-4788-92a8-12a223bcb03a)

after:
![after](https://github.com/user-attachments/assets/fd63f2bd-8c5f-45f3-946d-5646a519a80d)

AE:
![inv_op](https://github.com/user-attachments/assets/123e7600-400f-4616-8c79-5e9bfad49bb8)
