### PR TITLE
gl_engine: Fix GlRenderTarget::reset()

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTarget.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTarget.cpp
@@ -77,7 +77,7 @@ void GlRenderTarget::init(uint32_t width, uint32_t height, GLint resolveId)
 
 void GlRenderTarget::reset()
 {
-    if (mFbo == 0) return;
+    if (mFbo == 0 || mFbo == GL_INVALID_VALUE) return;
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
     GL_CHECK(glDeleteFramebuffers(1, &mFbo));
     GL_CHECK(glDeleteRenderbuffers(1, &mColorBuffer));


### PR DESCRIPTION
Avoid deleting the framebuffer when `mFbo == GL_INVALID_VALUE`, as this is not a valid framebuffer object.


mFbo is initialized with GL_INVALID_VALUE as its default value.
- https://github.com/thorvg/thorvg/blob/e3e0ab8579792d67aa299ff3ee3f6a93c53610d7/src/renderer/gl_engine/tvgGlRenderTarget.h#L53
- https://github.com/thorvg/thorvg/blob/e3e0ab8579792d67aa299ff3ee3f6a93c53610d7/src/renderer/gl_engine/tvgGlRenderTarget.cpp#L87
