### PR TITLE
sw_engine: improved the dropshadow effect support

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -297,7 +297,7 @@ struct SwSurface : RenderSurface
         blender = rhs->blender;
         compositor = rhs->compositor;
         blendMethod = rhs->blendMethod;
-     }
+    }
 };
 
 struct SwCompositor : RenderCompositor
@@ -669,7 +669,7 @@ uint32_t rasterUnpremultiply(uint32_t data);
 bool effectGaussianBlur(SwCompositor* cmp, SwSurface* surface, const RenderEffectGaussianBlur* params);
 bool effectGaussianBlurRegion(RenderEffectGaussianBlur* effect);
 void effectGaussianBlurUpdate(RenderEffectGaussianBlur* effect, const Matrix& transform);
-bool effectDropShadow(SwCompositor* cmp, SwSurface* surfaces[2], const RenderEffectDropShadow* params);
+bool effectDropShadow(SwCompositor* cmp, SwSurface* surfaces[2], const RenderEffectDropShadow* params, bool direct);
 bool effectDropShadowRegion(RenderEffectDropShadow* effect);
 void effectDropShadowUpdate(RenderEffectDropShadow* effect, const Matrix& transform);
 void effectFillUpdate(RenderEffectFill* effect);

--- a/src/renderer/sw_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/sw_engine/tvgSwPostEffect.cpp
@@ -266,26 +266,78 @@ static void _dropShadowFilter(uint32_t* dst, uint32_t* src, int stride, int w, i
     }
 }
 
