### PR TITLE
gl_engine: Introduce fill, tint, tritone effects for opengl renderer

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -208,4 +208,9 @@ struct GlGaussianBlur {
     float extend{};
 };
 
+struct GlEffectParams {
+    // fill: [0..3]: color
+    float params[4+4+4];
+};
+
 #endif /* _TVG_GL_COMMON_H_ */

--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -211,6 +211,7 @@ struct GlGaussianBlur {
 struct GlEffectParams {
     // fill:          [0..3]: color
     // tint:          [0..2]: black,  [4..6]: white,   [8]: intensity
+    // tritone:       [0..2]: shadow, [4..6]: midtone, [8..10]: highlight
     float params[4+4+4];
 };
 

--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -209,7 +209,8 @@ struct GlGaussianBlur {
 };
 
 struct GlEffectParams {
-    // fill: [0..3]: color
+    // fill:          [0..3]: color
+    // tint:          [0..2]: black,  [4..6]: white,   [8]: intensity
     float params[4+4+4];
 };
 

--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -437,7 +437,6 @@ void GlGaussianBlurTask::run()
 
 void GlEffectColorTransformTask::run()
 {
-    // const auto vp = getViewport();
     const auto width = mDstFbo->getWidth();
     const auto height = mDstFbo->getHeight();
     // get targets handles and pass to shader
@@ -447,7 +446,7 @@ void GlEffectColorTransformTask::run()
 
     GL_CHECK(glViewport(0, 0, width, height));
     GL_CHECK(glScissor(0, 0, width, height));
-    // we need to make full copy of dst to intermidiate buffers to be shure, that they are not containe prev data
+    // we need to make a full copy of dst to intermediate buffers to be sure that they don’t contain prev data.
     GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, mDstFbo->getFboId()));
     GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mDstCopyFbo->getResolveFboId()));
     GL_CHECK(glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST));

--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -447,7 +447,7 @@ void GlEffectColorTransformTask::run()
 
     GL_CHECK(glViewport(0, 0, width, height));
     GL_CHECK(glScissor(0, 0, width, height));
-    // we need to make full copy of dst to intermediate buffers to be sure, that they are not contained prev data
+    // we need to make full copy of dst to intermidiate buffers to be shure, that they are not containe prev data
     GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, mDstFbo->getFboId()));
     GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mDstCopyFbo->getResolveFboId()));
     GL_CHECK(glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST));

--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -237,4 +237,17 @@ private:
     GlRenderTarget* mDstCopyFbo1;
 };
 
+class GlEffectColorTransformTask: public GlRenderTask
+{
+public:
+    GlEffectColorTransformTask(GlProgram* program, GlRenderTarget* dstFbo, GlRenderTarget* dstCopyFbo):
+        GlRenderTask(program), mDstFbo(dstFbo), mDstCopyFbo(dstCopyFbo) {};
+    ~GlEffectColorTransformTask() {};
+
+    void run() override;
+private:
+    GlRenderTarget* mDstFbo;
+    GlRenderTarget* mDstCopyFbo;
+};
+
 #endif /* _TVG_GL_RENDER_TASK_H_ */

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -62,6 +62,10 @@ public:
 
         RT_GaussianVert,
         RT_GaussianHorz,
+        //RT_DropShadow,
+        RT_EffectFill,
+        RT_EffectTint,
+        RT_EffectTritone,
 
         RT_None,
     };
@@ -120,6 +124,8 @@ private:
     void endRenderPass(RenderCompositor* cmp);
 
     void effectGaussianBlurUpdate(RenderEffectGaussianBlur* effect, const Matrix& transform);
+    void effectFillUpdate(RenderEffectFill* effect, const Matrix& transform);
+
     bool effectGaussianBlurRegion(RenderEffectGaussianBlur* effect);
 
     void flush();

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -126,6 +126,7 @@ private:
     void effectGaussianBlurUpdate(RenderEffectGaussianBlur* effect, const Matrix& transform);
     void effectFillUpdate(RenderEffectFill* effect, const Matrix& transform);
     void effectTintUpdate(RenderEffectTint* effect, const Matrix& transform);
+    void effectTritoneUpdate(RenderEffectTritone* effect, const Matrix& transform);
 
     bool effectGaussianBlurRegion(RenderEffectGaussianBlur* effect);
 

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -125,6 +125,7 @@ private:
 
     void effectGaussianBlurUpdate(RenderEffectGaussianBlur* effect, const Matrix& transform);
     void effectFillUpdate(RenderEffectFill* effect, const Matrix& transform);
+    void effectTintUpdate(RenderEffectTint* effect, const Matrix& transform);
 
     bool effectGaussianBlurRegion(RenderEffectGaussianBlur* effect);
 

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -776,7 +776,7 @@ void main()
     
     for (int y = -radius; y <= radius; ++y) {
         float weight = gaussian(float(y), sigma);
-        vec2 offset = vec2(0.0, float(y) * texelSize.y);
+        vec2 offset = min(vec2(1.0), vec2(0.0, float(y) * texelSize.y));
         colorSum += texture(uSrcTexture, vUV + offset) * weight;
         weightSum += weight;
     }
@@ -812,7 +812,8 @@ void main()
     
     for (int y = -radius; y <= radius; ++y) {
         float weight = gaussian(float(y), sigma);
-        vec2 offset = vec2(float(y) * texelSize.x, 0.0);
+        //vec2 offset = vec2(float(y) * texelSize.x, 0.0);
+        vec2 offset = min(vec2(1.0), vec2(float(y) * texelSize.x, 0.0));
         colorSum += texture(uSrcTexture, vUV + offset) * weight;
         weightSum += weight;
     }
