### PR TITLE
lottie: use grow instead of reserve

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -535,11 +535,11 @@ void LottieBuilder::updateStar(LottiePolyStar* star, float frameNo, Matrix* tran
     }
 
     if (tvg::zero(innerRoundness) && tvg::zero(outerRoundness)) {
-        SHAPE(shape)->rs.path.pts.reserve(numPoints + 2);
-        SHAPE(shape)->rs.path.cmds.reserve(numPoints + 3);
+        SHAPE(shape)->rs.path.pts.grow(numPoints + 2);
+        SHAPE(shape)->rs.path.cmds.grow(numPoints + 3);
     } else {
-        SHAPE(shape)->rs.path.pts.reserve(numPoints * 3 + 2);
-        SHAPE(shape)->rs.path.cmds.reserve(numPoints + 3);
+        SHAPE(shape)->rs.path.pts.grow(numPoints * 3 + 2);
+        SHAPE(shape)->rs.path.cmds.grow(numPoints + 3);
         hasRoundness = true;
     }
 
@@ -626,11 +626,11 @@ void LottieBuilder::updatePolygon(LottieGroup* parent, LottiePolyStar* star, flo
     } else {
         shape = merging;
         if (hasRoundness) {
-            SHAPE(shape)->rs.path.pts.reserve(ptsCnt * 3 + 2);
-            SHAPE(shape)->rs.path.cmds.reserve(ptsCnt + 3);
+            SHAPE(shape)->rs.path.pts.grow(ptsCnt * 3 + 2);
+            SHAPE(shape)->rs.path.cmds.grow(ptsCnt + 3);
         } else {
-            SHAPE(shape)->rs.path.pts.reserve(ptsCnt + 2);
-            SHAPE(shape)->rs.path.cmds.reserve(ptsCnt + 3);
+            SHAPE(shape)->rs.path.pts.grow(ptsCnt + 2);
+            SHAPE(shape)->rs.path.cmds.grow(ptsCnt + 3);
         }
     }
 

--- a/src/loaders/lottie/tvgLottieModifier.cpp
+++ b/src/loaders/lottie/tvgLottieModifier.cpp
@@ -187,8 +187,8 @@ bool LottieRoundnessModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt
 
     auto& path = (next) ? *buffer : out;
 
-    path.cmds.reserve(inCmdsCnt * 2);
-    path.pts.reserve((uint32_t)(inPtsCnt * 1.5));
+    path.cmds.grow(inCmdsCnt * 2);
+    path.pts.grow((uint32_t)(inPtsCnt * 1.5));
     auto pivot = path.pts.count;
 
     uint32_t startIndex = 0;
@@ -325,8 +325,8 @@ bool LottieOffsetModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt, P
 {
     if (next) TVGERR("LOTTIE", "Offset has a next modifier?");
 
-    out.cmds.reserve(inCmdsCnt * 2);
-    out.pts.reserve(inPtsCnt * (join == StrokeJoin::Round ? 4 : 2));
+    out.cmds.grow(inCmdsCnt * 2);
+    out.pts.grow(inPtsCnt * (join == StrokeJoin::Round ? 4 : 2));
 
     Array<Bezier> stack{5};
     State state;


### PR DESCRIPTION
In cases where multiple shapes could be merged
into one (using shape 'merging'), using reserve
for cmds and pts wasn’t appropriate - the arrays
needed to be extended by a given amount, not
resized to it.