### PR TITLE
examples: fix first frame sync with window appearance

### DIFF
--- a/examples/Example.h
+++ b/examples/Example.h
@@ -198,13 +198,14 @@ struct Window
         if (!verify(canvas->draw())) return false;
         if (!verify(canvas->sync())) return false;
 
+        refresh();
+
         return true;
     }
 
     void show()
     {
         SDL_ShowWindow(window);
-        refresh();
 
         //Mainloop
         SDL_Event event;


### PR DESCRIPTION
In some examples, the first frame is black. This goes away if `refresh` before `SDL_ShowWindow `.

reproduce:
- run Blending example (GL,SW)


issue: #3314



|Previous | Patched |
|-|-|
|![Jul-25-2025 22-55-30](https://github.com/user-attachments/assets/27e64f57-6284-4125-bc11-ba2df2011f16)| ![Jul-25-2025 22-37-41](https://github.com/user-attachments/assets/84cd5237-dffe-42e5-a265-bca68460b679)|


