### PR TITLE
sw_engine: fix too small memory alloc for spans

### DIFF
--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -997,7 +997,7 @@ void rleFree(SwRle* rle)
 bool rleClip(SwRle *rle, const SwRle *clip)
 {
     if (rle->size == 0 || clip->size == 0) return false;
-    auto spanCnt = rle->size > clip->size ? rle->size : clip->size;
+    auto spanCnt = 2 * (rle->size > clip->size ? rle->size : clip->size); //factor 2 added for safety (no real cases observed where the factor exceeded 1.4)
     auto spans = tvg::malloc<SwSpan*>(sizeof(SwSpan) * (spanCnt));
     auto spansEnd = _intersectSpansRegion(clip, rle, spans, spanCnt);
 


### PR DESCRIPTION
In some clipping cases, the memory allocated for storing spans was too small. As a result, the entire clipped area might not have been rendered.
This has been resolved by adding an experimental factor to increase the size of allocated memory.

@issue: https://github.com/thorvg/thorvg/issues/3461

after:
![prezent](https://github.com/user-attachments/assets/aefa314d-7121-4822-ada7-991e016fe0dc)


before:
<img width="300" alt="Zrzut ekranu 2025-05-21 o 00 20 49" src="https://github.com/user-attachments/assets/6c6ad356-4ae8-4022-bbf4-09bc0ac3be57" />


after:
<img width="300" alt="Zrzut ekranu 2025-05-21 o 00 21 22" src="https://github.com/user-attachments/assets/4973a94c-7a56-498d-ba27-a5ecb1d24f31" />

sample:
```
        auto rect1 = tvg::Shape::gen();
        rect1->appendRect(100,100,10,100,1,1);
        rect1->appendRect(112,100,10,100,1,1);
        rect1->appendRect(124,100,10,100,1,1);
        rect1->appendRect(136,100,10,100,1,1);
        rect1->appendRect(148,100,10,100,1,1);
        rect1->appendRect(160,100,10,100,1,1);
        rect1->appendRect(172,100,10,100,1,1);
        rect1->appendRect(184,100,10,100,1,1);
        rect1->fill(255, 0, 0, 80);

        auto rect2 = static_cast<tvg::Shape*>(rect1->duplicate());
        rect2->fill(255, 0, 0, 255);

        canvas->push(rect1);


        auto clip1 = tvg::Shape::gen();
        clip1->appendRect(100,100,100,100,1,1);
        clip1->strokeFill(0, 0, 0);
        clip1->strokeWidth(2);
        clip1->rotate(2);
        canvas->push(clip1);

        auto clip2 = tvg::Shape::gen();
        clip2->appendRect(100,100,100,100,1,1);
        clip2->rotate(2);

        rect2->clip(clip2);
        canvas->push(rect2);
```