### PR TITLE
wg_engine: blending revision

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderTask.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderTask.cpp
@@ -43,9 +43,7 @@ void WgPaintTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandE
 void WgSceneTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
 {
     // begin the render pass for the current scene and clear the target content
-    WGPUColor color{};
-    if ((compose->method == MaskMethod::None) && (compose->blend != BlendMethod::Normal)) color = { 1.0, 1.0, 1.0, 0.0 };
-    compositor.beginRenderPassMS(encoder, renderTarget, true, color);
+    compositor.beginRenderPassMS(encoder, renderTarget, true);
     // run all childs (scenes and shapes)
     runChildren(context, compositor, encoder);
     // we must to end current render pass for current scene


### PR DESCRIPTION
enhanced image blending by properly applying unpremultiply/premultiply computations during blending operations.

blending sw
<img width="1802" height="1080" alt="blend_sw" src="https://github.com/user-attachments/assets/337f8e05-c986-4088-a47b-95e363bcbc1d" />

blending wg (after)
<img width="1920" height="1080" alt="blend_after" src="https://github.com/user-attachments/assets/c1830a53-891c-4035-9549-92629ce61bfc" />

blending wg (before)
<img width="1920" height="1080" alt="blend_before" src="https://github.com/user-attachments/assets/ee30ee29-90d2-4913-9788-e92811b2a958" />

issue: https://github.com/thorvg/thorvg/issues/3072