### PR TITLE
sw_engine: fine-tuning of render region calculation

### DIFF
--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -392,6 +392,14 @@ struct Line
 struct BBox
 {
     Point min, max;
+
+    void init()
+    {
+        min = {FLT_MAX, FLT_MAX};
+        max = {-FLT_MAX, -FLT_MAX};
+    }
+
+    bool valid() const { return (max.x > min.x && max.y > min.y); }
 };
 
 

--- a/src/renderer/sw_engine/tvgSwImage.cpp
+++ b/src/renderer/sw_engine/tvgSwImage.cpp
@@ -34,7 +34,7 @@ static inline bool _onlyShifted(const Matrix& m)
 }
 
 
-static bool _genOutline(SwImage* image, const Matrix& transform, SwMpool* mpool, unsigned tid)
+static void  _genOutline(SwImage* image, const Matrix& transform, SwMpool* mpool, unsigned tid)
 {
     image->outline = mpoolReqOutline(mpool, tid);
     auto outline = image->outline;
@@ -44,17 +44,25 @@ static bool _genOutline(SwImage* image, const Matrix& transform, SwMpool* mpool,
     outline->cntrs.reserve(1);
     outline->closed.reserve(1);
 
+    image->aabb.init();
+
     Point to[4];
-    auto w = static_cast<float>(image->w);
-    auto h = static_cast<float>(image->h);
-    to[0] = {0, 0};
-    to[1] = {w, 0};
-    to[2] = {w, h};
-    to[3] = {0, h};
+    to[0] = Point{0, 0} * transform;
+    to[1] = Point{float(image->w), 0} * transform;
+    to[2] = Point{float(image->w), float(image->h)} * transform;
+    to[3] = Point{0, float(image->h)} * transform;
+
+    auto capture = [](BBox& bbox, const Point& pts) {
+        if (pts.x < bbox.min.x) bbox.min.x = pts.x;
+        if (pts.x > bbox.max.x) bbox.max.x = pts.x;
+        if (pts.y < bbox.min.y) bbox.min.y = pts.y;
+        if (pts.y > bbox.max.y) bbox.max.y = pts.y;
+    };
 
     for (int i = 0; i < 4; i++) {
-        outline->pts.push(mathTransform(&to[i], transform));
+        outline->pts.push(TO_SWPOINT(to[i]));
         outline->types.push(SW_CURVE_TYPE_POINT);
+        capture(image->aabb, to[i]);
     }
 
     outline->pts.push(outline->pts[0]);
@@ -63,8 +71,6 @@ static bool _genOutline(SwImage* image, const Matrix& transform, SwMpool* mpool,
     outline->closed.push(true);
 
     image->outline = outline;
-
-    return true;
 }
 
 
@@ -85,13 +91,12 @@ bool imagePrepare(SwImage* image, const Matrix& transform, const RenderRegion& c
         auto scaleX = sqrtf((transform.e11 * transform.e11) + (transform.e21 * transform.e21));
         auto scaleY = sqrtf((transform.e22 * transform.e22) + (transform.e12 * transform.e12));
         image->scale = (fabsf(scaleX - scaleY) > 0.01f) ? 1.0f : scaleX;
-
         if (tvg::zero(transform.e12) && tvg::zero(transform.e21)) image->scaled = true;
         else image->scaled = false;
     }
 
-    if (!_genOutline(image, transform, mpool, tid)) return false;
-    return mathUpdateOutlineBBox(image->outline, clipBox, renderBox, image->direct);
+    _genOutline(image, transform, mpool, tid);
+    return mathUpdateBBox(image->aabb, clipBox, renderBox, image->direct);
 }
 
 


### PR DESCRIPTION
Compute the bounding box of the render region during path processing. Previously, this required an additional iteration over the points to perform the calculation.