### PR TITLE
revise the engine based bbox support

### DIFF
--- a/examples/BoundingBox.cpp
+++ b/examples/BoundingBox.cpp
@@ -30,11 +30,16 @@ struct UserExample : tvgexam::Example
 {
     void bbox(tvg::Canvas* canvas, tvg::Paint* paint)
     {
-        //aabb
-        {
-            float x, y, w, h;
-            paint->bounds(&x, &y, &w, &h);
+        // Ensure the paint is updated.
+        // In this example, we call update() on the paint directly,
+        // but instead of calling update multiple times,
+        // you can call Canvas::update() once and then retrieve the bounding boxes
+        // for all required paints.
+        canvas->update();
 
+        //aabb
+        float x, y, w, h;
+        if (tvgexam::verify(paint->bounds(&x, &y, &w, &h))) {
             auto bound = tvg::Shape::gen();
             bound->moveTo(x, y);
             bound->lineTo(x + w, y);
@@ -48,10 +53,8 @@ struct UserExample : tvgexam::Example
         }
 
         //obb
-        {
-            tvg::Point pts[4];
-            paint->bounds(pts);
-
+        tvg::Point pts[4];
+        if (tvgexam::verify(paint->bounds(pts))) {
             auto bound = tvg::Shape::gen();
             bound->moveTo(pts[0].x, pts[0].y);
             bound->lineTo(pts[1].x, pts[1].y);
@@ -213,7 +216,7 @@ struct UserExample : tvgexam::Example
 
         {
             auto scene = tvg::Scene::gen();
-            scene->translate(350, 590);
+            scene->translate(330, 640);
             scene->scale(0.7f);
 
             auto shape = tvg::Shape::gen();
@@ -222,6 +225,11 @@ struct UserExample : tvgexam::Example
             shape->lineTo(0, 200);
             shape->fill(0, 255, 0);
             shape->close();
+
+            shape->strokeWidth(30);
+            shape->strokeFill(255, 255, 255);
+            shape->strokeJoin(tvg::StrokeJoin::Bevel);
+
             scene->push(shape);
 
             canvas->push(scene);
@@ -230,7 +238,7 @@ struct UserExample : tvgexam::Example
 
         {
             auto scene = tvg::Scene::gen();
-            scene->translate(650, 590);
+            scene->translate(650, 650);
             scene->scale(0.7f);
             scene->rotate(20);
 
@@ -240,6 +248,10 @@ struct UserExample : tvgexam::Example
             shape->lineTo(0, 200);
             shape->fill(0, 255, 255);
             shape->close();
+
+            shape->strokeWidth(20);
+            shape->strokeFill(0, 0, 255);
+
             scene->push(shape);
 
             canvas->push(scene);
@@ -248,7 +260,7 @@ struct UserExample : tvgexam::Example
 
         {
             auto scene = tvg::Scene::gen();
-            scene->translate(790, 390);
+            scene->translate(800, 420);
             scene->scale(0.5f);
             scene->rotate(20);
 
@@ -260,7 +272,7 @@ struct UserExample : tvgexam::Example
             shape->fill(255, 0, 255);
             shape->strokeWidth(30);
             shape->strokeFill(0, 255, 255);
-            shape->strokeJoin(tvg::StrokeJoin::Round);
+            shape->strokeJoin(tvg::StrokeJoin::Miter);
 
             tvg::Matrix m = {1.8794f, -0.6840f, 0.0f, 0.6840f,  1.8794f, 0.0f, 0.0f, 0.0f, 1.0f};
             shape->transform(m);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -446,37 +446,45 @@ public:
 
     /**
      * @brief Retrieves the object-oriented bounding box (OBB) of the paint object in canvas space.
-     * 
+     *
      * This function returns the bounding box of the paint, as an oriented bounding box (OBB) after transformations are applied.
+     * The returned values @p pt4 may have invalid if the operation fails. Thus, please check the retval.
+     *
+     * This bounding box can be used to obtain the transformed bounding region in canvas space
+     * by taking the geometry's axis-aligned bounding box (AABB) in the object's local coordinate space
+     * and applying the object's transformations.
      *
      * @param[out] pt4 An array of four points representing the bounding box. The array size must be 4.
      *
-     * @retval Result::InvalidArguments @p pt4 is @c nullptr.
-     * @retval Result::InsufficientCondition If it failed to compute the bounding box (mostly due to invalid path information).
+     * @retval Result::InsufficientCondition If the paint has not been updated by the canvas.
      * 
-     * @see Paint::bounds(float* x, float* y, folat* w, float* h)
+     * @see Paint::bounds(float* x, float* y, float* w, float* h)
      * @see Canvas::update()
      *
      * @since 1.0
      */
-    Result bounds(Point* pt4) const noexcept;
+    Result bounds(Point* pt4) noexcept;
 
     /**
      * @brief Retrieves the axis-aligned bounding box (AABB) of the paint object in canvas space.
      *
-     * This function returns the bounding box of the paint, as an axis-aligned bounding box (AABB) after transformations are applied.
+     * Returns the bounding box of the paint as an axis-aligned bounding box (AABB), with all relevant transformations applied.
+     * The returned values @p x, @p y, @p w, @p h, may have invalid if the operation fails. Thus, please check the retval.
+     *
+     * This bounding box can be used to determine the actual rendered area of the object on the canvas,
+     * for purposes such as hit-testing, culling, or layout calculations.
      *
      * @param[out] x The x-coordinate of the upper-left corner of the bounding box.
      * @param[out] y The y-coordinate of the upper-left corner of the bounding box.
      * @param[out] w The width of the bounding box.
      * @param[out] h The height of the bounding box.
      *
-     * @retval Result::InsufficientCondition If it failed to compute the bounding box (mostly due to invalid path information).
+     * @retval Result::InsufficientCondition If the paint has not been updated by the canvas.
      *
      * @see Paint::bounds(Point* pt4)
      * @see Canvas::update()
      */
-    Result bounds(float* x, float* y, float* w, float* h) const noexcept;
+    Result bounds(float* x, float* y, float* w, float* h) noexcept;
 
     /**
      * @brief Checks whether a given region intersects the filled area of the paint.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -924,7 +924,11 @@ TVG_API bool tvg_paint_intersects(Tvg_Paint* paint, int32_t x, int32_t y, int32_
 /**
  * @brief Retrieves the axis-aligned bounding box (AABB) of the paint object in canvas space.
  *
- * This function returns the bounding box of the paint, as an axis-aligned bounding box (AABB) after transformations are applied.
+ * Returns the bounding box of the paint as an axis-aligned bounding box (AABB), with all relevant transformations applied.
+ * The returned values @p x, @p y, @p w, @p h, may have invalid if the operation fails. Thus, please check the retval.
+ *
+ * This bounding box can be used to determine the actual rendered area of the object on the canvas,
+ * for purposes such as hit-testing, culling, or layout calculations.
  *
  * @param[in] paint The Tvg_Paint object of which to get the bounds.
  * @param[out] x The x-coordinate of the upper-left corner of the bounding box.
@@ -936,15 +940,20 @@ TVG_API bool tvg_paint_intersects(Tvg_Paint* paint, int32_t x, int32_t y, int32_
  * @retval TVG_RESULT_INSUFFICIENT_CONDITION If it failed to compute the bounding box (mostly due to invalid path information).
  *
  * @see tvg_paint_get_obb()
- * @see tvg_canvas_update_paint()
+ * @see tvg_canvas_update()
  */
-TVG_API Tvg_Result tvg_paint_get_aabb(const Tvg_Paint* paint, float* x, float* y, float* w, float* h);
+TVG_API Tvg_Result tvg_paint_get_aabb(Tvg_Paint* paint, float* x, float* y, float* w, float* h);
 
 
 /**
  * @brief Retrieves the object-oriented bounding box (OBB) of the paint object in canvas space.
  *
  * This function returns the bounding box of the paint, as an oriented bounding box (OBB) after transformations are applied.
+ * The returned values @p pt4 may have invalid if the operation fails. Thus, please check the retval.
+ *
+ * This bounding box can be used to obtain the transformed bounding region in canvas space
+ * by taking the geometry's axis-aligned bounding box (AABB) in the object's local coordinate space
+ * and applying the object's transformations.
  *
  * @param[in] paint The Tvg_Paint object of which to get the bounds.
  * @param[out] pt4 An array of four points representing the bounding box. The array size must be 4.
@@ -953,11 +962,11 @@ TVG_API Tvg_Result tvg_paint_get_aabb(const Tvg_Paint* paint, float* x, float* y
  * @retval TVG_RESULT_INSUFFICIENT_CONDITION If it failed to compute the bounding box (mostly due to invalid path information).
  *
  * @see tvg_paint_get_aabb()
- * @see tvg_canvas_update_paint()
+ * @see tvg_canvas_update()
  *
  * @since 1.0
  */
-TVG_API Tvg_Result tvg_paint_get_obb(const Tvg_Paint* paint, Tvg_Point* pt4);
+TVG_API Tvg_Result tvg_paint_get_obb(Tvg_Paint* paint, Tvg_Point* pt4);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -284,15 +284,15 @@ TVG_API Tvg_Result tvg_paint_get_opacity(const Tvg_Paint* paint, uint8_t* opacit
 }
 
 
-TVG_API Tvg_Result tvg_paint_get_aabb(const Tvg_Paint* paint, float* x, float* y, float* w, float* h)
+TVG_API Tvg_Result tvg_paint_get_aabb(Tvg_Paint* paint, float* x, float* y, float* w, float* h)
 {
-    if (paint) return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->bounds(x, y, w, h);
+    if (paint) return (Tvg_Result) reinterpret_cast<Paint*>(paint)->bounds(x, y, w, h);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
-TVG_API Tvg_Result tvg_paint_get_obb(const Tvg_Paint* paint, Tvg_Point* pt4)
+TVG_API Tvg_Result tvg_paint_get_obb(Tvg_Paint* paint, Tvg_Point* pt4)
 {
-    if (paint) return (Tvg_Result) reinterpret_cast<const Paint*>(paint)->bounds((Point*)pt4);
+    if (paint) return (Tvg_Result) reinterpret_cast<Paint*>(paint)->bounds((Point*)pt4);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 

--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -181,6 +181,13 @@ static inline void operator*=(Matrix& lhs, const Matrix& rhs)
 }
 
 
+static inline Matrix operator*(const Matrix* lhs, const Matrix& rhs)
+{
+    if (lhs) return *lhs * rhs;
+    return rhs;
+}
+
+
 static inline void log(const Matrix& m)
 {
     TVGLOG("COMMON", "Matrix: [%f %f %f] [%f %f %f] [%f %f %f]", m.e11, m.e12, m.e13, m.e21, m.e22, m.e23, m.e31, m.e32, m.e33);
@@ -205,8 +212,8 @@ static inline constexpr const Point operator*=(Point& pt, const Matrix* m)
 
 static inline Point operator*(const Point& pt, const Matrix* m)
 {
-    if (!m) return pt;
-    return pt * *m;
+    if (m) return pt * *m;
+    return pt;
 }
 
 
@@ -392,6 +399,12 @@ struct Line
 struct BBox
 {
     Point min, max;
+
+    void init()
+    {
+        min = {FLT_MAX, FLT_MAX};
+        max = {-FLT_MAX, -FLT_MAX};
+    }
 };
 
 

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -883,6 +883,16 @@ bool GlRenderer::sync()
 }
 
 
+bool GlRenderer::bounds(RenderData data, TVG_UNUSED Point* pt4, TVG_UNUSED const Matrix& m)
+{
+    if (data) {
+        //TODO: stroking bounding box is required
+        TVGLOG("GL_ENGINE", "bounds() is not supported!");
+    }
+    return false;
+}
+
+
 RenderRegion GlRenderer::region(RenderData data)
 {
     auto pass = currentPass();

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -101,6 +101,7 @@ public:
     bool postRender() override;
     void dispose(RenderData data) override;;
     RenderRegion region(RenderData data) override;
+    bool bounds(RenderData data, Point* pt4, const Matrix& m) override;
     bool blend(BlendMethod method) override;
     ColorSpace colorSpace() override;
     const RenderSurface* mainSurface() override;

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -655,6 +655,7 @@ bool shapeGenFillColors(SwShape* shape, const Fill* fill, const Matrix& transfor
 bool shapeGenStrokeFillColors(SwShape* shape, const Fill* fill, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable);
 void shapeResetFill(SwShape* shape);
 void shapeResetStrokeFill(SwShape* shape);
+bool shapeStrokeBBox(SwShape& shape, const RenderShape* rshape, Point* pt4, const Matrix& m, SwMpool* mpool);
 void shapeDelFill(SwShape* shape);
 void shapeDelStrokeFill(SwShape* shape);
 

--- a/src/renderer/sw_engine/tvgSwMath.cpp
+++ b/src/renderer/sw_engine/tvgSwMath.cpp
@@ -273,9 +273,7 @@ SwPoint mathTransform(const Point* to, const Matrix& transform)
 
 bool mathUpdateOutlineBBox(const SwOutline* outline, const RenderRegion& clipBox, RenderRegion& renderBox, bool fastTrack)
 {
-    if (!outline) return false;
-
-    if (outline->pts.empty() || outline->cntrs.empty()) {
+    if (!outline || outline->pts.empty() || outline->cntrs.empty()) {
         renderBox.reset();
         return false;
     }

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -722,12 +722,23 @@ void SwRenderer::prepare(RenderEffect* effect, const Matrix& transform)
 }
 
 
+bool SwRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
+{
+    if (!data) return false;
+
+    auto task = static_cast<SwShapeTask*>(data);
+    task->done();
+
+    return shapeStrokeBBox(task->shape, task->rshape, pt4, m, task->mpool);
+}
+
+
 bool SwRenderer::intersectsShape(RenderData data, const RenderRegion& region)
 {
     auto task = static_cast<SwShapeTask*>(data);
     task->done();
 
-    if (!task->bounds().intersected(region)) return false;
+    if (!task->valid || !task->bounds().intersected(region)) return false;
     if (rleIntersect(task->shape.strokeRle, region)) return true;
     return task->shape.rle ? rleIntersect(task->shape.rle, region): task->shape.fastTrack;
 }
@@ -738,7 +749,7 @@ bool SwRenderer::intersectsImage(RenderData data, const RenderRegion& region)
     auto task = static_cast<SwImageTask*>(data);
     task->done();
 
-    if (!task->bounds().intersected(region)) return false;
+    if (!task->valid || !task->bounds().intersected(region)) return false;
 
     //aabb & obb transformed image intersection
     auto rad = tvg::radian(task->transform);

--- a/src/renderer/sw_engine/tvgSwRenderer.h
+++ b/src/renderer/sw_engine/tvgSwRenderer.h
@@ -47,6 +47,7 @@ public:
     bool postRender() override;
     void dispose(RenderData data) override;
     RenderRegion region(RenderData data) override;
+    bool bounds(RenderData data, Point* pt4, const Matrix& m) override;
     bool blend(BlendMethod method) override;
     ColorSpace colorSpace() override;
     const RenderSurface* mainSurface() override;

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -308,9 +308,8 @@ namespace tvg
 
         bool intersects(const RenderRegion& region);
         RenderRegion bounds();
+        bool bounds(Point* pt4, const Matrix* pm, bool obb);
         Iterator* iterator();
-        Result bounds(float* x, float* y, float* w, float* h, Matrix* pm, bool stroking);
-        Result bounds(Point* pt4, Matrix* pm, bool obb, bool stroking);
         RenderData update(RenderMethod* renderer, const Matrix& pm, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper = false);
         bool render(RenderMethod* renderer);
         Paint* duplicate(Paint* ret = nullptr);

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -129,13 +129,13 @@ struct PictureImpl : Picture
         return false;
     }
 
-    Result bounds(Point* pt4, Matrix& m, TVG_UNUSED bool obb, TVG_UNUSED bool stroking) const
+    bool bounds(Point* pt4, const Matrix& m, TVG_UNUSED bool obb)
     {
         pt4[0] = Point{0.0f, 0.0f} * m;
         pt4[1] = Point{w, 0.0f} * m;
         pt4[2] = Point{w, h} * m;
         pt4[3] = Point{0.0f, h} * m;
-        return Result::Success;
+        return true;
     }
 
     Result load(const char* filename)

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -58,12 +58,10 @@ bool RenderMethod::viewport(const RenderRegion& vp)
 /* RenderPath Class Implementation                                      */
 /************************************************************************/
 
-bool RenderPath::bounds(Matrix* m, float* x, float* y, float* w, float* h)
+bool RenderPath::bounds(const Matrix* m, BBox& box)
 {
-    //unexpected
     if (cmds.empty() || cmds.first() == PathCommand::CubicTo) return false;
 
-    BBox box = {{FLT_MAX, FLT_MAX}, {-FLT_MAX, -FLT_MAX}};
     auto pt = pts.begin();
     auto cmd = cmds.begin();
 
@@ -101,12 +99,6 @@ bool RenderPath::bounds(Matrix* m, float* x, float* y, float* w, float* h)
         }
         ++cmd;
     }
-
-    if (x) *x = box.min.x;
-    if (y) *y = box.min.y;
-    if (w) *w = box.max.x - box.min.x;
-    if (h) *h = box.max.y - box.min.y;
-
     return true;
 }
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -29,6 +29,7 @@
 #include "tvgArray.h"
 #include "tvgLock.h"
 #include "tvgColor.h"
+#include "tvgMath.h"
 
 namespace tvg
 {
@@ -262,7 +263,7 @@ struct RenderPath
         cmds.push(PathCommand::CubicTo);
     }
 
-    bool bounds(Matrix* m, float* x, float* y, float* w, float* h);
+    bool bounds(const Matrix* m, BBox& box);
 };
 
 struct RenderTrimPath
@@ -559,6 +560,7 @@ public:
     virtual bool postRender() = 0;
     virtual void dispose(RenderData data) = 0;
     virtual RenderRegion region(RenderData data) = 0;
+    virtual bool bounds(RenderData data, Point* pt4, const Matrix& m) = 0;
     virtual bool blend(BlendMethod method) = 0;
     virtual ColorSpace colorSpace() = 0;
     virtual const RenderSurface* mainSurface() = 0;

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -225,16 +225,17 @@ struct SceneImpl : Scene
         return vport;
     }
 
-    Result bounds(Point* pt4, Matrix& m, bool obb, bool stroking)
+    bool bounds(Point* pt4, const Matrix& m, bool obb)
     {
-        if (paints.empty()) return Result::InsufficientCondition;
+        if (paints.empty()) return false;
 
         Point min = {FLT_MAX, FLT_MAX};
         Point max = {-FLT_MAX, -FLT_MAX};
+        auto ret = false;
 
         for (auto paint : paints) {
             Point tmp[4];
-            if (PAINT(paint)->bounds(tmp, obb ? nullptr : &m, false, stroking) != Result::Success) continue;
+            if (!PAINT(paint)->bounds(tmp, obb ? nullptr : &m, false)) continue;
             //Merge regions
             for (int i = 0; i < 4; ++i) {
                 if (tmp[i].x < min.x) min.x = tmp[i].x;
@@ -242,6 +243,7 @@ struct SceneImpl : Scene
                 if (tmp[i].y < min.y) min.y = tmp[i].y;
                 if (tmp[i].y > max.y) max.y = tmp[i].y;
             }
+            ret = true;
         }
         pt4[0] = min;
         pt4[1] = Point{max.x, min.y};
@@ -255,8 +257,9 @@ struct SceneImpl : Scene
             pt4[3] *= m;
         }
 
-        return Result::Success;
+        return ret;
     }
+
 
     bool intersects(const RenderRegion& region)
     {

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -149,11 +149,10 @@ struct TextImpl : Text
         return SHAPE(shape)->intersects(region);
     }
 
-
-    Result bounds(Point* pt4, Matrix& m, bool obb, TVG_UNUSED bool stroking)
+    bool bounds(Point* pt4, const Matrix& m, bool obb)
     {
-        if (load() == 0.0f) return Result::InsufficientCondition;
-        return PAINT(shape)->bounds(pt4, &m, obb, true);
+        if (load() == 0.0f) return false;
+        return PAINT(shape)->bounds(pt4, &m, obb);
     }
 
     Paint* duplicate(Paint* ret)

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -263,6 +263,15 @@ void WgRenderer::dispose(RenderData data) {
 }
 
 
+bool WgRenderer::bounds(RenderData data, Point* pt4, TVG_UNUSED const Matrix& m)
+{
+    if (data) {
+        //TODO: stroking bounding box is required
+        TVGLOG("WG_ENGINE", "bounds() is not supported!");
+    }
+    return false;
+}
+
 RenderRegion WgRenderer::region(RenderData data)
 {
     if (!data) return {};

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -39,6 +39,7 @@ public:
     bool postRender() override;
     void dispose(RenderData data) override;
     RenderRegion region(RenderData data) override;
+    bool bounds(RenderData data, Point* pt4, const Matrix& m) override;
     bool blend(BlendMethod method) override;
     ColorSpace colorSpace() override;
     const RenderSurface* mainSurface() override;

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -125,8 +125,7 @@ bool GifSaver::save(Animation* animation, Paint* bg, const char* filename, TVG_U
     close();
 
     auto picture = animation->picture();
-    float x, y;
-    x = y = 0;
+    auto x = 0.0f, y = 0.0f;
     picture->bounds(&x, &y, &vsize[0], &vsize[1]);
 
     //cut off the negative space

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -137,13 +137,12 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
 {
     Initializer::init();
     {
+        auto buffer = unique_ptr<uint32_t[]>(new uint32_t[500*500]);
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
-        uint32_t buffer[100*100];
-        canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888);
+        canvas->target(buffer.get(), 500, 500, 500, ColorSpace::ARGB8888);
 
         auto shape = Shape::gen();
         canvas->push(shape);
-        canvas->sync();
 
         //Negative
         float x = 0, y = 0, w = 0, h = 0;
@@ -152,13 +151,16 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
         //Case 1
         REQUIRE(shape->appendRect(0.0f, 10.0f, 20.0f, 100.0f, 50.0f, 50.0f) == Result::Success);
         REQUIRE(shape->translate(100.0f, 111.0f) == Result::Success);
+
+        canvas->update();
+
+        //Positive
         REQUIRE(shape->bounds(&x, &y, &w, &h) == Result::Success);
         REQUIRE(x == 100.0f);
         REQUIRE(y == 121.0f);
         REQUIRE(w == 20.0f);
         REQUIRE(h == 100.0f);
 
-        REQUIRE(canvas->update() == Result::Success);
         Point pts[4];
         REQUIRE(shape->bounds(pts) == Result::Success);
         REQUIRE(pts[0].x == 100.0f);
@@ -170,19 +172,23 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
         REQUIRE(pts[2].y == 221.0f);
         REQUIRE(pts[3].y == 221.0f);
 
+        REQUIRE(canvas->sync() == Result::Success);
+
         //Case 2
         REQUIRE(shape->reset() == Result::Success);
         REQUIRE(shape->moveTo(0.0f, 10.0f) == Result::Success);
         REQUIRE(shape->lineTo(20.0f, 210.0f) == Result::Success);
         auto identity = Matrix{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
         REQUIRE(shape->transform(identity) == Result::Success);
+
+        REQUIRE(canvas->update() == Result::Success);
+
         REQUIRE(shape->bounds(&x, &y, &w, &h) == Result::Success);
         REQUIRE(x == 0.0f);
         REQUIRE(y == 10.0f);
         REQUIRE(w == 20.0f);
         REQUIRE(h == 200.0f);
 
-        REQUIRE(canvas->update() == Result::Success);
         REQUIRE(shape->bounds(pts) == Result::Success);
         REQUIRE(pts[0].x == 0.0f);
         REQUIRE(pts[3].x == 0.0f);


### PR DESCRIPTION
- Refactored to use bounding box information provided by the rendering engine
to ensure accurate AABB/OBB support, including stroke visuals.
Note that this requires paints to be properly pushed into the canvas,
and may affect API behavior.

- Updated Lottie/SVG loaders to use internal AABB functions,
which now exclude stroke bounds. The previous implementation
was also inaccurate in this regard.

- Adjusted example & tests accordingly.

Note:
- GL and WG render engines do not yet support these updates.
- This change may break backward compatibility in existing applications.

Before:
<img width="898" height="892" alt="image" src="https://github.com/user-attachments/assets/b9d7fd28-9791-44aa-acdc-4d6c8dc7fe25" />


After:
<img width="906" height="910" alt="image" src="https://github.com/user-attachments/assets/3f5e23ab-04e9-4efc-910d-d537c1d9bbce" />
