### PR TITLE
sw_engine: handle radial grad edge case

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -160,7 +160,7 @@ struct SwFill
     uint32_t* ctable;
     FillSpread spread;
 
-    bool solid = false; //solid color fill with the last color from colorStops
+    uint8_t solid = 0; //solid fill: 1: use the last colorStop (r == 0); 2: use the first colorStop (r == fr)
     bool translucent;
 };
 


### PR DESCRIPTION
Handle the case when the start and end circles of
the radial gradient are the same - this caused
a division by zero. The case is now handled separately. Rendering output remains unchanged.

sample:
```
<svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
  <defs>
    <radialGradient id="myGradient"  gradientUnits="userSpaceOnUse"
      r="0.5" fr="0.5" >
      <stop offset="0" stop-color="gold" />
      <stop offset="1" stop-color="red" />
    </radialGradient>
  </defs>

  <circle cx="200" cy="200" r="200" fill="url(#myGradient)" />
</svg>
```

warning on main with asan+undef:
```
../src/renderer/sw_engine/tvgSwFill.cpp:334:35: runtime error: nan is outside the range of representable values of type 'int'
```