### PR TITLE
renderer: fix emsdk compilation warning

### DIFF
--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -391,7 +391,7 @@ Result Paint::bounds(Point* pt4) const noexcept
 bool Paint::intersects(int32_t x, int32_t y, int32_t w, int32_t h) noexcept
 {
     if (w <= 0 || h <= 0) return false;
-    return pImpl->intersects({x, y, x + w, y + h});
+    return pImpl->intersects({{x, y}, {x + w, y + h}});
 }
 
 


### PR DESCRIPTION
add recomended braces to initialize RenderRegion
<img width="545" height="388" alt="image" src="https://github.com/user-attachments/assets/367bc71a-e5ee-4087-a937-773df2cbc26e" />
