### PR TITLE
wg_engine: Fixed typo in comment

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -228,7 +228,7 @@ void WgCompositor::renderShape(WgContext& context, WgRenderDataShape* renderData
 {
     assert(renderData);
     assert(renderPassEncoder);
-    // apply clip path if neccessary
+    // apply clip path if necessary
     if (renderData->clips.count != 0) {
         renderClipPath(context, renderData);
         if (renderData->strokeFirst) {
@@ -265,7 +265,7 @@ void WgCompositor::renderImage(WgContext& context, WgRenderDataPicture* renderDa
 {
     assert(renderData);
     assert(renderPassEncoder);
-    // apply clip path if neccessary
+    // apply clip path if necessary
     if (renderData->clips.count != 0) {
         renderClipPath(context, renderData);
         clipImage(context, renderData);


### PR DESCRIPTION
## Changes
This pull request includes minor typo corrections in comments within the `src/renderer/wg_engine/tvgWgCompositor.cpp` file. Specifically, the word "neccessary" was corrected to "necessary" in two functions.