### PR TITLE
sw_engine: fine-tuning of render region calculation

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -251,8 +251,8 @@ struct SwShape
 
 struct SwImage
 {
-    SwOutline*   outline = nullptr;
-    SwRle*   rle = nullptr;
+    SwOutline* outline = nullptr;
+    SwRle* rle = nullptr;
     union {
         pixel_t*  data;      //system based data pointer
         uint32_t* buf32;     //for explicit 32bits channels
@@ -263,7 +263,6 @@ struct SwImage
     int32_t      oy = 0;         //offset y
     float        scale;
     uint8_t      channelSize;
-
     bool         direct = false;  //draw image directly (with offset)
     bool         scaled = false;  //draw scaled image
 };
@@ -325,6 +324,11 @@ struct SwMpool
 static inline int32_t TO_SWCOORD(float val)
 {
     return int32_t(val * 64.0f);
+}
+
+static inline SwPoint TO_SWPOINT(const Point& pt)
+{
+    return {TO_SWCOORD(pt.x), TO_SWCOORD(pt.y)};
 }
 
 static inline uint32_t JOIN(uint8_t c0, uint8_t c1, uint8_t c2, uint8_t c3)
@@ -644,8 +648,7 @@ int64_t mathDiff(int64_t angle1, int64_t angle2);
 int64_t mathLength(const SwPoint& pt);
 int mathCubicAngle(const SwPoint* base, int64_t& angleIn, int64_t& angleMid, int64_t& angleOut);
 int64_t mathMean(int64_t angle1, int64_t angle2);
-SwPoint mathTransform(const Point* to, const Matrix& transform);
-bool mathUpdateOutlineBBox(const SwOutline* outline, const RenderRegion& clipBox, RenderRegion& renderBox, bool fastTrack);
+bool mathUpdateBBox(const RenderRegion& clipBox, RenderRegion& renderBox, bool fastTrack);
 
 void shapeReset(SwShape& shape);
 bool shapePrepare(SwShape& shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool hasComposite);
@@ -664,7 +667,7 @@ void shapeDelFill(SwShape& shape);
 
 void strokeReset(SwStroke* stroke, const RenderShape* shape, const Matrix& transform, SwMpool* mpool, unsigned tid);
 bool strokeParseOutline(SwStroke* stroke, const SwOutline& outline, SwMpool* mpool, unsigned tid);
-SwOutline* strokeExportOutline(SwStroke* stroke, SwMpool* mpool, unsigned tid);
+SwOutline* strokeExportOutline(SwStroke* stroke, RenderRegion& aabb, const Matrix& transform, SwMpool* mpool, unsigned tid);
 void strokeFree(SwStroke* stroke);
 
 bool imagePrepare(SwImage& image, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid);

--- a/src/renderer/sw_engine/tvgSwImage.cpp
+++ b/src/renderer/sw_engine/tvgSwImage.cpp
@@ -34,27 +34,35 @@ static inline bool _onlyShifted(const Matrix& m)
 }
 
 
