### PR TITLE
gl_engine: fix FBO validation

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTarget.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTarget.cpp
@@ -31,7 +31,7 @@ GlRenderTarget::~GlRenderTarget()
 
 void GlRenderTarget::init(uint32_t width, uint32_t height, GLint resolveId)
 {
-    if (mFbo != GL_INVALID_VALUE || width == 0 || height == 0) return;
+    if (mFbo != 0 || width == 0 || height == 0) return;
     mWidth = width;
     mHeight = height;
 
@@ -84,7 +84,11 @@ void GlRenderTarget::reset()
     GL_CHECK(glDeleteRenderbuffers(1, &mDepthStencilBuffer));
     GL_CHECK(glDeleteFramebuffers(1, &mResolveFbo));
     GL_CHECK(glDeleteTextures(1, &mColorTex));
-    mFbo = GL_INVALID_VALUE;
+    mFbo = 0;
+    mColorBuffer = 0;
+    mDepthStencilBuffer = 0;
+    mResolveFbo = 0;
+    mColorTex = 0;
 }
 
 GlRenderTargetPool::GlRenderTargetPool(uint32_t maxWidth, uint32_t maxHeight): mMaxWidth(maxWidth), mMaxHeight(maxHeight), mPool() {}

--- a/src/renderer/gl_engine/tvgGlRenderTarget.h
+++ b/src/renderer/gl_engine/tvgGlRenderTarget.h
@@ -44,13 +44,13 @@ public:
     void setViewport(const RenderRegion& vp) { mViewport = vp; }
     const RenderRegion& getViewport() const { return mViewport; }
 
-    bool invalid() const { return mFbo == GL_INVALID_VALUE; }
+    bool invalid() const { return mFbo == 0; }
 
 private:
     uint32_t mWidth = 0;
     uint32_t mHeight = 0;
     RenderRegion mViewport{};
-    GLuint mFbo = GL_INVALID_VALUE;
+    GLuint mFbo = 0;
     GLuint mColorBuffer = 0;
     GLuint mDepthStencilBuffer = 0;
     GLuint mResolveFbo = 0;

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -790,7 +790,7 @@ bool GlRenderer::clear()
 bool GlRenderer::target(void* context, int32_t id, uint32_t w, uint32_t h)
 {
     //assume the context zero is invalid
-    if (!context || id == GL_INVALID_VALUE || w == 0 || h == 0) return false;
+    if (!context || w == 0 || h == 0) return false;
 
     if (mContext) currentContext();
 


### PR DESCRIPTION
At the moment, we use the value GL_INVALID_VALUE to mark an invalid handle for FBO, which is not correct.
It is more correct to use the value 0, which signals that the buffer was not created. 
Canvas initialization processes have also been adjusted

See Lottie, MultiCanvas examples