### PR TITLE
renderer: added an API to set the visibility of the Paint object.

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -319,6 +319,27 @@ public:
     const Paint* parent() const noexcept;
 
     /**
+     * @brief Sets the visibility of the Paint object.
+     *
+     * This is useful for selectively excluding paint objects during rendering.
+     *
+     * @param[in] on A boolean flag indicating visibility. The default is @c true.
+     *               @c true, the object will be rendered by the engine.
+     *               @c false, the object will be excluded from the drawing process.
+     *
+     * @note An invisible object is not considered inactive—it may still participate
+     *       in internal update processing if its properties are updated, but it will not
+     *       be taken into account for the final drawing output. To completely deactivate
+     *       a paint object, remove it from the canvas.
+     *
+     * @see Paint::visible() const
+     * @see Result Canvas::remove(Paint* paint)
+     *
+     * @since 1.0
+     */
+    Result visible(bool on) noexcept;
+
+    /**
      * @brief Sets the angle by which the object is rotated.
      *
      * The angle in measured clockwise from the horizontal axis.
@@ -464,7 +485,7 @@ public:
      * intersects the geometric fill region of the paint object.
      *
      * This is useful for hit-testing purposes, such as detecting whether a user interaction (e.g., touch or click)
-     * occurs within a visible painted region.
+     * occurs within a painted region.
      *
      * The paint must be updated in a Canvas beforehand—typically after the Canvas has been
      * drawn and synchronized.
@@ -479,7 +500,8 @@ public:
      * @note To test a single point, set the region size to w = 1, h = 1.
      * @note For efficiency, an AABB (axis-aligned bounding box) test is performed internally before precise hit detection.
      * @note This test does not take into account the results of blending or masking.
-     * @note Experimental API.
+     * @note This test does take into account the the hidden paints as well. @see Paint::visible()
+     * @note Experimental API
      */
     bool intersects(int32_t x, int32_t y, int32_t w = 1, int32_t h = 1) noexcept;
 
@@ -522,6 +544,18 @@ public:
      * @since 1.0
      */
     Shape* clip() const noexcept;
+
+    /**
+     * @brief Gets the current visibility status of the Paint object.
+     *
+     * @return true if the object is visible and will be rendered.
+     *         false if the object is hidden and will not be rendered.
+     *
+     * @see Paint::visible(bool on)
+     *
+     * @since 1.0
+     */
+    bool visible() const noexcept;
 
     /**
      * @brief Increment the reference count for the Paint instance.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -736,6 +736,44 @@ TVG_API uint16_t tvg_paint_unref(Tvg_Paint* paint, bool free);
 TVG_API uint16_t tvg_paint_get_ref(const Tvg_Paint* paint);
 
 
+/**
+ * @brief Sets the visibility of the Paint object.
+ *
+ * This is useful for selectively excluding paint objects during rendering.
+ *
+ * @param[in] paint The Tvg_Paint object to set the visibility status.
+ * @param[in] on A boolean flag indicating visibility. The default is @c true.
+ *               @c true, the object will be rendered by the engine.
+ *               @c false, the object will be excluded from the drawing process.
+ *
+ * @note An invisible object is not considered inactive—it may still participate
+ *       in internal update processing if its properties are updated, but it will not
+ *       be taken into account for the final drawing output. To completely deactivate
+ *       a paint object, remove it from the canvas.
+ *
+ * @see tvg_paint_get_visible()
+ * @see tvg_canvas_remove()
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_paint_set_visible(Tvg_Paint* paint, bool visible);
+
+
+/**
+ * @brief Gets the current visibility status of the Paint object.
+ *
+ * @param[in] paint The Tvg_Paint object to return the visibility status.
+ *
+ * @return true if the object is visible and will be rendered.
+ *         false if the object is hidden and will not be rendered.
+ *
+ * @see tvg_paint_set_visible()
+ *
+ * @since 1.0
+ */
+TVG_API bool tvg_paint_get_visible(const Tvg_Paint* paint);
+
+
 /*!
 * @brief Scales the given Tvg_Paint object by the given factor.
 *
@@ -861,7 +899,7 @@ TVG_API Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint);
  * intersects the geometric fill region of the paint object.
  *
  * This is useful for hit-testing purposes, such as detecting whether a user interaction (e.g., touch or click)
- * occurs within a visible painted region.
+ * occurs within a painted region.
  *
  * The paint must be updated in a Canvas beforehand—typically after the Canvas has been
  * drawn and synchronized.
@@ -877,7 +915,8 @@ TVG_API Tvg_Paint* tvg_paint_duplicate(Tvg_Paint* paint);
  * @note To test a single point, set the region size to w = 1, h = 1.
  * @note For efficiency, an AABB (axis-aligned bounding box) test is performed internally before precise hit detection.
  * @note This test does not take into account the results of blending or masking.
- * @note Experimental API.
+ * @note This test does take into account the the hidden paints as well. @see tvg_paint_set_visible().
+ * @note Experimental API
  */
 TVG_API bool tvg_paint_intersects(Tvg_Paint* paint, int32_t x, int32_t y, int32_t w, int32_t h);
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -180,6 +180,20 @@ TVG_API Tvg_Result tvg_paint_del(Tvg_Paint* paint)
 }
 
 
