### PR TITLE
lottie: update text using def font

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -934,7 +934,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
 
     if (!p || !text->font) return;
 
-    if (text->font->origin != LottieFont::Origin::Embedded) {
+    if (text->font->origin != LottieFont::Origin::Embedded || text->font->chars.empty()) {
         _fontText(doc, layer->scene);
         return;
     }


### PR DESCRIPTION
In cases where the JSON does not include glyphs
information, an attempts is made to update the text 
using the any loaded font, regardless of the specified 
font path origin.

@Issue: https://github.com/thorvg/thorvg.swift/issues/6

result:
<img width="400" alt="Zrzut ekranu 2025-05-14 o 23 38 44" src="https://github.com/user-attachments/assets/2d7a38d8-ba97-4fa4-a76c-81ad04cf99a4" />

sample:
[org.json](https://github.com/user-attachments/files/20214642/org.json)


NOTE:
1. text is not correctly placed - this will be solved in a separate pr.
2. lottie specs are not clear about the default font path origin value - we have samples in which it is not specified for both, embedded and local