### PR TITLE
wasm: rename player binary for web presets support

### DIFF
--- a/src/bindings/wasm/meson.build
+++ b/src/bindings/wasm/meson.build
@@ -6,7 +6,7 @@ if cc.get_id() == 'emscripten'
     thorvg_wasm_dep = declare_dependency(include_directories
                                          : include_directories('.'), sources
                                          : source_file)
-    executable('thorvg-wasm',
+    executable('thorvg',
         [],
         include_directories : headers,
         dependencies : [thorvg_lib_dep, thorvg_wasm_dep],


### PR DESCRIPTION
This PR is to align with `thorvg.web` preset-player support: https://github.com/thorvg/thorvg.web/pull/137

issue: https://github.com/thorvg/thorvg/issues/3481