### PR TITLE
wasm: align wasm-opt binary with build EMSDK version

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -74,6 +74,7 @@ thorvg_lib = library(
 )
 
 thorvg_dep = declare_dependency(
+  compile_args: (lib_type == 'static') ? ['-DTVG_STATIC'] : [],
   include_directories: thorvg_inc,
   link_with: thorvg_lib,
 )

--- a/wasm_build.sh
+++ b/wasm_build.sh
@@ -27,5 +27,5 @@ if [ ! -d "./build_wasm" ]; then
 fi
 
 ninja -C build_wasm/
-wasm-opt build_wasm/src/bindings/wasm/thorvg-wasm.wasm -Oz --converge -all -o build_wasm/src/bindings/wasm/thorvg-wasm.wasm
+$EMSDK/upstream/bin/wasm-opt build_wasm/src/bindings/wasm/thorvg-wasm.wasm -Oz --converge -all -o build_wasm/src/bindings/wasm/thorvg-wasm.wasm
 ls -lrt build_wasm/src/bindings/wasm/*.{js,wasm}

--- a/wasm_build.sh
+++ b/wasm_build.sh
@@ -13,16 +13,16 @@ fi
 if [ ! -d "./build_wasm" ]; then
     if [[ "$BACKEND" == "wg" ]]; then
       sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32_wg.txt > /tmp/.wasm_cross.txt
-      meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="wg" --cross-file /tmp/.wasm_cross.txt build_wasm
+      meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="wg" -Dfile=false -Dpartial=false --cross-file /tmp/.wasm_cross.txt build_wasm
     elif [[ "$BACKEND" == "sw" ]]; then
       sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32_sw.txt > /tmp/.wasm_cross.txt
-      meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" --cross-file /tmp/.wasm_cross.txt build_wasm
+      meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dfile=false -Dpartial=false --cross-file /tmp/.wasm_cross.txt build_wasm
     elif [[ "$BACKEND" == "gl" ]]; then
       sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32_gl.txt > /tmp/.wasm_cross.txt
-      meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="gl" --cross-file /tmp/.wasm_cross.txt build_wasm
+      meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="gl" -Dpartial=false -Dfile=false --cross-file /tmp/.wasm_cross.txt build_wasm
     else
       sed "s|EMSDK:|$EMSDK|g" ./cross/wasm32.txt > /tmp/.wasm_cross.txt
-      meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="wg, gl, sw" --cross-file /tmp/.wasm_cross.txt build_wasm
+      meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dengines="all" -Dfile=false -Dpartial=false --cross-file /tmp/.wasm_cross.txt build_wasm
     fi
 fi
 


### PR DESCRIPTION
Replace global wasm-opt with EMSDK's bundled version to ensure toolchain consistency and avoid version mismatches.