### PR TITLE
gl_engine: fix gauss border clamping

### DIFF
--- a/src/renderer/gl_engine/tvgGlEffect.cpp
+++ b/src/renderer/gl_engine/tvgGlEffect.cpp
@@ -77,7 +77,9 @@ GlRenderTask* GlEffect::render(RenderEffectGaussianBlur* effect, GlRenderTarget*
     auto dstCopyFbo1 = blendPool[1]->getRenderTarget(vp);
 
     // add uniform data
+    float viewport[4] {(float)vp.min.x, (float)vp.min.y, (float)vp.max.x, (float)vp.max.y};
     auto blurOffset = gpuBuffer->push((GlGaussianBlur*)(effect->rd), sizeof(GlGaussianBlur), true);
+    auto viewportOffset = gpuBuffer->push(viewport, sizeof(viewport), true);
 
     // create gaussian blur tasks
     auto task = new GlGaussianBlurTask(dstFbo, dstCopyFbo0, dstCopyFbo1);
@@ -86,11 +88,13 @@ GlRenderTask* GlEffect::render(RenderEffectGaussianBlur* effect, GlRenderTarget*
     // horizontal blur task and geometry
     task->horzTask = new GlRenderTask(pBlurH);
     task->horzTask->addBindResource(GlBindingResource{0, pBlurH->getUniformBlockIndex("Gaussian"), gpuBuffer->getBufferId(), blurOffset, sizeof(GlGaussianBlur)});
+    task->horzTask->addBindResource(GlBindingResource{1, pBlurH->getUniformBlockIndex("Viewport"), gpuBuffer->getBufferId(), viewportOffset, sizeof(viewport)});
     task->horzTask->addVertexLayout(GlVertexLayout{0, 2, 2 * sizeof(float), voffset});
     task->horzTask->setDrawRange(ioffset, 6);
     // vertical blur task and geometry
     task->vertTask = new GlRenderTask(pBlurV);
     task->vertTask->addBindResource(GlBindingResource{0, pBlurV->getUniformBlockIndex("Gaussian"), gpuBuffer->getBufferId(), blurOffset, sizeof(GlGaussianBlur)});
+    task->vertTask->addBindResource(GlBindingResource{1, pBlurV->getUniformBlockIndex("Viewport"), gpuBuffer->getBufferId(), viewportOffset, sizeof(viewport)});
     task->vertTask->addVertexLayout(GlVertexLayout{0, 2, 2 * sizeof(float), voffset});
     task->vertTask->setDrawRange(ioffset, 6);
 
@@ -156,8 +160,10 @@ GlRenderTask* GlEffect::render(RenderEffectDropShadow* effect, GlRenderTarget* d
     auto dstCopyFbo1 = blendPool[1]->getRenderTarget(vp);
 
     // add uniform data
+    float viewport[4] {(float)vp.min.x, (float)vp.min.y, (float)vp.max.x, (float)vp.max.y};
     GlDropShadow* params = (GlDropShadow*)(effect->rd);
     auto paramsOffset = gpuBuffer->push(params, sizeof(GlDropShadow), true);
+    auto viewportOffset = gpuBuffer->push(viewport, sizeof(viewport), true);
 
     // create gaussian blur tasks
     auto task = new GlEffectDropShadowTask(pDropShadow, dstFbo, dstCopyFbo0, dstCopyFbo1);
@@ -170,12 +176,14 @@ GlRenderTask* GlEffect::render(RenderEffectDropShadow* effect, GlRenderTarget* d
     // horizontal blur task and geometry
     task->horzTask = new GlRenderTask(pBlurH);
     task->horzTask->addBindResource(GlBindingResource{0, pBlurH->getUniformBlockIndex("Gaussian"), gpuBuffer->getBufferId(), paramsOffset, sizeof(GlGaussianBlur)});
+    task->horzTask->addBindResource(GlBindingResource{1, pBlurH->getUniformBlockIndex("Viewport"), gpuBuffer->getBufferId(), viewportOffset, sizeof(viewport)});
     task->horzTask->addVertexLayout(GlVertexLayout{0, 2, 2 * sizeof(float), voffset});
     task->horzTask->setDrawRange(ioffset, 6);
 
     // vertical blur task and geometry
     task->vertTask = new GlRenderTask(pBlurV);
     task->vertTask->addBindResource(GlBindingResource{0, pBlurV->getUniformBlockIndex("Gaussian"), gpuBuffer->getBufferId(), paramsOffset, sizeof(GlGaussianBlur)});
+    task->vertTask->addBindResource(GlBindingResource{1, pBlurV->getUniformBlockIndex("Viewport"), gpuBuffer->getBufferId(), viewportOffset, sizeof(viewport)});
     task->vertTask->addVertexLayout(GlVertexLayout{0, 2, 2 * sizeof(float), voffset});
     task->vertTask->setDrawRange(ioffset, 6);
 

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -746,6 +746,10 @@ layout(std140) uniform Gaussian {
     float dummy0;
 } uGaussian;
 
+layout(std140) uniform Viewport {
+    vec4 vp;
+} uViewport;
+
 in vec2 vUV;
 out vec4 FragColor;
 
@@ -763,9 +767,11 @@ void main()
     int radius = int(uGaussian.extend);
     
     for (int y = -radius; y <= radius; ++y) {
-        float weight = gaussian(float(y), sigma);
         vec2 offset = vec2(0.0, float(y) * texelSize.y);
-        colorSum += texture(uSrcTexture, vUV + offset) * weight;
+        vec2 coord = vUV + offset;
+        float pixCoord = uViewport.vp.y - coord.y / texelSize.y;
+        float weight = pixCoord < uViewport.vp.w ? gaussian(float(y), sigma) : 0.0;
+        colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
     }
     
@@ -782,6 +788,10 @@ layout(std140) uniform Gaussian {
     float dummy0;
 } uGaussian;
 
+layout(std140) uniform Viewport {
+    vec4 vp;
+} uViewport;
+
 in vec2 vUV;
 out vec4 FragColor;
 
@@ -799,9 +809,11 @@ void main()
     int radius = int(uGaussian.extend);
     
     for (int y = -radius; y <= radius; ++y) {
-        float weight = gaussian(float(y), sigma);
         vec2 offset = vec2(float(y) * texelSize.x, 0.0);
-        colorSum += texture(uSrcTexture, vUV + offset) * weight;
+        vec2 coord = vUV + offset;
+        float pixCoord = uViewport.vp.x + coord.x / texelSize.x;
+        float weight = pixCoord < uViewport.vp.z ? gaussian(float(y), sigma) : 0.0;
+        colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
     }
     


### PR DESCRIPTION
fixed observable border clamping for gauss filter in opengl

by design, the gl renderer creates temporary off-screen buffers for rendering scenes, 
including for applying effects. the size of the off-screen buffer depends on the scene bbox 
and it is offset relative to the screen to the beginning of the bbox. 
in this case, the off-screen buffer may extend beyond the screen boundaries, 
but the scene will only be rendered in the area of intersection of the screen and the buffer itself. in
this case, we do not have enough data to apply the gaussian filter, 
since the source of data for it may be neighboring pixels that were initially cut off 
and are not in the area of intersection of the screen viewport and the off-screen buffer. 
we can cut off such pixels when calculating the gaussian filter by first passing the active viewport 
to the shader and not taking into account the pixels that are not included in it


https://github.com/thorvg/thorvg/issues/3677

<img width="975" height="849" alt="image" src="https://github.com/user-attachments/assets/7fae56f0-e4e4-4639-826d-7e409abb2e4c" />
