### PR TITLE
sw_engine: fine-tune image composition

### DIFF
--- a/src/renderer/sw_engine/tvgSwRaster.cpp
+++ b/src/renderer/sw_engine/tvgSwRaster.cpp
@@ -710,8 +710,7 @@ static bool _rasterScaledMattedRleImage(SwSurface* surface, const SwImage& image
         for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst, cmp += csize) {
             SCALED_IMAGE_RANGE_X
             auto src = scaleMethod(image.buf32, image.stride, image.w, image.h, sx, sy, miny, maxy, sampleSize);
-            src = ALPHA_BLEND(src, (a == 255) ? alpha(cmp) : MULTIPLY(alpha(cmp), a));
-            *dst = src + ALPHA_BLEND(*dst, IA(src));
+            *dst = INTERPOLATE(src, *dst, MULTIPLY(A(src), ((a == 255) ? alpha(cmp) : MULTIPLY(alpha(cmp), a))));
         }
     }
     return true;
@@ -789,13 +788,11 @@ static bool _rasterDirectMattedRleImage(SwSurface* surface, const SwImage& image
         auto a = MULTIPLY(span->coverage, opacity);
         if (a == 255) {
             for (auto x = 0; x < len; ++x, ++dst, ++img, cmp += csize) {
-                auto tmp = ALPHA_BLEND(*img, alpha(cmp));
-                *dst = tmp + ALPHA_BLEND(*dst, IA(tmp));
+                *dst = INTERPOLATE(*img, *dst, MULTIPLY(A(*img), alpha(cmp)));
             }
         } else {
             for (auto x = 0; x < len; ++x, ++dst, ++img, cmp += csize) {
-                auto tmp = ALPHA_BLEND(*img, MULTIPLY(a, alpha(cmp)));
-                *dst = tmp + ALPHA_BLEND(*dst, IA(tmp));
+                *dst = INTERPOLATE(*img, *dst, MULTIPLY(A(*img), MULTIPLY(a, alpha(cmp))));
             }
         }
     }
@@ -886,8 +883,7 @@ static bool _rasterScaledMattedImage(SwSurface* surface, const SwImage& image, c
         for (auto x = bbox.min.x; x < bbox.max.x; ++x, ++dst, cmp += csize) {
             SCALED_IMAGE_RANGE_X
             auto src = scaleMethod(image.buf32, image.stride, image.w, image.h, sx, sy, miny, maxy, sampleSize);
-            auto tmp = ALPHA_BLEND(src, opacity == 255 ? alpha(cmp) : MULTIPLY(opacity, alpha(cmp)));
-            *dst = tmp + ALPHA_BLEND(*dst, IA(tmp));
+            *dst = INTERPOLATE(src, *dst, MULTIPLY(A(src), (opacity == 255 ? alpha(cmp) : MULTIPLY(opacity, alpha(cmp)))));
         }
         dbuffer += surface->stride;
         cbuffer += surface->compositor->image.stride * csize;
@@ -984,13 +980,11 @@ static bool _rasterDirectMattedImage(SwSurface* surface, const SwImage& image, c
             auto src = sbuffer;
             if (opacity == 255) {
                 for (auto dst = dbuffer; dst < dbuffer + w; ++dst, ++src, cmp += csize) {
-                    auto tmp = ALPHA_BLEND(*src, alpha(cmp));
-                    *dst = tmp + ALPHA_BLEND(*dst, IA(tmp));
+                    *dst = INTERPOLATE(*src, *dst, MULTIPLY(A(*src), alpha(cmp)));
                 }
             } else {
                 for (auto dst = dbuffer; dst < dbuffer + w; ++dst, ++src, cmp += csize) {
-                    auto tmp = ALPHA_BLEND(*src, MULTIPLY(opacity, alpha(cmp)));
-                    *dst = tmp + ALPHA_BLEND(*dst, IA(tmp));
+                    *dst = INTERPOLATE(*src, *dst, MULTIPLY(A(*src), MULTIPLY(opacity, alpha(cmp))));
                 }
             }
             cbuffer += surface->compositor->image.stride * csize;
@@ -1003,13 +997,11 @@ static bool _rasterDirectMattedImage(SwSurface* surface, const SwImage& image, c
             auto src = sbuffer;
             if (opacity == 255) {
                 for (auto dst = dbuffer; dst < dbuffer + w; ++dst, ++src, cmp += csize) {
-                    auto tmp = MULTIPLY(A(*src), alpha(cmp));
-                    *dst = tmp + MULTIPLY(*dst, 255 - tmp);
+                    *dst = INTERPOLATE8(*src, *dst, MULTIPLY(A(*src), alpha(cmp)));
                 }
             } else {
                 for (auto dst = dbuffer; dst < dbuffer + w; ++dst, ++src, cmp += csize) {
-                    auto tmp = MULTIPLY(A(*src), MULTIPLY(opacity, alpha(cmp)));
-                    *dst = tmp + MULTIPLY(*dst, 255 - tmp);
+                    *dst = INTERPOLATE8(*src, *dst, MULTIPLY(A(*src), MULTIPLY(opacity, alpha(cmp))));
                 }
             }
             cbuffer += surface->compositor->image.stride * csize;


### PR DESCRIPTION
Apply one single INTERPOATE() instead of multiple ALPHA_BLENDS() while it's compatible