### PR TITLE
gl_engine: fix compilation warning with RenderRegion data type

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -861,7 +861,7 @@ bool GlRenderer::sync()
 
 RenderRegion GlRenderer::region(RenderData data)
 {
-    if (currentPass()->isEmpty()) return {0, 0, 0, 0};
+    if (currentPass()->isEmpty()) return { {0, 0}, {0, 0} };
 
     auto shape = reinterpret_cast<GlShape*>(data);
     auto bounds = shape->geometry.getBounds();


### PR DESCRIPTION
emsdk warning message
![image](https://github.com/user-attachments/assets/b5230542-5154-4c2c-8c7f-cc4520108e97)
