### PR TITLE
renderer: support duplicate effects

### DIFF
--- a/examples/Duplicate.cpp
+++ b/examples/Duplicate.cpp
@@ -103,9 +103,9 @@ struct UserExample : tvgexam::Example
         //Duplicate Picture - svg
         {
             auto picture1 = tvg::Picture::gen();
-            if (!tvgexam::verify(picture1->load(EXAMPLE_DIR"/svg/tiger.svg"))) return false;
+            if (!tvgexam::verify(picture1->load(EXAMPLE_DIR"/svg/2684.svg"))) return false;
             picture1->translate(350, 200);
-            picture1->scale(0.25);
+            picture1->scale(4);
 
             auto picture2 = picture1->duplicate();
             picture2->translate(550, 250);

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -272,7 +272,40 @@ struct SceneImpl : Scene
             dup->paints.push_back(cdup);
         }
 
-        if (effects) TVGERR("RENDERER", "TODO: Duplicate Effects?");
+        if (effects) {
+            dup->effects = new Array<RenderEffect*>;
+            ARRAY_FOREACH(p, *effects) {
+                RenderEffect* ret = nullptr;
+                switch ((*p)->type) {
+                    case SceneEffect::GaussianBlur: {
+                        ret = new RenderEffectGaussianBlur(*(RenderEffectGaussianBlur*)(*p));
+                        break;
+                    }
+                    case SceneEffect::DropShadow: {
+                        ret = new RenderEffectDropShadow(*(RenderEffectDropShadow*)(*p));
+                        break;
+                    }
+                    case SceneEffect::Fill: {
+                        ret = new RenderEffectFill(*(RenderEffectFill*)(*p));
+                        break;
+                    }
+                    case SceneEffect::Tint: {
+                        ret = new RenderEffectTint(*(RenderEffectTint*)(*p));
+                        break;
+                    }
+                    case SceneEffect::Tritone: {
+                        ret = new RenderEffectTritone(*(RenderEffectTritone*)(*p));
+                        break;
+                    }
+                    default: break;
+                }
+                if (ret) {
+                    ret->rd = nullptr;
+                    ret->valid = false;
+                    dup->effects->push(ret);
+                }
+            }
+        }
 
         return scene;
     }


### PR DESCRIPTION

<img width="1616" height="1658" alt="CleanShot 2025-07-23 at 17 19 17@2x" src="https://github.com/user-attachments/assets/7472b214-6018-4fda-a2a2-3468bcaa0ac1" />


Implement effect duplication functionality for all RenderEffect types to enable proper Scene duplication with effects.

issue: https://github.com/thorvg/thorvg/issues/3631