### PR TITLE
examples: changed animatable window size.

### DIFF
--- a/examples/CustomTransform.cpp
+++ b/examples/CustomTransform.cpp
@@ -90,8 +90,8 @@ struct UserExample : tvgexam::Example
         m.e23 = t23;
 
         //translate
-        m.e13 = progress * 300.0f + 300.0f;
-        m.e23 = progress * -100.0f + 300.0f;
+        m.e13 = progress * 500.0f + 300.0f;
+        m.e23 = progress * -100.0f + 380.0f;
 
         shape->transform(m);
 
@@ -108,5 +108,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv, true);
+    return tvgexam::main(new UserExample, argc, argv, true, 960, 960);
 }

--- a/examples/DirectUpdate.cpp
+++ b/examples/DirectUpdate.cpp
@@ -116,5 +116,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv);
+    return tvgexam::main(new UserExample, argc, argv, false, 960, 960);
 }

--- a/examples/GradientTransform.cpp
+++ b/examples/GradientTransform.cpp
@@ -43,10 +43,10 @@ struct UserExample : tvgexam::Example
 
         //Shape1
         auto shape = tvg::Shape::gen();
-        shape->appendRect(-285, -300, 200, 200);
-        shape->appendRect(-185, -200, 300, 300, 100, 100);
-        shape->appendCircle(115, 100, 100, 100);
-        shape->appendCircle(115, 200, 170, 100);
+        shape->appendRect(-285, -300, 280, 280);
+        shape->appendRect(-145, -160, 380, 380, 100, 100);
+        shape->appendCircle(195, 180, 140, 140);
+        shape->appendCircle(235, 320, 210, 140);
 
         //LinearGradient
         auto fill = tvg::LinearGradient::gen();
@@ -70,12 +70,12 @@ struct UserExample : tvgexam::Example
 
         //Shape2
         auto shape2 = tvg::Shape::gen();
-        shape2->appendRect(-50, -50, 100, 100);
-        shape2->translate(400, 400);
+        shape2->appendRect(-50, -50, 180, 180);
+        shape2->translate(480, 480);
 
         //LinearGradient
         auto fill2 = tvg::LinearGradient::gen();
-        fill2->linear(-50, -50, 50, 50);
+        fill2->linear(-50, -50, 130, 130);
 
         //Gradient Color Stops
         tvg::Fill::ColorStop colorStops2[2];
@@ -86,7 +86,7 @@ struct UserExample : tvgexam::Example
         shape2->fill(fill2);
 
         shape2->rotate(360 * progress);
-        shape2->translate(400 + progress * 300, 400);
+        shape2->translate(480 + progress * 300, 480);
 
         canvas->push(shape2);
 
@@ -110,7 +110,7 @@ struct UserExample : tvgexam::Example
         fill3->colorStops(colorStops3, 4);
 
         shape3->fill(fill3);
-        shape3->translate(400, 400);
+        shape3->translate(480, 480);
 
         //Update Shape3
         shape3->rotate(-360.0f * progress);
@@ -129,5 +129,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv, true);
+    return tvgexam::main(new UserExample, argc, argv, true, 960, 960);
 }

--- a/examples/ImageRotation.cpp
+++ b/examples/ImageRotation.cpp
@@ -57,8 +57,8 @@ struct UserExample : tvgexam::Example
         tvg::Matrix m = {1.0f, 0.0f, 0.0f, 0.0f, 0.1f, 0.0f, 0.0f, 0.0f, 1.0f};
 
         //center pivoting
-        m.e13 += 400;
-        m.e23 += 400;
+        m.e13 += 480;
+        m.e23 += 480;
 
         //rotation
         auto degree = tvgexam::progress(elapsed, 4.0f) * 360.0f;
@@ -69,10 +69,10 @@ struct UserExample : tvgexam::Example
         m.e22 = cosf(radian);
 
         //scaling
-        m.e11 *= 0.75f;
-        m.e21 *= 0.75f;
-        m.e22 *= 0.75f;
-        m.e12 *= 0.75f;
+        m.e11 *= 0.8f;
+        m.e21 *= 0.8f;
+        m.e22 *= 0.8f;
+        m.e12 *= 0.8f;
 
         //center pivoting
         m.e13 += (-400 * m.e11 + -400 * m.e12);
@@ -93,5 +93,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv, true);
+    return tvgexam::main(new UserExample, argc, argv, true, 960 ,960);
 }

