### PR TITLE
lottie: fixed a repeater opacity logic

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -42,7 +42,6 @@ struct RenderRepeater
     float rotation;
     uint8_t startOpacity;
     uint8_t endOpacity;
-    bool interpOpacity;
     bool inorder;
 };
 


### PR DESCRIPTION
preserve the target opacity by multiplying,
do not overwrite it.