### PR TITLE
wg_engine: uniform stage buffers implementation

### DIFF
--- a/src/renderer/wg_engine/tvgWgBindGroups.cpp
+++ b/src/renderer/wg_engine/tvgWgBindGroups.cpp
@@ -104,8 +104,14 @@ WGPUBindGroup WgBindGroupLayouts::createBindGroupStrorage3RO(WGPUTextureView tex
 
 WGPUBindGroup WgBindGroupLayouts::createBindGroupBuffer1Un(WGPUBuffer buff)
 {
+    return createBindGroupBuffer1Un(buff, 0, wgpuBufferGetSize(buff));
+}
+
+
+WGPUBindGroup WgBindGroupLayouts::createBindGroupBuffer1Un(WGPUBuffer buff, uint64_t offset, uint64_t size)
+{
     const WGPUBindGroupEntry bindGroupEntrys[] = {
-        { .binding = 0, .buffer = buff, .size = wgpuBufferGetSize(buff) }
+        { .binding = 0, .buffer = buff, .offset = offset, .size = size }
     };
     const WGPUBindGroupDescriptor bindGroupDesc { .layout = layoutBuffer1Un, .entryCount = 1, .entries = bindGroupEntrys };
     return wgpuDeviceCreateBindGroup(device, &bindGroupDesc);

--- a/src/renderer/wg_engine/tvgWgBindGroups.h
+++ b/src/renderer/wg_engine/tvgWgBindGroups.h
@@ -49,6 +49,7 @@ public:
     WGPUBindGroup createBindGroupStrorage2RO(WGPUTextureView texView0, WGPUTextureView texView1);
     WGPUBindGroup createBindGroupStrorage3RO(WGPUTextureView texView0, WGPUTextureView texView1, WGPUTextureView texView2);
     WGPUBindGroup createBindGroupBuffer1Un(WGPUBuffer buff);
+    WGPUBindGroup createBindGroupBuffer1Un(WGPUBuffer buff, uint64_t offset, uint64_t size);
     WGPUBindGroup createBindGroupBuffer2Un(WGPUBuffer buff0, WGPUBuffer buff1);
     WGPUBindGroup createBindGroupBuffer3Un(WGPUBuffer buff0, WGPUBuffer buff1, WGPUBuffer buff2);
     void releaseBindGroup(WGPUBindGroup& bindGroup);

--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -39,7 +39,8 @@ private:
     // pipelines
     WgPipelines pipelines{};
     // stage buffers
-    WgRenderDataStageBuffer stageBuffer{};
+    WgStageBufferGeometry stageBufferGeometry{};
+    WgStageBufferUniform<WgShaderTypePaintSettings> stageBufferPaint;
     // global stencil/depth buffer handles
     WGPUTexture texDepthStencil{};
     WGPUTextureView texViewDepthStencil{};

--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -167,17 +167,17 @@ void WgPipelines::initialize(WgContext& context)
 
     const WgBindGroupLayouts& layouts = context.layouts;
     // bind group layouts helpers
-    const WGPUBindGroupLayout bindGroupLayoutsStencil[] { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un };
-    const WGPUBindGroupLayout bindGroupLayoutsDepth[]   { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un, layouts.layoutBuffer1Un };
+    const WGPUBindGroupLayout bindGroupLayoutsStencil[] { layouts.layoutBuffer1Un, layouts.layoutBuffer1Un };
+    const WGPUBindGroupLayout bindGroupLayoutsDepth[]   { layouts.layoutBuffer1Un, layouts.layoutBuffer1Un, layouts.layoutBuffer1Un };
     // bind group layouts normal blend
-    const WGPUBindGroupLayout bindGroupLayoutsSolid[]    { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un, layouts.layoutBuffer1Un };
-    const WGPUBindGroupLayout bindGroupLayoutsGradient[] { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un, layouts.layoutTexSampledBuff2Un };
-    const WGPUBindGroupLayout bindGroupLayoutsImage[]    { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un, layouts.layoutTexSampled };
+    const WGPUBindGroupLayout bindGroupLayoutsSolid[]    { layouts.layoutBuffer1Un, layouts.layoutBuffer1Un };
+    const WGPUBindGroupLayout bindGroupLayoutsGradient[] { layouts.layoutBuffer1Un, layouts.layoutBuffer1Un, layouts.layoutTexSampled };
+    const WGPUBindGroupLayout bindGroupLayoutsImage[]    { layouts.layoutBuffer1Un, layouts.layoutBuffer1Un, layouts.layoutTexSampled };
     const WGPUBindGroupLayout bindGroupLayoutsScene[]    { layouts.layoutTexSampled, layouts.layoutBuffer1Un };
     // bind group layouts custom blend
-    const WGPUBindGroupLayout bindGroupLayoutsSolidBlend[]    { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un, layouts.layoutBuffer1Un, layouts.layoutTexSampled };
-    const WGPUBindGroupLayout bindGroupLayoutsGradientBlend[] { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un, layouts.layoutTexSampledBuff2Un, layouts.layoutTexSampled };
-    const WGPUBindGroupLayout bindGroupLayoutsImageBlend[]    { layouts.layoutBuffer1Un, layouts.layoutBuffer2Un, layouts.layoutTexSampled, layouts.layoutTexSampled };
+    const WGPUBindGroupLayout bindGroupLayoutsSolidBlend[]    { layouts.layoutBuffer1Un, layouts.layoutBuffer1Un, layouts.layoutBuffer1Un, layouts.layoutTexSampled };
+    const WGPUBindGroupLayout bindGroupLayoutsGradientBlend[] { layouts.layoutBuffer1Un, layouts.layoutBuffer1Un, layouts.layoutTexSampled, layouts.layoutTexSampled };
+    const WGPUBindGroupLayout bindGroupLayoutsImageBlend[]    { layouts.layoutBuffer1Un, layouts.layoutBuffer1Un, layouts.layoutTexSampled, layouts.layoutTexSampled };
     const WGPUBindGroupLayout bindGroupLayoutsSceneBlend[]    { layouts.layoutTexSampled, layouts.layoutTexSampled, layouts.layoutBuffer1Un };
     // bind group layouts scene compose
     const WGPUBindGroupLayout bindGroupLayoutsSceneCompose[] { layouts.layoutTexSampled, layouts.layoutTexSampled };
@@ -229,7 +229,7 @@ void WgPipelines::initialize(WgContext& context)
     layout_stencil = createPipelineLayout(context.device, bindGroupLayoutsStencil, 2);
     layout_depth = createPipelineLayout(context.device, bindGroupLayoutsDepth, 3);
     // layouts normal blend
-    layout_solid    = createPipelineLayout(context.device, bindGroupLayoutsSolid, 3);
+    layout_solid    = createPipelineLayout(context.device, bindGroupLayoutsSolid, 2);
     layout_gradient = createPipelineLayout(context.device, bindGroupLayoutsGradient, 3);
     layout_image    = createPipelineLayout(context.device, bindGroupLayoutsImage, 3);
     layout_scene    = createPipelineLayout(context.device, bindGroupLayoutsScene, 2);

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -66,8 +66,10 @@ struct WgMeshDataGroup {
 struct WgImageData {
     WGPUTexture texture{};
     WGPUTextureView textureView{};
+    WGPUBindGroup bindGroup{};
 
     void update(WgContext& context, const RenderSurface* surface);
+    void update(WgContext& context, const Fill* fill);
     void release(WgContext& context);
 };
 
@@ -76,37 +78,29 @@ enum class WgRenderRasterType { Solid = 0, Gradient, Image };
 
 struct WgRenderSettings
 {
-    WGPUBuffer bufferGroupSolid{};
-    WGPUBindGroup bindGroupSolid{};
-    WGPUTexture texGradient{};
-    WGPUTextureView texViewGradient{};
-    WGPUBuffer bufferGroupGradient{};
-    WGPUBuffer bufferGroupTransfromGrad{};
-    WGPUBindGroup bindGroupGradient{};
+    uint32_t bindGroupInd{};
+    WgShaderTypePaintSettings settings;
+    WgImageData gradientData;
     WgRenderSettingsType fillType{};
     WgRenderRasterType rasterType{};
     bool skip{};
 
-    void updateFill(WgContext& context, const Fill* fill);
-    void updateColor(WgContext& context, const RenderColor& c);
+    void update(WgContext& context, const tvg::Matrix& transform, tvg::ColorSpace cs, uint8_t opacity);
+    void update(WgContext& context, const Fill* fill);
+    void update(WgContext& context, const RenderColor& c);
     void release(WgContext& context);
 };
 
 struct WgRenderDataPaint
 {
-    WGPUBuffer bufferModelMat{};
-    WGPUBuffer bufferBlendSettings{};
-    WGPUBindGroup bindGroupPaint{};
-    RenderRegion viewport{};
     BBox aabb{{},{}};
-    float opacity{};
+    RenderRegion viewport{};
     Array<WgRenderDataPaint*> clips;
 
     virtual ~WgRenderDataPaint() {};
     virtual void release(WgContext& context);
     virtual Type type() { return Type::Undefined; };
 
-    void update(WgContext& context, const tvg::Matrix& transform, tvg::ColorSpace cs, uint8_t opacity);
     void updateClips(tvg::Array<tvg::RenderData> &clips);
 };
 
@@ -147,7 +141,7 @@ public:
 
 struct WgRenderDataPicture: public WgRenderDataPaint
 {
-    WGPUBindGroup bindGroupPicture{};
+    WgRenderSettings renderSettings{};
     WgImageData imageData{};
     WgMeshData meshData{};
 
@@ -221,7 +215,7 @@ public:
     void release(WgContext& context);
 };
 
-class WgRenderDataStageBuffer {
+class WgStageBufferGeometry {
 private:
     Array<uint8_t> vbuffer;
     Array<uint8_t> ibuffer;
@@ -238,6 +232,52 @@ public:
     void clear();
     void flush(WgContext& context);
     void bind(WGPURenderPassEncoder renderPass, size_t voffset, size_t toffset);
+};
+
+// typed uniform stage buffer with related bind groups handling
+template<typename T>
+class WgStageBufferUniform {
+private:
+    Array<T> ubuffer;
+    WGPUBuffer ubuffer_gpu{};
+    Array<WGPUBindGroup> bbuffer;
+public:
+    // append uniform data to cpu staged buffer and return related bind group index
+    uint32_t append(const T& value) {
+        ubuffer.push(value);
+        return ubuffer.count - 1;
+    }
+
+    void flush(WgContext& context) {
+        // flush data to gpu buffer from cpu memory including reserved data to prevent future gpu buffer reallocations
+        bool bufferChanged = context.allocateBufferUniform(ubuffer_gpu, (void*)ubuffer.data, ubuffer.reserved*sizeof(T));
+        // if gpu buffer handle was changed we must to remove all created binding groups
+        if (bufferChanged) releaseBindGroups(context);
+        // allocate bind groups for all new data items
+        for (uint32_t i = bbuffer.count; i < ubuffer.count; i++)
+            bbuffer.push(context.layouts.createBindGroupBuffer1Un(ubuffer_gpu, i*sizeof(T), sizeof(T)));
+        assert(bbuffer.count >= ubuffer.count);
+    }
+
+    // please, use index that was returned from append method
+    WGPUBindGroup operator[](const uint32_t index) const {
+        return bbuffer[index];
+    }
+
+    void clear() {
+        ubuffer.clear();
+    }
+
+    void release(WgContext& context) {
+        context.releaseBuffer(ubuffer_gpu);
+        releaseBindGroups(context);
+    }
+
+    void releaseBindGroups(WgContext& context) {
+        ARRAY_FOREACH(p, bbuffer)
+            context.layouts.releaseBindGroup(*p);
+        bbuffer.clear();
+    }
 };
 
 #endif // _TVG_WG_RENDER_DATA_H_

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -147,18 +147,18 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
     // update paint settings
     if ((!data) || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Blend))) {
-        renderDataShape->update(mContext, transform, mTargetSurface.cs, opacity);
+        renderDataShape->renderSettingsShape.update(mContext, transform, mTargetSurface.cs, opacity);
+        renderDataShape->renderSettingsStroke.update(mContext, transform, mTargetSurface.cs, opacity);
         renderDataShape->fillRule = rshape.rule;
     }
 
     // setup fill settings
     renderDataShape->viewport = mViewport;
-    renderDataShape->opacity = opacity;
-    if (flags & RenderUpdateFlag::Gradient && rshape.fill) renderDataShape->renderSettingsShape.updateFill(mContext, rshape.fill);
-    else if (flags & RenderUpdateFlag::Color) renderDataShape->renderSettingsShape.updateColor(mContext, rshape.color);
+    if (flags & RenderUpdateFlag::Gradient && rshape.fill) renderDataShape->renderSettingsShape.update(mContext, rshape.fill);
+    else if (flags & RenderUpdateFlag::Color) renderDataShape->renderSettingsShape.update(mContext, rshape.color);
     if (rshape.stroke) {
-        if (flags & RenderUpdateFlag::GradientStroke && rshape.stroke->fill) renderDataShape->renderSettingsStroke.updateFill(mContext, rshape.stroke->fill);
-        else if (flags & RenderUpdateFlag::Stroke) renderDataShape->renderSettingsStroke.updateColor(mContext, rshape.stroke->color);
+        if (flags & RenderUpdateFlag::GradientStroke && rshape.stroke->fill) renderDataShape->renderSettingsStroke.update(mContext, rshape.stroke->fill);
+        else if (flags & RenderUpdateFlag::Stroke) renderDataShape->renderSettingsStroke.update(mContext, rshape.stroke->color);
     }
 
     // store clips data
@@ -177,9 +177,8 @@ RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
 
     // update paint settings
     renderDataPicture->viewport = mViewport;
-    renderDataPicture->opacity = opacity;
     if (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Blend)) {
-        renderDataPicture->update(mContext, transform, surface->cs, opacity);
+        renderDataPicture->renderSettings.update(mContext, transform, surface->cs, opacity);
     }
 
     // update image data
@@ -192,6 +191,7 @@ RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
 
     return renderDataPicture;
 }
