### PR TITLE
renderer: Added null check in Paint::Impl:clip

### DIFF
--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -163,7 +163,7 @@ namespace tvg
 
         Result clip(Paint* clp)
         {
-            if (PAINT(clp)->parent) return Result::InsufficientCondition;
+            if (clp && PAINT(clp)->parent) return Result::InsufficientCondition;
             if (clipper) PAINT(clipper)->unref(clipper != clp);
             clipper = clp;
             if (clp) {


### PR DESCRIPTION
Prevents field accessing on `nullptr`.

Resolve: #3404