### PR TITLE
wg_engine: geometry stage buffers implementation

### DIFF
--- a/src/renderer/wg_engine/meson.build
+++ b/src/renderer/wg_engine/meson.build
@@ -7,6 +7,7 @@ source_file = [
     'tvgWgRenderData.h',
     'tvgWgRenderer.h',
     'tvgWgRenderTarget.h',
+    'tvgWgRenderTask.h',
     'tvgWgShaderSrc.h',
     'tvgWgShaderTypes.h',
     'tvgWgBindGroups.cpp',
@@ -17,6 +18,7 @@ source_file = [
     'tvgWgRenderData.cpp',
     'tvgWgRenderer.cpp',
     'tvgWgRenderTarget.cpp',
+    'tvgWgRenderTask.cpp',
     'tvgWgShaderSrc.cpp',
     'tvgWgShaderTypes.cpp'
 ]

--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -269,3 +269,34 @@ void WgContext::releaseQueue(WGPUQueue& queue)
         queue = nullptr;
     }
 }
+
+
+WGPUCommandEncoder WgContext::createCommandEncoder()
+{
+    WGPUCommandEncoderDescriptor commandEncoderDesc{};
+    return wgpuDeviceCreateCommandEncoder(device, &commandEncoderDesc);
+}
+
+
+void WgContext::submitCommandEncoder(WGPUCommandEncoder commandEncoder)
+{
+    const WGPUCommandBufferDescriptor commandBufferDesc{};
+    WGPUCommandBuffer commandsBuffer = wgpuCommandEncoderFinish(commandEncoder, &commandBufferDesc);
+    wgpuQueueSubmit(queue, 1, &commandsBuffer);
+    wgpuCommandBufferRelease(commandsBuffer);
+}
+
+
+void WgContext::releaseCommandEncoder(WGPUCommandEncoder& commandEncoder)
+{
+    if (commandEncoder) {
+        wgpuCommandEncoderRelease(commandEncoder);
+        commandEncoder = nullptr;
+    }
+}
+
+
+bool WgContext::invalid()
+{
+    return !instance || !device;
+}

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -71,10 +71,12 @@ struct WgContext {
     // release buffer objects
     void releaseBuffer(WGPUBuffer& buffer);
 
-    bool invalid()
-    {
-        return !instance || !device;
-    }
+    // command encoder
+    WGPUCommandEncoder createCommandEncoder();
+    void submitCommandEncoder(WGPUCommandEncoder encoder);
+    void releaseCommandEncoder(WGPUCommandEncoder& encoder);
+
+    bool invalid();
 };
 
 #endif // _TVG_WG_COMMON_H_

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -28,22 +28,19 @@
 #include "tvgWgShaderTypes.h"
 
 struct WgMeshData {
-    WGPUBuffer bufferPosition{};
-    WGPUBuffer bufferTexCoord{};
-    WGPUBuffer bufferIndex{};
-    size_t vertexCount{};
-    size_t indexCount{};
-
-    void draw(WgContext& context, WGPURenderPassEncoder renderPassEncoder);
-    void drawFan(WgContext& context, WGPURenderPassEncoder renderPassEncoder);
-    void drawImage(WgContext& context, WGPURenderPassEncoder renderPassEncoder);
+    Array<Point> vbuffer;
+    Array<Point> tbuffer;
+    Array<uint32_t> ibuffer;
+    size_t voffset{};
+    size_t toffset{};
+    size_t ioffset{};
 
     void update(WgContext& context, const WgVertexBuffer& vertexBuffer);
     void update(WgContext& context, const WgIndexedVertexBuffer& vertexBufferInd);
     void bbox(WgContext& context, const Point pmin, const Point pmax);
     void imageBox(WgContext& context, float w, float h);
     void blitBox(WgContext& context);
-    void release(WgContext& context);
+    void release(WgContext& context) {};
 };
 
 class WgMeshDataPool {
@@ -222,6 +219,25 @@ public:
     WgRenderDataEffectParams* allocate(WgContext& context);
     void free(WgContext& context, WgRenderDataEffectParams* renderData);
     void release(WgContext& context);
+};
+
+class WgRenderDataStageBuffer {
+private:
+    Array<uint8_t> vbuffer;
+    Array<uint8_t> ibuffer;
+public:
+    WGPUBuffer vbuffer_gpu{};
+    WGPUBuffer ibuffer_gpu{};
+
+    void append(WgMeshData* meshData);
+    void append(WgMeshDataGroup* meshDataGroup);
+    void append(WgRenderDataShape* renderDataShape);
+    void append(WgRenderDataPicture* renderDataPicture);
+    void initialize(WgContext& context){};
+    void release(WgContext& context);
+    void clear();
+    void flush(WgContext& context);
+    void bind(WGPURenderPassEncoder renderPass, size_t voffset, size_t toffset);
 };
 
 #endif // _TVG_WG_RENDER_DATA_H_

