### PR TITLE
lottie: safety++

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -474,7 +474,7 @@ struct LottieText : LottieObject, LottieRenderPooler<tvg::Shape>
     }
 
     LottieTextDoc doc;
-    LottieFont* font;
+    LottieFont* font = nullptr;
     LottieTextFollowPath* followPath = nullptr;
     Array<LottieTextRange*> ranges;
 


### PR DESCRIPTION
Prevents a crash when the font family in the text document does not match any font in the provided font list.

sample:
[text.json](https://github.com/user-attachments/files/19691540/text.json)
