### PR TITLE
build: Use Meson-provided summaries

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -166,59 +166,73 @@ if get_option('tests')
    subdir('test')
 endif
 
-summary = '''
+summary(
+  {
+    'Build Type': get_option('buildtype'),
+    'Prefix': get_option('prefix'),
+    'Multi-Tasking': get_option('threads'),
+    'SIMD Instruction': simd_type,
+    'Log Message': get_option('log'),
+    'Tests': get_option('tests'),
+    'Examples': get_option('examples'),
+  },
+  bool_yn: true,
+)
 
-Summary:
-    ThorVG version:             @0@
-    Build Type:                 @1@
-    Prefix:                     @2@
-    Multi-Tasking:              @3@
-    SIMD Instruction:           @4@
-    Raster Engine (SW):         @5@
-    Raster Engine (GL):         @6@
-    Raster Engine (WG):         @7@
-    Loader (SVG):               @8@
-    Loader (TTF):               @9@
-    Loader (LOTTIE):            @10@
-    Loader (PNG):               @11@
-    Loader (JPG):               @12@
-    Loader (WEBP):              @13@
-    Saver (GIF):                @14@
-    Binding (CAPI):             @15@
-    Binding (WASM_BETA):        @16@
-    Log Message:                @17@
-    Tests:                      @18@
-    Examples:                   @19@
-    Tool (Svg2Png):             @20@
-    Tool (Lottie2Gif):          @21@
-    Extra (Lottie Expressions): @22@
-    Extra (OpenGL Variant):     @23@
+summary(
+  {
+    'SW': sw_engine,
+    'GL': gl_engine,
+    'WG': wg_engine,
+  },
+  section: 'Raster Engine',
+  bool_yn: true,
+)
 
-'''.format(
-        meson.project_version(),
-        get_option('buildtype'),
-        get_option('prefix'),
-        get_option('threads'),
-        simd_type,
-        sw_engine,
-        gl_engine,
-        wg_engine,
-        svg_loader,
-        ttf_loader,
-        lottie_loader,
-        png_loader,
-        jpg_loader,
-        webp_loader,
-        gif_saver,
-        get_option('bindings').contains('capi'),
-        get_option('bindings').contains('wasm_beta'),
-        get_option('log'),
-        get_option('tests'),
-        get_option('examples'),
-        svg2png,
-        lottie2gif,
-        lottie_expressions,
-        gl_variant
-    )
+summary(
+  {
+    'SVG': svg_loader,
+    'TTF': ttf_loader,
+    'LOTTIE': lottie_loader,
+    'PNG': png_loader,
+    'JPG': jpg_loader,
+    'WEBP': webp_loader,
+  },
+  section: 'Loader',
+  bool_yn: true,
+)
 
-message(summary)
+summary(
+  {
+    'GIF': gif_saver,
+  },
+  section: 'Saver',
+  bool_yn: true,
+)
+
+summary(
+  {
+    'CAPI': get_option('bindings').contains('capi'),
+    'WASM_BETA': get_option('bindings').contains('wasm_beta'),
+  },
+  section: 'Binding',
+  bool_yn: true,
+)
+
+summary(
+  {
+    'Svg2Png': svg2png,
+    'Lottie2Gif': lottie2gif,
+  },
+  section: 'Tool',
+  bool_yn: true,
+)
+
+summary(
+  {
+    'Lottie Expressions': lottie_expressions,
+    'OpenGL Variant': gl_variant,
+  },
+  section: 'Extra',
+  bool_yn: true,
+)


### PR DESCRIPTION
Meson has provided a summary function since 0.53.0, so there's no need to generate a summary message manually. The Meson function also has support for separate sections and styled output for booleans.

It now looks like:
![Screenshot From 2025-06-20 18-02-03](https://github.com/user-attachments/assets/2acfc17b-9ff4-4d0e-899b-5f40d82edc22)
