### PR TITLE
renderer: refactored to share gl stroke dasher among engines

### DIFF
--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -39,12 +39,11 @@ class Stroker
     };
 public:
     Stroker(GlGeometryBuffer* buffer, const Matrix& matrix);
-    void stroke(const RenderShape *rshape, const RenderPath& path);
+    void stroke(const RenderShape *rshape);
     RenderRegion bounds() const;
 
 private:
     void doStroke(const RenderPath& path);
-    void doDashStroke(const RenderPath& path, const float* patterns, uint32_t patternCnt, float offset, float length);
 
     float strokeRadius() const
     {
@@ -73,34 +72,6 @@ private:
     State mStrokeState = {};
     Point mLeftTop = {0.0f, 0.0f};
     Point mRightBottom = {0.0f, 0.0f};
-};
-
-class DashStroke
-{
-public:
-    DashStroke(Array<PathCommand>* cmds, Array<Point>* pts, const float* patterns, uint32_t patternCnt, float offset, float length);
-    void doStroke(const RenderPath& path, bool drawPoint);
-
-private:
-    void drawPoint(const Point& p);
-    void dashLineTo(const Point& pt, bool drawPoint);
-    void dashCubicTo(const Point& pt1, const Point& pt2, const Point& pt3, bool drawPoint);
-    void moveTo(const Point& pt);
-    void lineTo(const Point& pt);
-    void cubicTo(const Point& pt1, const Point& pt2, const Point& pt3);
-
-    Array<PathCommand>* mCmds;
-    Array<Point>* mPts;
-    const float* mDashPattern;
-    uint32_t mDashCount;
-    float mDashOffset;
-    float mDashLength;
-    float mCurrLen = 0.0f;
-    int32_t mCurrIdx = 0;
-    bool mCurOpGap = false;
-    bool mMove = true;
-    Point mPtStart = {};
-    Point mPtCur = {};
 };
 
 class BWTessellator

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -233,6 +233,31 @@ struct RenderPath
         cmds.clear();
     }
 
+    void close()
+    {
+        cmds.push(PathCommand::Close);
+    }
+
+    void moveTo(const Point& pt)
+    {
+        pts.push(pt);
+        cmds.push(PathCommand::MoveTo);
+    }
+
+    void lineTo(const Point& pt)
+    {
+        pts.push(pt);
+        cmds.push(PathCommand::LineTo);
+    }
+
+    void cubicTo(const Point& cnt1, const Point& cnt2, const Point& end)
+    {
+        pts.push(cnt1);
+        pts.push(cnt2);
+        pts.push(end);
+        cmds.push(PathCommand::CubicTo);
+    }
+
     bool bounds(Matrix* m, float* x, float* y, float* w, float* h);
 };
 
@@ -256,7 +281,7 @@ struct RenderStroke
     float width = 0.0f;
     RenderColor color{};
     Fill *fill = nullptr;
-    struct {
+    struct Dash {
         float* pattern = nullptr;
         uint32_t count = 0;
         float offset = 0.0f;
@@ -383,6 +408,8 @@ struct RenderShape
         if (!stroke) return 4.0f;
         return stroke->miterlimit;;
     }
+
+    bool strokeDash(RenderPath& out) const;
 };
 
 struct RenderEffect


### PR DESCRIPTION
Move stroke dasher to the common code space to create an abillity to use it on the cross API renderers (wg and gl). 
Stroke dasher is a path-to-path operation, same as path trim, so can be placed to the common space.
Now RenderShape can generate dashed path by himself.
Dashing mechanics fully hiden from the user but can be used in gl and wg renderers.

issue: https://github.com/thorvg/thorvg/issues/3557