### PR TITLE
common: generalize bezier math

### DIFF
--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -121,6 +121,12 @@ static inline constexpr const Matrix identity()
 }
 
 
+static inline float scaling(const Matrix& m)
+{
+    return sqrtf(m.e11 * m.e11 + m.e21 * m.e21);
+}
+
+
 static inline void scale(Matrix* m, const Point& p)
 {
     m->e11 *= p.x;
@@ -330,6 +336,21 @@ static inline Point operator-(const Point& a)
     return {-a.x, -a.y};
 }
 
+enum class Orientation
+{
+    Linear = 0,
+    Clockwise,
+    CounterClockwise,
+};
+
+
+static inline Orientation orientation(const Point& p1, const Point& p2, const Point& p3)
+{
+    auto val = cross(p2 - p1, p3 - p1);
+    if (zero(val)) return Orientation::Linear;
+    else return val > 0 ? Orientation::Clockwise : Orientation::CounterClockwise;
+}
+
 
 static inline void log(const Point& pt)
 {
@@ -362,6 +383,13 @@ struct Bezier
     Point ctrl2;
     Point end;
 
+    Bezier() {}
+    Bezier(const Point& p0, const Point& p1, const Point& p2, const Point& p3):
+        start(p0), ctrl1(p1), ctrl2(p2), end(p3) {}
+    // Constructor that approximates a quarter-circle segment of arc between 'start' and 'end' points 
+    // using a cubic Bezier curve with a given 'radius'.
+    Bezier(const Point& start, const Point& end, float radius);
+
     void split(float t, Bezier& left);
     void split(Bezier& left, Bezier& right) const;
     void split(float at, Bezier& left, Bezier& right) const;
@@ -372,8 +400,11 @@ struct Bezier
     Point at(float t) const;
     float angle(float t) const;
     void bounds(Point& min, Point& max) const;
-};
+    bool flatten() const;
+    uint32_t segments() const;
 
+    Bezier operator*(const Matrix& m);
+};
 
 /************************************************************************/
 /* Geometry functions                                                   */

--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -81,11 +81,6 @@
 
 
 
-static inline float getScaleFactor(const Matrix& m)
-{
-    return sqrtf(m.e11 * m.e11 + m.e21 * m.e21);
-}
-
 enum class GlStencilMode {
     None,
     FillNonZero,

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -214,7 +214,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdat
     auto a = MULTIPLY(c.a, sdata.opacity);
 
     if (flag & RenderUpdateFlag::Stroke) {
-        float strokeWidth = sdata.rshape->strokeWidth() * getScaleFactor(sdata.geometry.matrix);
+        float strokeWidth = sdata.rshape->strokeWidth() * scaling(sdata.geometry.matrix);
         if (strokeWidth < MIN_GL_STROKE_WIDTH) {
             float alpha = strokeWidth / MIN_GL_STROKE_WIDTH;
             a = MULTIPLY(a, static_cast<uint8_t>(alpha * 255));


### PR DESCRIPTION
added or moved new functionality for bezier curves:
1. generate bezier curve as an arc
2. estimate the number of points for optimal tessellation
3. check that bezier curve is close to a straight line 
This functions is useful for gl/wg renderers and are general for math lib atself