### PR TITLE
wasm: apply conditional GIF saver support

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -438,6 +438,7 @@ public:
 
     bool save2Gif(string data)
     {
+#ifdef THORVG_GIF_SAVER_SUPPORT
         errorMsg = NoError;
 
         if (data.empty()) {
@@ -496,6 +497,10 @@ public:
         saver->sync();
 
         return true;
+#else
+        errorMsg = "GIF saver is not supported";
+        return false;
+#endif
     }
 
     // TODO: Advanced APIs wrt Interactivity & theme methods...


### PR DESCRIPTION
Add conditional compilation for the GIF saver functionality in the WASM binding. This allows proper WASM builds even when the GIF saver is disabled, preventing unnecessary binary size for preset variants.

related: https://github.com/thorvg/thorvg/issues/3481