### PR TITLE
wg_engine: task-based rendering implementation

### DIFF
--- a/src/renderer/wg_engine/meson.build
+++ b/src/renderer/wg_engine/meson.build
@@ -7,6 +7,7 @@ source_file = [
     'tvgWgRenderData.h',
     'tvgWgRenderer.h',
     'tvgWgRenderTarget.h',
+    'tvgWgRenderTask.h',
     'tvgWgShaderSrc.h',
     'tvgWgShaderTypes.h',
     'tvgWgBindGroups.cpp',
@@ -17,6 +18,7 @@ source_file = [
     'tvgWgRenderData.cpp',
     'tvgWgRenderer.cpp',
     'tvgWgRenderTarget.cpp',
+    'tvgWgRenderTask.cpp',
     'tvgWgShaderSrc.cpp',
     'tvgWgShaderTypes.cpp'
 ]

--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -269,3 +269,34 @@ void WgContext::releaseQueue(WGPUQueue& queue)
         queue = nullptr;
     }
 }
+
+
+WGPUCommandEncoder WgContext::createCommandEncoder()
+{
+    WGPUCommandEncoderDescriptor commandEncoderDesc{};
+    return wgpuDeviceCreateCommandEncoder(device, &commandEncoderDesc);
+}
+
+
+void WgContext::submitCommandEncoder(WGPUCommandEncoder commandEncoder)
+{
+    const WGPUCommandBufferDescriptor commandBufferDesc{};
+    WGPUCommandBuffer commandsBuffer = wgpuCommandEncoderFinish(commandEncoder, &commandBufferDesc);
+    wgpuQueueSubmit(queue, 1, &commandsBuffer);
+    wgpuCommandBufferRelease(commandsBuffer);
+}
+
+
+void WgContext::releaseCommandEncoder(WGPUCommandEncoder& commandEncoder)
+{
+    if (commandEncoder) {
+        wgpuCommandEncoderRelease(commandEncoder);
+        commandEncoder = nullptr;
+    }
+}
+
+
+bool WgContext::invalid()
+{
+    return !instance || !device;
+}

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -71,10 +71,13 @@ struct WgContext {
     // release buffer objects
     void releaseBuffer(WGPUBuffer& buffer);
 
-    bool invalid()
-    {
-        return !instance || !device;
-    }
+    // command encoder
+    WGPUCommandEncoder createCommandEncoder();
+    void submitCommandEncoder(WGPUCommandEncoder encoder);
+    void releaseCommandEncoder(WGPUCommandEncoder& encoder);
+
+    // invalidate context
+    bool invalid();
 };
 
 #endif // _TVG_WG_COMMON_H_

--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -52,10 +52,10 @@ private:
     // current render pass handles
     WGPURenderPassEncoder renderPassEncoder{};
     WGPUCommandEncoder commandEncoder{};
-    WgRenderStorage* currentTarget{};
-    // intermediate render storages
-    WgRenderStorage storageTemp0;
-    WgRenderStorage storageTemp1;
+    WgRenderTarget* currentTarget{};
+    // intermediate render targets
+    WgRenderTarget targetTemp0;
+    WgRenderTarget targetTemp1;
     WGPUBindGroup bindGroupStorageTemp{};
     // composition and blend geometries
     WgMeshData meshData;
@@ -65,8 +65,8 @@ private:
     
     // viewport utilities
     RenderRegion shrinkRenderRegion(RenderRegion& rect);
-    void copyTexture(const WgRenderStorage* dst, const WgRenderStorage* src);
-    void copyTexture(const WgRenderStorage* dst, const WgRenderStorage* src, const RenderRegion& region);
+    void copyTexture(const WgRenderTarget* dst, const WgRenderTarget* src);
+    void copyTexture(const WgRenderTarget* dst, const WgRenderTarget* src, const RenderRegion& region);
 
     // shapes
     void drawShape(WgContext& context, WgRenderDataShape* renderData);
@@ -84,8 +84,8 @@ private:
     void clipImage(WgContext& context, WgRenderDataPicture* renderData);
 
     // scenes
-    void drawScene(WgContext& context, WgRenderStorage* scene, WgCompose* compose);
-    void blendScene(WgContext& context, WgRenderStorage* src, WgCompose* compose);
+    void drawScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose);
+    void blendScene(WgContext& context, WgRenderTarget* src, WgCompose* compose);
 
     // the renderer prioritizes clipping with the stroke over the shape's fill
     void markupClipPath(WgContext& context, WgRenderDataShape* renderData);
