### PR TITLE
lottie: use cubics instead of lines

### DIFF
--- a/src/loaders/lottie/tvgLottieModifier.h
+++ b/src/loaders/lottie/tvgLottieModifier.h
@@ -102,7 +102,7 @@ private:
         uint32_t movetoInIndex = 0;
     };
 
-    void line(RenderPath& out, PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t& curPt, uint32_t curCmd, State& state, float offset, bool degenerated);
+    void line(RenderPath& out, PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t& curPt, uint32_t curCmd, State& state, float offset);
     void corner(RenderPath& out, Line& line, Line& nextLine, uint32_t movetoIndex, bool nextClose);
 };
 


### PR DESCRIPTION
115 lines added
74 lines removed
(in pucker bloat I can remove 14 lines because of this changes

pros:
- _appendRect fun - I added one extra cubic command to close the shape using cubics. thank that in pucker bloat no extra support for rectangles is necessary - easier to implement

cons:
- more points - but it is not observed in increased memory usage, so not really a con