### PR TITLE
wg_engine: sync up to update the engine work to webgpu_native v22

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -507,9 +507,10 @@ private:
 int init()
 {
 #ifdef THORVG_WG_RASTER_SUPPORT
-    TvgWgEngine::init();
-#endif
+    return TvgWgEngine::init();
+#else
     return 0;
+#endif
 }
 
 

--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -156,16 +156,15 @@ void WgCompositor::beginRenderPass(WGPUCommandEncoder commandEncoder, WgRenderSt
         .depthLoadOp = WGPULoadOp_Clear, .depthStoreOp = WGPUStoreOp_Discard, .depthClearValue = 1.0f,
         .stencilLoadOp = WGPULoadOp_Clear, .stencilStoreOp = WGPUStoreOp_Discard, .stencilClearValue = 0
     };
-    //WGPURenderPassDepthStencilAttachment depthStencilAttachment{ .view = texViewStencil, .depthClearValue = 1.0f, .stencilLoadOp = WGPULoadOp_Clear, .stencilStoreOp = WGPUStoreOp_Discard };
-    WGPURenderPassColorAttachment colorAttachment{};
-    colorAttachment.view = target->texViewMS,
-    colorAttachment.loadOp = clear ? WGPULoadOp_Clear : WGPULoadOp_Load,
-    colorAttachment.storeOp = WGPUStoreOp_Store;
-    colorAttachment.resolveTarget = target->texView;
-    colorAttachment.clearValue = clearColor;
-    #ifdef __EMSCRIPTEN__
-    colorAttachment.depthSlice = WGPU_DEPTH_SLICE_UNDEFINED;
-    #endif
+    const WGPURenderPassColorAttachment colorAttachment{
+        .view = target->texViewMS,
+        .depthSlice = WGPU_DEPTH_SLICE_UNDEFINED,
+        .resolveTarget = target->texView,
+        .loadOp = clear ? WGPULoadOp_Clear : WGPULoadOp_Load,
+        .storeOp = WGPUStoreOp_Store,
+        .clearValue = clearColor
+        
+    };
     WGPURenderPassDescriptor renderPassDesc{ .colorAttachmentCount = 1, .colorAttachments = &colorAttachment, .depthStencilAttachment = &depthStencilAttachment };
     renderPassEncoder = wgpuCommandEncoderBeginRenderPass(commandEncoder, &renderPassDesc);
     assert(renderPassEncoder);
@@ -273,10 +272,12 @@ void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRender
         .depthLoadOp = WGPULoadOp_Load, .depthStoreOp = WGPUStoreOp_Discard,
         .stencilLoadOp = WGPULoadOp_Load, .stencilStoreOp = WGPUStoreOp_Discard
     };
-    WGPURenderPassColorAttachment colorAttachment { .view = dstView, .loadOp = WGPULoadOp_Load, .storeOp = WGPUStoreOp_Store };
-    #ifdef __EMSCRIPTEN__
-    colorAttachment.depthSlice = WGPU_DEPTH_SLICE_UNDEFINED;
-    #endif
+    const WGPURenderPassColorAttachment colorAttachment { 
+        .view = dstView,
+        .depthSlice = WGPU_DEPTH_SLICE_UNDEFINED,
+        .loadOp = WGPULoadOp_Load,
+        .storeOp = WGPUStoreOp_Store,
+    };
     const WGPURenderPassDescriptor renderPassDesc{ .colorAttachmentCount = 1, .colorAttachments = &colorAttachment, .depthStencilAttachment = &depthStencilAttachment };
     WGPURenderPassEncoder renderPass = wgpuCommandEncoderBeginRenderPass(encoder, &renderPassDesc);
     wgpuRenderPassEncoderSetBindGroup(renderPass, 0, src->bindGroupTexure, 0, nullptr);

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -125,8 +125,11 @@ bool WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint3
     #endif
         .width = width,
         .height = height,
-    #ifndef __EMSCRIPTEN__
-        .presentMode = WGPUPresentMode_Fifo,
+    #ifdef __EMSCRIPTEN__
+        .presentMode = WGPUPresentMode_Fifo
+    #elif __linux__
+    #else
+        .presentMode = WGPUPresentMode_Immediate
     #endif
     };
     wgpuSurfaceConfigure(surface, &surfaceConfiguration);


### PR DESCRIPTION
Only minor changes required
preservation support of emsdk

Performance with [v22.1.0.5](https://github.com/gfx-rs/wgpu-native/releases/tag/v22.1.0.5)
```
Windows Lottie wg
v19: 140 ms
v22: 124 ms (+10%)
```

issue: https://github.com/thorvg/thorvg/issues/2909
_note_ issue https://github.com/thorvg/thorvg/issues/3331 are still there