### PR TITLE
wg/gl: add composition blend mode

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -985,7 +985,7 @@ bool GlRenderer::blend(BlendMethod method)
 
     if (method == mBlendMethod) return true;
 
-    mBlendMethod = method;
+    mBlendMethod = (method == BlendMethod::Composition ? BlendMethod::Normal : method);
 
     return true;
 }

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -286,7 +286,8 @@ bool WgRenderer::blend(BlendMethod method)
     //TODO: support
     if (method == BlendMethod::Hue || method == BlendMethod::Saturation || method == BlendMethod::Color || method == BlendMethod::Luminosity || method == BlendMethod::HardMix) return false;
 
-    mBlendMethod = method;
+    mBlendMethod = (method == BlendMethod::Composition ? BlendMethod::Normal : method);
+
     return true;
 }
 


### PR DESCRIPTION
Set the scene to use Composition mode so that it generates a pre-composition image, and then normal blend with destination.

wg and gl are already craetes intermediate buffers in a case of custom blend or composition. so only what we need to do is reinterpret the composition blend as a normal blend

```
        auto bg = tvg::Shape::gen();
        bg->appendRect(0, 0, 1000, 1000);
        bg->fill(50, 50, 50);
        canvas->push(bg);

        auto scene = tvg::Scene::gen();
        scene->blend(tvg::BlendMethod::Composition);

        auto shape = tvg::Shape::gen();
        shape->appendRect(100, 100, 200, 200);
        shape->fill(255, 0, 0);
        shape->blend(tvg::BlendMethod::Add);
        scene->push(shape);

        canvas->push(scene);
```

<img width="1360" height="387" alt="image" src="https://github.com/user-attachments/assets/ff005509-1728-4580-8eeb-22d9697899e3" />


https://github.com/thorvg/thorvg/pull/3621