### PR TITLE
wasm: enable closure optimization for JS glue

### DIFF
--- a/cross/wasm32.txt
+++ b/cross/wasm32.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_gl.txt
+++ b/cross/wasm32_gl.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_sw.txt
+++ b/cross/wasm32_sw.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_wg.txt
+++ b/cross/wasm32_wg.txt
@@ -12,7 +12,7 @@ exe_suffix = 'js'
 
 [built-in options]
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1']
 
 [host_machine]
 system = 'emscripten'


### PR DESCRIPTION
Add --closure=1 to all wasm cross files (default/sw/gl/wg) to minimize JS glue code size and improve DCE.

This optimization also helps contain bundle size growth as player modules diversify and multiple glue files are introduced.

---

### Glue code reduction (JS) `-55%`


Glue code size is reduced by -55% without WASM size increasement.

<img width="1568" height="230" alt="CleanShot 2025-08-08 at 17 46 56@2x" src="https://github.com/user-attachments/assets/ecf8aeed-9eb9-4246-a182-94e1a6cca200" />

<img width="1630" height="244" alt="CleanShot 2025-08-08 at 17 45 54@2x" src="https://github.com/user-attachments/assets/78f18216-a158-4320-a695-f9b27d02c6ec" />


---


### Test

**Common Test:**
- [x] SW
- [x] GL
- [x] WG

**Module bundler compatibility:**
- [x] Webpack
- [x] Vite

**Framework compatibility**
- [x] React
- [x] Vue
- [x] Svelte