### PR TITLE
lottie/parser: fix uint8_t overflow in getValue function

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -264,11 +264,11 @@ bool LottieParser::getValue(uint8_t& val)
 {
     if (peekType() == kArrayType) {
         enterArray();
-        if (nextArrayValue()) val = (uint8_t)(getFloat() * 2.55f);
+        if (nextArrayValue()) val = (uint8_t)(tvg::clamp(getFloat() * 2.55f, 0.0f, 255.0f));
         //discard rest
         while (nextArrayValue()) getFloat();
     } else {
-        val = (uint8_t)(getFloat() * 2.55f);
+        val = (uint8_t)(tvg::clamp(getFloat() * 2.55f, 0.0f, 255.0f));
     }
     return false;
 }


### PR DESCRIPTION
## Test file :  [text-radialGradient-stroke.json](https://github.com/user-attachments/files/21415559/text-radialGradient-stroke.json)


<img width="1492" height="176" alt="CleanShot 2025-07-25 at 01 53 21@2x" src="https://github.com/user-attachments/assets/e9a6b9a8-1372-4e8f-89e7-70d6aba1ca99" />


---

Fix runtime error when float values exceed uint8_t range (0-255). The getValue(uint8_t&) function was directly casting float values multiplied by 2.55f to uint8_t without range validation.

This caused overflow errors when input values exceeded ~100% (e.g. opacity value is greater than 100).

Added tvg::clamp() to ensure values stay within valid uint8_t range (0-255), preventing runtime overflow errors.