### PR TITLE
capi: add scene effects

### DIFF
--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -214,14 +214,16 @@ void contents()
 
         Tvg_Paint *text = tvg_text_new();
         tvg_text_set_font(text, "SentyCloud", 25.0f, "");
-        tvg_text_set_fill_color(text, 0, 0, 255);
+        tvg_text_set_fill_color(text, 200, 200, 255);
         tvg_text_set_text(text, "\xE7\xB4\xA2\xE5\xB0\x94\x56\x47\x20\xE6\x98\xAF\xE6\x9C\x80\xE5\xA5\xBD\xE7\x9A\x84");
         tvg_paint_translate(text, 50.0f, 380.0f);
         tvg_canvas_push(canvas, text);
     }
 
-    //Text 2
+    //Text 2 with Scene effect
     {
+        Tvg_Paint* scene = tvg_scene_new();
+
         //load from a memory
         FILE* file = fopen(EXAMPLE_DIR"/font/Arial.ttf", "rb");
         if (file) {
@@ -240,16 +242,21 @@ void contents()
 
         Tvg_Gradient* grad = tvg_radial_gradient_new();
         tvg_radial_gradient_set(grad, 200.0f, 200.0f, 20.0f, 200.0f, 200.0f, 0.0f);
-        Tvg_Color_Stop color_stops[2] = {{0.0f, 255, 0, 255, 255}, {1.0f, 0, 0, 255, 255}};
+        Tvg_Color_Stop color_stops[2] = {{0.0f, 255, 255, 255, 255}, {1.0f, 0, 0, 255, 255}};
         tvg_gradient_set_color_stops(grad, color_stops, 2);
         tvg_gradient_set_spread(grad, TVG_STROKE_FILL_REFLECT);
 
         Tvg_Paint *text = tvg_text_new();
-        tvg_text_set_font(text, "Arial", 20.0f, "italic");
+        tvg_text_set_font(text, "Arial", 40.0f, "italic");
         tvg_text_set_gradient(text, grad);
         tvg_text_set_text(text, "ThorVG is the best");
-        tvg_paint_translate(text, 70.0f, 420.0f);
-        tvg_canvas_push(canvas, text);
+        tvg_paint_translate(text, 20.0f, 420.0f);
+
+        //Apply GaussianBlur post effect (sigma, direction, border option, quality)
+        tvg_scene_push_effect_gaussian_blur(scene, 2.5, 0, 0, 100);
+        tvg_scene_push(scene, text);
+
+        tvg_canvas_push(canvas, scene);
     }
 }
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1949,6 +1949,7 @@ TVG_API Tvg_Paint* tvg_scene_new(void);
  */
 TVG_API Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint);
 
+
 /**
  * @brief Adds a paint object to the scene.
  *
@@ -1968,6 +1969,7 @@ TVG_API Tvg_Result tvg_scene_push(Tvg_Paint* scene, Tvg_Paint* paint);
  */
 TVG_API Tvg_Result tvg_scene_push_at(Tvg_Paint* scene, Tvg_Paint* target, Tvg_Paint* at);
 
+
 /**
  * @brief Removes a paint object from the scene.
  *
@@ -1983,6 +1985,116 @@ TVG_API Tvg_Result tvg_scene_push_at(Tvg_Paint* scene, Tvg_Paint* target, Tvg_Pa
  * @since 1.0
  */
 TVG_API Tvg_Result tvg_scene_remove(Tvg_Paint* scene, Tvg_Paint* paint);
