### PR TITLE
lottie: fix points calculation for rounded polygon

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -641,6 +641,7 @@ void LottieBuilder::updatePolygon(LottieGroup* parent, LottiePolyStar* star, flo
     auto in = Point{x, y} * transform;
     shape->moveTo(in.x, in.y);
 
+    auto coeff = anglePerPoint * radius * outerRoundness * POLYGON_MAGIC_NUMBER;
     for (size_t i = 0; i < ptsCnt; i++) {
         auto previousX = x;
         auto previousY = y;
@@ -649,16 +650,11 @@ void LottieBuilder::updatePolygon(LottieGroup* parent, LottiePolyStar* star, flo
 
         if (hasRoundness) {
             auto cp1Theta = tvg::atan2(previousY, previousX) - MATH_PI2 * direction;
-            auto cp1Dx = cosf(cp1Theta);
-            auto cp1Dy = sinf(cp1Theta);
+            auto cp1x = coeff * cosf(cp1Theta);
+            auto cp1y = coeff * sinf(cp1Theta);
             auto cp2Theta = tvg::atan2(y, x) - MATH_PI2 * direction;
-            auto cp2Dx = cosf(cp2Theta);
-            auto cp2Dy = sinf(cp2Theta);
-
-            auto cp1x = anglePerPoint * radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp1Dx;
-            auto cp1y = anglePerPoint * radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp1Dy;
-            auto cp2x = anglePerPoint * radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp2Dx;
-            auto cp2y = anglePerPoint * radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp2Dy;
+            auto cp2x = coeff * cosf(cp2Theta);
+            auto cp2y = coeff * sinf(cp2Theta);
 
             auto in2 = Point{previousX - cp1x, previousY - cp1y} * transform;
             auto in3 = Point{x + cp2x, y + cp2y} * transform;

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -613,7 +613,7 @@ void LottieBuilder::updatePolygon(LottieGroup* parent, LottiePolyStar* star, flo
     auto radius = star->outerRadius(frameNo, tween, exps);
     auto outerRoundness = star->outerRoundness(frameNo, tween, exps) * 0.01f;
 
-    auto angle = deg2rad(-90.0f);
+    auto angle = -MATH_PI2;
     auto anglePerPoint = 2.0f * MATH_PI / float(ptsCnt);
     auto direction = star->clockwise ? 1.0f : -1.0f;
     auto hasRoundness = !tvg::zero(outerRoundness);
@@ -655,10 +655,10 @@ void LottieBuilder::updatePolygon(LottieGroup* parent, LottiePolyStar* star, flo
             auto cp2Dx = cosf(cp2Theta);
             auto cp2Dy = sinf(cp2Theta);
 
-            auto cp1x = radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp1Dx;
-            auto cp1y = radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp1Dy;
-            auto cp2x = radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp2Dx;
-            auto cp2y = radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp2Dy;
+            auto cp1x = anglePerPoint * radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp1Dx;
+            auto cp1y = anglePerPoint * radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp1Dy;
+            auto cp2x = anglePerPoint * radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp2Dx;
+            auto cp2y = anglePerPoint * radius * outerRoundness * POLYGON_MAGIC_NUMBER * cp2Dy;
 
             auto in2 = Point{previousX - cp1x, previousY - cp1y} * transform;
             auto in3 = Point{x + cp2x, y + cp2y} * transform;


### PR DESCRIPTION
Added missing factor.

before:
<img width="200" alt="Zrzut ekranu 2025-05-14 o 00 24 42" src="https://github.com/user-attachments/assets/34584f42-4a26-4d9d-9303-e9735d682b3f" />

after:
<img width="200" alt="Zrzut ekranu 2025-05-14 o 00 18 07" src="https://github.com/user-attachments/assets/1970f179-b5a4-4a10-abf8-6aa6c3892c72" />

AE:
<img width="200" alt="Zrzut ekranu 2025-05-13 o 23 46 33" src="https://github.com/user-attachments/assets/fde9f7f9-f709-4df7-bf3b-92cf8e70c7ca" />

sample:
[polygon_rounded.json](https://github.com/user-attachments/files/20196622/polygon_rounded.json)
