### PR TITLE
gl_engine: fix memory leak on target resize

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTarget.h
+++ b/src/renderer/gl_engine/tvgGlRenderTarget.h
@@ -28,11 +28,11 @@
 class GlRenderTarget
 {
 public:
-    GlRenderTarget() = default;
-    GlRenderTarget(uint32_t width, uint32_t height);
+    GlRenderTarget();
     ~GlRenderTarget();
 
-    void init(GLint resolveId);
+    void init(uint32_t width, uint32_t height, GLint resolveId);
+    void reset();
 
     GLuint getFboId() { return mFbo; }
     GLuint getResolveFboId() { return mResolveFbo; }

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -52,6 +52,8 @@ void GlRenderer::flush()
 {
     clearDisposes();
 
+    mRootTarget.reset();
+
     ARRAY_FOREACH(p, mComposePool) delete(*p);
     mComposePool.clear();
 
@@ -834,9 +836,8 @@ bool GlRenderer::target(void* context, int32_t id, uint32_t w, uint32_t h)
 
     currentContext();
 
-    mRootTarget = GlRenderTarget(surface.w, surface.h);
     mRootTarget.setViewport({0, 0, static_cast<int32_t>(surface.w), static_cast<int32_t>(surface.h)});
-    mRootTarget.init(mTargetFboId);
+    mRootTarget.init(surface.w, surface.h, mTargetFboId);
 
     return true;
 }


### PR DESCRIPTION
We must to remove offscreen render buffers during removing render target

https://github.com/thorvg/thorvg/issues/3210