### PR TITLE
lottie/slot: hotfix multiple overriding case

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -192,10 +192,8 @@ void LottieSlot::reset()
 {
     if (!overridden) return;
 
-    auto shallow = pairs.count == 1 ? true : false;
-
     ARRAY_FOREACH(pair, pairs) {
-        pair->obj->override(pair->prop, shallow, true);
+        pair->obj->override(pair->prop, true);
         delete(pair->prop);
         pair->prop = nullptr;
     }
@@ -206,7 +204,6 @@ void LottieSlot::reset()
 void LottieSlot::apply(LottieProperty* prop, bool byDefault)
 {
     auto copy = !overridden && !byDefault;
-    auto shallow = pairs.count == 1 ? true : false;
 
     //apply slot object to all targets
     ARRAY_FOREACH(pair, pairs) {
@@ -214,22 +211,30 @@ void LottieSlot::apply(LottieProperty* prop, bool byDefault)
         switch (type) {
             case LottieProperty::Type::Float: {
                 if (copy) pair->prop = new LottieFloat(static_cast<LottieTransform*>(pair->obj)->rotation);
-                pair->obj->override(prop, shallow, !copy);
+                LottieFloat targetProp;
+                targetProp.copy(*static_cast<LottieFloat*>(prop), false);
+                pair->obj->override(&targetProp, !copy);
                 break;
             }
             case LottieProperty::Type::Scalar: {
                 if (copy) pair->prop = new LottieScalar(static_cast<LottieTransform*>(pair->obj)->scale);
-                pair->obj->override(prop, shallow, !copy);
+                LottieScalar targetProp;
+                targetProp.copy(*static_cast<LottieScalar*>(prop), false);
+                pair->obj->override(&targetProp, !copy);
                 break;
             }
             case LottieProperty::Type::Vector: {
                 if (copy) pair->prop = new LottieVector(static_cast<LottieTransform*>(pair->obj)->position);
-                pair->obj->override(prop, shallow, !copy);
+                LottieVector targetProp;
+                targetProp.copy(*static_cast<LottieVector*>(prop), false);
+                pair->obj->override(&targetProp, !copy);
                 break;
             }
             case LottieProperty::Type::Color: {
                 if (copy) pair->prop = new LottieColor(static_cast<LottieSolid*>(pair->obj)->color);
-                pair->obj->override(prop, shallow, !copy);
+                LottieColor targetProp;
+                targetProp.copy(*static_cast<LottieColor*>(prop), false);
+                pair->obj->override(&targetProp, !copy);
                 break;
             }
             case LottieProperty::Type::Opacity: {
@@ -237,22 +242,30 @@ void LottieSlot::apply(LottieProperty* prop, bool byDefault)
                     if (pair->obj->type == LottieObject::Type::Transform) pair->prop = new LottieOpacity(static_cast<LottieTransform*>(pair->obj)->opacity);
                     else pair->prop = new LottieOpacity(static_cast<LottieSolid*>(pair->obj)->opacity);
                 }
-                pair->obj->override(prop, shallow, !copy);
+                LottieOpacity targetProp;
+                targetProp.copy(*static_cast<LottieOpacity*>(prop), false);
+                pair->obj->override(&targetProp, !copy);
                 break;
             }
             case LottieProperty::Type::ColorStop: {
                 if (copy) pair->prop = new LottieColorStop(static_cast<LottieGradient*>(pair->obj)->colorStops);
-                pair->obj->override(prop, shallow, !copy);
+                LottieColorStop targetProp;
+                targetProp.copy(*static_cast<LottieColorStop*>(prop), false);
+                pair->obj->override(&targetProp, !copy);
                 break;
             }
             case LottieProperty::Type::TextDoc: {
                 if (copy) pair->prop = new LottieTextDoc(static_cast<LottieText*>(pair->obj)->doc);
-                pair->obj->override(prop, shallow, !copy);
+                LottieTextDoc targetProp;
+                targetProp.copy(*static_cast<LottieTextDoc*>(prop), false);
+                pair->obj->override(&targetProp, !copy);
                 break;
             }
             case LottieProperty::Type::Image: {
                 if (copy) pair->prop = new LottieBitmap(static_cast<LottieImage*>(pair->obj)->data);
-                pair->obj->override(prop, shallow, !copy);
+                LottieBitmap targetProp;
+                targetProp.copy(*static_cast<LottieBitmap*>(prop), false);
+                pair->obj->override(&targetProp, !copy);
                 break;
             }
             default: break;
@@ -492,6 +505,7 @@ uint32_t LottieGradient::populate(ColorStop& color, size_t count)
 
     color.input->reset();
     delete(color.input);
+    color.input = nullptr;
 
     return output.count;
 }

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -278,7 +278,7 @@ struct LottieObject
     {
     }
 
-    virtual void override(LottieProperty* prop, bool shallow, bool release)
+    virtual void override(LottieProperty* prop, bool release)
     {
         TVGERR("LOTTIE", "Unsupported slot type");
     }
@@ -464,10 +464,10 @@ struct LottieText : LottieObject, LottieRenderPooler<tvg::Shape>
         LottieObject::type = LottieObject::Text;
     }
 
-    void override(LottieProperty* prop, bool shallow, bool release = false) override
+    void override(LottieProperty* prop, bool release = false) override
     {
         if (release) doc.release();
-        doc.copy(*static_cast<LottieTextDoc*>(prop), shallow);
+        doc.copy(*static_cast<LottieTextDoc*>(prop), false);
     }
 
     LottieProperty* property(uint16_t ix) override
@@ -685,27 +685,27 @@ struct LottieTransform : LottieObject
         return nullptr;
     }
 
