### PR TITLE
lottie: fix timeRemap frame boundary handling

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -694,6 +694,7 @@ float LottieLayer::remap(LottieComposition* comp, float frameNo, LottieExpressio
 {
     if (timeRemap.frames || timeRemap.value >= 0.0f) {
         frameNo = comp->frameAtTime(timeRemap(frameNo, exp));
+        if (frameNo >= comp->frameCnt() * timeStretch) return cache.frameNo;
     } else {
         frameNo -= startFrame;
     }


### PR DESCRIPTION
| Previous                                                                                      | Patched                                                                                      |
|-----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
| ![CleanShot 2025-07-25 at 00 01 33](https://github.com/user-attachments/assets/2ae4cb16-6abc-4443-ae5a-1e0f17fc5c35) | ![CleanShot 2025-07-25 at 00 00 33](https://github.com/user-attachments/assets/c9c1a0db-e7ea-434e-baae-3df1d80b3a8e) |


Issue file: [smile.json](https://github.com/user-attachments/files/21413769/smile.json)


Fix logic bug in LottieLayer::remap() where timeRemap calculation could exceed frame boundaries. When the calculated mapping frame goes beyond outFrame, now returns the last valid frameNo instead of potentially invalid frame values.

> For example, outFrame is `163`, remapped frame is `256` → **out of range**

> lottie-web corrects the frame using the last used frameNo, I applied the same approach.

This ensures proper frame clamping for timeRemap animations and prevents out-of-bounds frame access.

issue: https://github.com/thorvg/thorvg/issues/3591