### PR TITLE
renderer: hotfix for partial rendering dirty update issue

### DIFF
--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -77,7 +77,7 @@ struct SceneImpl : Scene
     ~SceneImpl()
     {
         clearPaints();
-        resetEffects();
+        resetEffects(false);
     }
 
     void size(const Point& size)
@@ -385,7 +385,7 @@ struct SceneImpl : Scene
         return new SceneIterator(&paints);
     }
 
-    Result resetEffects()
+    Result resetEffects(bool damage = true)
     {
         if (effects) {
             ARRAY_FOREACH(p, *effects) {
@@ -394,6 +394,7 @@ struct SceneImpl : Scene
             }
             delete(effects);
             effects = nullptr;
+            if (damage) impl.damage(vport);
         }
         return Result::Success;
     }


### PR DESCRIPTION
A corner case was found where the scene was not properly updated when effects were cleaned up.

This issue only affects partial rendering. The fix adds the dirty region when effects are changed to ensure proper updates.