+
+
+/**
+ * @brief Resets all previously applied scene effects.
+ *
+ * This function clears all effects that have been applied to the scene,
+ * restoring it to its original state without any post-processing.
+ *
+ * @param[in] scene A pointer to the Tvg_Paint scene object.
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_scene_reset_effects(Tvg_Paint* scene);
+
+
+/**
+ * @brief Applies a Gaussian blur effect to the scene.
+ *
+ * This function applies a Gaussian blur filter to the scene as a post-processing effect.
+ * The blur can be applied in different directions with configurable border handling and quality settings.
+ *
+ * @param[in] scene A pointer to the Tvg_Paint scene object.
+ * @param[in] sigma The blur radius (sigma) value. Must be greater than 0.
+ * @param[in] direction Blur direction: 0 = both directions, 1 = horizontal only, 2 = vertical only.
+ * @param[in] border Border handling method: 0 = duplicate, 1 = wrap.
+ * @param[in] quality Blur quality level [0 - 100].
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_scene_push_effect_gaussian_blur(Tvg_Paint* scene, double sigma, int direction, int border, int quality);
+
+
+/**
+ * @brief Applies a drop shadow effect to the scene.
+ *
+ * This function applies a drop shadow with a Gaussian blur to the scene. The shadow 
+ * can be customized using color, opacity, angle, distance, blur radius (sigma), 
+ * and quality parameters.
+ *
+ * @param[in] scene A pointer to the Tvg_Paint scene object.
+ * @param[in] r Red channel value of the shadow color [0 - 255].
+ * @param[in] g Green channel value of the shadow color [0 - 255].
+ * @param[in] b Blue channel value of the shadow color [0 - 255].
+ * @param[in] a Alpha (opacity) channel value of the shadow [0 - 255].
+ * @param[in] angle Shadow direction in degrees [0 - 360].
+ * @param[in] distance Distance of the shadow from the original object.
+ * @param[in] sigma Gaussian blur sigma value for the shadow. Must be > 0.
+ * @param[in] quality Blur quality level [0 - 100].
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_scene_push_effect_drop_shadow(Tvg_Paint* scene, int r, int g, int b, int a, double angle, double distance, double sigma, int quality);
+
+
+/**
+ * @brief Applies a fill color effect to the scene.
+ *
+ * This function overrides the scene's content colors with the specified fill color.
+ *
+ * @param[in] scene A pointer to the Tvg_Paint scene object.
+ * @param[in] r Red color channel value [0 - 255].
+ * @param[in] g Green color channel value [0 - 255].
+ * @param[in] b Blue color channel value [0 - 255].
+ * @param[in] a Alpha (opacity) channel value [0 - 255].
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_scene_push_effect_fill(Tvg_Paint* scene, int r, int g, int b, int a);
+
+
+/**
+ * @brief Applies a tint effect to the scene.
+ *
+ * This function tints the current scene using specified black and white color values,
+ * modulated by a given intensity.
+ *
+ * @param[in] scene A pointer to the Tvg_Paint scene object.
+ * @param[in] black_r Red component of the black color [0 - 255].
+ * @param[in] black_g Green component of the black color [0 - 255].
+ * @param[in] black_b Blue component of the black color [0 - 255].
+ * @param[in] white_r Red component of the white color [0 - 255].
+ * @param[in] white_g Green component of the white color [0 - 255].
+ * @param[in] white_b Blue component of the white color [0 - 255].
+ * @param[in] intensity Tint intensity value [0 - 100].
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_scene_push_effect_tint(Tvg_Paint* scene, int black_r, int black_g, int black_b, int white_r, int white_g, int white_b, double intensity);
+
+
+/**
+ * @brief Applies a tritone color effect to the scene.
+ *
+ * This function applies a tritone color effect to the given scene using three sets of RGB values 
+ * representing shadow, midtone, and highlight colors.
+ *
+ * @param[in] scene A pointer to the Tvg_Paint scene object.
+ * @param[in] shadow_r Red component of the shadow color [0 - 255].
+ * @param[in] shadow_g Green component of the shadow color [0 - 255].
+ * @param[in] shadow_b Blue component of the shadow color [0 - 255].
+ * @param[in] midtone_r Red component of the midtone color [0 - 255].
+ * @param[in] midtone_g Green component of the midtone color [0 - 255].
+ * @param[in] midtone_b Blue component of the midtone color [0 - 255].
+ * @param[in] highlight_r Red component of the highlight color [0 - 255].
+ * @param[in] highlight_g Green component of the highlight color [0 - 255].
+ * @param[in] highlight_b Blue component of the highlight color [0 - 255].
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_scene_push_effect_tritone(Tvg_Paint* scene, int shadow_r, int shadow_g, int shadow_b, int midtone_r, int midtone_g, int midtone_b, int highlight_r, int highlight_g, int highlight_b);
 
 /** \} */   // end defgroup ThorVGCapi_Scene
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -778,6 +778,48 @@ TVG_API Tvg_Result tvg_scene_remove(Tvg_Paint* scene, Tvg_Paint* paint)
 }
 
 
+TVG_API Tvg_Result tvg_scene_reset_effects(Tvg_Paint* scene)
+{
+    if (scene) return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push(SceneEffect::ClearAll);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
+TVG_API Tvg_Result tvg_scene_push_effect_drop_shadow(Tvg_Paint* scene, int r, int g, int b, int a, double angle, double distance, double sigma, int quality)
+{
+    if (scene) return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push(SceneEffect::DropShadow, r, g, b, a, angle, distance, sigma, quality);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
+TVG_API Tvg_Result tvg_scene_push_effect_gaussian_blur(Tvg_Paint* scene, double sigma, int direction, int border, int quality)
+{
+    if (scene) return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push(SceneEffect::GaussianBlur, sigma, direction, border, quality);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
+TVG_API Tvg_Result tvg_scene_push_effect_fill(Tvg_Paint* scene, int r, int g, int b, int a)
+{
+    if (scene) return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push(SceneEffect::Fill, r, g, b, a);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
+TVG_API Tvg_Result tvg_scene_push_effect_tint(Tvg_Paint* scene, int black_r, int black_g, int black_b, int white_r, int white_g, int white_b, double intensity)
+{
+    if (scene) return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push(SceneEffect::Tint, black_r, black_g, black_b, white_r, white_g, white_b, intensity);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
+TVG_API Tvg_Result tvg_scene_push_effect_tritone(Tvg_Paint* scene, int shadow_r, int shadow_g, int shadow_b, int midtone_r, int midtone_g, int midtone_b, int highlight_r, int highlight_g, int highlight_b)
+{
+    if (scene) return (Tvg_Result) reinterpret_cast<Scene*>(scene)->push(SceneEffect::Tritone, shadow_r, shadow_g, shadow_b, midtone_r, midtone_g, midtone_b, highlight_r, highlight_g, highlight_b);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
 /************************************************************************/
 /* Text API                                                            */
 /************************************************************************/


### PR DESCRIPTION
```
+ Tvg_Result tvg_scene_reset_effects(Tvg_Paint* scene)
+ Tvg_Result tvg_scene_push_effect_gaussian_blur(Tvg_Paint* scene, double sigma, int direction, int border, int quality)
+ Tvg_Result tvg_scene_push_effect_drop_shadow(Tvg_Paint* scene, int r, int g, int b, int a, double angle, double distance, double sigma, int quality)
+ Tvg_Result tvg_scene_push_effect_fill(Tvg_Paint* scene, int r, int g, int b, int a)
+ Tvg_Result tvg_scene_push_effect_tint(Tvg_Paint* scene, int black_r, int black_g, int black_b, int white_r, int white_g, int white_b, double intensity)
+ Tvg_Result tvg_scene_push_effect_tritone(Tvg_Paint* scene, int shadow_r, int shadow_g, int shadow_b, int midtone_r, int midtone_g, int midtone_b, int highlight_r, int highlight_g, int highlight_b)
```
issue: https://github.com/thorvg/thorvg/issues/3580