### PR TITLE
engines: corrected wrong tint effects

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -175,8 +175,8 @@ enum class MaskMethod : uint8_t
     None = 0,       ///< No Masking is applied.
     Alpha,          ///< Alpha Masking using the masking target's pixels as an alpha value.
     InvAlpha,       ///< Alpha Masking using the complement to the masking target's pixels as an alpha value.
-    Luma,           ///< Alpha Masking using the grayscale (0.2125R + 0.7154G + 0.0721*B) of the masking target's pixels. @since 0.9
-    InvLuma,        ///< Alpha Masking using the grayscale (0.2125R + 0.7154G + 0.0721*B) of the complement to the masking target's pixels. @since 0.11
+    Luma,           ///< Alpha Masking using the grayscale (0.2126R + 0.7152G + 0.0722*B) of the masking target's pixels. @since 0.9
+    InvLuma,        ///< Alpha Masking using the grayscale (0.2126R + 0.7152G + 0.0722*B) of the complement to the masking target's pixels. @since 0.11
     Add,            ///< Combines the target and source objects pixels using target alpha. (T * TA) + (S * (255 - TA)) (Experimental API)
     Subtract,       ///< Subtracts the source color from the target color while considering their respective target alpha. (T * TA) - (S * (255 - TA)) (Experimental API)
     Intersect,      ///< Computes the result by taking the minimum value between the target alpha and the source alpha and multiplies it with the target color. (T * min(TA, SA)) (Experimental API)

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -126,11 +126,11 @@ typedef enum {
  * @ingroup ThorVGCapi_Paint
  */
 typedef enum {
-    TVG_MASK_METHOD_NONE = 0,      ///< No masking is applied.
-    TVG_MASK_METHOD_ALPHA,         ///< The pixels of the source and the target are alpha blended. As a result, only the part of the source, which intersects with the target is visible.
-    TVG_MASK_METHOD_INVERSE_ALPHA, ///< The pixels of the source and the complement to the target's pixels are alpha blended. As a result, only the part of the source which is not covered by the target is visible.
-    TVG_MASK_METHOD_LUMA,          ///< The source pixels are converted to grayscale (luma value) and alpha blended with the target. As a result, only the part of the source which intersects with the target is visible. @since 0.9
-    TVG_MASK_METHOD_INVERSE_LUMA,  ///< The source pixels are converted to grayscale (luma value) and complement to the target's pixels are alpha blended. As a result, only the part of the source which is not covered by the target is visible. @since 0.14
+    TVG_MASK_METHOD_NONE = 0,      ///< No Masking is applied.
+    TVG_MASK_METHOD_ALPHA,         ///< Alpha Masking using the masking target's pixels as an alpha value.
+    TVG_MASK_METHOD_INVERSE_ALPHA, ///< Alpha Masking using the complement to the masking target's pixels as an alpha value.
+    TVG_MASK_METHOD_LUMA,          ///< Alpha Masking using the grayscale (0.2126R + 0.7152G + 0.0722*B) of the masking target's pixels. @since 0.9
+    TVG_MASK_METHOD_INVERSE_LUMA,  ///< Alpha Masking using the grayscale (0.2126R + 0.7152G + 0.0722*B) of the complement to the masking target's pixels. @since 0.11
     TVG_MASK_METHOD_ADD,           ///< Combines the target and source objects pixels using target alpha. (T * TA) + (S * (255 - TA)) (Experimental API)
     TVG_MASK_METHOD_SUBTRACT,      ///< Subtracts the source color from the target color while considering their respective target alpha. (T * TA) - (S * (255 - TA)) (Experimental API)
     TVG_MASK_METHOD_INTERSECT,     ///< Computes the result by taking the minimum value between the target alpha and the source alpha and multiplies it with the target color. (T * min(TA, SA)) (Experimental API)

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -861,11 +861,11 @@ out vec4 FragColor;
 void main()
 {
     vec4 orig = texture(uSrcTexture, vUV);
-    float luma = dot(orig.rgb, vec3(0.2125, 0.7154, 0.0721));
+    float luma = dot(orig.rgb, vec3(0.2126, 0.7152, 0.0722));
     vec4 black = uParams.params[0];
     vec4 white = uParams.params[1];
     float intens = uParams.params[2].r;
-    FragColor = mix(orig, mix(white, black, luma), intens) * orig.a;
+    FragColor = mix(orig, mix(black, white, luma), intens) * orig.a;
 } 
 )";
 
@@ -881,7 +881,7 @@ out vec4 FragColor;
 void main()
 {
     vec4 orig = texture(uSrcTexture, vUV);
-    float luma = dot(orig.rgb, vec3(0.2125, 0.7154, 0.0721));
+    float luma = dot(orig.rgb, vec3(0.2126, 0.7152, 0.0722));
     vec4 shadow = uParams.params[0];
     vec4 midtone = uParams.params[1];
     vec4 highlight = uParams.params[2];

--- a/src/renderer/sw_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/sw_engine/tvgSwPostEffect.cpp
@@ -494,9 +494,8 @@ bool effectTint(SwCompositor* cmp, const RenderEffectTint* params, bool direct)
             auto dst = dbuffer;
             auto src = sbuffer;
             for (size_t x = 0; x < w; ++x, ++dst, ++src) {
-                auto tmp = rasterUnpremultiply(*src);
-                auto val = INTERPOLATE(INTERPOLATE(black, white, luma((uint8_t*)&tmp)), tmp, params->intensity);
-                *dst = INTERPOLATE(val, *dst, MULTIPLY(opacity, A(tmp)));
+                auto val = INTERPOLATE(INTERPOLATE(white, black, luma((uint8_t*)src)), *src, params->intensity);
+                *dst = INTERPOLATE(val, *dst, MULTIPLY(opacity, A(*src)));
             }
             dbuffer += cmp->image.stride;
             sbuffer += cmp->recoverSfc->stride;

--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -103,14 +103,14 @@ static inline uint8_t _ialpha(uint8_t* a)
 static inline uint8_t _abgrLuma(uint8_t* c)
 {
     auto v = *(uint32_t*)c;
-    return ((((v&0xff)*54) + (((v>>8)&0xff)*183) + (((v>>16)&0xff)*19))) >> 8; //0.2125*R + 0.7154*G + 0.0721*B
+    return ((((v&0xff)*54) + (((v>>8)&0xff)*182) + (((v>>16)&0xff)*19))) >> 8; //0.2126*R + 0.7152*G + 0.0722*B
 }
 
 
 static inline uint8_t _argbLuma(uint8_t* c)
 {
     auto v = *(uint32_t*)c;
-    return ((((v&0xff)*19) + (((v>>8)&0xff)*183) + (((v>>16)&0xff)*54))) >> 8; //0.0721*B + 0.7154*G + 0.2125*R
+    return ((((v&0xff)*19) + (((v>>8)&0xff)*182) + (((v>>16)&0xff)*54))) >> 8; //0.0722*B + 0.7152*G + 0.2126*R
 }
 
 

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -852,11 +852,11 @@ fn cs_main_tint(@builtin(global_invocation_id) gid: vec3u) {
     let uid = min(gid.xy + vmin, vmax);
 
     let orig = textureLoad(imageSrc, uid, 0);
-    let luma: f32 = dot(orig.rgb, vec3f(0.2125, 0.7154, 0.0721));
+    let luma: f32 = dot(orig.rgb, vec3f(0.2126, 0.7152, 0.0722));
     let black = settings[0];
     let white = settings[1];
     let intens = settings[2].r;
-    let color = mix(orig, mix(white, black, luma), intens) * orig.a;
+    let color = mix(orig, mix(black, white, luma), intens) * orig.a;
     textureStore(imageTrg, uid.xy, color);
 }
 
@@ -870,7 +870,7 @@ fn cs_main_tritone(@builtin(global_invocation_id) gid: vec3u) {
     let uid = min(gid.xy + vmin, vmax);
 
     let orig = textureLoad(imageSrc, uid, 0);
-    let luma: f32 = dot(orig.rgb, vec3f(0.2125, 0.7154, 0.0721));
+    let luma: f32 = dot(orig.rgb, vec3f(0.2126, 0.7152, 0.0722));
     let shadow = settings[0];
     let midtone = settings[1];
     let highlight = settings[2];


### PR DESCRIPTION
- corrected the reversed black/white intensity multiplication.
- made a minor adjustment to the luma equation.
- updated and aligned the API documentation accordingly.

before- > after:
![image](https://github.com/user-attachments/assets/81db5e28-9b63-483f-8bcb-c8e15a7b3fbc)
