### PR TITLE
gl_engine: use full screen intermediate render targets

### DIFF
--- a/src/renderer/gl_engine/tvgGlEffect.h
+++ b/src/renderer/gl_engine/tvgGlEffect.h
@@ -48,9 +48,9 @@ private:
     bool region(RenderEffectGaussianBlur* effect);
     bool region(RenderEffectDropShadow* effect);
 
-    GlRenderTask* render(RenderEffectGaussianBlur* effect, GlRenderTarget* dstFbo, Array<GlRenderTargetPool*>& blendPool, const RenderRegion& vp, uint32_t voffset, uint32_t ioffset);
-    GlRenderTask* render(RenderEffectDropShadow* effect, GlRenderTarget* dstFbo, Array<GlRenderTargetPool*>& blendPool, const RenderRegion& vp, uint32_t voffset, uint32_t ioffset);
-    GlRenderTask* render(RenderEffect* effect, GlRenderTarget* dstFbo, Array<GlRenderTargetPool*>& blendPool, const RenderRegion& vp, uint32_t voffset, uint32_t ioffset);
+    GlRenderTask* render(RenderEffectGaussianBlur* effect, GlRenderTarget* dstFbo, GlRenderTargetPool& pool, const RenderRegion& vp, uint32_t voffset, uint32_t ioffset);
+    GlRenderTask* render(RenderEffectDropShadow* effect, GlRenderTarget* dstFbo, GlRenderTargetPool& pool, const RenderRegion& vp, uint32_t voffset, uint32_t ioffset);
+    GlRenderTask* render(RenderEffect* effect, GlRenderTarget* dstFbo, GlRenderTargetPool& pool, const RenderRegion& vp, uint32_t voffset, uint32_t ioffset);
 
 public:
     GlEffect(GlStageBuffer* buffer);
@@ -58,7 +58,7 @@ public:
 
     void update(RenderEffect* effect, const Matrix& transform);
     bool region(RenderEffect* effect);
-    bool render(RenderEffect* effect, GlRenderPass* pass, Array<GlRenderTargetPool*>& blendPool);
+    bool render(RenderEffect* effect, GlRenderPass* pass, GlRenderTargetPool& pool);
 };
 
 #endif /* _TVG_GL_EFFECT_H_ */

--- a/src/renderer/gl_engine/tvgGlRenderTarget.h
+++ b/src/renderer/gl_engine/tvgGlRenderTarget.h
@@ -25,6 +25,10 @@
 
 #include "tvgGlCommon.h"
 
+/************************************************************************/
+/* GlRenderTarget Class Implementation                              */
+/************************************************************************/
+
 class GlRenderTarget
 {
 public:
@@ -41,7 +45,9 @@ public:
     uint32_t getWidth() const { return mWidth; }
     uint32_t getHeight() const { return mHeight; }
 
-    void setViewport(const RenderRegion& vp) { mViewport = vp; }
+    void setViewport(const RenderRegion& vp) { 
+        mViewport = vp;
+    }
     const RenderRegion& getViewport() const { return mViewport; }
 
     bool invalid() const { return mFbo == 0; }
@@ -57,15 +63,23 @@ private:
     GLuint mColorTex = 0;
 };
 
+/************************************************************************/
+/* GlRenderTargetPool Class Implementation                              */
+/************************************************************************/
+
 class GlRenderTargetPool {
 public:
-    GlRenderTargetPool(uint32_t maxWidth, uint32_t maxHeight);
+    GlRenderTargetPool();
     ~GlRenderTargetPool();
 
-    GlRenderTarget* getRenderTarget(const RenderRegion& vp, GLuint resolveId = 0);
+    void init(uint32_t width, uint32_t height);
+    void reset();
+
+    GlRenderTarget* getRenderTarget(GLuint resolveId = 0);
+    void freeRenderTarget(GlRenderTarget* renderTarget);
 private:
-    uint32_t mMaxWidth = 0;
-    uint32_t mMaxHeight = 0;
+    uint32_t mWidth = 0;
+    uint32_t mHeight = 0;
     Array<GlRenderTarget*> mPool;
 };
 

--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -210,9 +210,6 @@ void GlComposeTask::run()
     GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
     GL_CHECK(glDepthMask(0));
 
