### PR TITLE
sw_engine: dropshadow stability++

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -672,7 +672,7 @@ uint32_t rasterUnpremultiply(uint32_t data);
 bool effectGaussianBlur(SwCompositor* cmp, SwSurface* surface, const RenderEffectGaussianBlur* params);
 bool effectGaussianBlurRegion(RenderEffectGaussianBlur* effect);
 void effectGaussianBlurUpdate(RenderEffectGaussianBlur* effect, const Matrix& transform);
-bool effectDropShadow(SwCompositor* cmp, SwSurface* surfaces[2], const RenderEffectDropShadow* params, bool direct);
+bool effectDropShadow(SwCompositor* cmp, SwSurface* surfaces[2], const RenderEffectDropShadow* params);
 bool effectDropShadowRegion(RenderEffectDropShadow* effect);
 void effectDropShadowUpdate(RenderEffectDropShadow* effect, const Matrix& transform);
 void effectFillUpdate(RenderEffectFill* effect);

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -731,7 +731,7 @@ bool SwRenderer::render(RenderCompositor* cmp, const RenderEffect* effect, bool 
             cmp1->compositor->valid = false;
             auto cmp2 = request(surface->channelSize, true);
             SwSurface* surfaces[] = {cmp1, cmp2};
-            auto ret = effectDropShadow(p, surfaces, static_cast<const RenderEffectDropShadow*>(effect), direct);
+            auto ret = effectDropShadow(p, surfaces, static_cast<const RenderEffectDropShadow*>(effect));
             cmp1->compositor->valid = true;
             return ret;
         }


### PR DESCRIPTION
removed the direct rendering optimization of the dropshadow, because it's a buggy.