### PR TITLE
lottie: fix offset with miter join

### DIFF
--- a/src/loaders/lottie/tvgLottieModifier.cpp
+++ b/src/loaders/lottie/tvgLottieModifier.cpp
@@ -121,9 +121,12 @@ void LottieOffsetModifier::corner(RenderPath& out, Line& line, Line& nextLine, u
                 auto norm = normal(line.pt1, line.pt2);
                 auto nextNorm = normal(nextLine.pt1, nextLine.pt2);
                 auto miterDirection = (norm + nextNorm) / length(norm + nextNorm);
+                if (1.0f <= miterLimit * fabsf(miterDirection.x * norm.x + miterDirection.y * norm.y)) {
+                    out.cmds.push(PathCommand::LineTo);
+                    out.pts.push(intersect);
+                }
                 out.cmds.push(PathCommand::LineTo);
-                if (1.0f <= miterLimit * fabsf(miterDirection.x * norm.x + miterDirection.y * norm.y)) out.pts.push(intersect);
-                else out.pts.push(nextLine.pt1);
+                out.pts.push(nextLine.pt1);
             } else {
                 out.cmds.push(PathCommand::LineTo);
                 out.pts.push(nextLine.pt1);


### PR DESCRIPTION
One point was skipped during the creation of the offset corner. The error was not visible because the point lies on the line, but it will become apparent if further modifiers are applied to the object (not supported now).

samples not supported now (#3378 used to render the sample):

before this change:
<img width="400" alt="Zrzut ekranu 2025-06-12 o 23 17 35" src="https://github.com/user-attachments/assets/47f50733-0327-43e4-a3a2-c83c6103fc5e" />

after this change:
<img width="400" alt="Zrzut ekranu 2025-06-12 o 23 17 17" src="https://github.com/user-attachments/assets/681136a4-9e97-4147-9a61-290b0ed609ef" />

AE:
<img width="400" alt="Zrzut ekranu 2025-06-12 o 23 18 48" src="https://github.com/user-attachments/assets/dd4fc13a-6ad3-471f-b0e0-31a0d5d93599" />


sample:
[pucker_rect_op_miter4.json](https://github.com/user-attachments/files/20716506/pucker_rect_op_miter4.json)
