### PR TITLE
gl_engine: fix broken blending visual

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -346,9 +346,11 @@ void GlSceneBlendTask::run()
     GL_CHECK(glViewport(0, 0, mParentWidth, mParentHeight));
     GL_CHECK(glScissor(0, 0, mParentWidth, mParentHeight));
 
+    GL_CHECK(glDisable(GL_DEPTH_TEST));
     GL_CHECK(glBlendFunc(GL_ONE, GL_ZERO));
     GlRenderTask::run();
     GL_CHECK(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+    GL_CHECK(glEnable(GL_DEPTH_TEST));
 }
 
 


### PR DESCRIPTION
Fixed broken blending visuals.
We must to turn off depth testing during custom scene blending

<img width="1026" height="1053" alt="image" src="https://github.com/user-attachments/assets/c984327f-4d34-443b-93d6-1c85cd3633c4" />

https://github.com/thorvg/thorvg/issues/3722