### PR TITLE
lottie: interpret null as a float value of 0

### DIFF
--- a/src/loaders/lottie/tvgLottieParserHandler.cpp
+++ b/src/loaders/lottie/tvgLottieParserHandler.cpp
@@ -100,7 +100,8 @@ int LookaheadParserHandler::getInt()
 float LookaheadParserHandler::getFloat()
 {
     if (state != kHasNumber) {
-        Error();
+        if (state == kHasNull) parseNext();  //interpret null as 0
+        else Error();
         return 0;
     }
     auto result = val.GetFloat();


### PR DESCRIPTION
It may happen that a float value is saved as null. In such cases, it should be interpreted as 0 without raising an error.

<img width="800" alt="Zrzut ekranu 2025-05-6 o 19 53 41" src="https://github.com/user-attachments/assets/6ad6b644-8327-4727-9582-0ae0bcc55a8a" />
