### PR TITLE
gl_engine: fix always-true clear flag

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -195,23 +195,20 @@ void GlComposeTask::run()
 {
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getSelfFbo()));
 
-    // clear this fbo
-    if (mClearBuffer) {
-        // we must clear all area of fbo
-        GL_CHECK(glViewport(0, 0, mFbo->getWidth(), mFbo->getHeight()));
-        GL_CHECK(glScissor(0, 0, mFbo->getWidth(), mFbo->getHeight()));
-        GL_CHECK(glClearColor(0, 0, 0, 0));
-        GL_CHECK(glClearStencil(0));
-    #ifdef THORVG_GL_TARGET_GLES
-        GL_CHECK(glClearDepthf(0.0));
-    #else
-        GL_CHECK(glClearDepth(0.0));
-    #endif
-        GL_CHECK(glDepthMask(1));
+    // we must clear all area of fbo
+    GL_CHECK(glViewport(0, 0, mFbo->getWidth(), mFbo->getHeight()));
+    GL_CHECK(glScissor(0, 0, mFbo->getWidth(), mFbo->getHeight()));
+    GL_CHECK(glClearColor(0, 0, 0, 0));
+    GL_CHECK(glClearStencil(0));
+#ifdef THORVG_GL_TARGET_GLES
+    GL_CHECK(glClearDepthf(0.0));
+#else
+    GL_CHECK(glClearDepth(0.0));
+#endif
+    GL_CHECK(glDepthMask(1));
 
-        GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
-        GL_CHECK(glDepthMask(0));
-    }
+    GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+    GL_CHECK(glDepthMask(0));
 
     GL_CHECK(glViewport(0, 0, mRenderWidth, mRenderHeight));
     GL_CHECK(glScissor(0, 0, mRenderWidth, mRenderHeight));

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -853,6 +853,9 @@ bool GlRenderer::sync()
 
     clearDisposes();
 
+    // Reset clear buffer flag to default (false) after use.    
+    mClearBuffer = false; 
+
     delete task;
 
     return true;

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -153,7 +153,7 @@ private:
     } mDisposed;
 
     BlendMethod mBlendMethod = BlendMethod::Normal;
-    bool mClearBuffer = true;  //FIXME: clear buffer should be optional (default is false)
+    bool mClearBuffer = false;
 };
 
 #endif /* _TVG_GL_RENDERER_H_ */


### PR DESCRIPTION
The clear flag specified in Canvas::draw is ignored when set to false, since GlRenderer::mClearBuffer is never explicitly reset to false.

This commit ensures that mClearBuffer is reset to its default (false) after being used, so that the clear operation behaves correctly per draw.


- Note: GlComposeTask: always clear since the bound framebuffer is selfFbo
    - `GlComposeTask::run`: `GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getSelfFbo()));`
    -  `GlBlitTask::run`: `GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getTargetFbo()));`
- Issue: #1779
- History: 
    - https://github.com/thorvg/thorvg/commit/548962f5f8868429b9ebf5ce6fb9005dcb9a606a#diff-9e1e59292fa7b422d5ff866d9b48e16bdd61ab18bed965fa9d1a6b809bca7ee0R110
    - https://github.com/thorvg/thorvg/commit/cc2fa23359b9c07c13cb6cedf11298386d80517c#diff-9e1e59292fa7b422d5ff866d9b48e16bdd61ab18bed965fa9d1a6b809bca7ee0L111

### reproduce

```cpp
// Example.h
void tempFunc(){}
void (*ClearColor)() = tempFunc;

// Example.h, Window::draw
    bool draw()
    {
        ClearColor();
        //...
    }
// Example.h, Window::ready
    bool ready()
    {
        if (!canvas) return false;

        if (!example->content(canvas, width, height)) return false;

        //initiate the first rendering before window pop-up.
        ClearColor();
        if (!verify(canvas->draw())) return false;
```

```cpp
// examples/Shapes.cpp
#include <OpenGL/gl3.h>
void GL_ClearColor()
{
    glClearColor(1.0f,0.5f,0.25f,1.0f);
    glClear(GL_COLOR_BUFFER_BIT);
}

// examples/Shapes.cpp
int main(int argc, char **argv)
{
    ClearColor = GL_ClearColor;
```
|main branch| fixed branch|
|-|-|
|![image](https://github.com/user-attachments/assets/d99485cc-761b-4447-bfbf-20bdd5f5a44e)|![image](https://github.com/user-attachments/assets/088c8b4c-250d-4d3d-aaff-87d5095b20c8) | 