-
-static void _dropShadowShift(uint32_t* dst, uint32_t* src, int dstride, int sstride, RenderRegion& bbox, SwPoint& offset, uint8_t opacity)
+static void _shift(uint32_t** dst, uint32_t** src, int dstride, int sstride, int wmax, int hmax, const RenderRegion& bbox, const SwPoint& offset, SwSize& size)
 {
-    src += (bbox.min.y * sstride + bbox.min.x);
-    dst += (bbox.min.y * dstride + bbox.min.x);
+    size.w = bbox.max.x - bbox.min.x;
+    size.h = bbox.max.y - bbox.min.y;
 
-    auto w = bbox.max.x - bbox.min.x;
-    auto h = bbox.max.y - bbox.min.y;
+    //shift
+    if (bbox.min.x + offset.x < 0) *src -= offset.x;
+    else *dst += offset.x;
+
+    if (bbox.min.y + offset.y < 0) *src -= (offset.y * sstride);
+    else *dst += (offset.y * dstride);
+
+    if (size.w + bbox.min.x + offset.x > wmax) size.w -= (size.w + bbox.min.x + offset.x - wmax);
+    if (size.h + bbox.min.y + offset.y > hmax) size.h -= (size.h + bbox.min.y + offset.y - hmax);
+}
+
+
+static void _dropShadowNoFilter(SwImage* dimg, SwImage* simg, const RenderRegion& bbox, const SwPoint& offset, uint32_t color)
+{
+    int dstride = dimg->stride;
+    int sstride = simg->stride;
+
+    auto src = simg->buf32 + (bbox.min.y * sstride + bbox.min.x);
+    auto dst = dimg->buf32 + (bbox.min.y * dstride + bbox.min.x);
+
+    //for shadow
+    auto src2 = src;
+    auto dst2 = dst;
+
+    SwSize size;
+    _shift(&dst2, &src2, dimg->stride, simg->stride, dimg->w, dimg->h, bbox, offset, size);
+
+    //shadow
+    for (auto y = 0; y < size.h; ++y) {
+        auto s2 = src2;
+        auto d2 = dst2;
+        for (int x = 0; x < size.w; ++x, ++d2, ++s2) {
+            *d2 = ALPHA_BLEND(color, A(*s2));
+        }
+        src2 += sstride;
+        dst2 += dstride;
+    }
+
+    //original
+    for (auto y = 0; y < (bbox.max.y - bbox.min.y); ++y) {
+        auto s = src;
+        auto d = dst;
+        for (int x = 0; x < (bbox.max.x - bbox.min.x); ++x, ++d, ++s) {
+            *d = *s + ALPHA_BLEND(*d, IA(*s));
+        }
+        src += sstride;
+        dst += dstride;
+    }
+}
+
+
+static void _dropShadowShift(SwImage* dimg, SwImage* simg, RenderRegion& bbox, const SwPoint& offset, uint8_t opacity)
+{
+    int dstride = dimg->stride;
+    int sstride = simg->stride;
+
+    auto src = simg->buf32 + (bbox.min.y * sstride + bbox.min.x);
+    auto dst = dimg->buf32 + (bbox.min.y * dstride + bbox.min.x);
+
     auto translucent = (opacity < 255);
 
-    //shift offset
-    if (bbox.min.x + offset.x < 0) src -= offset.x;
-    else dst += offset.x;
+    SwSize size;
+    _shift(&dst, &src, dimg->stride, simg->stride, dimg->w, dimg->h, bbox, offset, size);
 
-    if (bbox.min.y + offset.y < 0) src -= (offset.y * sstride);
-    else dst += (offset.y * dstride);
-
-    for (auto y = 0; y < h; ++y) {
-        if (translucent) rasterTranslucentPixel32(dst, src, w, opacity);
-        else rasterPixel32(dst, src, w, opacity);
+    for (auto y = 0; y < size.h; ++y) {
+        if (translucent) rasterTranslucentPixel32(dst, src, size.w, opacity);
+        else rasterPixel32(dst, src, size.w, opacity);
         src += sstride;
         dst += dstride;
     }
@@ -322,7 +374,7 @@ void effectDropShadowUpdate(RenderEffectDropShadow* params, const Matrix& transf
     rd->extends = _gaussianInit(rd, std::pow(params->sigma * scale, 2), params->quality);
 
     //invalid
-    if (rd->extends == 0 || params->color[3] == 0) {
+    if (params->color[3] == 0) {
         params->valid = false;
         return;
     }
@@ -330,7 +382,7 @@ void effectDropShadowUpdate(RenderEffectDropShadow* params, const Matrix& transf
     //offset
     if (params->distance > 0.0f) {
         auto radian = tvg::deg2rad(90.0f - params->angle);
-        rd->offset = {(int32_t)(params->distance * cosf(radian)), (int32_t)(-1.0f * params->distance * sinf(radian))};
+        rd->offset = {(int32_t)((params->distance * scale) * cosf(radian)), (int32_t)(-1.0f * (params->distance * scale) * sinf(radian))};
     } else {
         rd->offset = {0, 0};
     }
@@ -362,6 +414,12 @@ bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffe
 
     TVGLOG("SW_ENGINE", "DropShadow region(%d, %d, %d, %d) params(%f %f %f), level(%d)", bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y, params->angle, params->distance, params->sigma, data->level);
 
+    //no filter required
+    if (params->sigma == 0.0f)  {
+        _dropShadowNoFilter(buffer[1], &cmp->image, bbox, data->offset, color);
+        std::swap(cmp->image.buf32, buffer[1]->buf32);
+        return true;
+    }
     //saving the original image in order to overlay it into the filtered image.
     _dropShadowFilter(back, front, stride, w, h, bbox, data->kernel[0], color, false);
     std::swap(front, buffer[0]->buf32);
@@ -387,7 +445,7 @@ bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffe
 
     //draw to the intermediate surface
     rasterClear(surface[1], bbox.min.x, bbox.min.y, w, h);
-    _dropShadowShift(buffer[1]->buf32, cmp->image.buf32, stride, stride, bbox, data->offset, params->color[3]);
+    _dropShadowShift(buffer[1], &cmp->image, bbox, data->offset, params->color[3]);
     std::swap(cmp->image.buf32, buffer[1]->buf32);
 
     //compositing shadow and body
@@ -476,8 +534,6 @@ bool effectTint(SwCompositor* cmp, const RenderEffectTint* params, bool direct)
 
     TVGLOG("SW_ENGINE", "Tint region(%d, %d, %d, %d), param(%d %d %d, %d %d %d, %d)", bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y, params->black[0], params->black[1], params->black[2], params->white[0], params->white[1], params->white[2], params->intensity);
 
-    /* Tint Formula: (1 - L) * Black + L * White, where the L is Luminance. */
-
     if (direct) {
         auto dbuffer = cmp->recoverSfc->buf32 + (bbox.min.y * cmp->recoverSfc->stride + bbox.min.x);
         auto sbuffer = cmp->image.buf32 + (bbox.min.y * cmp->image.stride + bbox.min.x);
@@ -516,11 +572,6 @@ bool effectTint(SwCompositor* cmp, const RenderEffectTint* params, bool direct)
 
 static uint32_t _trintone(uint32_t s, uint32_t m, uint32_t h, int l)
 {
-    /* Tritone Formula:
-       if (L < 0.5) { (1 - 2L) * Shadow + 2L * Midtone }
-       else { (1 - 2(L - 0.5)) * Midtone + (2(L - 0.5)) * Highlight }
-       Where the L is Luminance. */
-
     if (l < 128) {
         auto a = std::min(l * 2, 255);
         return ALPHA_BLEND(s, 255 - a) + ALPHA_BLEND(m, a);

--- a/src/renderer/sw_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/sw_engine/tvgSwPostEffect.cpp
@@ -283,33 +283,40 @@ static void _shift(uint32_t** dst, uint32_t** src, int dstride, int sstride, int
 }
 
 
+static void _dropShadowNoFilter(uint32_t* dst, uint32_t* src, int dstride, int sstride, int dw, int dh, const RenderRegion& bbox, const SwPoint& offset, uint32_t color, uint8_t opacity, bool direct)
+{
+    src += (bbox.min.y * sstride + bbox.min.x);
+    dst += (bbox.min.y * dstride + bbox.min.x);
+
+    SwSize size;
+    _shift(&dst, &src, dstride, sstride, dw, dh, bbox, offset, size);
+
+    for (auto y = 0; y < size.h; ++y) {
+        auto s2 = src;
+        auto d2 = dst;
+        for (int x = 0; x < size.w; ++x, ++d2, ++s2) {
+            auto a = MULTIPLY(opacity, A(*s2));
+            if (!direct || a == 255) *d2 = ALPHA_BLEND(color, a);
+            else *d2 = INTERPOLATE(color, *d2, a);
+        }
+        src += sstride;
+        dst += dstride;
+    }
+}
+
+
 static void _dropShadowNoFilter(SwImage* dimg, SwImage* simg, const RenderRegion& bbox, const SwPoint& offset, uint32_t color)
 {
     int dstride = dimg->stride;
     int sstride = simg->stride;
 
+    //shadow image
+    _dropShadowNoFilter(dimg->buf32, simg->buf32, dstride, sstride, dimg->w, dimg->h, bbox, offset, color, 255, false);
+
+    //original image
     auto src = simg->buf32 + (bbox.min.y * sstride + bbox.min.x);
     auto dst = dimg->buf32 + (bbox.min.y * dstride + bbox.min.x);
 
-    //for shadow
-    auto src2 = src;
-    auto dst2 = dst;
-
-    SwSize size;
-    _shift(&dst2, &src2, dimg->stride, simg->stride, dimg->w, dimg->h, bbox, offset, size);
-
-    //shadow
-    for (auto y = 0; y < size.h; ++y) {
-        auto s2 = src2;
-        auto d2 = dst2;
-        for (int x = 0; x < size.w; ++x, ++d2, ++s2) {
-            *d2 = ALPHA_BLEND(color, A(*s2));
-        }
-        src2 += sstride;
-        dst2 += dstride;
-    }
-
-    //original
     for (auto y = 0; y < (bbox.max.y - bbox.min.y); ++y) {
         auto s = src;
         auto d = dst;
@@ -322,21 +329,16 @@ static void _dropShadowNoFilter(SwImage* dimg, SwImage* simg, const RenderRegion
 }
 
 
-static void _dropShadowShift(SwImage* dimg, SwImage* simg, RenderRegion& bbox, const SwPoint& offset, uint8_t opacity)
+static void _dropShadowShift(uint32_t* dst, uint32_t* src, int dstride, int sstride, int dw, int dh, const RenderRegion& bbox, const SwPoint& offset, uint8_t opacity, bool direct)
 {
-    int dstride = dimg->stride;
-    int sstride = simg->stride;
-
-    auto src = simg->buf32 + (bbox.min.y * sstride + bbox.min.x);
-    auto dst = dimg->buf32 + (bbox.min.y * dstride + bbox.min.x);
-
-    auto translucent = (opacity < 255);
+    src += (bbox.min.y * sstride + bbox.min.x);
+    dst += (bbox.min.y * dstride + bbox.min.x);
 
     SwSize size;
-    _shift(&dst, &src, dimg->stride, simg->stride, dimg->w, dimg->h, bbox, offset, size);
+    _shift(&dst, &src, dstride, sstride, dw, dh, bbox, offset, size);
 
     for (auto y = 0; y < size.h; ++y) {
-        if (translucent) rasterTranslucentPixel32(dst, src, size.w, opacity);
+        if (direct) rasterTranslucentPixel32(dst, src, size.w, opacity);
         else rasterPixel32(dst, src, size.w, opacity);
         src += sstride;
         dst += dstride;
@@ -394,7 +396,7 @@ void effectDropShadowUpdate(RenderEffectDropShadow* params, const Matrix& transf
 //A quite same integration with effectGaussianBlur(). See it for detailed comments.
 //surface[0]: the original image, to overlay it into the filtered image.
 //surface[1]: temporary buffer for generating the filtered image.
-bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffectDropShadow* params)
+bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffectDropShadow* params, bool direct)
 {
     //FIXME: if the body is partially visible due to clipping, the shadow also becomes partially visible.
 
@@ -412,14 +414,21 @@ bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffe
     auto front = cmp->image.buf32;
     auto back = buffer[1]->buf32;
 
+    auto opacity = direct ? MULTIPLY(params->color[3], cmp->opacity) : params->color[3];
+
     TVGLOG("SW_ENGINE", "DropShadow region(%d, %d, %d, %d) params(%f %f %f), level(%d)", bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y, params->angle, params->distance, params->sigma, data->level);
 
     //no filter required
     if (params->sigma == 0.0f)  {
-        _dropShadowNoFilter(buffer[1], &cmp->image, bbox, data->offset, color);
-        std::swap(cmp->image.buf32, buffer[1]->buf32);
+        if (direct) {
+            _dropShadowNoFilter(cmp->recoverSfc->buf32, cmp->image.buf32, cmp->recoverSfc->stride, cmp->image.stride, cmp->recoverSfc->w, cmp->recoverSfc->h, bbox, data->offset, color, opacity, direct);
+        } else {
+            _dropShadowNoFilter(buffer[1], &cmp->image, bbox, data->offset, color);
+            std::swap(cmp->image.buf32, buffer[1]->buf32);
+        }
         return true;
     }
+
     //saving the original image in order to overlay it into the filtered image.
     _dropShadowFilter(back, front, stride, w, h, bbox, data->kernel[0], color, false);
     std::swap(front, buffer[0]->buf32);
@@ -443,10 +452,16 @@ bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffe
     rasterXYFlip(front, back, stride, h, w, bbox, true);
     std::swap(cmp->image.buf32, back);
 
+    //draw to the main surface directly
+    if (direct) {
+        _dropShadowShift(cmp->recoverSfc->buf32, cmp->image.buf32, cmp->recoverSfc->stride, cmp->image.stride, cmp->recoverSfc->w, cmp->recoverSfc->h, bbox, data->offset, opacity, direct);
+        std::swap(cmp->image.buf32, buffer[0]->buf32);
+        return true;
+    }
+
     //draw to the intermediate surface
     rasterClear(surface[1], bbox.min.x, bbox.min.y, w, h);
-    _dropShadowShift(buffer[1], &cmp->image, bbox, data->offset, params->color[3]);
-    std::swap(cmp->image.buf32, buffer[1]->buf32);
+    _dropShadowShift(buffer[1]->buf32, cmp->image.buf32, buffer[1]->stride, cmp->image.stride, buffer[1]->w, buffer[1]->h, bbox, data->offset, opacity, direct);
 
     //compositing shadow and body
     auto s = buffer[0]->buf32 + (bbox.min.y * buffer[0]->stride + bbox.min.x);

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -739,7 +739,7 @@ bool SwRenderer::render(RenderCompositor* cmp, const RenderEffect* effect, bool 
             cmp1->compositor->valid = false;
             auto cmp2 = request(surface->channelSize, true);
             SwSurface* surfaces[] = {cmp1, cmp2};
-            auto ret = effectDropShadow(p, surfaces, static_cast<const RenderEffectDropShadow*>(effect));
+            auto ret = effectDropShadow(p, surfaces, static_cast<const RenderEffectDropShadow*>(effect), direct);
             cmp1->compositor->valid = true;
             return ret;
         }

--- a/src/renderer/tvgCommon.h
+++ b/src/renderer/tvgCommon.h
@@ -71,8 +71,6 @@ namespace tvg {
 
     enum class FileType { Png = 0, Jpg, Webp, Svg, Lot, Ttf, Raw, Gif, Unknown };
 
-    using Size = Point;
-
     #ifdef THORVG_LOG_ENABLED
         constexpr auto ErrorColor = "\033[31m";  //red
         constexpr auto ErrorBgColor = "\033[41m";//bg red


### PR DESCRIPTION
- shadow rendering was skipped when the blur value was 0. it now correctly renders shadows without blur.

- this also fixes the distance offset scalability.

issue: https://github.com/thorvg/thorvg/issues/3602