+
 
 bool WgRenderer::preRender()
 {


### PR DESCRIPTION
Introduced stage buffer for uniforms to reduce number of memory shafles from cpu to gpu memory

**Refactor: Unified Uniform Buffer for Improved Performance**
This pull request introduces a stage buffer for uniforms, significantly reducing memory transfers calls between the CPU and GPU.

**Problem**
Previously, each shape managed its transformation settings, opacity, colors, and gradients in separate data structures. This necessitated the creation of individual uniform buffers on the GPU, leading to a high volume of data transfers calls from system memory to video memory.

**Solution**
Now, all shape-related data (fills and strokes settings) are consolidated into a single, shared data structure. During rendering, this data is accumulated on demand into a single buffer, which can then be written to video memory in a single call.

**WebGPU Considerations**
This approach leverages WebGPU's bind groups to link buffer data with named uniforms in shaders. There were a few key considerations:

 - Bind Group Creation Cost: Creating bind groups can be a moderately expensive operation. If the buffer's memory address changes, all referencing bind groups must be recreated, which can impact performance. To mitigate this, both the buffer and bind groups can now be pre-allocated.
 - Offset Alignment: WebGPU's _minUniformBufferOffsetAlignment_ (see spec 3.6.2. Limits) requires bind group offsets within the buffer to be a multiple of 256 bytes. Our current total data size for all necessary information is 192 bytes, leaving a 64-byte reserve to accommodate this alignment.

**Impact**
This change required modifications to the shaders, pipelines, and intra-shader data structures. Ultimately, by using a common buffer for shape properties, we've reduced data write requests to video memory in complex scenarios from **tens of thousands** to just **one**. This also allows us to **allocate fewer** buffer handles, further optimizing resource usage. This has resulted in a significant performance increase.

Tested on windows/macos/linux/emsdk
see: https://github.com/thorvg/thorvg/issues/3505