-static bool _genOutline(SwImage& image, const Matrix& transform, SwMpool* mpool, unsigned tid)
+static void  _genOutline(SwImage& image, const Matrix& transform, RenderRegion& aabb, SwMpool* mpool, unsigned tid)
 {
-    image.outline = mpoolReqOutline(mpool, tid);
-    auto outline = image.outline;
+    auto outline = mpoolReqOutline(mpool, tid);
 
     outline->pts.reserve(5);
     outline->types.reserve(5);
     outline->cntrs.reserve(1);
     outline->closed.reserve(1);
 
+    aabb = {{INT32_MAX, INT32_MAX}, {-INT32_MAX, -INT32_MAX}};
+
     Point to[4];
-    auto w = static_cast<float>(image.w);
-    auto h = static_cast<float>(image.h);
-    to[0] = {0, 0};
-    to[1] = {w, 0};
-    to[2] = {w, h};
-    to[3] = {0, h};
+    to[0] = Point{0, 0} * transform;
+    to[1] = Point{float(image.w), 0} * transform;
+    to[2] = Point{float(image.w), float(image.h)} * transform;
+    to[3] = Point{0, float(image.h)} * transform;
+
+    auto capture = [](RenderRegion& bbox, const SwPoint& pts) {
+        if (pts.x < bbox.min.x) bbox.min.x = pts.x;
+        if (pts.x > bbox.max.x) bbox.max.x = pts.x;
+        if (pts.y < bbox.min.y) bbox.min.y = pts.y;
+        if (pts.y > bbox.max.y) bbox.max.y = pts.y;
+    };
 
     for (int i = 0; i < 4; i++) {
-        outline->pts.push(mathTransform(&to[i], transform));
+        auto pt = TO_SWPOINT(to[i]);
+        outline->pts.push(pt);
         outline->types.push(SW_CURVE_TYPE_POINT);
+        capture(aabb, pt);
     }
 
     outline->pts.push(outline->pts[0]);
@@ -62,10 +70,8 @@ static bool _genOutline(SwImage& image, const Matrix& transform, SwMpool* mpool,
     outline->cntrs.push(outline->pts.count - 1);
     outline->closed.push(true);
 
+    outline->fillRule = FillRule::NonZero;
     image.outline = outline;
-    image.outline->fillRule = FillRule::NonZero;
-
-    return true;
 }
 
 
@@ -86,13 +92,11 @@ bool imagePrepare(SwImage& image, const Matrix& transform, const RenderRegion& c
         auto scaleX = sqrtf((transform.e11 * transform.e11) + (transform.e21 * transform.e21));
         auto scaleY = sqrtf((transform.e22 * transform.e22) + (transform.e12 * transform.e12));
         image.scale = (fabsf(scaleX - scaleY) > 0.01f) ? 1.0f : scaleX;
-
         if (tvg::zero(transform.e12) && tvg::zero(transform.e21)) image.scaled = true;
         else image.scaled = false;
     }
-
-    if (!_genOutline(image, transform, mpool, tid)) return false;
-    return mathUpdateOutlineBBox(image.outline, clipBox, renderBox, image.direct);
+    _genOutline(image, transform, renderBox, mpool, tid);
+    return mathUpdateBBox(clipBox, renderBox, image.direct);
 }
 
 

--- a/src/renderer/sw_engine/tvgSwMath.cpp
+++ b/src/renderer/sw_engine/tvgSwMath.cpp
@@ -262,44 +262,16 @@ int64_t mathDiff(int64_t angle1, int64_t angle2)
 }
 
 
-SwPoint mathTransform(const Point* to, const Matrix& transform)
+bool mathUpdateBBox(const RenderRegion& clipBox, RenderRegion& renderBox, bool fastTrack)
 {
-    auto tx = to->x * transform.e11 + to->y * transform.e12 + transform.e13;
-    auto ty = to->x * transform.e21 + to->y * transform.e22 + transform.e23;
-
-    return {TO_SWCOORD(tx), TO_SWCOORD(ty)};
-}
-
-
-bool mathUpdateOutlineBBox(const SwOutline* outline, const RenderRegion& clipBox, RenderRegion& renderBox, bool fastTrack)
-{
-    if (!outline || outline->pts.empty() || outline->cntrs.empty()) {
-        renderBox.reset();
-        return false;
-    }
-
-    auto pt = outline->pts.begin();
-
-    auto xMin = pt->x;
-    auto xMax = pt->x;
-    auto yMin = pt->y;
-    auto yMax = pt->y;
-
-    for (++pt; pt < outline->pts.end(); ++pt) {
-        if (xMin > pt->x) xMin = pt->x;
-        if (xMax < pt->x) xMax = pt->x;
-        if (yMin > pt->y) yMin = pt->y;
-        if (yMax < pt->y) yMax = pt->y;
-    }
-
     if (fastTrack) {
-        renderBox.min = {int32_t(round(xMin / 64.0f)), int32_t(round(yMin / 64.0f))};
-        renderBox.max = {int32_t(round(xMax / 64.0f)), int32_t(round(yMax / 64.0f))};
+        renderBox.min = {int32_t(nearbyint(renderBox.min.x / 64.0f)), int32_t(nearbyint(renderBox.min.y / 64.0f))};
+        renderBox.max = {int32_t(nearbyint(renderBox.max.x / 64.0f)), int32_t(nearbyint(renderBox.max.y / 64.0f))};
     } else {
-        renderBox.min = {xMin >> 6, yMin >> 6};
-        renderBox.max = {(xMax + 63) >> 6, (yMax + 63) >> 6};
+        renderBox.min = {renderBox.min.x >> 6, renderBox.min.y >> 6};
+        renderBox.max = {(renderBox.max.x + 63) >> 6, (renderBox.max.y + 63) >> 6};
     }
-
     renderBox.intersect(clipBox);
+
     return renderBox.valid();
 }

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -114,7 +114,7 @@ struct SwShapeTask : SwTask
 
         auto strokeWidth = validStrokeWidth(clipper);
         auto updateShape = flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform | RenderUpdateFlag::Clip);
