### PR TITLE
example: disable vsync of sw window for stability.

### DIFF
--- a/examples/Example.h
+++ b/examples/Example.h
@@ -283,6 +283,8 @@ struct Window
 
 struct SwWindow : Window
 {
+    SDL_Renderer* renderer = nullptr;
+
     SwWindow(Example* example, uint32_t width, uint32_t height, uint32_t threadsCnt) : Window(example, width, height, threadsCnt)
     {
         if (!initialized) return;
@@ -296,7 +298,15 @@ struct SwWindow : Window
             return;
         }
 
+        //VSync has been disabled. Remove this line if you need VSync enabled.
+        renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_PRESENTVSYNC);
+
         resize();
+    }
+
+    ~SwWindow()
+    {
+        if (renderer) SDL_DestroyRenderer(renderer);
     }
 
     void resize() override


### PR DESCRIPTION
SDL + software engine doesn't need the vsync?

Observed the rendering performance is noticeably unstable on Intel Arc chipsets with certain window sizes (ie 800x800) when VSync is enabled on software-rendered windows.

This might be a workaround, or it could be an issue with the driver or SDL.

Either way, the SDL + software engine doesn't need VSync.