### PR TITLE
wg_engine: move effects to fragment shaders

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -30,7 +30,6 @@ struct WgCompose: RenderCompositor
 {
     BlendMethod blend{};
     RenderRegion aabb{};
-    WgRenderDataViewport* rdViewport;
 };
 
 class WgCompositor
@@ -98,7 +97,6 @@ private:
     void markupClipPath(WgContext& context, WgRenderDataShape* renderData);
     void renderClipPath(WgContext& context, WgRenderDataPaint* paint);
     void clearClipPath(WgContext& context, WgRenderDataPaint* paint);
-
 public:
     void initialize(WgContext& context, uint32_t width, uint32_t height);
     void initPools(WgContext& context);
@@ -107,7 +105,8 @@ public:
     void resize(WgContext& context, uint32_t width, uint32_t height);
 
     // render passes workflow
-    void beginRenderPass(WGPUCommandEncoder encoder, WgRenderTarget* target, bool clear, WGPUColor clearColor = { 0.0, 0.0, 0.0, 0.0 });
+    void beginRenderPassMS(WGPUCommandEncoder encoder, WgRenderTarget* target, bool clear, WGPUColor clearColor = { 0.0, 0.0, 0.0, 0.0 });
+    void beginRenderPass(WGPUCommandEncoder encoder, WgRenderTarget* target);
     void endRenderPass();
 
     // stage buffers operations

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -47,7 +47,7 @@ private:
     // shader blit
     WGPUShaderModule shader_blit{};
     // shader effects
-    WGPUShaderModule shader_gauss;
+    WGPUShaderModule shader_shadow;
     WGPUShaderModule shader_effects;
 
     // layouts helpers
@@ -68,7 +68,7 @@ private:
     // layouts blit
     WGPUPipelineLayout layout_blit{};
     // layouts effects
-    WGPUPipelineLayout layout_gauss{};
+    WGPUPipelineLayout layout_shadow{};
     WGPUPipelineLayout layout_effects{};
 public:
     // pipelines stencil markup
@@ -98,12 +98,12 @@ public:
     // pipeline blit
     WGPURenderPipeline blit{};
     // effects
-    WGPUComputePipeline gaussian_horz{};
-    WGPUComputePipeline gaussian_vert{};
-    WGPUComputePipeline dropshadow{};
-    WGPUComputePipeline fill_effect{};
-    WGPUComputePipeline tint_effect{};
-    WGPUComputePipeline tritone_effect{};
+    WGPURenderPipeline gaussian_vert{};
+    WGPURenderPipeline gaussian_horz{};
+    WGPURenderPipeline dropshadow{};
+    WGPURenderPipeline fill_effect{};
+    WGPURenderPipeline tint_effect{};
+    WGPURenderPipeline tritone_effect{};
 private:
     void releaseGraphicHandles(WgContext& context);
     WGPUShaderModule createShaderModule(WGPUDevice device, const char* label, const char* code);

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -314,60 +314,6 @@ void WgRenderDataPicturePool::release(WgContext& context)
 }
 
 //***********************************************************************
-// WgRenderDataGaussian
-//***********************************************************************
-
-void WgRenderDataViewport::update(WgContext& context, const RenderRegion& region) {
-    WgShaderTypeVec4f viewport;
-    viewport.update(region);
-    bool bufferViewportChanged = context.allocateBufferUniform(bufferViewport, &viewport, sizeof(viewport));
-    if (bufferViewportChanged) {
-        context.layouts.releaseBindGroup(bindGroupViewport);
-        bindGroupViewport = context.layouts.createBindGroupBuffer1Un(bufferViewport);
-    }
-}
-
-
-void WgRenderDataViewport::release(WgContext& context) {
-    context.releaseBuffer(bufferViewport);
-    context.layouts.releaseBindGroup(bindGroupViewport);
-}
-
-//***********************************************************************
-// WgRenderDataViewportPool
-//***********************************************************************
-
-WgRenderDataViewport* WgRenderDataViewportPool::allocate(WgContext& context)
-{
-    WgRenderDataViewport* renderData{};
-    if (mPool.count > 0) {
-        renderData = mPool.last();
-        mPool.pop();
-    } else {
-        renderData = new WgRenderDataViewport();
-        mList.push(renderData);
-    }
-    return renderData;
-}
-
-
-void WgRenderDataViewportPool::free(WgContext& context, WgRenderDataViewport* renderData)
-{
-    if (renderData) mPool.push(renderData);
-}
-
-
-void WgRenderDataViewportPool::release(WgContext& context)
-{
-    ARRAY_FOREACH(p, mList) {
-        (*p)->release(context);
-        delete(*p);
-    }
-    mPool.clear();
-    mList.clear();
-}
-
-//***********************************************************************
 // WgRenderDataEffectParams
 //***********************************************************************
 
