### PR TITLE
avx/neon: remove double increment of the value

### DIFF
--- a/src/renderer/sw_engine/tvgSwRasterAvx.h
+++ b/src/renderer/sw_engine/tvgSwRasterAvx.h
@@ -204,8 +204,6 @@ static bool avxRasterTranslucentRle(SwSurface* surface, const SwRle* rle, const 
                 *dst = src + ALPHA_BLEND(*dst, ialpha);
                 dst++;
             }
-
-            ++span;
         }
     //8bit grayscale
     } else if (surface->channelSize == sizeof(uint8_t)) {

--- a/src/renderer/sw_engine/tvgSwRasterNeon.h
+++ b/src/renderer/sw_engine/tvgSwRasterNeon.h
@@ -123,8 +123,6 @@ static bool neonRasterTranslucentRle(SwSurface* surface, const SwRle* rle, const
 
             auto leftovers = (span->len - align) % 2;
             if (leftovers > 0) dst[span->len - 1] = src + ALPHA_BLEND(dst[span->len - 1], ialpha);
-
-            ++span;
         }
     //8bit grayscale
     } else if (surface->channelSize == sizeof(uint8_t)) {


### PR DESCRIPTION
The span was incremented both in the for loop instruction (ARRAY_FOREACH) and inside the loop body. Fixed.

@Issue: https://github.com/thorvg/thorvg/issues/3547

before:
<img width="387" alt="Zrzut ekranu 2025-06-18 o 00 36 36" src="https://github.com/user-attachments/assets/94565dd6-b680-422f-a97b-45c50ee8af93" />

after:
<img width="357" alt="Zrzut ekranu 2025-06-18 o 00 36 21" src="https://github.com/user-attachments/assets/6fe16316-7341-4bf6-adb5-0f86f7f11b63" />