-        auto updateFill = (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient));
+        auto updateFill = flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient);
 
         //Shape
         if (updateShape) {
@@ -175,7 +175,7 @@ struct SwShapeTask : SwTask
 
     void dispose() override
     {
-       shapeFree(shape);
+        shapeFree(shape);
     }
 };
 

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -47,34 +47,52 @@ static bool _outlineEnd(SwOutline& outline)
 }
 
 
-static bool _outlineMoveTo(SwOutline& outline, const Point* to, const Matrix& transform, bool closed = false)
+static bool _outlineMoveTo(SwOutline& outline, const SwPoint& to, bool closed = false)
 {
     //make it a contour, if the last contour is not closed yet.
     if (!closed) _outlineEnd(outline);
 
-    outline.pts.push(mathTransform(to, transform));
+    outline.pts.push(to);
     outline.types.push(SW_CURVE_TYPE_POINT);
     return false;
 }
 
 
-static void _outlineLineTo(SwOutline& outline, const Point* to, const Matrix& transform)
+static bool _outlineMoveTo(SwOutline& outline, const Point& to, bool closed = false)
 {
-    outline.pts.push(mathTransform(to, transform));
+    return _outlineMoveTo(outline, TO_SWPOINT(to), closed);
+}
+
+
+static void _outlineLineTo(SwOutline& outline, const SwPoint& to)
+{
+    outline.pts.push(to);
     outline.types.push(SW_CURVE_TYPE_POINT);
 }
 
 
-static void _outlineCubicTo(SwOutline& outline, const Point* ctrl1, const Point* ctrl2, const Point* to, const Matrix& transform)
+static void _outlineLineTo(SwOutline& outline, const Point& to)
 {
-    outline.pts.push(mathTransform(ctrl1, transform));
+    _outlineLineTo(outline, TO_SWPOINT(to));
+}
+
+
+static void _outlineCubicTo(SwOutline& outline, const SwPoint& ctrl1, const SwPoint& ctrl2, const SwPoint& to)
+{
+    outline.pts.push(ctrl1);
     outline.types.push(SW_CURVE_TYPE_CUBIC);
 
-    outline.pts.push(mathTransform(ctrl2, transform));
+    outline.pts.push(ctrl2);
     outline.types.push(SW_CURVE_TYPE_CUBIC);    
 
-    outline.pts.push(mathTransform(to, transform));
+    outline.pts.push(to);
     outline.types.push(SW_CURVE_TYPE_POINT);
+}
+
+
+static void _outlineCubicTo(SwOutline& outline, const Point& ctrl1, const Point& ctrl2, const Point& to)
+{
+    _outlineCubicTo(outline, TO_SWPOINT(ctrl1), TO_SWPOINT(ctrl2), TO_SWPOINT(to));
 }
 
 
