### PR TITLE
savers/gif: Unref bg after push to fix ref count

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -45,3 +45,4 @@ Benjamin <benjaminhalko@hotmail.com>
 Benson Muite <benson_muite@emailplus.com>
 kkocdko <kkocdko@gmail.com>
 SoonGeon Noh <nors.nsg@gmail.com>
+Giseong Ji <jiggyjiggy0323@gmail.com>

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -44,8 +44,8 @@ void GifSaver::run(unsigned tid)
 
     if (bg) {
         bg->unref();
+        bg = nullptr;
     }
-    bg = nullptr;
 
     canvas->push(animation->picture());
 

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -41,12 +41,6 @@ void GifSaver::run(unsigned tid)
     buffer = tvg::realloc<uint32_t*>(buffer, sizeof(uint32_t) * w * h);
     canvas->target(buffer, w, w, h, ColorSpace::ABGR8888S);
     canvas->push(bg);
-
-    if (bg) {
-        bg->unref();
-        bg = nullptr;
-    }
-
     canvas->push(animation->picture());
 
     //use the default fps
@@ -80,6 +74,11 @@ void GifSaver::run(unsigned tid)
     }
 
     if (!gifEnd(&writer)) TVGERR("GIF_SAVER", "Failed gif encoding");
+
+    if (bg) {
+        bg->unref();
+        bg = nullptr;
+    }
 }
 
 

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -41,6 +41,10 @@ void GifSaver::run(unsigned tid)
     buffer = tvg::realloc<uint32_t*>(buffer, sizeof(uint32_t) * w * h);
     canvas->target(buffer, w, w, h, ColorSpace::ABGR8888S);
     canvas->push(bg);
+
+    if (bg) {
+        bg->unref();
+    }
     bg = nullptr;
 
     canvas->push(animation->picture());

--- a/test/testSavers.cpp
+++ b/test/testSavers.cpp
@@ -27,7 +27,7 @@
 
 using namespace tvg;
 using namespace std;
-#if 0
+
 TEST_CASE("Saver Creation", "[tvgSavers]")
 {
     auto saver = unique_ptr<Saver>(Saver::gen());
@@ -36,41 +36,39 @@ TEST_CASE("Saver Creation", "[tvgSavers]")
 
 #if defined(THORVG_GIF_SAVER_SUPPORT) && defined(THORVG_LOTTIE_LOADER_SUPPORT)
 
-TEST_CASE("Save a lottie into gif", "[tvgSavers]")
-{
+TEST_CASE("Save a lottie into gif", "[tvgSavers]") {
     REQUIRE(Initializer::init() == Result::Success);
+    {
+        auto animation = Animation::gen();
+        REQUIRE(animation);
 
-    auto animation = Animation::gen();
-    REQUIRE(animation);
+        auto picture = animation->picture();
+        REQUIRE(picture);
+        REQUIRE(picture->load(TEST_DIR"/test.json") == Result::Success);
+        REQUIRE(picture->size(100, 100) == Result::Success);
 
-    auto picture = animation->picture();
-    REQUIRE(picture);
-    REQUIRE(picture->load(TEST_DIR"/test.json") == Result::Success);
-    REQUIRE(picture->size(100, 100) == Result::Success);
+        auto saver =  unique_ptr<Saver>(Saver::gen());
+        REQUIRE(saver);
+        REQUIRE(saver->save(animation, TEST_DIR"/test.gif") == Result::Success);
+        REQUIRE(saver->sync() == Result::Success);
 
-    auto saver =  unique_ptr<Saver>(Saver::gen());
-    REQUIRE(saver);
-    REQUIRE(saver->save(animation, TEST_DIR"/test.gif") == Result::Success);
-    REQUIRE(saver->sync() == Result::Success);
+        //with a background
+        auto animation2 = Animation::gen();
+        REQUIRE(animation2);
 
-    //with a background
-    auto animation2 = Animation::gen();
-    REQUIRE(animation2);
+        auto picture2 = animation2->picture();
+        REQUIRE(picture2);
+        REQUIRE(picture2->load(TEST_DIR"/test.json") == Result::Success);
+        REQUIRE(picture2->size(100, 100) == Result::Success);
 
-    auto picture2 = animation2->picture();
-    REQUIRE(picture2);
-    REQUIRE(picture2->load(TEST_DIR"/test.json") == Result::Success);
-    REQUIRE(picture2->size(100, 100) == Result::Success);
+        auto bg = Shape::gen();
+        REQUIRE(bg->fill(255, 255, 255) == Result::Success);
+        REQUIRE(bg->appendRect(0, 0, 100, 100) == Result::Success);
 
-    auto bg = Shape::gen();
-    REQUIRE(bg->fill(255, 255, 255) == Result::Success);
-    REQUIRE(bg->appendRect(0, 0, 100, 100) == Result::Success);
-
-    REQUIRE(saver->background(bg) == Result::Success);
-    REQUIRE(saver->save(animation2, TEST_DIR"/test.gif") == Result::Success);
-    REQUIRE(saver->sync() == Result::Success);
-
+        REQUIRE(saver->background(bg) == Result::Success);
+        REQUIRE(saver->save(animation2, TEST_DIR"/test.gif") == Result::Success);
+        REQUIRE(saver->sync() == Result::Success);
+    }
     REQUIRE(Initializer::term() == Result::Success);
 }
-#endif
 #endif


### PR DESCRIPTION
https://github.com/thorvg/thorvg/issues/3671#issuecomment-3143892584

1
The test failure in test/testSavers.cpp was due to an incorrect ref count of `bg`. 
Added unref in `GifSaver::run` to resolve it.

2
Added brace-format usage for Initializer
