### PR TITLE
web: support disabling emscripten

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -60,6 +60,10 @@ public: \
 #define _TVG_DECLARE_ACCESSOR(A) \
     friend A
 
+#if !defined(THORVG_USE_EMSCRIPTEN) && defined(__EMSCRIPTEN__)
+    #define THORVG_USE_EMSCRIPTEN 1
+#endif
+
 namespace tvg
 {
 

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ if all_engines or get_option('engines').contains('wg')
     config_h.set10('THORVG_WG_RASTER_SUPPORT', true)
 endif
 
-if !get_option('emscripten')
+if not get_option('emscripten')
     config_h.set10('THORVG_USE_EMSCRIPTEN', false)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,10 @@ if all_engines or get_option('engines').contains('wg')
     config_h.set10('THORVG_WG_RASTER_SUPPORT', true)
 endif
 
+if !get_option('emscripten')
+    config_h.set10('THORVG_USE_EMSCRIPTEN', false)
+endif
+
 #Tools
 all_tools = get_option('tools').contains('all')
 lottie2gif = all_tools or get_option('tools').contains('lottie2gif')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,6 +21,11 @@ option('threads',
    value: true,
    description: 'Enable the multi-threading task scheduler in thorvg')
 
+option('emscripten',
+   type: 'boolean',
+   value: true,
+   description: 'Use emscripten when available')
+
 option('simd',
    type: 'boolean',
    value: false,

--- a/src/loaders/lottie/rapidjson/rapidjson.h
+++ b/src/loaders/lottie/rapidjson/rapidjson.h
@@ -285,7 +285,7 @@
 
 //! Whether using 64-bit architecture
 #ifndef RAPIDJSON_64BIT
-#if defined(__LP64__) || (defined(__x86_64__) && defined(__ILP32__)) || defined(_WIN64) || defined(__EMSCRIPTEN__)
+#if defined(__LP64__) || (defined(__x86_64__) && defined(__ILP32__)) || defined(_WIN64) || THORVG_USE_EMSCRIPTEN
 #define RAPIDJSON_64BIT 1
 #else
 #define RAPIDJSON_64BIT 0

--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -43,7 +43,7 @@
 #include "tvgRender.h"
 #include "tvgMath.h"
 
-#ifdef __EMSCRIPTEN__
+#if THORVG_USE_EMSCRIPTEN
     #include <emscripten/html5_webgl.h>
     // query GL Error on WebGL is very slow, so disable it on WebGL
     #define GL_CHECK(x) x

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -65,7 +65,7 @@ void GlRenderer::flush()
 
 void GlRenderer::currentContext()
 {
-#ifdef __EMSCRIPTEN__
+#if THORVG_USE_EMSCRIPTEN
     auto targetContext = (EMSCRIPTEN_WEBGL_CONTEXT_HANDLE)mContext;
     if (emscripten_webgl_get_current_context() != targetContext) {
         emscripten_webgl_make_context_current(targetContext);

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -111,12 +111,12 @@ bool WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint3
         .device = context.device,
         .format = context.preferredFormat,
         .usage = WGPUTextureUsage_RenderAttachment,
-    #ifdef __EMSCRIPTEN__
+    #if THORVG_USE_EMSCRIPTEN
         .alphaMode = WGPUCompositeAlphaMode_Premultiplied,
     #endif
         .width = width,
         .height = height,
-    #ifdef __EMSCRIPTEN__
+    #if THORVG_USE_EMSCRIPTEN
         .presentMode = WGPUPresentMode_Fifo
     #elif __linux__
     #else

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -191,7 +191,7 @@ namespace Catch {
 
 ////////////////////////////////////////////////////////////////////////////////
 // We know some environments not to support full POSIX signals
-#if defined(__CYGWIN__) || defined(__QNX__) || defined(__EMSCRIPTEN__) || defined(__DJGPP__)
+#if defined(__CYGWIN__) || defined(__QNX__) || THORVG_USE_EMSCRIPTEN || defined(__DJGPP__)
     #define CATCH_INTERNAL_CONFIG_NO_POSIX_SIGNALS
 #endif
 


### PR DESCRIPTION
By moving `__EMSCRIPTEN__` to `THORVG_USE_EMSCRIPTEN` this allows users to force disable Emscripten, even if `__EMSCRIPTEN__` is already defined.

By default, nothing will change, but if you `#define THORVG_USE_EMSCRIPTEN false` it will turn off Emscripten support.

I know the full removal of Emscripten is planned (#3425), but this PR serves to act as a work around in the meantime.
Feel free to close this if it's too "hacky", or if a better solution is created.