### PR TITLE
lottie: skip timeStretch when timeRemap is present

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -693,11 +693,9 @@ void LottieLayer::prepare(RGB32* color)
 float LottieLayer::remap(LottieComposition* comp, float frameNo, LottieExpressions* exp)
 {
     if (timeRemap.frames || timeRemap.value >= 0.0f) {
-        frameNo = comp->frameAtTime(timeRemap(frameNo, exp));
-    } else {
-        frameNo -= startFrame;
+        return comp->frameAtTime(timeRemap(frameNo, exp));
     }
-    return (frameNo / timeStretch);
+    return (frameNo - startFrame) / timeStretch;
 }
 
 


### PR DESCRIPTION
Fixed logic correctly that was previously reverted due to a regression bug: 3edcde9b4e66bd9e722f5e011527c223ceec3e8f

> timeStretch should not be applied when timeRemap exists.

issue: https://github.com/thorvg/thorvg/issues/3591


### Test Result

**Lottie.cpp**



https://github.com/user-attachments/assets/02edb6db-335c-4a97-84aa-eccd83efb891





**Individual Sets**:

> Conducted testing with animations those have timeRemap property

| | | |
|--|--|--|
| ![CleanShot 1](https://github.com/user-attachments/assets/ca09a77a-8370-4196-8a93-bbc859dc9657) | ![CleanShot 2](https://github.com/user-attachments/assets/3c255533-449b-46e2-bef1-75e14434da59) | ![CleanShot 3](https://github.com/user-attachments/assets/8543739b-4d6a-4b31-98b9-8650623b288b) |
| ![CleanShot 2025-08-06 at 14 38 20](https://github.com/user-attachments/assets/60dd6860-2bd9-4e58-b969-4ba036733d8b) | ![CleanShot 2025-08-06 at 14 38 02](https://github.com/user-attachments/assets/ee14045f-5c2f-41c1-b0d2-4ee84b6f0b8d) | ![CleanShot 2025-08-06 at 14 37 29](https://github.com/user-attachments/assets/e76d0355-af3c-4d77-9969-a9b309f9d339) |
![CleanShot 2025-08-08 at 00 50 50](https://github.com/user-attachments/assets/ea4ff393-4be0-4af3-a8f0-f8cbf69b01b6) |  ![CleanShot 2025-08-08 at 00 52 04](https://github.com/user-attachments/assets/8e97fd51-bc97-446e-99bf-d03f2e9ed6e6) | ![CleanShot 2025-08-13 at 15 46 02](https://github.com/user-attachments/assets/8bab5be2-f2e9-4286-a54d-8c2b6e7d736d) |