-    void override(LottieProperty* prop, bool shallow, bool release) override
+    void override(LottieProperty* prop, bool release) override
     {
         switch (prop->type) {
             case LottieProperty::Type::Float: {
                 if (release) rotation.release();
-                rotation.copy(*static_cast<LottieFloat*>(prop), shallow);
+                rotation.copy(*static_cast<LottieFloat*>(prop), false);
                 break;
             }
             case LottieProperty::Type::Scalar: {
                 if (release) scale.release();
-                scale.copy(*static_cast<LottieScalar*>(prop), shallow);
+                scale.copy(*static_cast<LottieScalar*>(prop), false);
                 break;
             }
             case LottieProperty::Type::Vector: {
                 if (release) position.release();
-                position.copy(*static_cast<LottieVector*>(prop), shallow);
+                position.copy(*static_cast<LottieVector*>(prop), false);
                 break;
             }
             case LottieProperty::Type::Opacity: {
                 if (release) opacity.release();
-                opacity.copy(*static_cast<LottieOpacity*>(prop), shallow);
+                opacity.copy(*static_cast<LottieOpacity*>(prop), false);
                 break;
             }
             default: break;
@@ -756,10 +756,10 @@ struct LottieSolidStroke : LottieSolid, LottieStroke
         return LottieSolid::property(ix);
     }
 
-    void override(LottieProperty* prop, bool shallow, bool release) override
+    void override(LottieProperty* prop, bool release) override
     {
         if (release) color.release();
-        color.copy(*static_cast<LottieColor*>(prop), shallow);
+        color.copy(*static_cast<LottieColor*>(prop), false);
     }
 };
 
@@ -771,14 +771,14 @@ struct LottieSolidFill : LottieSolid
         LottieObject::type = LottieObject::SolidFill;
     }
 
-    void override(LottieProperty* prop, bool shallow, bool release) override
+    void override(LottieProperty* prop, bool release) override
     {
         if (prop->type == LottieProperty::Type::Color) {
             if (release) color.release();
-            color.copy(*static_cast<LottieColor*>(prop), shallow);
+            color.copy(*static_cast<LottieColor*>(prop), false);
         } else if (prop->type == LottieProperty::Type::Opacity) {
             if (release) opacity.release();
-            opacity.copy(*static_cast<LottieOpacity*>(prop), shallow);
+            opacity.copy(*static_cast<LottieOpacity*>(prop), false);
         }
     }
 
@@ -816,10 +816,10 @@ struct LottieGradient : LottieObject
         return nullptr;
     }
 
-    void override(LottieProperty* prop, bool shallow, bool release = false) override
+    void override(LottieProperty* prop, bool release = false) override
     {
         if (release) colorStops.release();
-        colorStops.copy(*static_cast<LottieColorStop*>(prop), shallow);
+        colorStops.copy(*static_cast<LottieColorStop*>(prop), false);
         prepare();
     }
 
@@ -871,10 +871,10 @@ struct LottieImage : LottieObject, LottieRenderPooler<tvg::Picture>
 {
     LottieBitmap data;
 
-    void override(LottieProperty* prop, bool shallow, bool release = false) override
+    void override(LottieProperty* prop, bool release = false) override
     {
         if (release) data.release();
-        data.copy(*static_cast<LottieBitmap*>(prop), shallow);
+        data.copy(*static_cast<LottieBitmap*>(prop), false);
         update();
     }
 

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -672,10 +672,21 @@ struct LottieColorStop : LottieProperty
             value.data = nullptr;
         }
 