@@ -386,7 +332,6 @@ void WgRenderDataEffectParams::update(WgContext& context, RenderEffectGaussianBl
     WgShaderTypeEffectParams effectParams;
     if (!effectParams.update(gaussian, transform)) return;
     update(context, effectParams);
-    level = int(WG_GAUSSIAN_MAX_LEVEL * ((gaussian->quality - 1) * 0.01f)) + 1;
     extend = effectParams.extend;
 }
 
@@ -397,7 +342,6 @@ void WgRenderDataEffectParams::update(WgContext& context, RenderEffectDropShadow
     WgShaderTypeEffectParams effectParams;
     if (!effectParams.update(dropShadow, transform)) return;
     update(context, effectParams);
-    level = int(WG_GAUSSIAN_MAX_LEVEL * ((dropShadow->quality - 1) * 0.01f)) + 1;
     extend = effectParams.extend;
     offset = effectParams.offset;
 }

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -120,28 +120,6 @@ public:
     void release(WgContext& context);
 };
 
-struct WgRenderDataViewport
-{
-    WGPUBindGroup bindGroupViewport{};
-    WGPUBuffer bufferViewport{};
-
-    void update(WgContext& context, const RenderRegion& region);
-    void release(WgContext& context);
-};
-
-class WgRenderDataViewportPool {
-private:
-    // pool contains all created but unused render data for viewport
-    Array<WgRenderDataViewport*> mPool;
-    // list contains all created render data for viewport
-    // to ensure that all created instances will be released
-    Array<WgRenderDataViewport*> mList;
-public:
-    WgRenderDataViewport* allocate(WgContext& context);
-    void free(WgContext& context, WgRenderDataViewport* renderData);
-    void release(WgContext& context);
-};
-
 // gaussian blur, drop shadow, fill, tint, tritone
 #define WG_GAUSSIAN_MAX_LEVEL 3
 struct WgRenderDataEffectParams
@@ -149,7 +127,6 @@ struct WgRenderDataEffectParams
     WGPUBindGroup bindGroupParams{};
     WGPUBuffer bufferParams{};
     uint32_t extend{};
-    uint32_t level{};
     Point offset{};
 
     void update(WgContext& context, WgShaderTypeEffectParams& effectParams);

