### PR TITLE
api: revise the canvas update() API

### DIFF
--- a/examples/ImageScaling.cpp
+++ b/examples/ImageScaling.cpp
@@ -54,7 +54,7 @@ struct UserExample : tvgexam::Example
 
         picture->scale((1.0f - progress) * 1.5f);
 
-        canvas->update(picture);
+        canvas->update();
 
         return true;
     }

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -733,16 +733,12 @@ public:
     Result remove(Paint* paint = nullptr) noexcept;
 
     /**
-     * @brief Request the canvas to update the paint objects.
+     * @brief Requests the canvas to update the paint for up-to-date render preparation.
      *
-     * If a @c nullptr is passed all paint objects retained by the Canvas are updated,
-     * otherwise only the paint to which the given @p paint points.
-     *
-     * @param[in] paint A pointer to the Paint object or @c nullptr.
-     *
-     * @note The Update behavior can be asynchronous if the assigned thread number is greater than zero.
+     * @note Only modified paint instances will undergo the internal update process.
+     * @note The update operation may be asynchronous if the assigned thread count is greater than zero.
      */
-    Result update(Paint* paint = nullptr) noexcept;
+    Result update() noexcept;
 
     /**
      * @brief Requests the canvas to render Paint objects.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -631,23 +631,6 @@ TVG_API Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas);
 
 
 /*!
-* @brief Updates the given Tvg_Paint object from the canvas before the rendering.
-*
-* If a client application using the TVG library does not update the entire canvas with tvg_canvas_update() in the frame
-* rendering process, Tvg_Paint objects previously added to the canvas should be updated manually with this function.
-*
-* @param[in] canvas The Tvg_Canvas object to which the @p paint belongs.
-* @param[in] paint The Tvg_Paint object to be updated.
-*
-* @return Tvg_Result enumeration.
-* @retval TVG_RESULT_INVALID_ARGUMENT In case a @c nullptr is passed as the argument.
-*
-* @see tvg_canvas_update()
-*/
-TVG_API Tvg_Result tvg_canvas_update_paint(Tvg_Canvas* canvas, Tvg_Paint* paint);
-
-
-/*!
 * @brief Requests the canvas to draw the Tvg_Paint objects.
 *
 * All paints from the given canvas will be rasterized to the buffer.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -134,14 +134,7 @@ TVG_API Tvg_Result tvg_canvas_remove(Tvg_Canvas* canvas, Tvg_Paint* paint)
 
 TVG_API Tvg_Result tvg_canvas_update(Tvg_Canvas* canvas)
 {
-    if (canvas) return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->update(nullptr);
-    return TVG_RESULT_INVALID_ARGUMENT;
-}
-
-
-TVG_API Tvg_Result tvg_canvas_update_paint(Tvg_Canvas* canvas, Tvg_Paint* paint)
-{
-    if (canvas && paint) return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->update((Paint*) paint);
+    if (canvas) return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->update();
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -55,11 +55,11 @@ Result Canvas::draw(bool clear) noexcept
 }
 
 
-Result Canvas::update(Paint* paint) noexcept
+Result Canvas::update() noexcept
 {
     TVGLOG("RENDERER", "Update S. ------------------------------ Canvas(%p)", this);
     if (pImpl->scene->paints().empty() || pImpl->status == Status::Drawing) return Result::InsufficientCondition;
-    auto ret = pImpl->update(paint, false);
+    auto ret = pImpl->update(false);
     TVGLOG("RENDERER", "Update E. ------------------------------ Canvas(%p)", this);
 
     return ret;

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -116,7 +116,7 @@ struct PictureImpl : Picture
         return Result::Success;
     }
 
-    Result bounds(Point* pt4, Matrix& m, TVG_UNUSED bool obb, TVG_UNUSED bool stroking)
+    Result bounds(Point* pt4, Matrix& m, TVG_UNUSED bool obb, TVG_UNUSED bool stroking) const
     {
         pt4[0] = Point{0.0f, 0.0f} * m;
         pt4[1] = Point{w, 0.0f} * m;

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -116,7 +116,7 @@ struct SceneImpl : Scene
             opacity = 255;
         }
         for (auto paint : paints) {
-            paint->pImpl->update(renderer, transform, clips, opacity, flag, false);
+            PAINT(paint)->update(renderer, transform, clips, opacity, flag, false);
         }
 
         if (effects) {

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -141,7 +141,7 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
     REQUIRE(w == 20.0f);
     REQUIRE(h == 100.0f);
 
-    REQUIRE(canvas->update(shape) == Result::Success);
+    REQUIRE(canvas->update() == Result::Success);
     Point pts[4];
     REQUIRE(shape->bounds(pts) == Result::Success);
     REQUIRE(pts[0].x == 100.0f);
@@ -165,7 +165,7 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
     REQUIRE(w == 20.0f);
     REQUIRE(h == 200.0f);
 
-    REQUIRE(canvas->update(shape) == Result::Success);
+    REQUIRE(canvas->update() == Result::Success);
     REQUIRE(shape->bounds(pts) == Result::Success);
     REQUIRE(pts[0].x == 0.0f);
     REQUIRE(pts[3].x == 0.0f);


### PR DESCRIPTION
Removed the paint parameter previously used to forcibly update a single paint.

This behavior was unsafe in ThorVG, as a single paint object may be connected to others through the scene graph.

Now, the canvas engine is responsible for properly updating all damaged paints as needed, allowing the user to simply call update() in any case.

API Modifications:

C++ API:
 Modified: Result Canvas::update(Paint* paint) -> Result Canvas::update()

CAPI:
 Removed: tvg_canvas_update_paint()

Issue: https://github.com/thorvg/thorvg/issues/3116