### PR TITLE
lottie: removed undesired embedded option.

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -934,7 +934,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
 
     if (!p || !text->font) return;
 
-    if (text->font->origin != LottieFont::Origin::Embedded) {
+    if (text->font->origin != LottieFont::Origin::Local || text->font->chars.empty()) {
         _fontText(doc, layer->scene);
         return;
     }

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -386,7 +386,7 @@ struct LottieTextRange
 
 struct LottieFont
 {
-    enum Origin : uint8_t { Local = 0, CssURL, ScriptURL, FontURL, Embedded };
+    enum Origin : uint8_t {Local = 0, CssURL, ScriptURL, FontURL};
 
     ~LottieFont()
     {
@@ -408,7 +408,7 @@ struct LottieFont
     char* style = nullptr;
     size_t dataSize = 0;
     float ascent = 0.0f;
-    Origin origin = Embedded;
+    Origin origin = Local;
 
     void prepare();
 };


### PR DESCRIPTION
Use local font by default and fall back if no glyphs exist.