### PR TITLE
lottie: fix stroke join for offset path

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -840,7 +840,7 @@ LottieOffsetPath* LottieParser::parseOffsetPath()
     while (auto key = nextObjectKey()) {
         if (parseCommon(offsetPath, key)) continue;
         else if (KEY_AS("a")) parseProperty(offsetPath->offset);
-        else if (KEY_AS("lj")) offsetPath->join = (StrokeJoin) getInt();
+        else if (KEY_AS("lj")) offsetPath->join = (StrokeJoin) (getInt() - 1);
         else if (KEY_AS("ml")) parseProperty(offsetPath->miterLimit);
         else skip();
     }


### PR DESCRIPTION
The incorrect line join used for OffsetPath was caused by changes to the StrokeJoin enum values in commit 34d731fa94bbc5b1b70415eea37b78acdb6405de. During those changes, the line join value for OffsetPath was mistakenly not updated.