### PR TITLE
renderer: revise the pImpl design with a better efficiency

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -801,8 +801,10 @@ public:
  *
  * Besides the APIs inherited from the Fill class, it enables setting and getting the linear gradient bounds.
  * The behavior outside the gradient bounds depends on the value specified in the spread API.
+ *
+ * @warning This class is not designed for inheritance.
  */
-class TVG_API LinearGradient final : public Fill
+class TVG_API LinearGradient : public Fill
 {
 public:
     /**
@@ -863,8 +865,9 @@ public:
  *
  * @brief A class representing the radial gradient fill of the Shape object.
  *
+ * @warning This class is not designed for inheritance.
  */
-class TVG_API RadialGradient final : public Fill
+class TVG_API RadialGradient : public Fill
 {
 public:
     /**
@@ -939,8 +942,10 @@ public:
  *
  * The stroke of Shape is an optional property in case the Shape needs to be represented with/without the outline borders.
  * It's efficient since the shape path and the stroking path can be shared with each other. It's also convenient when controlling both in one context.
+ *
+ * @warning This class is not designed for inheritance.
  */
-class TVG_API Shape final : public Paint
+class TVG_API Shape : public Paint
 {
 public:
     /**
@@ -1319,8 +1324,10 @@ public:
  *
  * @note Supported formats are depended on the available TVG loaders.
  * @note See Animation class if the picture data is animatable.
+ *
+ * @warning This class is not designed for inheritance.
  */
-class TVG_API Picture final : public Paint
+class TVG_API Picture : public Paint
 {
 public:
     /**
@@ -1450,8 +1457,10 @@ public:
  *
  * As a group, the scene can be transformed, made translucent and composited with other target paints,
  * its children will be affected by the scene world.
+ *
+ * @warning This class is not designed for inheritance.
  */
-class TVG_API Scene final : public Paint
+class TVG_API Scene : public Paint
 {
 public:
     /**
@@ -1546,9 +1555,11 @@ public:
  *
  * @brief A class to represent text objects in a graphical context, allowing for rendering and manipulation of unicode text.
  *
+ * @warning This class is not designed for inheritance.
+ *
  * @since 0.15
  */
-class TVG_API Text final : public Paint
+class TVG_API Text : public Paint
 {
 public:
     /**

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -481,7 +481,7 @@ void LottieBuilder::updatePath(LottieGroup* parent, LottieObject** child, float 
     if (ctx->repeaters.empty()) {
         _draw(parent, path, ctx);
         if (path->pathset(frameNo, SHAPE(ctx->merging)->rs.path, ctx->transform, tween, exps, ctx->modifier)) {
-            PAINT(ctx->merging)->update(RenderUpdateFlag::Path);
+            PAINT(ctx->merging)->mark(RenderUpdateFlag::Path);
         }
     } else {
         auto shape = path->pooling();
@@ -695,7 +695,7 @@ void LottieBuilder::updatePolystar(LottieGroup* parent, LottieObject** child, fl
         _draw(parent, star, ctx);
         if (star->type == LottiePolyStar::Star) updateStar(star, frameNo, (identity ? nullptr : &matrix), ctx->merging, ctx, tween, exps);
         else updatePolygon(parent, star, frameNo, (identity  ? nullptr : &matrix), ctx->merging, ctx, tween, exps);
-        PAINT(ctx->merging)->update(RenderUpdateFlag::Path);
+        PAINT(ctx->merging)->mark(RenderUpdateFlag::Path);
     } else {
         auto shape = star->pooling();
         shape->reset();
@@ -1037,7 +1037,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
                     auto group = static_cast<LottieGroup*>(*p);
                     ARRAY_FOREACH(p, group->children) {
                         if (static_cast<LottiePath*>(*p)->pathset(frameNo, SHAPE(shape)->rs.path, nullptr, tween, exps)) {
-                            PAINT(shape)->update(RenderUpdateFlag::Path);
+                            PAINT(shape)->mark(RenderUpdateFlag::Path);
                         }
                     }
                 }

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -1469,10 +1469,10 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
     if (clipper) {
         sdata->updateFlag = (rshape.stroke && (rshape.stroke->width > 0)) ? RenderUpdateFlag::Stroke : RenderUpdateFlag::Path;
     } else {
-        if (alphaF) sdata->updateFlag = static_cast<RenderUpdateFlag>(RenderUpdateFlag::Color | sdata->updateFlag);
-        if (rshape.fill) sdata->updateFlag = static_cast<RenderUpdateFlag>(RenderUpdateFlag::Gradient | sdata->updateFlag);
-        if (alphaS) sdata->updateFlag = static_cast<RenderUpdateFlag>(RenderUpdateFlag::Stroke | sdata->updateFlag);
-        if (rshape.strokeFill()) sdata->updateFlag = static_cast<RenderUpdateFlag>(RenderUpdateFlag::GradientStroke | sdata->updateFlag);
+        if (alphaF) sdata->updateFlag = (RenderUpdateFlag::Color | sdata->updateFlag);
+        if (rshape.fill) sdata->updateFlag = (RenderUpdateFlag::Gradient | sdata->updateFlag);
+        if (alphaS) sdata->updateFlag = (RenderUpdateFlag::Stroke | sdata->updateFlag);
+        if (rshape.strokeFill()) sdata->updateFlag = (RenderUpdateFlag::GradientStroke | sdata->updateFlag);
     }
 
     if (sdata->updateFlag == RenderUpdateFlag::None) return sdata;

--- a/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/src/renderer/sw_engine/tvgSwFill.cpp
@@ -67,10 +67,10 @@ static uint32_t _estimateAAMargin(const Fill* fdata)
     constexpr float marginScalingFactor = 800.0f;
 
     if (fdata->type() == Type::RadialGradient) {
-        auto radius = RADIAL(fdata)->r;
+        auto radius = CONST_RADIAL(fdata)->r;
         return tvg::zero(radius) ? 0 : static_cast<uint32_t>(marginScalingFactor / radius);
     } else {
-        auto grad = LINEAR(fdata);
+        auto grad = CONST_LINEAR(fdata);
         Point p1 {grad->x1, grad->y1};
         Point p2 {grad->x2, grad->y2};
         auto len = length(&p1, &p2);
@@ -226,7 +226,7 @@ bool _prepareLinear(SwFill* fill, const LinearGradient* linear, const Matrix& pT
     fill->linear.dy /= len;
     fill->linear.offset = -fill->linear.dx * x1 - fill->linear.dy * y1;
 
-    auto transform = pTransform * linear->transform();
+    const auto& transform = pTransform * linear->transform();
 
     Matrix itransform;
     if (!inverse(&transform, &itransform)) return false;
@@ -279,7 +279,7 @@ bool _prepareRadial(SwFill* fill, const RadialGradient* radial, const Matrix& pT
 
     if (fill->radial.a > 0) fill->radial.invA = 1.0f / fill->radial.a;
 
-    auto transform = pTransform * radial->transform();
+    const auto& transform = pTransform * radial->transform();
 
     Matrix itransform;
     if (!inverse(&transform, &itransform)) return false;

--- a/src/renderer/tvgCommon.h
+++ b/src/renderer/tvgCommon.h
@@ -89,8 +89,6 @@ namespace tvg {
 
     uint16_t THORVG_VERSION_NUMBER();
 
-    #define PIMPL(INST, CLASS) ((CLASS::Impl*)INST->pImpl)   //Access to pimpl
-
     #define TVG_DELETE(PAINT) \
     if (PAINT->refCnt() == 0) delete(PAINT)
 

--- a/src/renderer/tvgFill.cpp
+++ b/src/renderer/tvgFill.cpp
@@ -27,16 +27,8 @@
 /* Fill Class Implementation                                            */
 /************************************************************************/
 
-Fill::Fill()
-{
-}
-
-
-Fill::~Fill()
-{
-    delete(pImpl);
-}
-
+Fill::Fill() = default;
+Fill::~Fill() = default;
 
 Result Fill::colorStops(const ColorStop* colorStops, uint32_t cnt) noexcept
 {
@@ -79,7 +71,9 @@ Matrix& Fill::transform() const noexcept
 
 Fill* Fill::duplicate() const noexcept
 {
-    return pImpl->duplicate();
+    if (type() == Type::LinearGradient) return CONST_LINEAR(this)->duplicate();
+    else if (type() == Type::RadialGradient) return CONST_RADIAL(this)->duplicate();
+    return nullptr;
 }
 
 
@@ -87,11 +81,7 @@ Fill* Fill::duplicate() const noexcept
 /* RadialGradient Class Implementation                                  */
 /************************************************************************/
 
-
-RadialGradient::RadialGradient()
-{
-    Fill::pImpl = new Impl;
-}
+RadialGradient::RadialGradient() = default;
 
 
 Result RadialGradient::radial(float cx, float cy, float r, float fx, float fy, float fr) noexcept
@@ -102,13 +92,13 @@ Result RadialGradient::radial(float cx, float cy, float r, float fx, float fy, f
 
 Result RadialGradient::radial(float* cx, float* cy, float* r, float* fx, float* fy, float* fr) const noexcept
 {
-    return RADIAL(this)->radial(cx, cy, r, fx, fy, fr);
+    return CONST_RADIAL(this)->radial(cx, cy, r, fx, fy, fr);
 }
 
 
 RadialGradient* RadialGradient::gen() noexcept
 {
-    return new RadialGradient;
+    return new RadialGradientImpl;
 }
 
 
@@ -122,11 +112,7 @@ Type RadialGradient::type() const noexcept
 /* LinearGradient Class Implementation                                  */
 /************************************************************************/
 
-
-LinearGradient::LinearGradient()
-{
-    Fill::pImpl = new Impl;
-}
+LinearGradient::LinearGradient() = default;
 
 
 Result LinearGradient::linear(float x1, float y1, float x2, float y2) noexcept
@@ -137,13 +123,13 @@ Result LinearGradient::linear(float x1, float y1, float x2, float y2) noexcept
 
 Result LinearGradient::linear(float* x1, float* y1, float* x2, float* y2) const noexcept
 {
-    return LINEAR(this)->linear(x1, y1, x2, y2);
+    return CONST_LINEAR(this)->linear(x1, y1, x2, y2);
 }
 
 
 LinearGradient* LinearGradient::gen() noexcept
 {
-    return new LinearGradient;
+    return new LinearGradientImpl;
 }
 
 

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -163,7 +163,7 @@ Paint* Paint::Impl::duplicate(Paint* ret)
 
     //duplicate Transform
     ret->pImpl->tr = tr;
-    ret->pImpl->renderFlag |= RenderUpdateFlag::Transform;
+    ret->pImpl->mark(RenderUpdateFlag::Transform);
 
     ret->pImpl->opacity = opacity;
 
@@ -247,7 +247,7 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
     /* 2. Clipping */
     if (this->clipper) {
         auto pclip = PAINT(this->clipper);
-        if (pclip->renderFlag) renderFlag |= RenderUpdateFlag::Clip;
+        if (pclip->renderFlag) mark(RenderUpdateFlag::Clip);
         pclip->ctxFlag &= ~ContextFlag::FastTrack;   //reset
         viewport = renderer->viewport();
         /* TODO: Intersect the clipper's clipper, if both are FastTrack.
@@ -263,7 +263,7 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
     }
 
     /* 3. Main Update */
-    auto newFlag = static_cast<RenderUpdateFlag>(pFlag | renderFlag);
+    auto newFlag = pFlag | renderFlag;
     renderFlag = RenderUpdateFlag::None;
     opacity = MULTIPLY(opacity, this->opacity);
 
@@ -317,15 +317,8 @@ Result Paint::Impl::bounds(Point* pt4, Matrix* pm, bool obb, bool stroking)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Paint :: Paint()
-{
-}
-
-
-Paint :: ~Paint()
-{
-    delete(pImpl);
-}
+Paint :: Paint() = default;
+Paint :: ~Paint() = default;
 
 
 Result Paint::rotate(float degree) noexcept
@@ -410,7 +403,7 @@ Result Paint::opacity(uint8_t o) noexcept
     if (pImpl->opacity == o) return Result::Success;
 
     pImpl->opacity = o;
-    pImpl->renderFlag |= RenderUpdateFlag::Color;
+    pImpl->mark(RenderUpdateFlag::Color);
 
     return Result::Success;
 }

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -27,7 +27,8 @@
 #include "tvgRender.h"
 #include "tvgMath.h"
 
-#define PAINT(A) PIMPL(A, Paint)
+
+#define PAINT(A) ((Paint::Impl*)A->pImpl)
 
 namespace tvg
 {
@@ -85,6 +86,7 @@ namespace tvg
 
         Impl(Paint* pnt) : paint(pnt)
         {
+            pnt->pImpl = this;
             reset();
         }
 
@@ -129,7 +131,7 @@ namespace tvg
             return refCnt;
         }
 
-        void update(RenderUpdateFlag flag)
+        void mark(RenderUpdateFlag flag)
         {
             renderFlag |= flag;
         }
@@ -138,7 +140,7 @@ namespace tvg
         {
             if (&tr.m != &m) tr.m = m;
             tr.overriding = true;
-            renderFlag |= RenderUpdateFlag::Transform;
+            mark(RenderUpdateFlag::Transform);
 
             return true;
         }
@@ -236,7 +238,7 @@ namespace tvg
             if (tr.overriding) return false;
             if (tvg::equal(degree, tr.degree)) return true;
             tr.degree = degree;
-            renderFlag |= RenderUpdateFlag::Transform;
+            mark(RenderUpdateFlag::Transform);
 
             return true;
         }
@@ -246,7 +248,7 @@ namespace tvg
             if (tr.overriding) return false;
             if (tvg::equal(factor, tr.scale)) return true;
             tr.scale = factor;
-            renderFlag |= RenderUpdateFlag::Transform;
+            mark(RenderUpdateFlag::Transform);
 
             return true;
         }
@@ -257,7 +259,7 @@ namespace tvg
             if (tvg::equal(x, tr.m.e13) && tvg::equal(y, tr.m.e23)) return true;
             tr.m.e13 = x;
             tr.m.e23 = y;
-            renderFlag |= RenderUpdateFlag::Transform;
+            mark(RenderUpdateFlag::Transform);
 
             return true;
         }
@@ -266,7 +268,7 @@ namespace tvg
         {
             if (blendMethod != method) {
                 blendMethod = method;
-                renderFlag |= RenderUpdateFlag::Blend;
+                mark(RenderUpdateFlag::Blend);
             }
         }
 

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -23,15 +23,12 @@
 #include "tvgPaint.h"
 #include "tvgPicture.h"
 
-Picture::Picture()
-{
-    pImpl = new Impl(this);
-}
+Picture::Picture() = default;
 
 
 Picture* Picture::gen() noexcept
 {
-    return new Picture;
+    return new PictureImpl;
 }
 
 
@@ -74,7 +71,7 @@ Result Picture::size(float w, float h) noexcept
 
 Result Picture::size(float* w, float* h) const noexcept
 {
-    return PICTURE(this)->size(w, h);
+    return CONST_PICTURE(this)->size(w, h);
 }
 
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -45,6 +45,12 @@ static inline void operator|=(RenderUpdateFlag& a, const RenderUpdateFlag b)
     a = RenderUpdateFlag(uint16_t(a) | uint16_t(b));
 }
 
+static inline RenderUpdateFlag operator|(const RenderUpdateFlag a, const RenderUpdateFlag b)
+{
+    return RenderUpdateFlag(uint16_t(a) | uint16_t(b));
+}
+
+
 struct RenderSurface
 {
     union {

--- a/src/renderer/tvgScene.cpp
+++ b/src/renderer/tvgScene.cpp
@@ -23,15 +23,12 @@
 #include "tvgScene.h"
 
 
-Scene::Scene()
-{
-    pImpl = new Impl(this);
-}
+Scene::Scene() = default;
 
 
 Scene* Scene::gen() noexcept
 {
-    return new Scene;
+    return new SceneImpl;
 }
 
 
@@ -56,7 +53,7 @@ Result Scene::remove(Paint* paint) noexcept
 
 const list<Paint*>& Scene::paints() const noexcept
 {
-    return SCENE(this)->paints;
+    return CONST_SCENE(this)->paints;
 }
 
 

--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -24,15 +24,12 @@
 #include "tvgShape.h"
 
 
-Shape :: Shape()
-{
-    pImpl = new Impl(this);
-}
+Shape :: Shape() = default;
 
 
 Shape* Shape::gen() noexcept
 {
-    return new Shape;
+    return new ShapeImpl;
 }
 
 
@@ -51,11 +48,11 @@ Result Shape::reset() noexcept
 
 Result Shape::path(const PathCommand** cmds, uint32_t* cmdsCnt, const Point** pts, uint32_t* ptsCnt) const noexcept
 {
-    if (cmds) *cmds = SHAPE(this)->rs.path.cmds.data;
-    if (cmdsCnt) *cmdsCnt = SHAPE(this)->rs.path.cmds.count;
+    if (cmds) *cmds = CONST_SHAPE(this)->rs.path.cmds.data;
+    if (cmdsCnt) *cmdsCnt = CONST_SHAPE(this)->rs.path.cmds.count;
 
-    if (pts) *pts = SHAPE(this)->rs.path.pts.data;
-    if (ptsCnt) *ptsCnt = SHAPE(this)->rs.path.pts.count;
+    if (pts) *pts = CONST_SHAPE(this)->rs.path.pts.data;
+    if (ptsCnt) *ptsCnt = CONST_SHAPE(this)->rs.path.pts.count;
 
     return Result::Success;
 }
@@ -124,14 +121,14 @@ Result Shape::fill(Fill* f) noexcept
 
 Result Shape::fill(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept
 {
-    SHAPE(this)->rs.fillColor(r, g, b, a);
+    CONST_SHAPE(this)->rs.fillColor(r, g, b, a);
     return Result::Success;
 }
 
 
 const Fill* Shape::fill() const noexcept
 {
-    return SHAPE(this)->rs.fill;
+    return CONST_SHAPE(this)->rs.fill;
 }
 
 
@@ -151,7 +148,7 @@ Result Shape::strokeWidth(float width) noexcept
 
 float Shape::strokeWidth() const noexcept
 {
-    return SHAPE(this)->rs.strokeWidth();
+    return CONST_SHAPE(this)->rs.strokeWidth();
 }
 
 
@@ -164,7 +161,7 @@ Result Shape::strokeFill(uint8_t r, uint8_t g, uint8_t b, uint8_t a) noexcept
 
 Result Shape::strokeFill(uint8_t* r, uint8_t* g, uint8_t* b, uint8_t* a) const noexcept
 {
-    if (!SHAPE(this)->rs.strokeFill(r, g, b, a)) return Result::InsufficientCondition;
+    if (!CONST_SHAPE(this)->rs.strokeFill(r, g, b, a)) return Result::InsufficientCondition;
     return Result::Success;
 }
 
@@ -177,7 +174,7 @@ Result Shape::strokeFill(Fill* f) noexcept
 
 const Fill* Shape::strokeFill() const noexcept
 {
-    return SHAPE(this)->rs.strokeFill();
+    return CONST_SHAPE(this)->rs.strokeFill();
 }
 
 
@@ -189,7 +186,7 @@ Result Shape::strokeDash(const float* dashPattern, uint32_t cnt, float offset) n
 
 uint32_t Shape::strokeDash(const float** dashPattern, float* offset) const noexcept
 {
-    return SHAPE(this)->rs.strokeDash(dashPattern, offset);
+    return CONST_SHAPE(this)->rs.strokeDash(dashPattern, offset);
 }
 
 
@@ -215,19 +212,19 @@ Result Shape::strokeMiterlimit(float miterlimit) noexcept
 
 StrokeCap Shape::strokeCap() const noexcept
 {
-    return SHAPE(this)->rs.strokeCap();
+    return CONST_SHAPE(this)->rs.strokeCap();
 }
 
 
 StrokeJoin Shape::strokeJoin() const noexcept
 {
-    return SHAPE(this)->rs.strokeJoin();
+    return CONST_SHAPE(this)->rs.strokeJoin();
 }
 
 
 float Shape::strokeMiterlimit() const noexcept
 {
-    return SHAPE(this)->rs.strokeMiterlimit();
+    return CONST_SHAPE(this)->rs.strokeMiterlimit();
 }
 
 
@@ -247,5 +244,5 @@ Result Shape::fill(FillRule r) noexcept
 
 FillRule Shape::fillRule() const noexcept
 {
-    return SHAPE(this)->rs.rule;
+    return CONST_SHAPE(this)->rs.rule;
 }

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -24,10 +24,7 @@
 #include "tvgText.h"
 
 
-Text::Text()
-{
-    pImpl = new Impl(this);
-}
+Text::Text() = default;
 
 
 Result Text::text(const char* text) noexcept
@@ -102,7 +99,7 @@ Result Text::fill(Fill* f) noexcept
 
 Text* Text::gen() noexcept
 {
-    return new Text;
+    return new TextImpl;
 }
 
 


### PR DESCRIPTION
The following is a redesign that extends the class internally.

The main goal is to preserve the characteristics of the pImpl idiom for data encapsulation, while simultaneously reducing the memory allocation overhead typically associated with pImpl.

The stragegy is here:
Rather than alloc the impl memory inside of the thorvg engine, impl extends the API classes in order to consolidate the memory.

size has been decreased by -4kb with optimization=s

issue: https://github.com/thorvg/thorvg/issues/3214