### PR TITLE
sw_engine: fix broken clipping in multi-threading

### DIFF
--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -867,10 +867,8 @@ void* SwRenderer::prepareCommon(SwTask* task, const Matrix& transform, const Arr
     //TODO: Failed threading them. It would be better if it's possible.
     //See: https://github.com/thorvg/thorvg/issues/1409
     //Guarantee composition targets get ready.
-    if (flags & RenderUpdateFlag::Clip) {
-        ARRAY_FOREACH(p, clips) {
-            static_cast<SwTask*>(*p)->done();
-        }
+    ARRAY_FOREACH(p, clips) {
+        static_cast<SwTask*>(*p)->done();
     }
 
     if (flags) TaskScheduler::request(task);

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -247,15 +247,13 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
     /* 2. Clipping */
     if (this->clipper) {
         auto pclip = PAINT(this->clipper);
-        if (pclip->renderFlag) mark(RenderUpdateFlag::Clip);
         pclip->ctxFlag &= ~ContextFlag::FastTrack;   //reset
         viewport = renderer->viewport();
-        /* TODO: Intersect the clipper's clipper, if both are FastTrack.
-           Update the subsequent clipper first and check its ctxFlag. */
         if (!pclip->clipper && SHAPE(this->clipper)->rs.strokeWidth() == 0.0f && _compFastTrack(renderer, this->clipper, pm, viewport)) {
             pclip->ctxFlag |= ContextFlag::FastTrack;
             compFastTrack = true;
         } else {
+            mark(RenderUpdateFlag::Clip);
             trd = pclip->update(renderer, pm, clips, 255, flag, true);
             clips.push(trd);
         }


### PR DESCRIPTION
Ensured proper synchronization of clippers.
This issue was introduced in an older version.