@@ -100,24 +100,24 @@ public:
     void resize(WgContext& context, uint32_t width, uint32_t height);
 
     // render passes workflow
-    void beginRenderPass(WGPUCommandEncoder encoder, WgRenderStorage* target, bool clear, WGPUColor clearColor = { 0.0, 0.0, 0.0, 0.0 });
+    void beginRenderPass(WGPUCommandEncoder encoder, WgRenderTarget* target, bool clear, WGPUColor clearColor = { 0.0, 0.0, 0.0, 0.0 });
     void endRenderPass();
 
     // render shapes, images and scenes
     void renderShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
     void renderImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod);
-    void renderScene(WgContext& context, WgRenderStorage* scene, WgCompose* compose);
-    void composeScene(WgContext& context, WgRenderStorage* src, WgRenderStorage* mask, WgCompose* compose);
+    void renderScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose);
+    void composeScene(WgContext& context, WgRenderTarget* src, WgRenderTarget* mask, WgCompose* compose);
 
-    // blit render storage to texture view (f.e. screen buffer)
-    void blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderStorage* src, WGPUTextureView dstView);
+    // blit render target to texture view (f.e. screen buffer)
+    void blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView);
 
     // effects
-    bool gaussianBlur(WgContext& context, WgRenderStorage* dst, const RenderEffectGaussianBlur* params, const WgCompose* compose);
-    bool dropShadow(WgContext& context, WgRenderStorage* dst, const RenderEffectDropShadow* params, const WgCompose* compose);
-    bool fillEffect(WgContext& context, WgRenderStorage* dst, const RenderEffectFill* params, const WgCompose* compose);
-    bool tintEffect(WgContext& context, WgRenderStorage* dst, const RenderEffectTint* params, const WgCompose* compose);
-    bool tritoneEffect(WgContext& context, WgRenderStorage* dst, const RenderEffectTritone* params, const WgCompose* compose);
+    bool gaussianBlur(WgContext& context, WgRenderTarget* dst, const RenderEffectGaussianBlur* params, const WgCompose* compose);
+    bool dropShadow(WgContext& context, WgRenderTarget* dst, const RenderEffectDropShadow* params, const WgCompose* compose);
+    bool fillEffect(WgContext& context, WgRenderTarget* dst, const RenderEffectFill* params, const WgCompose* compose);
+    bool tintEffect(WgContext& context, WgRenderTarget* dst, const RenderEffectTint* params, const WgCompose* compose);
+    bool tritoneEffect(WgContext& context, WgRenderTarget* dst, const RenderEffectTritone* params, const WgCompose* compose);
 };
 
 #endif // _TVG_WG_COMPOSITOR_H_

--- a/src/renderer/wg_engine/tvgWgRenderTarget.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.cpp
@@ -22,7 +22,7 @@
 
 #include "tvgWgRenderTarget.h"
 
