### PR TITLE
sw_engine: replacing a cast with rounding

### DIFF
--- a/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -113,8 +113,8 @@ static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage
     y = yStart;
 
     while (y < yEnd) {
-        x1 = (int32_t)_xa;
-        x2 = (int32_t)_xb;
+        x1 = nearbyint(_xa);
+        x2 = nearbyint(_xb);
 
         if (!region) {
             minx = INT32_MAX;
@@ -246,8 +246,8 @@ static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage* image,
     y = yStart;
 
     while (y < yEnd) {
-        x1 = (int32_t)_xa;
-        x2 = (int32_t)_xb;
+        x1 = nearbyint(_xa);
+        x2 = nearbyint(_xb);
 
         if (!region) {
             minx = INT32_MAX;


### PR DESCRIPTION
Casting a float to an int instead of rounding resulted in a visibly incorrect reduction of the rendered area.

@Issue: https://github.com/thorvg/thorvg/issues/3452