### PR TITLE
wg_engine/gl_engine: fix drop shadow blended color 

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -979,10 +979,11 @@ void GlRenderer::effectDropShadowUpdate(RenderEffectDropShadow* effect, const Ma
     dropShadow->sigma = sigma;
     dropShadow->scale = scale;
     dropShadow->level = int(GL_GAUSSIAN_MAX_LEVEL * ((effect->quality - 1) * 0.01f)) + 1;
-    dropShadow->color[0] = effect->color[0] / 255.0f;
-    dropShadow->color[1] = effect->color[1] / 255.0f;
-    dropShadow->color[2] = effect->color[2] / 255.0f;
     dropShadow->color[3] = effect->color[3] / 255.0f;
+    //Drop shadow effect applies blending in the shader (GL_BLEND disabled), so the color should be premultiplied:
+    dropShadow->color[0] = effect->color[0] / 255.0f * dropShadow->color[3];
+    dropShadow->color[1] = effect->color[1] / 255.0f * dropShadow->color[3];
+    dropShadow->color[2] = effect->color[2] / 255.0f * dropShadow->color[3];
     dropShadow->offset[0] = offset.x;
     dropShadow->offset[1] = offset.y;
     dropShadow->extend = 2 * std::max(sigma * scale + std::abs(offset.x), sigma * scale + std::abs(offset.y));

--- a/src/renderer/wg_engine/tvgWgShaderTypes.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.cpp
@@ -230,10 +230,13 @@ void WgShaderTypeEffectParams::update(const RenderEffectDropShadow* dropShadow, 
     params[1] = std::min(WG_GAUSSIAN_KERNEL_SIZE_MAX / kernel, scale);
     params[2] = kernel;
     params[3] = 0.0f;
-    params[4] = dropShadow->color[0] / 255.0f; // red
-    params[5] = dropShadow->color[1] / 255.0f; // green
-    params[6] = dropShadow->color[2] / 255.0f; // blue
+
     params[7] = dropShadow->color[3] / 255.0f; // alpha
+    //Color is premultiplied to avoid multiplication in the fragment shader:
+    params[4] = dropShadow->color[0] / 255.0f * params[7]; // red
+    params[5] = dropShadow->color[1] / 255.0f * params[7]; // green
+    params[6] = dropShadow->color[2] / 255.0f * params[7]; // blue
+
     params[8] = offset.x;
     params[9] = offset.y;
     extend = params[2] * 2; // kernel


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="400" alt="bbb" src="https://github.com/user-attachments/assets/8eca5934-0119-41af-83e4-2fbd7823435e" />|<img width="400" alt="bbb" src="https://github.com/user-attachments/assets/c3118ffd-b01c-4fc0-ab4b-5750bafa59cd" />|
|<img width="400" alt="bbb" src="https://github.com/user-attachments/assets/7430f5b5-91a3-4ff3-946e-4b7f96adaa41"/>|<img width="400" alt="bbb" src="https://github.com/user-attachments/assets/ee32dd40-3c7f-4cc1-9384-30b565082f4a"/>|