### PR TITLE
ttf/api: add metrics() api

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -284,6 +284,23 @@ struct Matrix
 
 
 /**
+ * @brief A data structure representing metrics for a single glyph.
+ *
+ * @since Experimental API
+ */
+struct GlyphMetrics
+{
+    Point kerning = {0.0f, 0.0f};
+
+    float advanceWidth;
+    float leftSideBearing;
+    float yOffset;
+    float minw;
+    float minh;
+};
+
+
+/**
  * @class Paint
  *
  * @brief An abstract class for managing graphical elements.
@@ -1667,6 +1684,23 @@ public:
      * @since 0.15
      */
     static Result unload(const char* filename) noexcept;
+
+     /**
+     * @brief Gets the detailed metrics for each glyph in the current text object.
+     *
+     * This function allocates memory internally to hold an array of glyph metrics corresponding to the currently set text and font.
+     *
+     * @param[out] metrics Pointer to an array of glyph metrics. Valid until the text is modified.
+     * @param[out] size The number of glyphs returned in the metrics array.
+     *
+     * @retval Result::InsufficientCondition If font or text was not set, a @c nullptr is passed as @p metrics, or font data loading/reading failed.
+     *
+     * @note The caller is responsible for freeing the allocated memory by calling this function again with the same @p metrics pointer and a @c nullptr @p size pointer.
+     * @note Must be called after setting both font() and text().
+     *
+     * @since Experimental API
+     */
+    Result metrics(GlyphMetrics** metrics, uint32_t* size) noexcept;
 
     /**
      * @brief Creates a new Text object.

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -297,6 +297,8 @@ struct GlyphMetrics
     float yOffset;
     float minw;
     float minh;
+    //for glyph<->text mapping:
+    uint32_t length;
 };
 
 

--- a/src/loaders/ttf/tvgTtfLoader.h
+++ b/src/loaders/ttf/tvgTtfLoader.h
@@ -49,6 +49,7 @@ struct TtfLoader : public FontLoader
     bool open(const char *data, uint32_t size, const char* rpath, bool copy) override;
     float transform(Paint* paint, FontMetrics& metrices, float fontSize, bool italic) override;
     bool read(Shape* shape, char* text, FontMetrics& out) override;
+    bool metrics(char* text, float fontSize, GlyphMetrics** metrics, uint32_t* size) override;
     void clear();
 };
 

--- a/src/loaders/ttf/tvgTtfReader.h
+++ b/src/loaders/ttf/tvgTtfReader.h
@@ -32,12 +32,7 @@
 struct TtfGlyphMetrics
 {
     uint32_t outline;    //glyph outline table offset
-
-    float advanceWidth;
-    float leftSideBearing;
-    float yOffset;
-    float minw;
-    float minh;
+    GlyphMetrics metrics;
 };
 
 
@@ -62,9 +57,9 @@ public:
     } metrics;
 
     bool header();
-    uint32_t glyph(uint32_t codepoint, TtfGlyphMetrics& gmetrics);
+    uint32_t glyph(uint32_t codepoint, GlyphMetrics& gmetric, uint32_t* goutline);
     void kerning(uint32_t lglyph, uint32_t rglyph, Point& out);
-    bool convert(Shape* shape, TtfGlyphMetrics& gmetrics, const Point& offset, const Point& kerning, uint16_t componentDepth);
+    bool convert(Shape* shape, const TtfGlyphMetrics& gmetric, const Point& offset, uint16_t componentDepth);
 
 private:
     //table offsets
@@ -82,8 +77,8 @@ private:
     uint32_t table(const char* tag);
     uint32_t outlineOffset(uint32_t glyph);
     uint32_t glyph(uint32_t codepoint);
-    bool glyphMetrics(uint32_t glyphIndex, TtfGlyphMetrics& gmetrics);
-    bool convertComposite(Shape* shape, TtfGlyphMetrics& gmetrics, const Point& offset, const Point& kerning, uint16_t componentDepth);
+    bool glyphMetrics(uint32_t glyphIndex, GlyphMetrics& gmetric, uint32_t* goutline);
+    bool convertComposite(Shape* shape, const TtfGlyphMetrics& gmetric, const Point& offset, uint16_t componentDepth);
     bool genPath(uint8_t* flags, uint16_t basePoint, uint16_t count);
     bool genSimpleOutline(Shape* shape, uint32_t outline, uint32_t cntrsCnt);
     bool points(uint32_t outline, uint8_t* flags, Point* pts, uint32_t ptsCnt, const Point& offset);

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -118,6 +118,7 @@ struct FontLoader : LoadModule
 
     virtual bool read(Shape* shape, char* text, FontMetrics& out) = 0;
     virtual float transform(Paint* paint, FontMetrics& mertrics, float fontSize, bool italic) = 0;
+    virtual bool metrics(char* text, float fontSize, GlyphMetrics** metrics, uint32_t* size) = 0;
 };
 
 #endif //_TVG_LOAD_MODULE_H_

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -107,3 +107,9 @@ Type Text::type() const noexcept
 {
     return Type::Text;
 }
+
+
+Result Text::metrics(GlyphMetrics** metrics, uint32_t* size) noexcept
+{
+    return TEXT(this)->metrics(metrics, size);
+}


### PR DESCRIPTION
Introduced the GlyphMetrics struct and the API:
  Result metrics(GlyphMetrics** metrics, uint32_t* size)
This allows retrieving glyph metrics for a given Text object. The font and utf8 content must be set beforehand using the font() and text() apis.

Memory for the metrics array is allocated internally by the API. It is the user's responsibility to free it by calling the same API with a valid metrics pointer and a nullptr passed as size.

@Issue: https://github.com/thorvg/thorvg/issues/3397

<img width="600" alt="metrics" src="https://github.com/user-attachments/assets/43ab60b0-059c-48fc-914c-9549d745bc18" />

<img width="300" alt="Zrzut ekranu 2025-05-22 o 07 57 13" src="https://github.com/user-attachments/assets/ac5c7b2f-124f-416c-a149-eb461c79dec3" />