@@ -835,5 +836,25 @@ void main()
     vec4 orig = texture(uSrcTexture, vUV);
     vec4 fill = uParams.params[0];
     FragColor = fill * orig.a * fill.a;
+} 
+)";
+
+const char* EFFECT_TINT = R"(
+uniform sampler2D uSrcTexture;
+layout(std140) uniform Params {
+    vec4 params[3];
+} uParams;
+
+in vec2 vUV;
+out vec4 FragColor;
+
+void main()
+{
+    vec4 orig = texture(uSrcTexture, vUV);
+    float luma = dot(orig.rgb, vec3(0.2125, 0.7154, 0.0721));
+    vec4 black = uParams.params[0];
+    vec4 white = uParams.params[1];
+    float intens = uParams.params[2].r;
+    FragColor = mix(orig, mix(white, black, luma), intens) * orig.a;
 } 
 )";

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -820,3 +820,20 @@ void main()
     FragColor = colorSum / weightSum;
 } 
 )";
+
+const char* EFFECT_FILL = R"(
+uniform sampler2D uSrcTexture;
+layout(std140) uniform Params {
+    vec4 params[3];
+} uParams;
+
+in vec2 vUV;
+out vec4 FragColor;
+
+void main()
+{
+    vec4 orig = texture(uSrcTexture, vUV);
+    vec4 fill = uParams.params[0];
+    FragColor = fill * orig.a * fill.a;
+} 
+)";

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -776,7 +776,7 @@ void main()
     
     for (int y = -radius; y <= radius; ++y) {
         float weight = gaussian(float(y), sigma);
-        vec2 offset = min(vec2(1.0), vec2(0.0, float(y) * texelSize.y));
+        vec2 offset = vec2(0.0, float(y) * texelSize.y);
         colorSum += texture(uSrcTexture, vUV + offset) * weight;
         weightSum += weight;
     }
@@ -812,8 +812,7 @@ void main()
     
     for (int y = -radius; y <= radius; ++y) {
         float weight = gaussian(float(y), sigma);
-        //vec2 offset = vec2(float(y) * texelSize.x, 0.0);
-        vec2 offset = min(vec2(1.0), vec2(float(y) * texelSize.x, 0.0));
+        vec2 offset = vec2(float(y) * texelSize.x, 0.0);
         colorSum += texture(uSrcTexture, vUV + offset) * weight;
         weightSum += weight;
     }
@@ -856,5 +855,31 @@ void main()
     vec4 white = uParams.params[1];
     float intens = uParams.params[2].r;
     FragColor = mix(orig, mix(white, black, luma), intens) * orig.a;
+} 
+)";
+
+const char* EFFECT_TRITONE = R"(
+uniform sampler2D uSrcTexture;
+layout(std140) uniform Params {
+    vec4 params[3];
+} uParams;
+
+in vec2 vUV;
+out vec4 FragColor;
+
+void main()
+{
+    vec4 orig = texture(uSrcTexture, vUV);
+    float luma = dot(orig.rgb, vec3(0.2125, 0.7154, 0.0721));
+    vec4 shadow = uParams.params[0];
+    vec4 midtone = uParams.params[1];
+    vec4 highlight = uParams.params[2];
+
+    FragColor = vec4(
+        luma >= 0.5f ? mix(midtone.r, highlight.r, (luma - 0.5f)*2.0f) : mix(shadow.r, midtone.r, luma * 2.0f),
+        luma >= 0.5f ? mix(midtone.g, highlight.g, (luma - 0.5f)*2.0f) : mix(shadow.g, midtone.g, luma * 2.0f),
+        luma >= 0.5f ? mix(midtone.b, highlight.b, (luma - 0.5f)*2.0f) : mix(shadow.b, midtone.b, luma * 2.0f),
+        luma >= 0.5f ? mix(midtone.a, highlight.a, (luma - 0.5f)*2.0f) : mix(shadow.a, midtone.a, luma * 2.0f)
+    ) * orig.a;
 } 
 )";

--- a/src/renderer/gl_engine/tvgGlShaderSrc.h
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.h
@@ -59,5 +59,6 @@ extern const char* GAUSSIAN_VERTICAL;
 extern const char* GAUSSIAN_HORIZONTAL;
 extern const char* EFFECT_FILL;
 extern const char* EFFECT_TINT;
+extern const char* EFFECT_TRITONE;
 
 #endif /* _TVG_GL_SHADERSRC_H_ */

--- a/src/renderer/gl_engine/tvgGlShaderSrc.h
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.h
@@ -57,5 +57,6 @@ extern const char* EXCLUSION_BLEND_FRAG;
 extern const char* EFFECT_VERTEX;
 extern const char* GAUSSIAN_VERTICAL;
 extern const char* GAUSSIAN_HORIZONTAL;
+extern const char* EFFECT_FILL;
 
 #endif /* _TVG_GL_SHADERSRC_H_ */

--- a/src/renderer/gl_engine/tvgGlShaderSrc.h
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.h
@@ -58,5 +58,6 @@ extern const char* EFFECT_VERTEX;
 extern const char* GAUSSIAN_VERTICAL;
 extern const char* GAUSSIAN_HORIZONTAL;
 extern const char* EFFECT_FILL;
+extern const char* EFFECT_TINT;
 
 #endif /* _TVG_GL_SHADERSRC_H_ */


### PR DESCRIPTION
Full support of fill, tint, tritone with all effects parameters
![image](https://github.com/user-attachments/assets/c14a08ce-e57e-49fe-9551-b7cee9a16219)