+        if (value.input) {
+            value.input->reset();
+            delete(value.input);
+            value.input = nullptr;
+        }
+
         if (!frames) return;
 
         ARRAY_FOREACH(p, *frames) {
             tvg::free((*p).value.data);
+            if ((*p).value.input) {
+                (*p).value.input->reset();
+                delete((*p).value.input);
+                (*p).value.input = nullptr;
+            }
         }
         tvg::free(frames->data);
         tvg::free(frames);
@@ -811,13 +822,30 @@ struct LottieColorStop : LottieProperty
                 frames = rhs.frames;
                 rhs.frames = nullptr;
             } else {
-                frames = new Array<LottieScalarFrame<ColorStop>>;
+                frames = tvg::calloc<Array<LottieScalarFrame<ColorStop>>*>(1, sizeof(Array<LottieScalarFrame<ColorStop>>));
                 *frames = *rhs.frames;
+
+                // Used for deep copying reusable slot properties.
+                for (uint32_t i = 0; i < rhs.frames->count; ++i) {
+                    if ((*rhs.frames)[i].value.input) {
+                        (*frames)[i].value.input = new Array<float>;
+                        *(*frames)[i].value.input = *(*rhs.frames)[i].value.input;
+                    }
+                    (*rhs.frames)[i].value.data = nullptr;
+                }
             }
         } else {
             frames = nullptr;
             value = rhs.value;
-            rhs.value = ColorStop();
+            if (shallow) rhs.value = ColorStop();
+            else {
+                // Used for deep copying reusable slot properties.
+                if (rhs.value.input) {
+                    value.input = new Array<float>;
+                    *value.input = *rhs.value.input;
+                }
+                rhs.value.data = nullptr;
+            }
         }
         populated = rhs.populated;
         count = rhs.count;


### PR DESCRIPTION
Fix incorrect overriding when reusing slots; use deep-copy for slot values to prevent unintended data clearing.

---

In the new slot API, when reusing a slot for overriding, a problem occurs due to shallow copying, causing properties not to override correctly.

Previously, each override created a new LottieProperty instance via LottieParser, which was then shallow-copied and overridden. This approach worked fine because the parsed property immediately lost ownership of its data—override() always operated on a fresh LottieProperty.

With the new design, we aim to reuse the same slot and property multiple times. Once a slot and its property are created, the slot’s data should remain valid even after overrides, and should only be freed when the LottieSlot is deleted or del() is called.

However, with this approach, applying the slot multiple times results in the property being overridden with an empty value starting from the second attempt.

---

### Examples

So basically when we reuse the slot after one proceeded, the result should remain the same.

1. Image Overriding

```cpp
const char* slotJson = R"({"path_img":{"p":{"id":"image_0","w":200,"h":300,"u":"images/","p":"logo.png","e":0}}})";
slotId3 = slot3->gen(slotJson);
if (!tvgexam::verify(slot3->apply(slotId3))) return false;
if (!tvgexam::verify(slot3->apply(0))) return false;
if (!tvgexam::verify(slot3->apply(slotId3))) return false; // Reuse the slot -> it should be the same as first `apply`
```

| Result | Expected |
|--------|----------|
| <img width="2050" height="1884" alt="CleanShot 2025-08-22 at 16 10 32@2x" src="https://github.com/user-attachments/assets/2cf9cfe4-2d04-480e-83f4-35cbd9d5d98a" />  | <img width="2052" height="1884" alt="CleanShot 2025-08-22 at 16 10 47@2x" src="https://github.com/user-attachments/assets/90469afd-2da0-4606-be7c-c7d46fce84c7" /> | 

2. Gradient Overriding

```cpp
const char* slotJson = R"({"gradient_fill":{"p":{"p":2,"k":{"k":[0,0.1,0.1,0.2,1,1,0.1,0.2,0,0,1,1]}}}})";
slotId1 = slot1->gen(slotJson);
if (!tvgexam::verify(slot1->apply(slotId1))) return false;
if (!tvgexam::verify(slot1->apply(0))) return false;
if (!tvgexam::verify(slot1->apply(slotId1))) return false;
```

| Result | Expected |
|--------|----------|
| <img width="2052" height="1884" alt="CleanShot 2025-08-22 at 16 13 22@2x" src="https://github.com/user-attachments/assets/9ce462cc-e7f1-4a89-82b5-ea2edb7c1e75" /> | <img width="2052" height="1884" alt="CleanShot 2025-08-22 at 16 13 10@2x" src="https://github.com/user-attachments/assets/32878b21-3d02-4e9d-8f3e-904ecca32420" />
