### PR TITLE
wg_engine: remove dead condition in target method

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -368,8 +368,7 @@ bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, 
     }
 
     // can not initialize renderer, give up
-    if (!instance || !device || !target || !width || !height)
-        return false;
+    if (!width || !height) return false;
 
     // device or instance was changed, need to recreate all instances
     if ((mContext.device != device) || (mContext.instance != instance)) {


### PR DESCRIPTION
Remove redundant instance/device/target checks in the second condition, since they are already early-exited in the first condition.