### PR TITLE
wg_engine: prevent deadlock when resizing

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -39,6 +39,8 @@ void WgCompositor::initialize(WgContext& context, uint32_t width, uint32_t heigh
     resize(context, width, height);
     // composition and blend geometries
     meshDataBlit.blitBox();
+    // force stage buffers initialization
+    flush(context);
 }
 
 

--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -111,11 +111,11 @@ public:
     void beginRenderPass(WGPUCommandEncoder encoder, WgRenderTarget* target, bool clear, WGPUColor clearColor = { 0.0, 0.0, 0.0, 0.0 });
     void endRenderPass();
 
-    // request shapes for drawing (staging)
-        // stage data
+    // stage buffers operations
     void reset(WgContext& context);
     void flush(WgContext& context);
 
+    // request shapes for drawing (staging)
     void requestShape(WgRenderDataShape* renderData);
     void requestImage(WgRenderDataPicture* renderData);
 

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -341,21 +341,23 @@ bool WgRenderer::sync()
     // there is no external dest buffer
     if (!dstTexture) return false;
 
-    // get external dest buffer
-    WGPUTextureView dstTextureView = mContext.createTextureView(dstTexture);
+    // insure that surface and offscreen target have the same size
+    if ((wgpuTextureGetWidth(dstTexture) == mRenderTargetRoot.width) && 
+        (wgpuTextureGetHeight(dstTexture) == mRenderTargetRoot.height)) {
+        // get external dest buffer
+        WGPUTextureView dstTextureView = mContext.createTextureView(dstTexture);
+        // create command encoder
+        WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
+        // show root offscreen buffer
+        mCompositor.blit(mContext, commandEncoder, &mRenderTargetRoot, dstTextureView);
+        mContext.submitCommandEncoder(commandEncoder);
+        mContext.releaseCommandEncoder(commandEncoder);
+        // release dest buffer view
+        mContext.releaseTextureView(dstTextureView);
+    }
 
-    // create command encoder
-    WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
-    // show root offscreen buffer
-    mCompositor.blit(mContext, commandEncoder, &mRenderTargetRoot, dstTextureView);
-    mContext.submitCommandEncoder(commandEncoder);
-    mContext.releaseCommandEncoder(commandEncoder);
-
-    // release dest buffer view
-    mContext.releaseTextureView(dstTextureView);
     return true;
 }
-
 
 // render target handle
 bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, uint32_t width, uint32_t height, int type)


### PR DESCRIPTION
There are two points causing deadlock on WebGPU's animation rendering pipeline when resizing.

These occurred in specific case, resize() is fired while animation is being loaded.
1. stage buffers are not initialized, so we must to force initialization
2. we must be sure, that target surface size is much with offscreen render targets

this solution is based on this proposals: https://github.com/thorvg/thorvg/pull/3529