--- a/src/renderer/wg_engine/tvgWgRenderTarget.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.cpp
@@ -32,13 +32,13 @@ void WgRenderTarget::initialize(WgContext& context, uint32_t width, uint32_t hei
     texViewMS = context.createTextureView(textureMS);
     bindGroupRead = context.layouts.createBindGroupStrorage1RO(texView);
     bindGroupWrite = context.layouts.createBindGroupStrorage1WO(texView);
-    bindGroupTexure = context.layouts.createBindGroupTexSampled(context.samplerNearestRepeat, texView);
+    bindGroupTexture = context.layouts.createBindGroupTexSampled(context.samplerNearestRepeat, texView);
 }
 
 
 void WgRenderTarget::release(WgContext& context)
 {
-    context.layouts.releaseBindGroup(bindGroupTexure);
+    context.layouts.releaseBindGroup(bindGroupTexture);
     context.layouts.releaseBindGroup(bindGroupWrite);
     context.layouts.releaseBindGroup(bindGroupRead);
     context.releaseTextureView(texViewMS);

--- a/src/renderer/wg_engine/tvgWgRenderTarget.h
+++ b/src/renderer/wg_engine/tvgWgRenderTarget.h
@@ -33,7 +33,7 @@ struct WgRenderTarget {
     WGPUTextureView texViewMS{};
     WGPUBindGroup bindGroupRead{};
     WGPUBindGroup bindGroupWrite{};
-    WGPUBindGroup bindGroupTexure{};
+    WGPUBindGroup bindGroupTexture{};
     uint32_t width{};
     uint32_t height{};
 

--- a/src/renderer/wg_engine/tvgWgRenderTask.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTask.cpp
@@ -45,7 +45,7 @@ void WgSceneTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandE
     // begin the render pass for the current scene and clear the target content
     WGPUColor color{};
     if ((compose->method == MaskMethod::None) && (compose->blend != BlendMethod::Normal)) color = { 1.0, 1.0, 1.0, 0.0 };
-    compositor.beginRenderPass(encoder, renderTarget, true, color);
+    compositor.beginRenderPassMS(encoder, renderTarget, true, color);
     // run all childs (scenes and shapes)
     runChildren(context, compositor, encoder);
     // we must to end current render pass for current scene
@@ -57,11 +57,11 @@ void WgSceneTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandE
     if (!renderTargetDst) return;
     // apply scene blending
     if (compose->method == MaskMethod::None) {
-        compositor.beginRenderPass(encoder, renderTargetDst, false);
+        compositor.beginRenderPassMS(encoder, renderTargetDst, false);
         compositor.renderScene(context, renderTarget, compose);
     // apply scene composition (for scenes, that have a handle to mask)
     } else if (renderTargetMsk) {
-        compositor.beginRenderPass(encoder, renderTargetDst, false);
+        compositor.beginRenderPassMS(encoder, renderTargetDst, false);
         compositor.composeScene(context, renderTarget, renderTargetMsk, compose);
     }
 }
@@ -72,7 +72,7 @@ void WgSceneTask::runChildren(WgContext& context, WgCompositor& compositor, WGPU
     ARRAY_FOREACH(task, children) {
         WgRenderTask* renderTask = *task;
         // we need to restore current render pass without clear
-        compositor.beginRenderPass(encoder, renderTarget, false);
+        compositor.beginRenderPassMS(encoder, renderTarget, false);
         // run children (shape or scene)
         renderTask->run(context, compositor, encoder);
     }

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -41,7 +41,6 @@ void WgRenderer::release()
     // clear render data paint pools
     mRenderDataShapePool.release(mContext);
     mRenderDataPicturePool.release(mContext);
-    mRenderDataViewportPool.release(mContext);
     mRenderDataEffectParamsPool.release(mContext);
 
     // clear render  pool
@@ -253,10 +252,6 @@ bool WgRenderer::postRender()
     mRenderTaskList.clear();
     ARRAY_FOREACH(p, mCompositorList) { delete (*p); };
     mCompositorList.clear();
-    ARRAY_FOREACH(p, mRenderDataViewportList) {
-        mRenderDataViewportPool.free(mContext, *p);
-    }
-    mRenderDataViewportList.clear();
     return true;
 }
 
@@ -431,12 +426,6 @@ RenderCompositor* WgRenderer::target(const RenderRegion& region, TVG_UNUSED Colo
     // create and setup compose data
     WgCompose* compose = new WgCompose();
     compose->aabb = region;
-    if (flags & PostProcessing) {
-        compose->aabb = region;
-        compose->rdViewport = mRenderDataViewportPool.allocate(mContext);
-        compose->rdViewport->update(mContext, region);
-        mRenderDataViewportList.push(compose->rdViewport);
-    }
     mCompositorList.push(compose);
     return compose;
 }

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -78,7 +78,6 @@ private:
     WgRenderTarget mRenderTargetRoot;
     Array<WgCompose*> mCompositorList;
     Array<WgRenderTarget*> mRenderTargetStack;
-    Array<WgRenderDataViewport*> mRenderDataViewportList;
     Array<WgSceneTask*> mSceneTaskStack;
     Array<WgRenderTask*> mRenderTaskList;
 
@@ -88,7 +87,6 @@ private:
     // render data paint pools
     WgRenderDataShapePool mRenderDataShapePool;
     WgRenderDataPicturePool mRenderDataPicturePool;
-    WgRenderDataViewportPool mRenderDataViewportPool;
     WgRenderDataEffectParamsPool mRenderDataEffectParamsPool;
 
     // rendering context

--- a/src/renderer/wg_engine/tvgWgShaderSrc.h
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.h
@@ -44,8 +44,8 @@ extern const char* cShaderSrc_Scene_Compose;
 // shaders blit
 extern const char* cShaderSrc_Blit;
 
-// compute shader sources: effects
-extern const char* cShaderSrc_GaussianBlur;
+// shader sources effects
+extern const char* cShaderSrc_Shadow;
 extern const char* cShaderSrc_Effects;
 
 #endif // _TVG_WG_SHEDER_SRC_H_


### PR DESCRIPTION
- move effects from from compute shader to fragment shaders through lightweight context switcher
- allign wg and gl effects math and shaders
- removed unneccessary viewport pool

https://github.com/thorvg/thorvg/issues/3649
https://github.com/thorvg/thorvg/issues/3637 - fixed