### PR TITLE
infra(ios): Set cpu family to aarch64 for meson compatibility

### DIFF
--- a/cross/ios_arm64.txt
+++ b/cross/ios_arm64.txt
@@ -17,6 +17,6 @@ cpp_link_args = ['-miphoneos-version-min=11.0']
 system = 'darwin'
 subsystem = 'ios'
 kernel = 'xnu'
-cpu_family = 'arm64'
-cpu = 'arm64'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
 endian = 'little'


### PR DESCRIPTION
Use meson's official cpu_family name 'aarch64' instead of 'arm64' for ios build.

![CleanShot 2025-06-08 at 02 36 52@2x](https://github.com/user-attachments/assets/52ee0979-eaa0-4c19-b016-40b01a6b147c)

Both aarch64 and arm64 technically refer to the same architecture. The standard CPU naming convention uses `aarch64`, but within the iOS ecosystem (including the Xcode toolchain), Apple employs its own naming convention, `arm64`.

Therefore, the naming of a configuration file such as `ios_arm64` is not incorrect in itself. However, meson recognizes only certain officially registered architectures, and since `arm64` is not among them, this can lead to issues when meson build is used.

For these reasons, I suggest using the `aarch64` cpu naming instead of `arm64` in meson related configuration lines while keeping the filename as is (ios_arm64).