@@ -97,31 +115,31 @@ static bool _outlineClose(SwOutline& outline)
 }
 
 
-static void _drawPoint(SwDashStroke& dash, const Point* start, const Matrix& transform)
+static void _drawPoint(SwDashStroke& dash, const Point& start)
 {
     if (dash.move || dash.pattern[dash.curIdx] < FLOAT_EPSILON) {
-        _outlineMoveTo(*dash.outline, start, transform);
+        _outlineMoveTo(*dash.outline, start);
         dash.move = false;
     }
-    _outlineLineTo(*dash.outline, start, transform);
+    _outlineLineTo(*dash.outline, start);
 }
 
 
-static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix& transform, bool validPoint)
+static void _dashLineTo(SwDashStroke& dash, const Point& to, const Matrix& transform, bool validPoint)
 {
-    Line cur = {dash.ptCur, *to};
+    Line cur = {dash.ptCur, to};
     auto len = cur.length();
     if (tvg::zero(len)) {
-        _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
+        _outlineMoveTo(*dash.outline, dash.ptCur * transform);
     //draw the current line fully
     } else if (len <= dash.curLen) {
         dash.curLen -= len;
         if (!dash.curOpGap) {
             if (dash.move) {
-                _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
+                _outlineMoveTo(*dash.outline, dash.ptCur * transform);
                 dash.move = false;
             }
-            _outlineLineTo(*dash.outline, to, transform);
+            _outlineLineTo(*dash.outline, to * transform);
         }
     //draw the current line partially
     } else {
@@ -132,13 +150,13 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix& trans
                 cur.split(dash.curLen, left, right);
                 if (!dash.curOpGap) {
                     if (dash.move || dash.pattern[dash.curIdx] - dash.curLen < FLOAT_EPSILON) {
-                        _outlineMoveTo(*dash.outline, &left.pt1, transform);
+                        _outlineMoveTo(*dash.outline, left.pt1 * transform);
                         dash.move = false;
                     }
-                    _outlineLineTo(*dash.outline, &left.pt2, transform);
+                    _outlineLineTo(*dash.outline, left.pt2 * transform);
                 }
             } else {
-                if (validPoint && !dash.curOpGap) _drawPoint(dash, &cur.pt1, transform);
+                if (validPoint && !dash.curOpGap) _drawPoint(dash, cur.pt1 * transform);
                 right = cur;
             }
             dash.curIdx = (dash.curIdx + 1) % dash.cnt;
@@ -152,10 +170,10 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix& trans
         dash.curLen -= len;
         if (!dash.curOpGap) {
             if (dash.move) {
-                _outlineMoveTo(*dash.outline, &cur.pt1, transform);
+                _outlineMoveTo(*dash.outline, cur.pt1 * transform);
                 dash.move = false;
             }
-            _outlineLineTo(*dash.outline, &cur.pt2, transform);
+            _outlineLineTo(*dash.outline, cur.pt2 * transform);
         }
         if (dash.curLen < 1 && TO_SWCOORD(len) > 1) {
             //move to next dash
@@ -164,26 +182,26 @@ static void _dashLineTo(SwDashStroke& dash, const Point* to, const Matrix& trans
             dash.curOpGap = !dash.curOpGap;
         }
     }
-    dash.ptCur = *to;
+    dash.ptCur = to;
 }
 
 