-void WgRenderStorage::initialize(WgContext& context, uint32_t width, uint32_t height)
+void WgRenderTarget::initialize(WgContext& context, uint32_t width, uint32_t height)
 {
     this->width = width;
     this->height = height;
@@ -36,7 +36,7 @@ void WgRenderStorage::initialize(WgContext& context, uint32_t width, uint32_t he
 }
 
 
-void WgRenderStorage::release(WgContext& context)
+void WgRenderTarget::release(WgContext& context)
 {
     context.layouts.releaseBindGroup(bindGroupTexure);
     context.layouts.releaseBindGroup(bindGroupWrite);
@@ -50,38 +50,38 @@ void WgRenderStorage::release(WgContext& context)
 }
 
 //*****************************************************************************
-// render storage pool
+// render target pool
 //*****************************************************************************
 
-WgRenderStorage* WgRenderStoragePool::allocate(WgContext& context)
+WgRenderTarget* WgRenderTargetPool::allocate(WgContext& context)
 {
-    WgRenderStorage* renderStorage{};
+    WgRenderTarget* renderTarget{};
     if (pool.count > 0) {
-        renderStorage = pool.last();
+        renderTarget = pool.last();
         pool.pop();
     } else {
-        renderStorage = new WgRenderStorage;
-        renderStorage->initialize(context, width, height);
-        list.push(renderStorage);
+        renderTarget = new WgRenderTarget;
+        renderTarget->initialize(context, width, height);
+        list.push(renderTarget);
     }
-    return renderStorage;
+    return renderTarget;
 };
 
 
-void WgRenderStoragePool::free(WgContext& context, WgRenderStorage* renderStorage)
+void WgRenderTargetPool::free(WgContext& context, WgRenderTarget* renderTarget)
 {
-    pool.push(renderStorage);
+    pool.push(renderTarget);
 };
 
 
-void WgRenderStoragePool::initialize(WgContext& context, uint32_t width, uint32_t height)
+void WgRenderTargetPool::initialize(WgContext& context, uint32_t width, uint32_t height)
 {
     this->width = width;
     this->height = height;
 }
 
 
-void WgRenderStoragePool::release(WgContext& context)
+void WgRenderTargetPool::release(WgContext& context)
 {
     ARRAY_FOREACH(p, list) {
        (*p)->release(context);

--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -26,7 +26,7 @@
 #include "tvgWgPipelines.h"
 #include "tvgRender.h"
 
-struct WgRenderStorage {
+struct WgRenderTarget {
     WGPUTexture texture{};
     WGPUTexture textureMS{};
     WGPUTextureView texView{};
@@ -42,15 +42,15 @@ struct WgRenderStorage {
 };
 
 
-class WgRenderStoragePool {
+class WgRenderTargetPool {
 private:
-    Array<WgRenderStorage*> list;
-    Array<WgRenderStorage*> pool;
+    Array<WgRenderTarget*> list;
+    Array<WgRenderTarget*> pool;
     uint32_t width{};
     uint32_t height{};
 public:
-    WgRenderStorage* allocate(WgContext& context);
-    void free(WgContext& context, WgRenderStorage* renderTarget);
+    WgRenderTarget* allocate(WgContext& context);
+    void free(WgContext& context, WgRenderTarget* renderTarget);
 
     void initialize(WgContext& context, uint32_t width, uint32_t height);
     void release(WgContext& context);

--- a/src/renderer/wg_engine/tvgWgRenderTask.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTask.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgRenderTask.h"
+#include <iostream>
+
+//***********************************************************************
+// WgPaintTask
+//***********************************************************************
+
+void WgPaintTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
+{
+    if (renderData->type() == tvg::Type::Shape)
+        compositor.renderShape(context, (WgRenderDataShape*)renderData, blendMethod);
+    if (renderData->type() == tvg::Type::Picture)
+        compositor.renderImage(context, (WgRenderDataPicture*)renderData, blendMethod);
+    else assert(true);
+}
+
+//***********************************************************************
+// WgSceneTask
+//***********************************************************************
+
+void WgSceneTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
+{
+    // we must to begin render pass target for current scene and clear content
+    WGPUColor color{};
+    if ((compose->method == MaskMethod::None) && (compose->blend != BlendMethod::Normal)) color = { 1.0, 1.0, 1.0, 0.0 };
+    compositor.beginRenderPass(encoder, renderTarget, true, color);
+    // run all childs (scenes and shapes)
+    runChildren(context, compositor, encoder);
+    // we must to end current render pass for current scene
+    compositor.endRenderPass();
+    // we must to apply effect for current scene
+    runEffect(context, compositor, encoder);
+    // there is no any sence to continue if scene did not have destination target (f.e. root scene)
+    if (!renderTargetDst) return;
+    // apply scene blending
+    if (compose->method == MaskMethod::None) {
+        compositor.beginRenderPass(encoder, renderTargetDst, false);
+        compositor.renderScene(context, renderTarget, compose);
+    // apply scene composition (for scenes, that have a handle to mask)
+    } else if (renderTargetMsk) {
+        compositor.beginRenderPass(encoder, renderTargetDst, false);
+        compositor.composeScene(context, renderTarget, renderTargetMsk, compose);
+    }
+}
+
+
+void WgSceneTask::runChildren(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
+{
+    ARRAY_FOREACH(task, children) {
+        WgRenderTask* renderTask = *task;
+        // we need to restore current render pass without clear
+        compositor.beginRenderPass(encoder, renderTarget, false);
+        // run child (shape or scene)
+        renderTask->run(context, compositor, encoder);
+    }
+}
+
+
+void WgSceneTask::runEffect(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
+{
+    if (!effect) return;
+    switch (effect->type) {
+        case SceneEffect::GaussianBlur: compositor.gaussianBlur(context, renderTarget, (RenderEffectGaussianBlur*)effect, compose); break;
+        case SceneEffect::DropShadow: compositor.dropShadow(context, renderTarget, (RenderEffectDropShadow*)effect, compose); break;
+        case SceneEffect::Fill: compositor.fillEffect(context, renderTarget, (RenderEffectFill*)effect, compose); break;
+        case SceneEffect::Tint: compositor.tintEffect(context, renderTarget, (RenderEffectTint*)effect, compose); break;
+        case SceneEffect::Tritone : compositor.tritoneEffect(context, renderTarget, (RenderEffectTritone*)effect, compose); break;
+        default: break;
+    }
+}

--- a/src/renderer/wg_engine/tvgWgRenderTask.h
+++ b/src/renderer/wg_engine/tvgWgRenderTask.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_RENDER_TASK_H_
+#define _TVG_WG_RENDER_TASK_H_
+ 
+#include "tvgWgCompositor.h"
+
+// base class for any renderable objects 
+struct WgRenderTask {
+    virtual ~WgRenderTask() {}
+    virtual void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) = 0;
+};
+
+// task for sinlge shape rendering
+struct WgPaintTask: public WgRenderTask {
+    // shape render properties
+    WgRenderDataPaint* renderData{};
+    BlendMethod blendMethod{};
+
+    WgPaintTask(WgRenderDataPaint* renderData, BlendMethod blendMethod) : 
+        renderData(renderData), blendMethod(blendMethod) {}
+    // apply shape execution, including custom blending and clipping
+    void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
+};
+
+// task for scene rendering with blending, composition and effect
+struct WgSceneTask: public WgRenderTask {
+public:
+    // parent scene (nullptr for root scene)
+    WgSceneTask* parent{};
+    // childs can be shapes or scenes tesks
+    Array<WgRenderTask*> children;
+    // scene blend/compose targets
+    WgRenderTarget* renderTarget{};
+    WgRenderTarget* renderTargetMsk{};
+    WgRenderTarget* renderTargetDst{};
+    // scene blend/compose properties
+    WgCompose* compose{};
+    // scene effect properties
+    const RenderEffect* effect{};
+
+    WgSceneTask(WgRenderTarget* renderTarget, WgCompose* compose, WgSceneTask* parent) :
+        parent(parent), renderTarget(renderTarget), compose(compose) {}
+    // run all, including all shapes drawing, blending, composition and effect
+    void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
+private:
+    void runChildren(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder);
+    void runEffect(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder);
+};
+ 
+ #endif // _TVG_WG_RENDER_TASK_H_
+ 

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -23,7 +23,7 @@
 #ifndef _TVG_WG_RENDERER_H_
 #define _TVG_WG_RENDERER_H_
 
-#include "tvgWgCompositor.h"
+#include "tvgWgRenderTask.h"
 
 class WgRenderer : public RenderMethod
 {
@@ -72,13 +72,15 @@ private:
     bool surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height);
 
     // render tree stacks
-    WgRenderStorage mRenderStorageRoot;
-    Array<WgCompose*> mCompositorStack;
-    Array<WgRenderStorage*> mRenderStorageStack;
+    WgRenderTarget mRenderTargetRoot;
+    Array<WgCompose*> mCompositorList;
+    Array<WgRenderTarget*> mRenderTargetStack;
     Array<WgRenderDataViewport*> mRenderDataViewportList;
+    Array<WgSceneTask*> mSceneTaskStack;
+    Array<WgRenderTask*> mRenderTaskList;
 
-    // render storage pool
-    WgRenderStoragePool mRenderStoragePool;
+    // render target pool
+    WgRenderTargetPool mRenderTargetPool;
 
     // render data paint pools
     WgRenderDataShapePool mRenderDataShapePool;
@@ -100,7 +102,6 @@ private:
     Key mDisposeKey{};
 
     // gpu handles
-    WGPUCommandEncoder mCommandEncoder{};
     WGPUTexture targetTexture{}; // external handle
     WGPUSurfaceTexture surfaceTexture{};
     WGPUSurface surface{};  // external handle


### PR DESCRIPTION
Implemented two-passed rendering:
1. Get information about current frame objects and organice rendering tree as a tasks
2. Run rendering process in post render stage

Supported shapes, images, scene blending, composition, masking and effects
Will be helpful for further optimization

see https://github.com/thorvg/thorvg/issues/3455