### PR TITLE
renderer: allow empty content during canvas rendering

### DIFF
--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -253,7 +253,7 @@ struct PictureImpl : Picture
 
     bool render(RenderMethod* renderer)
     {
-        bool ret = false;
+        auto ret = true;
         renderer->blend(impl.blendMethod);
 
         if (bitmap) return renderer->renderImage(impl.rd);


### PR DESCRIPTION
This allow more generous handling of failure cases for invalid content, thorvg can draw other successful contents.

Now, only raster engines can return fail cases in the picture.