### PR TITLE
renderer: add missing RenderUpdateFlag

### DIFF
--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -478,6 +478,7 @@ struct Shape::Impl : Paint::Impl
             rs.path.cmds.count += 10;
             rs.path.pts.count += 17;
         }
+        renderFlag |= RenderUpdateFlag::Path;
     }
 
     Paint* duplicate(Paint* ret)


### PR DESCRIPTION
Flag was missing in the appendRect().

sample:
```
            auto shape1 = tvg::Shape::gen();
            shape1->appendRect(10, 10, 100, 100);
            shape1->fill(0, 0, 255);
            canvas->push(shape1);

            shape1->appendRect(210, 10, 100, 100);
            canvas->update(shape1);
```

before:
<img width="300" alt="Zrzut ekranu 2025-04-16 o 11 11 46" src="https://github.com/user-attachments/assets/7c0b010b-3f10-418c-8a73-0175147dba8a" />

after:
<img width="300" alt="Zrzut ekranu 2025-04-16 o 11 11 25" src="https://github.com/user-attachments/assets/76a20974-4fe7-4378-9564-2be783160f6d" />

