### PR TITLE
docs: update test setup command to use `meson setup [options]`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ ThorVG uses GitHub infrastructure to automatically assign code reviewers for you
 After updating the ThorVG code, please ensure your changes don't break the library. We recommend conducting unit tests. You can easily run them using the following build commands:
 <br/>
 `
-$meson . build -Dtests=true -Dloaders="all" -Dsavers="all" -Dbindings="capi" -Dtools="all" -Dlog=true
+$meson setup build -Dtests=true -Dloaders="all" -Dsavers="all" -Dbindings="capi" -Dtools="all" -Dlog=true
 `
 <br />
 `


### PR DESCRIPTION
When running the following command:

```bash
$ meson . build -Dtests=true -Dloaders="all" -Dsavers="all" -Dbindings="capi" -Dtools="all" -Dlog=true
```
the following warning message is displayed:


`WARNING: Running the setup command as 'meson [options]' instead of 'meson setup [options]' is ambiguous and deprecated.` 

To remove this warning, `meson setup [options]` should be used.
