### PR TITLE
lottie: fix offsetting partially degenerated cubics 

### DIFF
--- a/src/loaders/lottie/tvgLottieModifier.cpp
+++ b/src/loaders/lottie/tvgLottieModifier.cpp
@@ -27,6 +27,12 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
+static bool _colinear(const Point* p)
+{
+    return tvg::zero(*p - *(p + 1)) && tvg::zero(*(p + 2) - *(p + 3));
+}
+
+
 static void _roundCorner(Array<PathCommand>& cmds, Array<Point>& pts, Point& prev, Point& curr, Point& next, float r)
 {
     auto lenPrev = length(prev - curr);
@@ -192,14 +198,10 @@ bool LottieRoundnessModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt
                 break;
             }
             case PathCommand::CubicTo: {
-                auto& prev = inPts[iPts - 1];
-                auto& curr = inPts[iPts + 2];
-                if (iCmds < inCmdsCnt - 1 &&
-                    tvg::zero(inPts[iPts - 1] - inPts[iPts]) &&
-                    tvg::zero(inPts[iPts + 1] - inPts[iPts + 2])) {
-                    if (inCmds[iCmds + 1] == PathCommand::CubicTo &&
-                        tvg::zero(inPts[iPts + 2] - inPts[iPts + 3]) &&
-                        tvg::zero(inPts[iPts + 4] - inPts[iPts + 5])) {
+                if (iCmds < inCmdsCnt - 1 && _colinear(inPts + iPts - 1)) {
+                    auto& prev = inPts[iPts - 1];
+                    auto& curr = inPts[iPts + 2];
+                    if (inCmds[iCmds + 1] == PathCommand::CubicTo && _colinear(inPts + iPts + 2)) {
                         _roundCorner(path.cmds, path.pts, prev, curr, inPts[iPts + 5], r);
                         iPts += 3;
                         break;

--- a/src/loaders/lottie/tvgLottieModifier.cpp
+++ b/src/loaders/lottie/tvgLottieModifier.cpp
@@ -330,6 +330,10 @@ bool LottieOffsetModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt, P
     auto offset = _clockwise(inPts, inPtsCnt) ? this->offset : -this->offset;
     auto threshold = 1.0f / fabsf(offset) + 1.0f;
 
+    bool inside{};
+    Point intersect{};
+    bool degeneratedLine1{}, degeneratedLine3{};
+
     for (uint32_t iCmd = 0, iPt = 0; iCmd < inCmdsCnt; ++iCmd) {
         if (inCmds[iCmd] == PathCommand::MoveTo) {
             state.moveto = true;
@@ -338,7 +342,7 @@ bool LottieOffsetModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt, P
             line(out, inCmds, inCmdsCnt, inPts, iPt, iCmd, state, offset, false);
         } else if (inCmds[iCmd] == PathCommand::CubicTo) {
             //cubic degenerated to a line
-            if (tvg::zero(inPts[iPt - 1] - inPts[iPt]) || tvg::zero(inPts[iPt + 1] - inPts[iPt + 2])) {
+            if (_colinear(inPts + iPt - 1)) {
                 ++iPt;
                 line(out, inCmds, inCmdsCnt, inPts, iPt, iCmd, state, offset, true);
                 ++iPt;
@@ -350,7 +354,7 @@ bool LottieOffsetModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt, P
                 auto& bezier = stack.last();
                 auto len = tvg::length(bezier.start - bezier.ctrl1) + tvg::length(bezier.ctrl1 - bezier.ctrl2) + tvg::length(bezier.ctrl2 - bezier.end);
 
-                if (len >  threshold * bezier.length()) {
+                if (len >  threshold * bezier.length() && len > 1.0f) {
                     Bezier next;
                     bezier.split(0.5f, next);
                     stack.push(next);
@@ -358,9 +362,19 @@ bool LottieOffsetModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt, P
                 }
                 stack.pop();
 
-                auto line1 = _offset(bezier.start, bezier.ctrl1, offset);
+                degeneratedLine1 = _zero(bezier.start, bezier.ctrl1);
+                auto line1 = degeneratedLine1 ? state.line : _offset(bezier.start, bezier.ctrl1, offset);
                 auto line2 = _offset(bezier.ctrl1, bezier.ctrl2, offset);
-                auto line3 = _offset(bezier.ctrl2, bezier.end, offset);
+
+                //line3 from the previous iteration was degenerated to a point - calculate intersection with the last valid line (state.line)
+                if (degeneratedLine3) {
+                    _intersect(degeneratedLine1 ? line2 : line1, state.line, intersect, inside);
+                    out.pts.push(intersect);
+                    out.pts.push(intersect);
+                }
+
+                degeneratedLine3 = _zero(bezier.ctrl2, bezier.end);
+                auto& line3 = state.line = degeneratedLine3 ? line2 : _offset(bezier.ctrl2, bezier.end, offset);
 
                 if (state.moveto) {
                     out.cmds.push(PathCommand::MoveTo);
@@ -370,19 +384,22 @@ bool LottieOffsetModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt, P
                     state.moveto = false;
                 }
 
-                bool inside{};
-                Point intersect{};
-                _intersect(line1, line2, intersect, inside);
-                out.pts.push(intersect);
-                _intersect(line2, line3, intersect, inside);
-                out.pts.push(intersect);
-                out.pts.push(line3.pt2);
+                if (degeneratedLine1) out.pts.push(out.pts.last());
+                else {
+                    _intersect(line1, line2, intersect, inside);
+                    out.pts.push(intersect);
+                } 
+
+                if (!degeneratedLine3) {
+                    _intersect(line2, line3, intersect, inside);
+                    out.pts.push(intersect);
+                    out.pts.push(line3.pt2);
+                }
                 out.cmds.push(PathCommand::CubicTo);
             }
 
             iPt += 3;
-        }
-        else {
+        } else {
             if (!_zero(inPts[iPt - 1], inPts[state.movetoInIndex])) {
                 out.cmds.push(PathCommand::LineTo);
                 corner(out, state.line, state.firstLine, state.movetoOutIndex, true);


### PR DESCRIPTION
Until now, cases where a Bezier curve had `start == ctrl1` or
`ctrl2 == end` were incorrectly treated as linear segments.
This led to incorrect rendering, for example when offsetting
a polystar with outer roundness > 0 and inner roundness == 0.
Now such cases handled as proper curves with full cubic behavior.

before:
<img width="400" alt="Zrzut ekranu 2025-06-11 o 23 34 48" src="https://github.com/user-attachments/assets/b2e8c7b0-e206-4727-811e-8cd041a436ef" />

after:
<img width="400" alt="Zrzut ekranu 2025-06-11 o 23 35 10" src="https://github.com/user-attachments/assets/7dc5564d-c451-4722-86a6-f079d30809ac" />

AE (even here visible some artefacts):
<img width="200" alt="Zrzut ekranu 2025-06-11 o 23 37 05" src="https://github.com/user-attachments/assets/74fbaf28-ad4d-4c3f-8962-922d46c20b50" />
<img width="200" alt="Zrzut ekranu 2025-06-11 o 23 37 01" src="https://github.com/user-attachments/assets/afaf3147-3eb6-4159-a397-019fcca88d05" />


samples:
[sample1.json](https://github.com/user-attachments/files/20698386/sample1.json)
[sample2.json](https://github.com/user-attachments/files/20698387/sample2.json)