### PR TITLE
ttf: prevent crash while converting utf8 to unicode

### DIFF
--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -284,6 +284,7 @@ bool TtfLoader::read(Shape* shape, char* text, FontMetrics& out)
 
     auto n = strlen(text);
     auto code = _codepoints(text, n);
+    if (!code) return false;
 
     //TODO: optimize with the texture-atlas?
     TtfGlyphMetrics gmetrics;


### PR DESCRIPTION
If wrong utf8 sequence if given as an input, decoding return nullptr and it has to be handled correctly.

test:
crash occurred when unicode was passed in expressions - can be also recreated with this incorrect utf8 sequence:
```
        auto text12 = tvg::Text::gen();
        text12->font("SentyCloud", 50);
        text12->fill(255, 25, 25);
        text12->text("\xF8\x88\x80\x80\x80");
        text12->translate(0, 525);
        canvas->push(text12);
```