-    GL_CHECK(glViewport(0, 0, mRenderWidth, mRenderHeight));
-    GL_CHECK(glScissor(0, 0, mRenderWidth, mRenderHeight));
-
     ARRAY_FOREACH(p, mTasks) {
         (*p)->run();
     }
@@ -244,7 +241,7 @@ void GlComposeTask::onResolve()
 {
     GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, getSelfFbo()));
     GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, getResolveFboId()));
-    GL_CHECK(glBlitFramebuffer(0, 0, mRenderWidth, mRenderHeight, 0, 0, mRenderWidth, mRenderHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST));
+    GL_CHECK(glBlitFramebuffer(0, 0, mFbo->getWidth(), mFbo->getHeight(), 0, 0, mFbo->getWidth(), mFbo->getHeight(), GL_COLOR_BUFFER_BIT, GL_NEAREST));
 }
 
 
@@ -305,7 +302,7 @@ void GlDrawBlitTask::run()
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getTargetFbo()));
 
     GL_CHECK(glViewport(0, 0, mParentWidth, mParentHeight));
-    GL_CHECK(glScissor(0, 0, mParentWidth, mParentWidth));
+    GL_CHECK(glScissor(0, 0, mParentWidth, mParentHeight));
     GlRenderTask::run();
 }
 

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -132,10 +132,9 @@ private:
     GlRenderTarget mRootTarget;
     GlEffect mEffect;
     Array<GlProgram*> mPrograms;
-    Array<GlRenderTargetPool*> mComposePool;
-    Array<GlRenderTargetPool*> mBlendPool;
     Array<GlRenderPass*> mRenderPassStack;
     Array<GlCompositor*> mComposeStack;
+    GlRenderTargetPool mRenderTargetPool;
 
     //Disposed resources. They should be released on synced call.
     struct {

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -746,10 +746,6 @@ layout(std140) uniform Gaussian {
     float dummy0;
 } uGaussian;
 
-layout(std140) uniform Viewport {
-    vec4 vp;
-} uViewport;
-
 in vec2 vUV;
 out vec4 FragColor;
 
@@ -769,8 +765,7 @@ void main()
     for (int y = -radius; y <= radius; ++y) {
         vec2 offset = vec2(0.0, float(y) * texelSize.y);
         vec2 coord = vUV + offset;
-        float pixCoord = uViewport.vp.y - coord.y / texelSize.y;
-        float weight = pixCoord < uViewport.vp.w ? gaussian(float(y), sigma) : 0.0;
+        float weight = clamp(coord.y, 0.0, 1.0) == coord.y ? gaussian(float(y), sigma) : 0.0;
         colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
     }
@@ -787,10 +782,6 @@ layout(std140) uniform Gaussian {
     float extend;
     float dummy0;
 } uGaussian;
-
-layout(std140) uniform Viewport {
-    vec4 vp;
-} uViewport;
 
 in vec2 vUV;
 out vec4 FragColor;
@@ -811,8 +802,7 @@ void main()
     for (int y = -radius; y <= radius; ++y) {
         vec2 offset = vec2(float(y) * texelSize.x, 0.0);
         vec2 coord = vUV + offset;
-        float pixCoord = uViewport.vp.x + coord.x / texelSize.x;
-        float weight = pixCoord < uViewport.vp.z ? gaussian(float(y), sigma) : 0.0;
+        float weight = clamp(coord.x, 0.0, 1.0) == coord.x ? gaussian(float(y), sigma) : 0.0;
         colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
     }


### PR DESCRIPTION
by design the gl renderer created offscreen buffers of different sizes based on the scene box size. Because of this different offscreen buffers had their own coordinate system and had to deal with the alignment of offscreen buffers and the window buffer. It also meant having multiple buffer pools for different sizes. This complicates the logic and creates the need to recalculate alignment, viewports and scissors every frame, as well as texture coordinates for shaders.

Now all offscreen buffers have the same size as the window buffer, which simplifies the pool logic, as well as the blending/compositing/effects logic. The number of created buffers is equal to the depth of the scene graph, including temporary buffers for copies of the window buffer

https://github.com/thorvg/thorvg/issues/3698 - Render Targets