### PR TITLE
build: Export TVG_STATIC to parent projects

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -74,6 +74,7 @@ thorvg_lib = library(
 )
 
 thorvg_dep = declare_dependency(
+  compile_args: (lib_type == 'static') ? ['-DTVG_STATIC'] : [],
   include_directories: thorvg_inc,
   link_with: thorvg_lib,
 )


### PR DESCRIPTION
On Windows, you need to consistently set `__declspec` on symbols. This is handled automatically in `thorvg.h` for shared libraries, and left out entirely for static libraries by the `TVG_STATIC` define.

When building as a subproject with static libraries, it is thus useful to export `TVG_STATIC` to the parent project, or else `thorvg.h` will attempt to set `__declspec` for a shared library (when the parent project uses it), and linkage will fail.