### PR TITLE
lottie: fix layer update

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1366,19 +1366,23 @@ void LottieBuilder::updateEffect(LottieLayer* layer, float frameNo)
 
 void LottieBuilder::updateLayer(LottieComposition* comp, Scene* scene, LottieLayer* layer, float frameNo)
 {
-    layer->scene = nullptr;
+    //Prepare render data
+    layer->scene = Scene::gen();
+    layer->scene->id = layer->id;
 
     //visibility
-    if (frameNo < layer->inFrame || frameNo >= layer->outFrame) return;
+    if (frameNo < layer->inFrame || frameNo >= layer->outFrame) {
+        scene->push(layer->scene);
+        return;
+    }
 
     updateTransform(layer, frameNo);
 
     //full transparent scene. no need to perform
-    if (layer->type != LottieLayer::Null && layer->cache.opacity == 0) return;
-
-    //Prepare render data
-    layer->scene = Scene::gen();
-    layer->scene->id = layer->id;
+    if (layer->type != LottieLayer::Null && layer->cache.opacity == 0) {
+        scene->push(layer->scene);
+        return;
+    }
 
     //ignore opacity when Null layer?
     if (layer->type != LottieLayer::Null) layer->scene->opacity(layer->cache.opacity);


### PR DESCRIPTION
If a layer’s inPoint and/or outPoint differs from
the overall animation range, it must continue to be updated past those points so that it correctly becomes invisible. Otherwise, the last updated frame remains stuck on screen.
Likewise, when a layer’s opacity suddenly drops to zero, it should still be redrawn as fully transparent.

samples:
[op.json](https://github.com/user-attachments/files/21143067/op.json)
[update.json](https://github.com/user-attachments/files/21143069/update.json)

before:
![before](https://github.com/user-attachments/assets/3b7b7699-e4e3-42cb-a6cf-27657d7f3d17)

after:
![after](https://github.com/user-attachments/assets/f6b9afde-4f89-4ffc-9863-56360be7858e)

