### PR TITLE
wasm: add TypeScript bindings for the WASM module

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -30,6 +30,9 @@ using namespace emscripten;
 using namespace std;
 using namespace tvg;
 
+EMSCRIPTEN_DECLARE_VAL_TYPE(Uint8Array);
+EMSCRIPTEN_DECLARE_VAL_TYPE(Float32Array);
+
 static const char* NoError = "None";
 
 struct TvgEngineMethod
@@ -37,9 +40,9 @@ struct TvgEngineMethod
     virtual ~TvgEngineMethod() {}
     virtual Canvas* init(string&) = 0;
     virtual void resize(Canvas* canvas, int w, int h) = 0;
-    virtual val output(int w, int h)
+    virtual Uint8Array output(int w, int h)
     {
-        return val(typed_memory_view<uint8_t>(0, nullptr));
+        return Uint8Array(val(typed_memory_view<uint8_t>(0, nullptr)));
     }
 
     void loadFont() {
@@ -74,9 +77,9 @@ struct TvgSwEngine : TvgEngineMethod
         static_cast<SwCanvas*>(canvas)->target((uint32_t *)buffer, w, w, h, ColorSpace::ABGR8888S);
     }
 
-    val output(int w, int h) override
+    Uint8Array output(int w, int h) override
     {
-        return val(typed_memory_view(w * h * 4, buffer));
+        return Uint8Array(val(typed_memory_view(w * h * 4, buffer)));
     }
 };
 
@@ -278,9 +281,9 @@ public:
         return errorMsg;
     }
 
-    val size()
+    Float32Array size()
     {
-        return val(typed_memory_view(2, psize));
+        return Float32Array(val(typed_memory_view(2, psize)));
     }
 
     float duration()
@@ -345,17 +348,17 @@ public:
         return true;
     }
 
-    val render()
+    Uint8Array render()
     {
         errorMsg = NoError;
 
-        if (!canvas || !animation) return val(typed_memory_view<uint8_t>(0, nullptr));
+        if (!canvas || !animation) return Uint8Array(val(typed_memory_view<uint8_t>(0, nullptr)));
 
         if (!updated) return engine->output(width, height);
 
         if (canvas->draw(true) != Result::Success) {
             errorMsg = "draw() fail";
-            return val(typed_memory_view<uint8_t>(0, nullptr));
+            return Uint8Array(val(typed_memory_view<uint8_t>(0, nullptr)));
         }
 
         canvas->sync();
@@ -530,6 +533,8 @@ void term()
 
 EMSCRIPTEN_BINDINGS(thorvg_bindings)
 {
+    register_type<Uint8Array>("Uint8Array");
+    register_type<Float32Array>("Float32Array");
     emscripten::function("init", &init);
     emscripten::function("term", &term);
 

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -242,8 +242,6 @@ struct SwShape
     SwFill* fill = nullptr;
     SwRle* rle = nullptr;
     SwRle* strokeRle = nullptr;
-    RenderRegion bbox;           //Keep it boundary without stroke region. Using for optimal filling.
-
     bool fastTrack = false;   //Fast Track: axis-aligned rectangle without any clips?
 };
 
@@ -647,7 +645,7 @@ bool mathUpdateOutlineBBox(const SwOutline* outline, const RenderRegion& clipBox
 void shapeReset(SwShape* shape);
 bool shapePrepare(SwShape* shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool hasComposite);
 bool shapePrepared(const SwShape* shape);
-bool shapeGenRle(SwShape* shape, const RenderShape* rshape, bool antiAlias);
+bool shapeGenRle(SwShape* shape, const RenderRegion& bbox, bool antiAlias);
 void shapeDelOutline(SwShape* shape, SwMpool* mpool, uint32_t tid);
 void shapeResetStroke(SwShape* shape, const RenderShape* rshape, const Matrix& transform);
 bool shapeGenStrokeRle(SwShape* shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid);

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -435,12 +435,11 @@ static SwOutline* _genOutline(SwShape* shape, const RenderShape* rshape, const M
 
 bool shapePrepare(SwShape* shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool hasComposite)
 {
-    if (auto out = _genOutline(shape, rshape, transform, mpool, tid, hasComposite, rshape->trimpath())) shape->outline = out;
-    else return false;
-    if (!mathUpdateOutlineBBox(shape->outline, clipBox, renderBox, shape->fastTrack)) return false;
+    if (shape->outline = _genOutline(shape, rshape, transform, mpool, tid, hasComposite, rshape->trimpath())) {
+        return mathUpdateOutlineBBox(shape->outline, clipBox, renderBox, shape->fastTrack);
+    }
+    return false;
 
-    shape->bbox = renderBox;
-    return true;
 }
 
 
@@ -450,13 +449,13 @@ bool shapePrepared(const SwShape* shape)
 }
 
 
-bool shapeGenRle(SwShape* shape, TVG_UNUSED const RenderShape* rshape, bool antiAlias)
+bool shapeGenRle(SwShape* shape, const RenderRegion& bbox, bool antiAlias)
 {
     //Case A: Fast Track Rectangle Drawing
     if (shape->fastTrack) return true;
 
     //Case B: Normal Shape RLE Drawing
-    if ((shape->rle = rleRender(shape->rle, shape->outline, shape->bbox, antiAlias))) return true;
+    if ((shape->rle = rleRender(shape->rle, shape->outline, bbox, antiAlias))) return true;
 
     return false;
 }
@@ -473,7 +472,6 @@ void shapeReset(SwShape* shape)
 {
     rleReset(shape->rle);
     shape->fastTrack = false;
-    shape->bbox.reset();
 }
 
 

--- a/wasm_build_tsd.sh
+++ b/wasm_build_tsd.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#https://github.com/thorvg/thorvg/wiki/ThorVG-Viewer-Development-Guide
+
+EMSDK="$1"
+TMP_DIR="/tmp/.build_wasm_tsd"
+OUT_DIR="build_wasm/src/bindings/wasm"
+
+if [ ! -d "$OUT_DIR" ]; then
+    echo "[ERROR] $OUT_DIR does not exist. Please run wasm_build.sh first."
+    exit 1
+fi
+
+rm -rf "$TMP_DIR"
+
+sed "s|EMSDK:|$EMSDK|g; s|'--bind'|'--bind', '--emit-tsd=thorvg-wasm.d.ts'|g" ./cross/wasm32.txt > /tmp/.wasm_cross.txt
+meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="all" -Dsavers="all" -Dthreads=false -Dbindings="wasm_beta" -Dpartial=false -Dengines="all" --cross-file /tmp/.wasm_cross.txt "$TMP_DIR"
+
+ninja -C "$TMP_DIR/"
+mv "$TMP_DIR/src/bindings/wasm/thorvg-wasm.d.ts" "$OUT_DIR"
+
+rm -rf "$TMP_DIR"
+
+ls -lrt "$OUT_DIR"/*.d.ts


### PR DESCRIPTION
This PR improves TypeScript bindings for the WASM module by:

- Enables `.d.ts` generation via `--emit-tsd`
- Defines custom `val`-based types using `EMSCRIPTEN_DECLARE_VAL_TYPE`

These changes are related to [`thorvg.web#16`](https://github.com/thorvg/thorvg.web/issues/16), which requests better TypeScript support for the WASM output.

This PR focuses on updating the C++ binding layer. A follow-up change may be submitted to `thorvg.web` to utilize these bindings in the front-end.