### PR TITLE
renderer: fixed a clippging update isssue

### DIFF
--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -119,49 +119,38 @@ struct SwShapeTask : SwTask
 
         auto strokeWidth = validStrokeWidth(clipper);
         SwBBox renderRegion{};
-        auto visibleFill = false;
-
-        //This checks also for the case, if the invisible shape turned to visible by alpha.
-        auto prepareShape = !shapePrepared(&shape) && flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient);
+        auto updateShape = (RenderUpdateFlag::Path | RenderUpdateFlag::Transform | RenderUpdateFlag::Clip);
+        auto updateFill = false;
 
         //Shape
-        if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform) || prepareShape) {
-            auto alpha = rshape->color.a;
-            alpha = MULTIPLY(alpha, opacity);
-            visibleFill = (alpha > 0 || rshape->fill);
-            shapeReset(&shape);
-            if (visibleFill || clipper) {
-                if (!shapePrepare(&shape, rshape, transform, bbox, renderRegion, mpool, tid, clips.count > 0 ? true : false)) {
-                    visibleFill = false;
+        if (updateShape || flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient)) {
+            updateFill = (MULTIPLY(rshape->color.a, opacity) || rshape->fill);
+            if (updateShape) shapeReset(&shape);
+            if (updateFill || clipper) {
+                if (shapePrepare(&shape, rshape, transform, bbox, renderRegion, mpool, tid, clips.count > 0 ? true : false)) {
+                    if (!shapeGenRle(&shape, rshape, antialiasing(strokeWidth))) goto err;
+                } else {
+                    updateFill = false;
                     renderRegion.reset();
                 }
             }
         }
         //Fill
-        if (flags & (RenderUpdateFlag::Path |RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Color)) {
-            if (visibleFill || clipper) {
-                if (!shapeGenRle(&shape, rshape, antialiasing(strokeWidth))) goto err;
-            }
+        if (updateFill) {
             if (auto fill = rshape->fill) {
                 auto ctable = (flags & RenderUpdateFlag::Gradient) ? true : false;
                 if (ctable) shapeResetFill(&shape);
                 if (!shapeGenFillColors(&shape, fill, transform, surface, opacity, ctable)) goto err;
-            } else {
-                shapeDelFill(&shape);
             }
         }
         //Stroke
-        if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Stroke | RenderUpdateFlag::Transform)) {
-            if (strokeWidth > 0.0f) {
-                shapeResetStroke(&shape, rshape, transform);
-                if (!shapeGenStrokeRle(&shape, rshape, transform, bbox, renderRegion, mpool, tid)) goto err;
-                if (auto fill = rshape->strokeFill()) {
-                    auto ctable = (flags & RenderUpdateFlag::GradientStroke) ? true : false;
-                    if (ctable) shapeResetStrokeFill(&shape);
-                    if (!shapeGenStrokeFillColors(&shape, fill, transform, surface, opacity, ctable)) goto err;
-                }
-            } else {
-                shapeDelStroke(&shape);
+        if ((updateShape || flags & RenderUpdateFlag::Stroke) && (strokeWidth > 0.0f)) {
+            shapeResetStroke(&shape, rshape, transform);
+            if (!shapeGenStrokeRle(&shape, rshape, transform, bbox, renderRegion, mpool, tid)) goto err;
+            if (auto fill = rshape->strokeFill()) {
+                auto ctable = (flags & RenderUpdateFlag::GradientStroke) ? true : false;
+                if (ctable) shapeResetStrokeFill(&shape);
+                if (!shapeGenStrokeFillColors(&shape, fill, transform, surface, opacity, ctable)) goto err;
             }
         }
 

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -246,15 +246,17 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
 
     /* 2. Clipping */
     if (this->clipper) {
-        PAINT(this->clipper)->ctxFlag &= ~ContextFlag::FastTrack;   //reset
+        auto pclip = PAINT(this->clipper);
+        if (pclip->renderFlag) renderFlag |= RenderUpdateFlag::Clip;
+        pclip->ctxFlag &= ~ContextFlag::FastTrack;   //reset
         viewport = renderer->viewport();
         /* TODO: Intersect the clipper's clipper, if both are FastTrack.
            Update the subsequent clipper first and check its ctxFlag. */
-        if (!PAINT(this->clipper)->clipper && SHAPE(this->clipper)->rs.strokeWidth() == 0.0f && _compFastTrack(renderer, this->clipper, pm, viewport) == Result::Success) {
-            PAINT(this->clipper)->ctxFlag |= ContextFlag::FastTrack;
+        if (!pclip->clipper && SHAPE(this->clipper)->rs.strokeWidth() == 0.0f && _compFastTrack(renderer, this->clipper, pm, viewport) == Result::Success) {
+            pclip->ctxFlag |= ContextFlag::FastTrack;
             compFastTrack = Result::Success;
         } else {
-            trd = PAINT(this->clipper)->update(renderer, pm, clips, 255, pFlag, true);
+            trd = pclip->update(renderer, pm, clips, 255, pFlag, true);
             clips.push(trd);
             compFastTrack = Result::InsufficientCondition;
         }

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -77,8 +77,8 @@ namespace tvg
                 tvg::rotate(&m, degree);
             }
         } tr;
+        RenderUpdateFlag renderFlag = RenderUpdateFlag::None;
         BlendMethod blendMethod;
-        uint8_t renderFlag;
         uint8_t ctxFlag;
         uint8_t opacity;
         uint8_t refCnt = 0;       //reference count

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -37,8 +37,13 @@ using pixel_t = uint32_t;
 
 #define DASH_PATTERN_THRESHOLD 0.001f
 
-enum RenderUpdateFlag : uint8_t {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, Blend = 128, All = 255};
+enum RenderUpdateFlag : uint16_t {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, Blend = 128, Clip = 256, All = 0xffff};
 enum CompositionFlag : uint8_t {Invalid = 0, Opacity = 1, Blending = 2, Masking = 4, PostProcessing = 8};  //Composition Purpose
+
+static inline void operator|=(RenderUpdateFlag& a, const RenderUpdateFlag b)
+{
+    a = RenderUpdateFlag(uint16_t(a) | uint16_t(b));
+}
 
 struct RenderSurface
 {


### PR DESCRIPTION
ThorVG did not consider updates to the clipping path when a paint object was modified after being added to the scene.

This fix ensures that any updates to clipping are correctly reflected during rendering.

issue: https://github.com/thorvg/thorvg/issues/3403