### PR TITLE
lottie: follow path fixes

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -65,6 +65,7 @@ float LottieTextFollowPath::prepare(LottieMask* mask, float frameNo, float scale
 {
     this->mask = mask;
     Matrix m{1.0f / scale, 0.0f, 0.0f, 0.0f, 1.0f / scale, 0.0f, 0.0f, 0.0f, 1.0f};
+    path.clear();
     mask->pathset(frameNo, path, &m, tween, exps);
 
     pts = path.pts.data;
@@ -112,7 +113,7 @@ Point LottieTextFollowPath::position(float lenSearched, float& angle)
     if (lenSearched > totalLen) {
         //shape is closed -> wrapping
         if (path.cmds.last() == PathCommand::Close) {
-            lenSearched -= totalLen;
+            while (lenSearched > totalLen) lenSearched -= totalLen;
             pts = path.pts.data;
             cmds = path.cmds.data;
             cmdsCnt = path.cmds.count;

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -110,7 +110,7 @@ Point LottieTextFollowPath::position(float lenSearched, float& angle)
     };
 
     //beyond the curve
-    if (lenSearched > totalLen) {
+    if (lenSearched >= totalLen) {
         //shape is closed -> wrapping
         if (path.cmds.last() == PathCommand::Close) {
             while (lenSearched > totalLen) lenSearched -= totalLen;
@@ -148,7 +148,7 @@ Point LottieTextFollowPath::position(float lenSearched, float& angle)
 
     while (cmdsCnt > 0) {
         auto dLen = length();
-        if (currentLen + dLen <= lenSearched) {
+        if (currentLen + dLen < lenSearched) {
             shift();
             currentLen += dLen;
             continue;


### PR DESCRIPTION
[lottie: fix mask length in follow path](https://github.com/thorvg/thorvg/commit/6a39276e91b0866fee89044c49deba513bc24e55) 

Each time the 'updateText' was called, the mask
path (if the follow path existed) was appended
to the previous one, causing it to grow infinitely.
A 'clear' call on the existing path was missing.


[lottie: fix crash on follow path](https://github.com/thorvg/thorvg/commit/7f296f9bc0ab3ea06751d0757526f7fdbf260991) 

It could happen that the searched text position
(distance from the start pointt) on the follow path
was exactly equal to the path length. In such a case,
the cmds pointer pointed to the last element, and in
the next iteration, this caused a crash.

Test:
[sample](https://github.com/user-attachments/files/19671764/follow_rect.json) to test crash (on mac intel, not every time)