### PR TITLE
wasm: apply conditional TTF loader support

### DIFF
--- a/src/bindings/wasm/tvgWasmDefaultFont.h
+++ b/src/bindings/wasm/tvgWasmDefaultFont.h
@@ -95,6 +95,8 @@
 #ifndef _TVG_WASM_DEFAULT_FONT_H_
 #define _TVG_WASM_DEFAULT_FONT_H_
 
+#ifdef THORVG_TTF_LOADER_SUPPORT
+
 #include <cstddef>
 #include <atomic>
 
@@ -143,5 +145,14 @@ inline const char* requestFont() {
 
     return reinterpret_cast<const char*>(_fontData);
 }
+
+#else
+
+constexpr size_t DEFAULT_FONT_SIZE = 0;
+
+inline void retrieveFont() {}
+inline const char* requestFont() { return nullptr; }
+
+#endif
 
 #endif //_TVG_WASM_DEFAULT_FONT_H_


### PR DESCRIPTION
Add conditional compilation for the TTF loader in the WASM binding. This allows proper WASM builds even when the TTF loader is disabled, preventing unnecessary binary size increase from unused font additions. Default font functionality is preserved when the loader is enabled.

This helps maintain an optimal binary size when building a lightweight version of the player.

related: https://github.com/thorvg/thorvg/issues/3481