### PR TITLE
webgpu: introduce windows build scripts

### DIFF
--- a/cross/win32_wg.txt
+++ b/cross/win32_wg.txt
@@ -1,0 +1,15 @@
+[binaries]
+c     = 'gcc'
+cpp   = 'g++'
+ar    = 'ar'
+strip = 'strip'
+
+[built-in options]
+cpp_args      = ['-I../build/include']
+cpp_link_args = ['-L../build/lib', '-lwgpu_native.dll', '-lSDL2main', '-lSDL2.dll', '-lmingw32']
+
+[host_machine]
+system     = 'windows'
+cpu_family = 'x86_64'
+cpu        = 'x86_64'
+endian     = 'little'

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -8,10 +8,12 @@ if target_opengles
     examples_compiler_flags += '-DTHORVG_GL_TARGET_GLES=1'
 endif
 
-examples_dep = [dependency('sdl2')]
+# dependencies for sdl2 for windows are described in the corresponding cross file
+examples_dep = [dependency('sdl2', required : host_machine.system() not in ['emscripten', 'windows'])]
 
 if all_engines or get_option('engines').contains('wg')
-    examples_dep += dependency('wgpu_native')
+    # dependencies for webgpu for windows are described in the corresponding cross file
+    examples_dep += dependency('wgpu_native', required : host_machine.system() not in ['emscripten', 'windows'])
     if host_machine.system() == 'darwin'
         add_languages('objcpp')
         examples_dep += declare_dependency(link_args: ['-lobjc', '-framework', 'Cocoa', '-framework', 'CoreVideo', '-framework', 'IOKit', '-framework', 'QuartzCore'])

--- a/src/renderer/wg_engine/meson.build
+++ b/src/renderer/wg_engine/meson.build
@@ -21,10 +21,8 @@ source_file = [
     'tvgWgShaderTypes.cpp'
 ]
 
-wgpu_dep = []
-if host_machine.system() != 'emscripten'
-    wgpu_dep = dependency('wgpu_native')
-endif
+# dependencies for webgpu for windows are described in the corresponding cross file
+wgpu_dep = dependency('wgpu_native', required : host_machine.system() not in ['emscripten', 'windows'])
 
 engine_dep += [declare_dependency(
     dependencies        : wgpu_dep,


### PR DESCRIPTION
To simplify development and testing for windows platform introduce meson build stripts and cross file for windows platform

this is a part of migration to webgpu v24
should not impact to other platforms

issue: https://github.com/thorvg/thorvg/issues/2909

also, please see windows build instructions: 
https://github.com/thorvg/thorvg/wiki/WebGPU-Raster-Engine-Development#windows-mingw