### PR TITLE
wg_engine: prevent potential pipeline deadlock when resizing

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -39,6 +39,8 @@ void WgCompositor::initialize(WgContext& context, uint32_t width, uint32_t heigh
     resize(context, width, height);
     // composition and blend geometries
     meshDataBlit.blitBox();
+
+    flush(context);
 }
 
 
@@ -186,6 +188,13 @@ void WgCompositor::endRenderPass()
         currentTarget = nullptr;
     }
 }
+
+
+void WgCompositor::prepareRenderPass()
+{
+    if (renderPassEncoder) endRenderPass();
+}
+
 
 void WgCompositor::reset(WgContext& context)
 {

--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -110,6 +110,7 @@ public:
     // render passes workflow
     void beginRenderPass(WGPUCommandEncoder encoder, WgRenderTarget* target, bool clear, WGPUColor clearColor = { 0.0, 0.0, 0.0, 0.0 });
     void endRenderPass();
+    void prepareRenderPass();
 
     // request shapes for drawing (staging)
         // stage data

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -330,6 +330,7 @@ bool WgRenderer::sync()
     if (mContext.invalid()) return false;
 
     disposeObjects();
+    mCompositor.prepareRenderPass();
 
     // if texture buffer used
     WGPUTexture dstTexture = targetTexture;


### PR DESCRIPTION
There are two points causing deadlock on WebGPU's animation rendering pipeline when resizing.

These occurred in specific case, resize() is fired while animation is being loaded.
1. renderPassEncoder is available, and causing runtime error by assert. → changed logic, ends render pass if it is being proceeded.

2. `stageBufferGeometry` isn't prepared when canvas->sync() called before preRender → Add condition to ensure stageBuffer isn't null