-static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ctrl2, const Point* to, const Matrix& transform, bool validPoint)
+static void _dashCubicTo(SwDashStroke& dash, const Point& ctrl1, const Point& ctrl2, const Point& to, const Matrix& transform, bool validPoint)
 {
-    Bezier cur = {dash.ptCur, *ctrl1, *ctrl2, *to};
+    Bezier cur = {dash.ptCur, ctrl1, ctrl2, to};
     auto len = cur.length();
 
     //draw the current line fully
     if (tvg::zero(len)) {
-        _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
+        _outlineMoveTo(*dash.outline, dash.ptCur * transform);
     } else if (len <= dash.curLen) {
         dash.curLen -= len;
         if (!dash.curOpGap) {
             if (dash.move) {
-                _outlineMoveTo(*dash.outline, &dash.ptCur, transform);
+                _outlineMoveTo(*dash.outline, dash.ptCur * transform);
                 dash.move = false;
             }
-            _outlineCubicTo(*dash.outline, ctrl1, ctrl2, to, transform);
+            _outlineCubicTo(*dash.outline, ctrl1 * transform, ctrl2 * transform, to * transform);
         }
     //draw the current line partially
     } else {
@@ -194,13 +212,13 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
                 cur.split(dash.curLen, left, right);
                 if (!dash.curOpGap) {
                     if (dash.move || dash.pattern[dash.curIdx] - dash.curLen < FLOAT_EPSILON) {
-                        _outlineMoveTo(*dash.outline, &left.start, transform);
+                        _outlineMoveTo(*dash.outline, left.start * transform);
                         dash.move = false;
                     }
-                    _outlineCubicTo(*dash.outline, &left.ctrl1, &left.ctrl2, &left.end, transform);
+                    _outlineCubicTo(*dash.outline, left.ctrl1 * transform, left.ctrl2 * transform, left.end * transform);
                 }
             } else {
-                if (validPoint && !dash.curOpGap) _drawPoint(dash, &cur.start, transform);
+                if (validPoint && !dash.curOpGap) _drawPoint(dash, cur.start * transform);
                 right = cur;
             }
             dash.curIdx = (dash.curIdx + 1) % dash.cnt;
@@ -214,10 +232,10 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
         dash.curLen -= len;
         if (!dash.curOpGap) {
             if (dash.move) {
-                _outlineMoveTo(*dash.outline, &cur.start, transform);
+                _outlineMoveTo(*dash.outline, cur.start * transform);
                 dash.move = false;
             }
-            _outlineCubicTo(*dash.outline, &cur.ctrl1, &cur.ctrl2, &cur.end, transform);
+            _outlineCubicTo(*dash.outline, cur.ctrl1 * transform, cur.ctrl2 * transform, cur.end * transform);
         }
         if (dash.curLen < 0.1f && TO_SWCOORD(len) > 1) {
             //move to next dash
@@ -226,13 +244,13 @@ static void _dashCubicTo(SwDashStroke& dash, const Point* ctrl1, const Point* ct
             dash.curOpGap = !dash.curOpGap;
         }
     }
-    dash.ptCur = *to;
+    dash.ptCur = to;
 }
 
 
 static void _dashClose(SwDashStroke& dash, const Matrix& transform, bool validPoint)
 {
-    _dashLineTo(dash, &dash.ptStart, transform, validPoint);
+    _dashLineTo(dash, dash.ptStart, transform, validPoint);
 }
 
 
@@ -318,12 +336,12 @@ static SwOutline* _genDashOutline(const RenderShape* rshape, const Matrix& trans
                 break;
             }
             case PathCommand::LineTo: {
-                _dashLineTo(dash, pts, transform, validPoint);
+                _dashLineTo(dash, pts[0], transform, validPoint);
                 ++pts;
                 break;
             }
             case PathCommand::CubicTo: {
-                _dashCubicTo(dash, pts, pts + 1, pts + 2, transform, validPoint);
+                _dashCubicTo(dash, pts[0], pts[1], pts[2], transform, validPoint);
                 pts += 3;
                 break;
             }
@@ -362,7 +380,7 @@ static bool _axisAlignedRect(const SwOutline* outline)
 }
 
 
