### PR TITLE
wg_engine: avoid forced texture flushes

### DIFF
--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -85,7 +85,6 @@ bool WgContext::allocateTexture(WGPUTexture& texture, uint32_t width, uint32_t h
         const WGPUTextureDataLayout textureDataLayout{ .bytesPerRow = 4 * width, .rowsPerImage = height };
         const WGPUExtent3D writeSize{ .width = width, .height = height, .depthOrArrayLayers = 1 };
         wgpuQueueWriteTexture(queue, &imageCopyTexture, data, 4 * width * height, &textureDataLayout, &writeSize);
-        wgpuQueueSubmit(queue, 0, nullptr);
     } else {
         releaseTexture(texture);
         texture = createTexture(width, height, format);
@@ -94,7 +93,6 @@ bool WgContext::allocateTexture(WGPUTexture& texture, uint32_t width, uint32_t h
         const WGPUTextureDataLayout textureDataLayout{ .bytesPerRow = 4 * width, .rowsPerImage = height };
         const WGPUExtent3D writeSize{ .width = width, .height = height, .depthOrArrayLayers = 1 };
         wgpuQueueWriteTexture(queue, &imageCopyTexture, data, 4 * width * height, &textureDataLayout, &writeSize);
-        wgpuQueueSubmit(queue, 0, nullptr);
         return true;
     }
     return false;
@@ -284,6 +282,12 @@ void WgContext::releaseCommandEncoder(WGPUCommandEncoder& commandEncoder)
         wgpuCommandEncoderRelease(commandEncoder);
         commandEncoder = nullptr;
     }
+}
+
+
+void WgContext::submit()
+{
+    wgpuQueueSubmit(queue, 0, nullptr);
 }
 
 

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -73,6 +73,7 @@ struct WgContext {
     void submitCommandEncoder(WGPUCommandEncoder encoder);
     void releaseCommandEncoder(WGPUCommandEncoder& encoder);
 
+    void submit();
     bool invalid();
 };
 

--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -199,6 +199,7 @@ void WgCompositor::flush(WgContext& context)
     stageBufferGeometry.append(&meshDataBlit);
     stageBufferGeometry.flush(context);
     stageBufferPaint.flush(context);
+    context.submit();
 }
 
 


### PR DESCRIPTION
After introducing staged buffers and tesk-based rendering removed the need for forced flush of each texture data into gpu.
General approach used for all data types.
Can increase performance on discrete GPUs.

```
Lottie wg (GF3060Ti)
main: 45
PR: 40
```