--- a/examples/Retaining.cpp
+++ b/examples/Retaining.cpp
@@ -34,19 +34,19 @@ struct UserExample : tvgexam::Example
     {
         //Prepare Round Rectangle
         auto shape1 = tvg::Shape::gen();
-        shape1->appendRect(0, 0, 400, 400, 50, 50);  //x, y, w, h, rx, ry
+        shape1->appendRect(0, 0, 480, 480, 50, 50);  //x, y, w, h, rx, ry
         shape1->fill(0, 255, 0);                     //r, g, b
         canvas->push(shape1);
 
         //Prepare Round Rectangle2
         auto shape2 = tvg::Shape::gen();
-        shape2->appendRect(100, 100, 400, 400, 50, 50);  //x, y, w, h, rx, ry
+        shape2->appendRect(140, 140, 480, 480, 50, 50);  //x, y, w, h, rx, ry
         shape2->fill(255, 255, 0);                       //r, g, b
         canvas->push(shape2);
 
         //Prepare Round Rectangle3
         auto shape3 = tvg::Shape::gen();
-        shape3->appendRect(200, 200, 400, 400, 50, 50);  //x, y, w, h, rx, ry
+        shape3->appendRect(280, 280, 480, 480, 50, 50);  //x, y, w, h, rx, ry
         shape3->fill(0, 255, 255);                       //r, g, b
         canvas->push(shape3);
 
@@ -54,14 +54,14 @@ struct UserExample : tvgexam::Example
         auto scene = tvg::Scene::gen();
 
         auto shape4 = tvg::Shape::gen();
-        shape4->appendCircle(400, 400, 100, 100);
+        shape4->appendCircle(520, 520, 140, 140);
         shape4->fill(255, 0, 0);
         shape4->strokeWidth(5);
         shape4->strokeFill(255, 255, 255);
         scene->push(shape4);
 
         auto shape5 = tvg::Shape::gen();
-        shape5->appendCircle(550, 550, 150, 150);
+        shape5->appendCircle(630, 630, 190, 190);
         shape5->fill(255, 0, 255);
         shape5->strokeWidth(5);
         shape5->strokeFill(255, 255, 255);
@@ -106,5 +106,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv, true);
+    return tvgexam::main(new UserExample, argc, argv, true, 960, 960);
 }

--- a/examples/SceneTransform.cpp
+++ b/examples/SceneTransform.cpp
@@ -64,8 +64,8 @@ struct UserExample : tvgexam::Example
         shape3->fill(0, 255, 255);                     //r, g, b
         scene->push(shape3);
 
-        scene->translate(350, 350);
-        scene->scale(0.5);
+        scene->translate(430, 430);
+        scene->scale(0.7f);
         scene->rotate(360 * progress);
 
         //Create Scene2
@@ -129,5 +129,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv, true);
+    return tvgexam::main(new UserExample, argc, argv, true, 960, 960);
 }

--- a/examples/Transform.cpp
+++ b/examples/Transform.cpp
@@ -43,12 +43,12 @@ struct UserExample : tvgexam::Example
 
         //Shape1
         auto shape = tvg::Shape::gen();
-        shape->appendRect(-285, -300, 200, 200);
-        shape->appendRect(-185, -200, 300, 300, 100, 100);
-        shape->appendCircle(115, 100, 100, 100);
-        shape->appendCircle(115, 200, 170, 100);
+        shape->appendRect(-285, -300, 280, 280);
+        shape->appendRect(-145, -160, 380, 380, 100, 100);
+        shape->appendCircle(155, 140, 140, 140);
+        shape->appendCircle(235, 320, 210, 140);
         shape->fill(255, 255, 255);
-        shape->translate(385, 400);
+        shape->translate(425, 480);
         shape->scale(1.0f - 0.75f * progress);
         shape->rotate(360 * progress);
 
@@ -56,9 +56,9 @@ struct UserExample : tvgexam::Example
 
         //Shape2
         auto shape2 = tvg::Shape::gen();
-        shape2->appendRect(-50, -50, 100, 100);
+        shape2->appendRect(-50, -50, 180, 180);
         shape2->fill(0, 255, 255);
-        shape2->translate(400, 400);
+        shape2->translate(480, 480);
         shape2->rotate(360 * progress);
         shape2->translate(400 + progress * 300, 400);
         canvas->push(shape2);
@@ -68,9 +68,9 @@ struct UserExample : tvgexam::Example
 
         /* Look, how shape3's origin is different with shape2
         The center of the shape is the anchor point for transformation. */
-        shape3->appendRect(100, 100, 150, 50, 20, 20);
+        shape3->appendRect(100, 100, 230, 130, 20, 20);
         shape3->fill(255, 0, 255);
-        shape3->translate(400, 400);
+        shape3->translate(560, 560);
         shape3->rotate(-360.0f * progress);
         shape3->scale(0.5f + progress);
         canvas->push(shape3);
@@ -86,5 +86,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv, true);
+    return tvgexam::main(new UserExample, argc, argv, true, 960, 960);
 }

--- a/examples/Update.cpp
+++ b/examples/Update.cpp
@@ -51,9 +51,9 @@ struct UserExample : tvgexam::Example
 
         //Shape
         auto shape = tvg::Shape::gen();
-        shape->appendRect(-100, -100, 200, 200, (100 * progress), (100 * progress));
+        shape->appendRect(-100, -100, 280, 280, (100 * progress), (100 * progress));
         shape->fill(rand() % 255, rand() % 255, rand() % 255);
-        shape->translate(800 * progress, 800 * progress);
+        shape->translate(960 * progress, 960 * progress);
         shape->scale(1.0f - 0.75f * progress);
         shape->rotate(360.0f * progress);
 
@@ -70,5 +70,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv, true);
+    return tvgexam::main(new UserExample, argc, argv, true, 960, 960);
 }


### PR DESCRIPTION
just changed the size to another one for better showcase since 800x800 is not preferred by intel arc chipset. animations look stutter.