### PR TITLE
sw_engine: prevent NaN in gradient pixel calculations

### DIFF
--- a/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/src/renderer/sw_engine/tvgSwFill.cpp
@@ -308,6 +308,7 @@ static inline uint32_t _fixedPixel(const SwFill* fill, int32_t pos)
 
 static inline uint32_t _pixel(const SwFill* fill, float pos)
 {
+    if (!std::isfinite(pos)) pos = 0;
     auto i = static_cast<int32_t>(pos * (GRADIENT_STOP_SIZE - 1) + 0.5f);
     return fill->ctable[_clamp(fill, i)];
 }


### PR DESCRIPTION
### Test file : [radial-basic-v2.json](https://github.com/user-attachments/files/21415205/radial-basic-v2.json)

<img width="1484" height="164" alt="CleanShot 2025-07-25 at 01 25 10@2x" src="https://github.com/user-attachments/assets/15620a3f-5a10-4851-95c0-81b8d4ef50b3" />

---


Add std::isfinite() check in _pixel() to prevent undefined behavior when NaN values are cast to int32_t. This prevents potential crashes during gradient color table indexing.

NaN can occur from:
- Division by zero in radial gradient calculations
- Negative values passed to sqrtf() in radial gradient determinant