-static SwOutline* _genOutline(SwShape& shape, const RenderShape* rshape, const Matrix& transform, SwMpool* mpool, unsigned tid, bool hasComposite, bool trimmed = false)
+static SwOutline* _genOutline(SwShape& shape, const RenderShape* rshape, const Matrix& transform, RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool hasComposite, bool trimmed)
 {
     PathCommand *cmds, *trimmedCmds = nullptr;
     Point *pts, *trimmedPts = nullptr;
@@ -391,6 +409,16 @@ static SwOutline* _genOutline(SwShape& shape, const RenderShape* rshape, const M
     auto outline = mpoolReqOutline(mpool, tid);
     auto closed = false;
 
+    //capture the render box
+    renderBox = {{INT32_MAX, INT32_MAX}, {-INT32_MAX, -INT32_MAX}};
+
+    auto capture = [](RenderRegion& bbox, const SwPoint& pts) {
+        if (pts.x < bbox.min.x) bbox.min.x = pts.x;
+        if (pts.x > bbox.max.x) bbox.max.x = pts.x;
+        if (pts.y < bbox.min.y) bbox.min.y = pts.y;
+        if (pts.y > bbox.max.y) bbox.max.y = pts.y;
+    };
+
     //Generate Outlines
     while (cmdCnt-- > 0) {
         switch (*cmds) {
@@ -399,19 +427,31 @@ static SwOutline* _genOutline(SwShape& shape, const RenderShape* rshape, const M
                 break;
             }
             case PathCommand::MoveTo: {
-                closed = _outlineMoveTo(*outline, pts, transform, closed);
+                auto p = TO_SWPOINT(*pts * transform);
+                closed = _outlineMoveTo(*outline, p, closed);
+                capture(renderBox, p);
                 ++pts;
                 break;
             }
             case PathCommand::LineTo: {
                 if (closed) closed = _outlineBegin(*outline);
-                _outlineLineTo(*outline, pts, transform);
+                auto p = TO_SWPOINT(*pts * transform);
+                _outlineLineTo(*outline, p);
+                capture(renderBox, p);
                 ++pts;
                 break;
             }
             case PathCommand::CubicTo: {
                 if (closed) closed = _outlineBegin(*outline);
-                _outlineCubicTo(*outline, pts, pts + 1, pts + 2, transform);
+                auto p0 = TO_SWPOINT(*(pts - 1) * transform);
+                auto p1 = TO_SWPOINT(*(pts + 0) * transform);
+                auto p2 = TO_SWPOINT(*(pts + 1) * transform);
+                auto p3 = TO_SWPOINT(*(pts + 2) * transform);
+                _outlineCubicTo(*outline, p1, p2, p3);
+                capture(renderBox, p0);
+                capture(renderBox, p1);
+                capture(renderBox, p2);
+                capture(renderBox, p3);
                 pts += 3;
                 break;
             }
@@ -437,8 +477,8 @@ static SwOutline* _genOutline(SwShape& shape, const RenderShape* rshape, const M
 
 bool shapePrepare(SwShape& shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool hasComposite)
 {
-    if ((shape.outline = _genOutline(shape, rshape, transform, mpool, tid, hasComposite, rshape->trimpath()))) {
-        if (mathUpdateOutlineBBox(shape.outline, clipBox, renderBox, shape.fastTrack)) {
+    if ((shape.outline = _genOutline(shape, rshape, transform, renderBox, mpool, tid, hasComposite, rshape->trimpath()))) { 
+        if (mathUpdateBBox(clipBox, renderBox, shape.fastTrack)) {
             shape.bbox = renderBox;
             return true;
         }
@@ -520,17 +560,16 @@ bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& 
     //Trimming & Normal style
     } else {
         if (!shape.outline) {
-            if (auto out = _genOutline(shape, rshape, transform, mpool, tid, false, rshape->trimpath())) shape.outline = out;
-            else return false;
+            shape.outline = _genOutline(shape, rshape, transform, renderBox, mpool, tid, false, rshape->trimpath());
+            if (!shape.outline) return false;
         }
         shapeOutline = shape.outline;
     }
 
     if (!strokeParseOutline(shape.stroke, *shapeOutline, mpool, tid)) return false;
 
-    auto strokeOutline = strokeExportOutline(shape.stroke, mpool, tid);
-
-    auto ret = mathUpdateOutlineBBox(strokeOutline, clipBox, renderBox, false);
+    auto strokeOutline = strokeExportOutline(shape.stroke, renderBox, transform, mpool, tid);
+    auto ret = mathUpdateBBox(clipBox, renderBox, false);
     if (ret) shape.strokeRle = rleRender(shape.strokeRle, strokeOutline, renderBox, true);
     mpoolRetStrokeOutline(mpool, tid);
     return ret;
@@ -571,42 +610,43 @@ void shapeResetStrokeFill(SwShape& shape)
 
 void shapeDelFill(SwShape& shape)
 {
-    if (!shape.fill) return;
-    fillFree(shape.fill);
-    shape.fill = nullptr;
+    if (shape.fill) {
+        fillFree(shape.fill);
+        shape.fill = nullptr;
+    }
 }
 
 
 bool shapeStrokeBBox(SwShape& shape, const RenderShape* rshape, Point* pt4, const Matrix& m, SwMpool* mpool)
 {
-    auto outline = _genOutline(shape, rshape, m, mpool, 0, false, rshape->trimpath());
+    RenderRegion renderBox;
+    auto outline = _genOutline(shape, rshape, m, renderBox, mpool, 0, false, rshape->trimpath());
     if (!outline) return false;
 
     if (rshape->strokeWidth() > 0.0f) {
         strokeReset(shape.stroke, rshape, m, mpool, 0);
         strokeParseOutline(shape.stroke, *outline, mpool, 0);
 
-        auto func = [](SwStrokeBorder* border, SwPoint& min, SwPoint& max) {
+        auto func = [](SwStrokeBorder* border, RenderRegion& renderBox) {
             ARRAY_FOREACH(pts, border->pts) {
-                if (pts->x < min.x) min.x = pts->x;
-                if (pts->x > max.x) max.x = pts->x;
-                if (pts->y < min.y) min.y = pts->y;
-                if (pts->y > max.y) max.y = pts->y;
+                if (pts->x < renderBox.min.x) renderBox.min.x = pts->x;
+                if (pts->x > renderBox.max.x) renderBox.max.x = pts->x;
+                if (pts->y < renderBox.min.y) renderBox.min.y = pts->y;
+                if (pts->y > renderBox.max.y) renderBox.max.y = pts->y;
             }
         };
 
-        SwPoint min = {INT32_MAX, INT32_MAX};
-        SwPoint max = {-INT32_MAX, -INT32_MAX};
-        func(shape.stroke->borders[0], min, max);
-        func(shape.stroke->borders[1], min, max);
-
-        pt4[0] = min.toPoint();
-        pt4[1] = SwPoint{max.x, min.y}.toPoint();
-        pt4[2] = max.toPoint();
-        pt4[3] = SwPoint{min.x, max.y}.toPoint();
+        renderBox = {{INT32_MAX, INT32_MAX}, {-INT32_MAX, -INT32_MAX}};
+        func(shape.stroke->borders[0], renderBox);
+        func(shape.stroke->borders[1], renderBox);
 
         mpoolRetStrokeOutline(mpool, 0);
     }
+
+    pt4[0] = SwPoint{renderBox.min.x, renderBox.min.y}.toPoint();
+    pt4[1] = SwPoint{renderBox.max.x, renderBox.min.y}.toPoint();
+    pt4[2] = SwPoint{renderBox.max.x, renderBox.max.y}.toPoint();
+    pt4[3] = SwPoint{renderBox.min.x, renderBox.max.y}.toPoint();
 
     shapeDelOutline(shape, mpool, 0);
 


### PR DESCRIPTION
Compute the bounding box of the render region during path processing. Previously, this required an additional iteration over the points to perform the calculation.