### PR TITLE
gl engine: fix broken blending visual (sub-scenes alignment)

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -330,17 +330,12 @@ void GlSceneBlendTask::run()
 {
     GlComposeTask::run();
     // copy the current fbo to the dstCopyFbo
-    RenderRegion vp = getViewport();
-    uint32_t dw = mDstCopyFbo->getViewport().w();
-    uint32_t dh = mDstCopyFbo->getViewport().h();
+    const auto& vp = getViewport();
     GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, getTargetFbo()));
     GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mDstCopyFbo->getResolveFboId()));
-    GL_CHECK(glViewport(0, 0, dw, dh));
-    GL_CHECK(glScissor(0, 0, dw, dh));
-    GL_CHECK(glBlitFramebuffer(
-        vp.min.x, vp.min.y, vp.max.x, vp.max.y,
-        vp.min.x, vp.min.y, vp.max.x, vp.max.y,
-        GL_COLOR_BUFFER_BIT, GL_LINEAR));
+    GL_CHECK(glViewport(0, 0, mDstCopyFbo->getWidth(), mDstCopyFbo->getHeight()));
+    GL_CHECK(glScissor(0, 0, mDstCopyFbo->getWidth(), mDstCopyFbo->getHeight()));
+    GL_CHECK(glBlitFramebuffer(vp.min.x, vp.min.y, vp.max.x, vp.max.y, 0, 0, vp.w(), vp.h(), GL_COLOR_BUFFER_BIT, GL_LINEAR));
 
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, getTargetFbo()));
     GL_CHECK(glViewport(0, 0, mParentWidth, mParentHeight));

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -629,7 +629,6 @@ GlProgram* GlRenderer::getBlendProgram(BlendMethod method, bool gradient, bool i
         shaderInd = methodInd + startInd;
         strcat(strcat(strcpy(fragShader, BLEND_IMAGE_FRAG_HEADER), helpers), shaderFunc[methodInd]);
     } else if (scene) {
-        vertShader = BLEND_SCENE_VERT_SHADER;
         startInd = (uint32_t)RenderTypes::RT_Blend_Scene_Normal;
         shaderInd = methodInd + startInd;
         strcat(strcat(strcpy(fragShader, BLEND_SCENE_FRAG_HEADER), helpers), shaderFunc[methodInd]);
@@ -751,7 +750,7 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
         mRenderPassStack.pop();
 
         if (!renderPass->isEmpty()) {
-            const auto& vp = currentPass()->getViewport();
+            const auto& vp = renderPass->getViewport();
             if (mBlendPool.count < 1) mBlendPool.push(new GlRenderTargetPool(surface.w, surface.h));
             if (mBlendPool.count < 2) mBlendPool.push(new GlRenderTargetPool(surface.w, surface.h));
             auto dstCopyFbo = mBlendPool[1]->getRenderTarget(vp);

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -592,20 +592,6 @@ const char* BLIT_FRAG_SHADER = TVG_COMPOSE_SHADER(
     }
 );
 
-const char* BLEND_SCENE_VERT_SHADER = R"(
-    layout(location = 0) in vec2 aLocation;
-    layout(location = 1) in vec2 aUV;
-    out vec2 vUV;
-    out vec2 vUVDst;
-
-    void main()
-    {
-        vUV = aUV;
-        vUVDst = aLocation * 0.5 + 0.5;
-        gl_Position = vec4(aLocation, 0.0, 1.0);
-    }
-)";
-
 const char* BLEND_SOLID_FRAG_HEADER = R"(
 uniform sampler2D uSrcTexture;
 uniform sampler2D uDstTexture;
@@ -699,7 +685,6 @@ uniform sampler2D uSrcTexture;
 uniform sampler2D uDstTexture;
 
 in vec2 vUV;
-in vec2 vUVDst;
 out vec4 FragColor;
 
 vec3 One = vec3(1.0, 1.0, 1.0);
@@ -709,7 +694,7 @@ FragData d;
 void getFragData() {
     // get source data
     vec4 colorSrc = texture(uSrcTexture, vUV);
-    vec4 colorDst = texture(uDstTexture, vUVDst);
+    vec4 colorDst = texture(uDstTexture, vUV);
     // fill fragment data
     d.Sc = colorSrc.rgb;
     d.Sa = colorSrc.a;

--- a/src/renderer/gl_engine/tvgGlShaderSrc.h
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.h
@@ -50,7 +50,6 @@ extern const char* STENCIL_FRAG_SHADER;
 extern const char* BLIT_VERT_SHADER;
 extern const char* BLIT_FRAG_SHADER;
 
-extern const char* BLEND_SCENE_VERT_SHADER;
 extern const char* BLEND_SOLID_FRAG_HEADER;
 extern const char* BLEND_GRADIENT_FRAG_HEADER;
 extern const char* BLEND_IMAGE_FRAG_HEADER;


### PR DESCRIPTION
Align intermediate fbo with source buffer instead of destination buffer. 
Align text coordinates for reading source and intermediate fbos.

<img width="802" height="832" alt="image" src="https://github.com/user-attachments/assets/84128207-f11d-473a-bec6-2bf948893148" />

https://github.com/thorvg/thorvg/issues/3722