### PR TITLE
sw_engine: ++raster color accuracy

### DIFF
--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -1706,6 +1706,7 @@ void rasterPremultiply(RenderSurface* surface)
         for (uint32_t x = 0; x < surface->w; ++x, ++dst) {
             auto c = *dst;
             auto a = (c >> 24);
+            if (a == 255 || a == 0) continue;
             *dst = (c & 0xff000000) + ((((c >> 8) & 0xff) * a) & 0xff00) + ((((c & 0x00ff00ff) * a) >> 8) & 0x00ff00ff);
         }
     }


### PR DESCRIPTION
Improves the color accuracy of rasterized images by skipping the pre-multiply step when the alpha is fully opaque or fully transparent.

fixes: #3429