### PR TITLE
lottie: avoid precision issues in radial gradient

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -519,7 +519,7 @@ Fill* LottieGradient::fill(float frameNo, uint8_t opacity, Tween& tween, LottieE
         if (tvg::zero(progress)) {
             static_cast<RadialGradient*>(fill)->radial(s.x, s.y, r, s.x, s.y, 0.0f);
         } else {
-            if (tvg::equal(progress, 1.0f)) progress = 0.99f;
+            progress = tvg::clamp(progress, -0.99f, 0.99f);
             auto startAngle = rad2deg(tvg::atan2(e.y - s.y, e.x - s.x));
             auto angle = deg2rad((startAngle + this->angle(frameNo, tween, exps)));
             auto fx = s.x + cos(angle) * progress * r;


### PR DESCRIPTION
If the focal point is exactly on the edge of the gradient's end circle, numerical errors may occur due to rounding, including potential division by zero. To ensure stability and consistency across the engines the focal point is slightly moved inward.

Note: 
Focal point support in the SW and WG engines is consistent with the SVG 1.1 standard, whereas the GL engine aligns with the SVG 2.0 standard. This change ensures compatibility with AE regardless of the engine's internal implementation.


before:
![Jun-17-2025 23-38-15](https://github.com/user-attachments/assets/3ff48759-ea23-4003-a001-63cc8605c2e2)

after:
![Jun-17-2025 23-35-33](https://github.com/user-attachments/assets/78e1ceba-9f93-4834-8e1b-f0eba1d00085)

samples:
[focal_HL-100.json](https://github.com/user-attachments/files/20784600/focal_HL-100.json)
[focal_HL.json](https://github.com/user-attachments/files/20784601/focal_HL.json)
[focal_HL100.json](https://github.com/user-attachments/files/20784602/focal_HL100.json)
