### PR TITLE
sw_engine: --size reduction

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -33,9 +33,8 @@
 #define SW_ANGLE_2PI (SW_ANGLE_PI << 1)
 #define SW_ANGLE_PI2 (SW_ANGLE_PI >> 1)
 
-using SwCoord = signed long;
-using SwFixed = signed long long;
-
+using SwCoord = int32_t;
+using SwFixed = int64_t;
 
 static inline float TO_FLOAT(SwCoord val)
 {

--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -196,7 +196,7 @@
 /************************************************************************/
 
 constexpr auto PIXEL_BITS = 8;   //must be at least 6 bits!
-constexpr auto ONE_PIXEL = (1L << PIXEL_BITS);
+constexpr auto ONE_PIXEL = (1 << PIXEL_BITS);
 
 using Area = long;
 


### PR DESCRIPTION
basically, sw engine aims for 32bits, it reduces
the bundle size by 1kb.

Need to carefully see any side effect in practice.