### PR TITLE
wg_engine: hsl blending support

### DIFF
--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -20,8 +20,8 @@
  * SOFTWARE.
  */
 
-#include "tvgWgPipelines.h"
 #include "tvgWgShaderSrc.h"
+#include "tvgWgPipelines.h"
 #include <cstring>
 #include <cassert>
 
@@ -354,10 +354,10 @@ void WgPipelines::initialize(WgContext& context)
         "fs_main_SoftLight",
         "fs_main_Difference",
         "fs_main_Exclusion",
-        "fs_main_Normal", //TODO: a padding for reserved Hue.
-        "fs_main_Normal", //TODO: a padding for reserved Saturation.
-        "fs_main_Normal", //TODO: a padding for reserved Color.
-        "fs_main_Normal", //TODO: a padding for reserved Luminosity.
+        "fs_main_Hue",
+        "fs_main_Saturation",
+        "fs_main_Color",
+        "fs_main_Luminosity",
         "fs_main_Add",
         "fs_main_Normal"  //TODO: a padding for reserved Hardmix.
     };

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -278,9 +278,6 @@ RenderRegion WgRenderer::region(RenderData data)
 
 bool WgRenderer::blend(BlendMethod method)
 {
-    //TODO: support
-    if (method == BlendMethod::Hue || method == BlendMethod::Saturation || method == BlendMethod::Color || method == BlendMethod::Luminosity) return false;
-
     mBlendMethod = (method == BlendMethod::Composition ? BlendMethod::Normal : method);
 
     return true;


### PR DESCRIPTION
Introduced HSL blending support for webgpu: Hue, Saturation, Color, Luminosity
Supported for all blending targets: solid, gradient, image, scene

sw/wg
<img width="1274" height="531" alt="image" src="https://github.com/user-attachments/assets/8047aabe-a5c2-4113-9c87-ba15a21588b4" />
<img width="1602" height="825" alt="image" src="https://github.com/user-attachments/assets/a05fab4c-d458-4843-aa81-131be21ff585" />

