### PR TITLE
lottie: fix precomposition with masking

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1174,8 +1174,8 @@ void LottieBuilder::updateMasks(LottieLayer* layer, float frameNo)
 {
     if (layer->masks.count == 0) return;
 
-    //Introduce an intermediate scene for embracing the matte + masking
-    if (layer->matteTarget) {
+    //Introduce an intermediate scene for embracing matte + masking or precomp clipping + masking replaced by clipping
+    if (layer->matteTarget || layer->type == LottieLayer::Precomp) {
         auto scene = Scene::gen();
         scene->push(layer->scene);
         layer->scene = scene;


### PR DESCRIPTION
A precomposition layer is clipped to its viewport. If the same layer also had a mask that was optimized using clipping, this clip was unintentionally overridden by the viewport clipping. This conflict is now fixed.

before:
<img width="300" alt="Zrzut ekranu 2025-05-21 o 00 39 51" src="https://github.com/user-attachments/assets/2b6ef8cf-5db5-4a23-944e-080235a1c317" />

after (same as in AE, lottie web):
<img width="300" alt="Zrzut ekranu 2025-05-21 o 00 40 49" src="https://github.com/user-attachments/assets/12ef22ee-bebc-42f4-9b7f-e1a75d7e8dba" />

sample:
[test.json](https://github.com/user-attachments/files/20357644/test.json)