+TVG_API Tvg_Result tvg_paint_set_visible(Tvg_Paint* paint, bool visible)
+{
+    if (paint) return (Tvg_Result) reinterpret_cast<Paint*>(paint)->visible(visible);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
+TVG_API bool tvg_paint_get_visible(const Tvg_Paint* paint)
+{
+    if (paint) return reinterpret_cast<const Paint*>(paint)->visible();
+    return false;
+}
+
+
 TVG_API uint16_t tvg_paint_ref(Tvg_Paint* paint)
 {
     if (paint) return reinterpret_cast<Paint*>(paint)->ref();

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -176,7 +176,7 @@ Paint* Paint::Impl::duplicate(Paint* ret)
 
 bool Paint::Impl::render(RenderMethod* renderer)
 {
-    if (opacity == 0) return true;
+    if (hidden || opacity == 0) return true;
 
     RenderCompositor* cmp = nullptr;
 
@@ -428,11 +428,10 @@ MaskMethod Paint::mask(const Paint** target) const noexcept
 
 Result Paint::opacity(uint8_t o) noexcept
 {
-    if (pImpl->opacity == o) return Result::Success;
-
-    pImpl->opacity = o;
-    pImpl->mark(RenderUpdateFlag::Color);
-
+    if (pImpl->opacity != o) {
+        pImpl->opacity = o;
+        pImpl->mark(RenderUpdateFlag::Color);
+    }
     return Result::Success;
 }
 
@@ -475,4 +474,16 @@ uint16_t Paint::refCnt() const noexcept
 const Paint* Paint::parent() const noexcept
 {
     return pImpl->parent;
+}
+
+
+Result Paint::visible(bool on) noexcept
+{
+    return pImpl->visible(!on);
+}
+
+
+bool Paint::visible() const noexcept
+{
+    return !pImpl->hidden;
 }

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -84,10 +84,12 @@ namespace tvg
         uint16_t refCnt = 0;       //reference count
         uint8_t ctxFlag;           //See enum ContextFlag
         uint8_t opacity;
+        bool hidden : 1;
 
         Impl(Paint* pnt) : paint(pnt)
         {
             pnt->pImpl = this;
+            hidden = false;
             reset();
         }
 
@@ -293,6 +295,15 @@ namespace tvg
                 blendMethod = method;
                 mark(RenderUpdateFlag::Blend);
             }
+        }
+
+        Result visible(bool hidden)
+        {
+            if (this->hidden != hidden) {
+                this->hidden = hidden;
+                damage();
+            }
+            return Result::Success;
         }
 
         bool intersects(const RenderRegion& region);

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -116,6 +116,23 @@ TEST_CASE("Opacity", "[tvgPaint]")
     REQUIRE(shape->opacity() == 0);
 }
 
+TEST_CASE("Visibility", "[tvgPaint]")
+{
+    auto shape = unique_ptr<Shape>(Shape::gen());
+    REQUIRE(shape);
+
+    REQUIRE(shape->visible() == true);
+
+    REQUIRE(shape->visible(false) == Result::Success);
+    REQUIRE(shape->visible() == false);
+
+    REQUIRE(shape->visible(false) == Result::Success);
+    REQUIRE(shape->visible() == false);
+
+    REQUIRE(shape->visible(true) == Result::Success);
+    REQUIRE(shape->visible() == true);
+}
+
 TEST_CASE("Bounding Box", "[tvgPaint]")
 {
     Initializer::init();


### PR DESCRIPTION
This is useful for selectively excluding paint objects during rendering.

Please note that, an invisible object is not considered inactive—it may still participate in internal update processing if its properties are updated, but it will not be taken into account for the final drawing output. To completely deactivate a paint object, remove it from the canvas.

C++ API
 + Result Paint::visible(bool on)
 + bool Paint::visible()

C API:
 + Tvg_Result tvg_paint_set_visible(Tvg_Paint* paint, bool visible)
 + bool tvg_paint_get_visible(const Tvg_Paint* paint)