--- a/src/renderer/wg_engine/tvgWgRenderTarget.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.cpp
@@ -22,7 +22,7 @@
 
 #include "tvgWgRenderTarget.h"
 
-void WgRenderStorage::initialize(WgContext& context, uint32_t width, uint32_t height)
+void WgRenderTarget::initialize(WgContext& context, uint32_t width, uint32_t height)
 {
     this->width = width;
     this->height = height;
@@ -36,7 +36,7 @@ void WgRenderStorage::initialize(WgContext& context, uint32_t width, uint32_t he
 }
 
 
-void WgRenderStorage::release(WgContext& context)
+void WgRenderTarget::release(WgContext& context)
 {
     context.layouts.releaseBindGroup(bindGroupTexure);
     context.layouts.releaseBindGroup(bindGroupWrite);
@@ -50,38 +50,38 @@ void WgRenderStorage::release(WgContext& context)
 }
 
 //*****************************************************************************
-// render storage pool
+// render target pool
 //*****************************************************************************
 
-WgRenderStorage* WgRenderStoragePool::allocate(WgContext& context)
+WgRenderTarget* WgRenderTargetPool::allocate(WgContext& context)
 {
-    WgRenderStorage* renderStorage{};
+    WgRenderTarget* renderTarget{};
     if (pool.count > 0) {
-        renderStorage = pool.last();
+        renderTarget = pool.last();
         pool.pop();
     } else {
-        renderStorage = new WgRenderStorage;
-        renderStorage->initialize(context, width, height);
-        list.push(renderStorage);
+        renderTarget = new WgRenderTarget;
+        renderTarget->initialize(context, width, height);
+        list.push(renderTarget);
     }
-    return renderStorage;
+    return renderTarget;
 };
 
 
-void WgRenderStoragePool::free(WgContext& context, WgRenderStorage* renderStorage)
+void WgRenderTargetPool::free(WgContext& context, WgRenderTarget* renderTarget)
 {
-    pool.push(renderStorage);
+    pool.push(renderTarget);
 };
 
 
-void WgRenderStoragePool::initialize(WgContext& context, uint32_t width, uint32_t height)
+void WgRenderTargetPool::initialize(WgContext& context, uint32_t width, uint32_t height)
 {
     this->width = width;
     this->height = height;
 }
 
 
-void WgRenderStoragePool::release(WgContext& context)
+void WgRenderTargetPool::release(WgContext& context)
 {
     ARRAY_FOREACH(p, list) {
        (*p)->release(context);

--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -26,7 +26,7 @@
 #include "tvgWgPipelines.h"
 #include "tvgRender.h"
 
-struct WgRenderStorage {
+struct WgRenderTarget {
     WGPUTexture texture{};
     WGPUTexture textureMS{};
     WGPUTextureView texView{};
@@ -42,15 +42,15 @@ struct WgRenderStorage {
 };
 
 
-class WgRenderStoragePool {
+class WgRenderTargetPool {
 private:
-    Array<WgRenderStorage*> list;
-    Array<WgRenderStorage*> pool;
+    Array<WgRenderTarget*> list;
+    Array<WgRenderTarget*> pool;
     uint32_t width{};
     uint32_t height{};
 public:
-    WgRenderStorage* allocate(WgContext& context);
-    void free(WgContext& context, WgRenderStorage* renderTarget);
+    WgRenderTarget* allocate(WgContext& context);
+    void free(WgContext& context, WgRenderTarget* renderTarget);
 
     void initialize(WgContext& context, uint32_t width, uint32_t height);
     void release(WgContext& context);

--- a/src/renderer/wg_engine/tvgWgRenderTask.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTask.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgRenderTask.h"
+#include <iostream>
+
+//***********************************************************************
+// WgPaintTask
+//***********************************************************************
+
+void WgPaintTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
+{
+    if (renderData->type() == tvg::Type::Shape)
+        compositor.renderShape(context, (WgRenderDataShape*)renderData, blendMethod);
+    if (renderData->type() == tvg::Type::Picture)
+        compositor.renderImage(context, (WgRenderDataPicture*)renderData, blendMethod);
+    else assert(true);
+}
+
+//***********************************************************************
+// WgSceneTask
+//***********************************************************************
+
+void WgSceneTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
+{
+    // begin the render pass for the current scene and clear the target content
+    WGPUColor color{};
+    if ((compose->method == MaskMethod::None) && (compose->blend != BlendMethod::Normal)) color = { 1.0, 1.0, 1.0, 0.0 };
+    compositor.beginRenderPass(encoder, renderTarget, true, color);
+    // run all childs (scenes and shapes)
+    runChildren(context, compositor, encoder);
+    // we must to end current render pass for current scene
+    compositor.endRenderPass();
+    // we must to apply effect for current scene
+    if (effect)
+        runEffect(context, compositor, encoder);
+    // there's no point in continuing if the scene has no destination target (e.g., the root scene)
+    if (!renderTargetDst) return;
+    // apply scene blending
+    if (compose->method == MaskMethod::None) {
+        compositor.beginRenderPass(encoder, renderTargetDst, false);
+        compositor.renderScene(context, renderTarget, compose);
+    // apply scene composition (for scenes, that have a handle to mask)
+    } else if (renderTargetMsk) {
+        compositor.beginRenderPass(encoder, renderTargetDst, false);
+        compositor.composeScene(context, renderTarget, renderTargetMsk, compose);
+    }
+}
+
+
+void WgSceneTask::runChildren(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
+{
+    ARRAY_FOREACH(task, children) {
+        WgRenderTask* renderTask = *task;
+        // we need to restore current render pass without clear
+        compositor.beginRenderPass(encoder, renderTarget, false);
+        // run children (shape or scene)
+        renderTask->run(context, compositor, encoder);
+    }
+}
+
+
+void WgSceneTask::runEffect(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
+{
+    assert(effect);
+    switch (effect->type) {
+        case SceneEffect::GaussianBlur: compositor.gaussianBlur(context, renderTarget, (RenderEffectGaussianBlur*)effect, compose); break;
+        case SceneEffect::DropShadow: compositor.dropShadow(context, renderTarget, (RenderEffectDropShadow*)effect, compose); break;
+        case SceneEffect::Fill: compositor.fillEffect(context, renderTarget, (RenderEffectFill*)effect, compose); break;
+        case SceneEffect::Tint: compositor.tintEffect(context, renderTarget, (RenderEffectTint*)effect, compose); break;
+        case SceneEffect::Tritone : compositor.tritoneEffect(context, renderTarget, (RenderEffectTritone*)effect, compose); break;
+        default: break;
+    }
+}

--- a/src/renderer/wg_engine/tvgWgRenderTask.h
+++ b/src/renderer/wg_engine/tvgWgRenderTask.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_RENDER_TASK_H_
+#define _TVG_WG_RENDER_TASK_H_
+ 
+#include "tvgWgCompositor.h"
+
+// base class for any renderable objects 
+struct WgRenderTask {
+    virtual ~WgRenderTask() {}
+    virtual void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) = 0;
+};
+
+// task for sinlge shape rendering
+struct WgPaintTask: public WgRenderTask {
+    // shape render properties
+    WgRenderDataPaint* renderData{};
+    BlendMethod blendMethod{};
+
+    WgPaintTask(WgRenderDataPaint* renderData, BlendMethod blendMethod) : 
+        renderData(renderData), blendMethod(blendMethod) {}
+    // apply shape execution, including custom blending and clipping
+    void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
+};
+
+// task for scene rendering with blending, composition and effect
+struct WgSceneTask: public WgRenderTask {
+public:
+    // parent scene (nullptr for root scene)
+    WgSceneTask* parent{};
+    // childs can be shapes or scenes tesks
+    Array<WgRenderTask*> children;
+    // scene blend/compose targets
+    WgRenderTarget* renderTarget{};
+    WgRenderTarget* renderTargetMsk{};
+    WgRenderTarget* renderTargetDst{};
+    // scene blend/compose properties
+    WgCompose* compose{};
+    // scene effect properties
+    const RenderEffect* effect{};
+
+    WgSceneTask(WgRenderTarget* renderTarget, WgCompose* compose, WgSceneTask* parent) :
+        parent(parent), renderTarget(renderTarget), compose(compose) {}
+    // run all, including all shapes drawing, blending, composition and effect
+    void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
+private:
+    void runChildren(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder);
+    void runEffect(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder);
+};
+ 
+ #endif // _TVG_WG_RENDER_TASK_H_
+ 

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -47,13 +47,13 @@ void WgRenderer::release()
     mRenderDataEffectParamsPool.release(mContext);
     WgMeshDataPool::gMeshDataPool->release(mContext);
 
-    // clear render storage pool
-    mRenderStoragePool.release(mContext);
+    // clear render  pool
+    mRenderTargetPool.release(mContext);
 
     // clear rendering tree stacks
-    mCompositorStack.clear();
-    mRenderStorageStack.clear();
-    mRenderStorageRoot.release(mContext);
+    mCompositorList.clear();
+    mRenderTargetStack.clear();
+    mRenderTargetRoot.release(mContext);
 
     // release context handles
     mCompositor.release(mContext);
@@ -195,50 +195,71 @@ RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
 
 bool WgRenderer::preRender()
 {
+    // invalidate context
     if (mContext.invalid()) return false;
-
-    // push rot render storage to the render tree stack
-    assert(mRenderStorageStack.count == 0);
-    mRenderStorageStack.push(&mRenderStorageRoot);
-    // create command encoder for drawing
-    WGPUCommandEncoderDescriptor commandEncoderDesc{};
-    mCommandEncoder = wgpuDeviceCreateCommandEncoder(mContext.device, &commandEncoderDesc);
-    // start root render pass
-    mCompositor.beginRenderPass(mCommandEncoder, mRenderStorageStack.last(), true);
+    // reset stage data
+    mCompositor.reset(mContext);
+    // push root render target to the render tree stack
+    assert(mRenderTargetStack.count == 0);
+    mRenderTargetStack.push(&mRenderTargetRoot);
+    // create root compose settings
+    WgCompose* compose = new WgCompose();
+    compose->aabb = { { 0, 0 }, { (int32_t)mTargetSurface.w, (int32_t)mTargetSurface.h } };
+    compose->blend = BlendMethod::Normal;
+    compose->method = MaskMethod::None;
+    compose->opacity = 255;
+    mCompositorList.push(compose);
+    // create root scene
+    WgSceneTask* sceneTask = new WgSceneTask(&mRenderTargetRoot, compose, nullptr);
+    mRenderTaskList.push(sceneTask);
+    mSceneTaskStack.push(sceneTask);
     return true;
 }
 
 
 bool WgRenderer::renderShape(RenderData data)
 {
-    // temporary simple render data to the current render target
-    mCompositor.renderShape(mContext, (WgRenderDataShape*)data, mBlendMethod);
+    WgPaintTask* paintTask = new WgPaintTask((WgRenderDataPaint*)data, mBlendMethod);
+    WgSceneTask* sceneTask = mSceneTaskStack.last();
+    sceneTask->children.push(paintTask);
+    mRenderTaskList.push(paintTask);
+    mCompositor.requestShape((WgRenderDataShape*)data);
     return true;
 }
 
 
 bool WgRenderer::renderImage(RenderData data)
 {
-    // temporary simple render data to the current render target
-    mCompositor.renderImage(mContext, (WgRenderDataPicture*)data, mBlendMethod);
+    WgPaintTask* paintTask = new WgPaintTask((WgRenderDataPaint*)data, mBlendMethod);
+    WgSceneTask* sceneTask = mSceneTaskStack.last();
+    sceneTask->children.push(paintTask);
+    mRenderTaskList.push(paintTask);
+    mCompositor.requestImage((WgRenderDataPicture*)data);
     return true;
 }
 
 
 bool WgRenderer::postRender()
 {
-    // end root render pass
-    mCompositor.endRenderPass();
-    // release command encoder
-    const WGPUCommandBufferDescriptor commandBufferDesc{};
-    WGPUCommandBuffer commandsBuffer = wgpuCommandEncoderFinish(mCommandEncoder, &commandBufferDesc);
-    wgpuQueueSubmit(mContext.queue, 1, &commandsBuffer);
-    wgpuCommandBufferRelease(commandsBuffer);
-    wgpuCommandEncoderRelease(mCommandEncoder);
-    // pop root render storage to the render tree stack
-    mRenderStorageStack.pop();
-    assert(mRenderStorageStack.count == 0);
-    // clear viewport list and store allocated handles to pool
+    // flush stage data to gpu
+    mCompositor.flush(mContext);
+    // create command encoder for drawing
+    WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
+    // run rendering (all the fun is here)
+    WgSceneTask* sceneTaskRoot = mSceneTaskStack.last();
+    sceneTaskRoot->run(mContext, mCompositor, commandEncoder);
+    // execute and release command encoder
+    mContext.submitCommandEncoder(commandEncoder);
+    mContext.releaseCommandEncoder(commandEncoder);
+    // clear the render tasks tree
+    mSceneTaskStack.pop();
+    assert(mSceneTaskStack.count == 0);
+    mRenderTargetStack.pop();
+    assert(mRenderTargetStack.count == 0);
+    ARRAY_FOREACH(p, mRenderTaskList) { delete (*p); };
+    mRenderTaskList.clear();
+    ARRAY_FOREACH(p, mCompositorList) { delete (*p); };
+    mCompositorList.clear();
     ARRAY_FOREACH(p, mRenderDataViewportList)
         mRenderDataViewportPool.free(mContext, *p);
     mRenderDataViewportList.clear();
@@ -325,18 +346,11 @@ bool WgRenderer::sync()
     WGPUTextureView dstTextureView = mContext.createTextureView(dstTexture);
 
     // create command encoder
-    const WGPUCommandEncoderDescriptor commandEncoderDesc{};
-    WGPUCommandEncoder commandEncoder = wgpuDeviceCreateCommandEncoder(mContext.device, &commandEncoderDesc);
-
+    WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
     // show root offscreen buffer
-    mCompositor.blit(mContext, commandEncoder, &mRenderStorageRoot, dstTextureView);
-
-    // release command encoder
-    const WGPUCommandBufferDescriptor commandBufferDesc{};
-    WGPUCommandBuffer commandsBuffer = wgpuCommandEncoderFinish(commandEncoder, &commandBufferDesc);
-    wgpuQueueSubmit(mContext.queue, 1, &commandsBuffer);
-    wgpuCommandBufferRelease(commandsBuffer);
-    wgpuCommandEncoderRelease(commandEncoder);
+    mCompositor.blit(mContext, commandEncoder, &mRenderTargetRoot, dstTextureView);
+    mContext.submitCommandEncoder(commandEncoder);
+    mContext.releaseCommandEncoder(commandEncoder);
 
     // release dest buffer view
     mContext.releaseTextureView(dstTextureView);
@@ -367,8 +381,8 @@ bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, 
         mContext.initialize(instance, device);
 
         // initialize render tree instances
-        mRenderStoragePool.initialize(mContext, width, height);
-        mRenderStorageRoot.initialize(mContext, width, height);
+        mRenderTargetPool.initialize(mContext, width, height);
+        mRenderTargetRoot.initialize(mContext, width, height);
         mCompositor.initialize(mContext, width, height);
 
         // store target properties
@@ -387,12 +401,12 @@ bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, 
     // update render targets dimentions
     if ((mTargetSurface.w != width) || (mTargetSurface.h != height) || (type == 0 ? (surface != (WGPUSurface)target) : (targetTexture != (WGPUTexture)target))) {
         // release render tagets
-        mRenderStoragePool.release(mContext);
-        mRenderStorageRoot.release(mContext);
+        mRenderTargetPool.release(mContext);
+        mRenderTargetRoot.release(mContext);
         clearTargets();
 
-        mRenderStoragePool.initialize(mContext, width, height);
-        mRenderStorageRoot.initialize(mContext, width, height);
+        mRenderTargetPool.initialize(mContext, width, height);
+        mRenderTargetRoot.initialize(mContext, width, height);
         mCompositor.resize(mContext, width, height);
 
         // store target properties
@@ -447,7 +461,7 @@ RenderCompositor* WgRenderer::target(const RenderRegion& region, TVG_UNUSED Colo
         compose->rdViewport->update(mContext, region);
         mRenderDataViewportList.push(compose->rdViewport);
     }
-    mCompositorStack.push(compose);
+    mCompositorList.push(compose);
     return compose;
 }
 
@@ -459,57 +473,52 @@ bool WgRenderer::beginComposite(RenderCompositor* cmp, MaskMethod method, uint8_
     compose->method = method;
     compose->opacity = opacity;
     compose->blend = mBlendMethod;
-    // end current render pass
-    mCompositor.endRenderPass();
-    // allocate new render storage and push to the render tree stack
-    WgRenderStorage* storage = mRenderStoragePool.allocate(mContext);
-    mRenderStorageStack.push(storage);
-    // begin newly added render pass
-    WGPUColor color{};
-    if ((compose->method == MaskMethod::None) && (compose->blend != BlendMethod::Normal)) color = { 1.0, 1.0, 1.0, 0.0 };
-    mCompositor.beginRenderPass(mCommandEncoder, mRenderStorageStack.last(), true, color);
+    WgSceneTask* sceneTaskCurrent = mSceneTaskStack.last();
+    // allocate new render target and push to the render tree stack
+    WgRenderTarget* renderTarget = mRenderTargetPool.allocate(mContext);
+    mRenderTargetStack.push(renderTarget);
+    // create and setup new scene task
+    WgSceneTask* sceneTask = new WgSceneTask(renderTarget, compose, sceneTaskCurrent);
+    sceneTaskCurrent->children.push(sceneTask);
+    mRenderTaskList.push(sceneTask);
+    mSceneTaskStack.push(sceneTask);
     return true;
 }
 
 
 bool WgRenderer::endComposite(RenderCompositor* cmp)
 {
-    // get current composition settings
-    WgCompose* comp = (WgCompose*)cmp;
-    // we must to end current render pass to run blend/composition mechanics
-    mCompositor.endRenderPass();
     // finish scene blending
-    if (comp->method == MaskMethod::None) {
-        // get source and destination render storages
-        WgRenderStorage* src = mRenderStorageStack.last();
-        mRenderStorageStack.pop();
-        WgRenderStorage* dst = mRenderStorageStack.last();
-        // begin previous render pass
-        mCompositor.beginRenderPass(mCommandEncoder, dst, false);
-        // apply composition
-        mCompositor.renderScene(mContext, src, comp);
+    if (cmp->method == MaskMethod::None) {
+        // get source and destination render targets
+        WgRenderTarget* src = mRenderTargetStack.last();
+        mRenderTargetStack.pop();
+        // pop source scene
+        WgSceneTask* srcScene = mSceneTaskStack.last();
+        mSceneTaskStack.pop();
+        // setup render target compose destitations
+        srcScene->renderTargetDst = mSceneTaskStack.last()->renderTarget;
+        srcScene->renderTargetMsk =  nullptr;
         // back render targets to the pool
-        mRenderStoragePool.free(mContext, src);
-    } else { // finish composition
-        // get source, mask and destination render storages
-        WgRenderStorage* src = mRenderStorageStack.last();
-        mRenderStorageStack.pop();
-        WgRenderStorage* msk = mRenderStorageStack.last();
-        mRenderStorageStack.pop();
-        WgRenderStorage* dst = mRenderStorageStack.last();
-        // begin previous render pass
-        mCompositor.beginRenderPass(mCommandEncoder, dst, false);
-        // apply composition
-        mCompositor.composeScene(mContext, src, msk, comp);
+        mRenderTargetPool.free(mContext, src);
+    } else { // finish scene composition
+        // get source, mask and destination render targets
+        WgRenderTarget* src = mRenderTargetStack.last();
+        mRenderTargetStack.pop();
+        WgRenderTarget* msk = mRenderTargetStack.last();
+        mRenderTargetStack.pop();
+        // get source and mask scenes
+        WgSceneTask* srcScene = mSceneTaskStack.last();
+        mSceneTaskStack.pop();
+        WgSceneTask* mskScene = mSceneTaskStack.last();
+        mSceneTaskStack.pop();
+        // setup render target compose destitations
+        srcScene->renderTargetDst = mSceneTaskStack.last()->renderTarget;
+        srcScene->renderTargetMsk = mskScene->renderTarget;
         // back render targets to the pool
-        mRenderStoragePool.free(mContext, src);
-        mRenderStoragePool.free(mContext, msk);
+        mRenderTargetPool.free(mContext, src);
+        mRenderTargetPool.free(mContext, msk);
     }
-
-    // delete current compositor settings
-    delete mCompositorStack.last();
-    mCompositorStack.pop();
-
     return true;
 }
 
@@ -606,20 +615,8 @@ bool WgRenderer::region(RenderEffect* effect)
 
 bool WgRenderer::render(RenderCompositor* cmp, const RenderEffect* effect, TVG_UNUSED bool direct)
 {
-    // we must to end current render pass to resolve ms texture before effect
-    mCompositor.endRenderPass();
-    WgCompose* comp = (WgCompose*)cmp;
-    WgRenderStorage* dst = mRenderStorageStack.last();
-
-    switch (effect->type) {
-        case SceneEffect::GaussianBlur: return mCompositor.gaussianBlur(mContext, dst, (RenderEffectGaussianBlur*)effect, comp);
-        case SceneEffect::DropShadow: return mCompositor.dropShadow(mContext, dst, (RenderEffectDropShadow*)effect, comp);
-        case SceneEffect::Fill: return mCompositor.fillEffect(mContext, dst, (RenderEffectFill*)effect, comp);
-        case SceneEffect::Tint: return mCompositor.tintEffect(mContext, dst, (RenderEffectTint*)effect, comp);
-        case SceneEffect::Tritone : return mCompositor.tritoneEffect(mContext, dst, (RenderEffectTritone*)effect, comp);
-        default: return false;
-    }
-    return false;
+    mSceneTaskStack.last()->effect = effect;
+    return true;
 }
 
 

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -23,7 +23,7 @@
 #ifndef _TVG_WG_RENDERER_H_
 #define _TVG_WG_RENDERER_H_
 
-#include "tvgWgCompositor.h"
+#include "tvgWgRenderTask.h"
 
 class WgRenderer : public RenderMethod
 {
@@ -72,13 +72,15 @@ private:
     bool surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height);
 
     // render tree stacks
-    WgRenderStorage mRenderStorageRoot;
-    Array<WgCompose*> mCompositorStack;
-    Array<WgRenderStorage*> mRenderStorageStack;
+    WgRenderTarget mRenderTargetRoot;
+    Array<WgCompose*> mCompositorList;
+    Array<WgRenderTarget*> mRenderTargetStack;
     Array<WgRenderDataViewport*> mRenderDataViewportList;
+    Array<WgSceneTask*> mSceneTaskStack;
+    Array<WgRenderTask*> mRenderTaskList;
 
-    // render storage pool
-    WgRenderStoragePool mRenderStoragePool;
+    // render target pool
+    WgRenderTargetPool mRenderTargetPool;
 
     // render data paint pools
     WgRenderDataShapePool mRenderDataShapePool;
@@ -100,7 +102,6 @@ private:
     Key mDisposeKey{};
 
     // gpu handles
-    WGPUCommandEncoder mCommandEncoder{};
     WGPUTexture targetTexture{}; // external handle
     WGPUSurfaceTexture surfaceTexture{};
     WGPUSurface surface{};  // external handle


### PR DESCRIPTION
Implemented task-based rendering and geometry stage buffers:
1. Get information about current frame objects
2. Accumulate geometry data into a stage buffer during frame rendering
3. Flush it to the GPU in single call
4. Run rendering process in post render stage

https://github.com/thorvg/thorvg/issues/3489
https://github.com/thorvg/thorvg/issues/3455

Lottie example performance:
```
main:    83 ms
staging: 67 ms
~25% boost
```

thorvg-wasm.wasm (linux, emsdk)
```
staging: 929864 bytes
main:    927727 bytes
```

1. Current Implementation: Per-Shape GPU Buffer Management
In the existing rendering pipeline, each geometric shape undergoes a distinct process of tessellation and subsequent GPU buffer allocation. Upon each geometry update, the tessellator processes the shape's path data, generating vertices and indices. These resulting data are then immediately written to dedicated GPU buffers—one vertex buffer and one index buffer per shape.

The workflow can be summarized as follows:

1.1. Prepare Stage (Current)
For each shape, the tessellation and GPU buffer flushing occur independently:

shape path 0 → tessellator → render data 0 (GPU vertex buffers flush)
shape path 1 → tessellator → render data 1 (GPU vertex buffers flush)
shape path 2 → tessellator → render data 2 (GPU vertex buffers flush)
... (and so on for all shapes)

This approach necessitates the creation of a unique set of vertex and index buffers on the GPU for every individual shape. Consequently, the system performs multiple write buffers calls, each targeting a distinct set of GPU buffers.

1.2. Render Stage (Current)
During the rasterization stage, each shape's dedicated GPU buffers are drawn sequentially:

render data 0 draw
render data 1 draw
render data 2 draw
... (and so on for all shapes)

1.3. Analysis of Current Approach
While straightforward, this method introduces considerable overhead. The repeated allocation of GPU memory for each shape and, more critically, the numerous individual write buffers calls, contribute to increased CPU-to-GPU communication latency. This frequent flushing of small data chunks can saturate the command queue and reduce overall rendering throughput.

2. Proposed Optimization: Consolidated GPU Buffer Management
The new, optimized approach aims to mitigate the inefficiencies of the current implementation by centralizing geometry data management. Instead of immediately flushing tessellated data to the GPU, the geometry of shapes is first stored in system (CPU) memory. During the rendering phase, the data for all shapes intended for drawing are aggregated into a single, common stage buffer before a consolidated flush operation to the GPU.

The optimized workflow is detailed below:

2.1. Prepare Stage (New)
In the preparation phase, tessellation still occurs per shape, but the resulting render data is retained in CPU memory:

```
shape path 0 → tessellator → render data 0 (CPU buffers)
shape path 1 → tessellator → render data 1 (CPU buffers)
shape path 2 → tessellator → render data 2 (CPU buffers)
... (and so on for all shapes)
```

2.2. Render Stage (New)
The key optimization occurs in the render stage. Geometry data from all shapes to be drawn are accumulated into a single, temporary common stage buffer. This buffer is then flushed to the GPU in a single, efficient operation:

```
render data 0 →
render data 1 → common stage buffer
render data 2 →
... (all accumulated)
common stage buffer flush
```

2.3. Raster Stage (New)
After the consolidated flush, the GPU can then draw the shapes from the now populated GPU buffers, which effectively contain the combined geometry data:

```
render data 0 draw
render data 1 draw
render data 2 draw
... (all drawn from the consolidated buffer)

```
2.4. Benefits of the New Approach
This optimized strategy offers several significant advantages:
- Reduced GPU Flushes: By accumulating data into a single stage buffer, the number of write buffers calls to the GPU is drastically reduced to just one per frame (or per batch of shapes). This minimizes CPU-to-GPU communication overhead.
- Improved Data Locality: Consolidating geometry data before transfer can lead to better cache utilization on the GPU side, as related data is transferred contiguously.
- Simplified GPU Memory Management: While still requiring GPU buffers, the management becomes simpler as a large, single buffer (or a few large buffers) can be used, rather than numerous small, fragmented ones.
