### PR TITLE
common: fix incorrect aabb of scenes

### DIFF
--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -194,7 +194,7 @@ struct Scene::Impl : Paint::Impl
         return ret;
     }
 
-    Result bounds(Point* pt4, Matrix& m, TVG_UNUSED bool obb, bool stroking)
+    Result bounds(Point* pt4, Matrix& m, bool obb, bool stroking)
     {
         if (paints.empty()) return Result::InsufficientCondition;
 
@@ -203,7 +203,7 @@ struct Scene::Impl : Paint::Impl
 
         for (auto paint : paints) {
             Point tmp[4];
-            if (PAINT(paint)->bounds(tmp, nullptr, false, stroking) != Result::Success) continue;
+            if (PAINT(paint)->bounds(tmp, obb ? nullptr : &m, false, stroking) != Result::Success) continue;
             //Merge regions
             for (int i = 0; i < 4; ++i) {
                 if (tmp[i].x < min.x) min.x = tmp[i].x;
@@ -212,10 +212,17 @@ struct Scene::Impl : Paint::Impl
                 if (tmp[i].y > max.y) max.y = tmp[i].y;
             }
         }
-        pt4[0] = min * m;
-        pt4[1] = Point{max.x, min.y} * m;
-        pt4[2] = max * m;
-        pt4[3] = Point{min.x, max.y} * m;
+        pt4[0] = min;
+        pt4[1] = Point{max.x, min.y};
+        pt4[2] = max;
+        pt4[3] = Point{min.x, max.y};
+
+        if (obb) {
+            pt4[0] *= m;
+            pt4[1] *= m;
+            pt4[2] *= m;
+            pt4[3] *= m;
+        }
 
         return Result::Success;
     }


### PR DESCRIPTION
- If you rotate a scene that contains a path, the AABB is incorrect.
  - The AABB of the scene is "wrapped" around the OBB for the child path, instead of being wrapped around the AABB for the child path.
  
![Screenshot 2025-04-08 104437](https://github.com/user-attachments/assets/1d83c9db-1270-410f-97da-0b99a5a3f529)

Now after these changes:

![image](https://github.com/user-attachments/assets/3b8c1345-b784-429e-8af6-777a1c11dbf0)
