### PR TITLE
wg_engine: remove unnecessary mesh pools

### DIFF
--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -200,10 +200,7 @@ bool WgContext::allocateBufferVertex(WGPUBuffer& buffer, const float* data, uint
         wgpuQueueWriteBuffer(queue, buffer, 0, data, size);
     else {
         releaseBuffer(buffer);
-        const WGPUBufferDescriptor bufferDesc {
-            .usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Vertex,
-            .size = size > WG_VERTEX_BUFFER_MIN_SIZE ? size : WG_VERTEX_BUFFER_MIN_SIZE
-        };
+        const WGPUBufferDescriptor bufferDesc { .usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Vertex, .size = size };
         buffer = wgpuDeviceCreateBuffer(device, &bufferDesc);
         wgpuQueueWriteBuffer(queue, buffer, 0, data, size);
         return true;
@@ -218,10 +215,7 @@ bool WgContext::allocateBufferIndex(WGPUBuffer& buffer, const uint32_t* data, ui
         wgpuQueueWriteBuffer(queue, buffer, 0, data, size);
     else {
         releaseBuffer(buffer);
-        const WGPUBufferDescriptor bufferDesc {
-            .usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Index,
-            .size = size > WG_INDEX_BUFFER_MIN_SIZE ? size : WG_INDEX_BUFFER_MIN_SIZE
-        };
+        const WGPUBufferDescriptor bufferDesc { .usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Index, .size = size };
         buffer = wgpuDeviceCreateBuffer(device, &bufferDesc);
         wgpuQueueWriteBuffer(queue, buffer, 0, data, size);
         return true;
@@ -241,10 +235,7 @@ bool WgContext::allocateBufferIndexFan(uint64_t vertexCount)
             indexes.push(i + 2);
         }
         releaseBuffer(bufferIndexFan);
-        WGPUBufferDescriptor bufferDesc{
-            .usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Index,
-            .size = indexCount * sizeof(uint32_t)
-        };
+        WGPUBufferDescriptor bufferDesc{ .usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Index, .size = indexCount * sizeof(uint32_t) };
         bufferIndexFan = wgpuDeviceCreateBuffer(device, &bufferDesc);
         wgpuQueueWriteBuffer(queue, bufferIndexFan, 0, &indexes[0], indexCount * sizeof(uint32_t));
         return true;

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -25,9 +25,6 @@
 
 #include "tvgWgBindGroups.h"
 
-#define WG_VERTEX_BUFFER_MIN_SIZE 2048
-#define WG_INDEX_BUFFER_MIN_SIZE 2048
-
 struct WgContext {
     // external webgpu handles
     WGPUInstance instance{};

--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -38,7 +38,7 @@ void WgCompositor::initialize(WgContext& context, uint32_t width, uint32_t heigh
     // create render targets handles
     resize(context, width, height);
     // composition and blend geometries
-    meshDataBlit.blitBox(context);
+    meshDataBlit.blitBox();
 }
 
 
@@ -54,8 +54,6 @@ void WgCompositor::initPools(WgContext& context)
 
 void WgCompositor::release(WgContext& context)
 {
-    // composition and blend geometries
-    meshDataBlit.release(context);
     // release render targets habdles
     resize(context, 0, 0);
     // release opacity pool

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -35,32 +35,20 @@ struct WgMeshData {
     size_t toffset{};
     size_t ioffset{};
 
-    void update(WgContext& context, const WgVertexBuffer& vertexBuffer);
-    void update(WgContext& context, const WgIndexedVertexBuffer& vertexBufferInd);
-    void bbox(WgContext& context, const Point pmin, const Point pmax);
-    void imageBox(WgContext& context, float w, float h);
-    void blitBox(WgContext& context);
-    void release(WgContext& context) {};
-};
-
-class WgMeshDataPool {
-private:
-    Array<WgMeshData*> mPool;
-    Array<WgMeshData*> mList;
-public:
-    static WgMeshDataPool* gMeshDataPool;
-    WgMeshData* allocate(WgContext& context);
-    void free(WgContext& context, WgMeshData* meshData);
-    void release(WgContext& context);
+    void update(const WgVertexBuffer& vertexBuffer);
+    void update(const WgIndexedVertexBuffer& vertexBufferInd);
+    void bbox(const Point pmin, const Point pmax);
+    void imageBox(float w, float h);
+    void blitBox();
 };
 
 struct WgMeshDataGroup {
     Array<WgMeshData*> meshes{};
     
-    void append(WgContext& context, const WgVertexBuffer& vertexBuffer);
-    void append(WgContext& context, const WgIndexedVertexBuffer& vertexBufferInd);
-    void append(WgContext& context, const Point pmin, const Point pmax);
-    void release(WgContext& context);
+    void append(const WgVertexBuffer& vertexBuffer);
+    void append(const WgIndexedVertexBuffer& vertexBufferInd);
+    void append(const Point pmin, const Point pmax);
+    void release();
 };
 
 struct WgImageData {
@@ -118,13 +106,13 @@ struct WgRenderDataShape: public WgRenderDataPaint
     bool strokeFirst{};
     FillRule fillRule{};
 
-    void appendShape(WgContext& context, const WgVertexBuffer& vertexBuffer);
-    void appendStroke(WgContext& context, const WgIndexedVertexBuffer& vertexBufferInd);
+    void appendShape(const WgVertexBuffer& vertexBuffer);
+    void appendStroke(const WgIndexedVertexBuffer& vertexBufferInd);
     void updateBBox(Point pmin, Point pmax);
     void updateAABB(const Matrix& tr);
-    void updateMeshes(WgContext& context, const RenderShape& rshape, const Matrix& tr, WgGeometryBufferPool* pool);
-    void proceedStrokes(WgContext& context, const RenderStroke* rstroke, const WgVertexBuffer& buff, WgGeometryBufferPool* pool);
-    void releaseMeshes(WgContext& context);
+    void updateMeshes(const RenderShape& rshape, const Matrix& tr, WgGeometryBufferPool* pool);
+    void proceedStrokes(const RenderStroke* rstroke, const WgVertexBuffer& buff, WgGeometryBufferPool* pool);
+    void releaseMeshes();
     void release(WgContext& context) override;
     Type type() override { return Type::Shape; };
 };
@@ -219,6 +207,7 @@ class WgStageBufferGeometry {
 private:
     Array<uint8_t> vbuffer;
     Array<uint8_t> ibuffer;
+    uint32_t vmaxcount{};
 public:
     WGPUBuffer vbuffer_gpu{};
     WGPUBuffer ibuffer_gpu{};
@@ -231,7 +220,6 @@ public:
     void release(WgContext& context);
     void clear();
     void flush(WgContext& context);
-    void bind(WGPURenderPassEncoder renderPass, size_t voffset, size_t toffset);
 };
 
 // typed uniform stage buffer with related bind groups handling

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -45,7 +45,6 @@ void WgRenderer::release()
     mRenderDataPicturePool.release(mContext);
     mRenderDataViewportPool.release(mContext);
     mRenderDataEffectParamsPool.release(mContext);
-    WgMeshDataPool::gMeshDataPool->release(mContext);
 
     // clear render  pool
     mRenderTargetPool.release(mContext);
@@ -142,7 +141,7 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
     // update geometry
     if ((!data) || (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Stroke))) {
-        renderDataShape->updateMeshes(mContext, rshape, transform, mBufferPool.pool);
+        renderDataShape->updateMeshes(rshape, transform, mBufferPool.pool);
     }
 
     // update paint settings


### PR DESCRIPTION
remove unnecessary mesh pools

Previously, deleted shapes and geometry were saved in pools for further reuse. This was necessary to save and reuse allocated GPU handles

Now, after stage buffers for geometry and uniforms were introduced, this is no longer necessary.

The changes will include:
- simplification of internal logic
- reduction of allocated memory
- slight reduction in bundle size

```
// thorvg-wasm.wasm
main: 925213
PR:   923835

```