### PR TITLE
lottie: ensuring rectangle closure

### DIFF
--- a/src/loaders/lottie/tvgLottieModifier.cpp
+++ b/src/loaders/lottie/tvgLottieModifier.cpp
@@ -377,12 +377,7 @@ bool LottieOffsetModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt, P
             }
 
             iPt += 3;
-        }
-        else {
-            if (!tvg::zero(inPts[iPt - 1] - inPts[state.movetoInIndex])) {
-                out.cmds.push(PathCommand::LineTo);
-                corner(out, state.line, state.firstLine, state.movetoOutIndex, true);
-            }
+        } else {
             out.cmds.push(PathCommand::Close);
         }
     }


### PR DESCRIPTION
A rectangle with roundness = 0 is the only shape where one of its sides is created using a close command. This exceptional case requires additional handling of the close command for every modifier. By adding an extra lineTo command to the rectangle path, its becomes consistent with other shapes, eliminating the special case inside modifiers algorithms.

Note: this change does not produce any visible effects. 