### PR TITLE
api: revise the text apis

### DIFF
--- a/examples/Blending.cpp
+++ b/examples/Blending.cpp
@@ -31,7 +31,8 @@ struct UserExample : tvgexam::Example
     void blender(tvg::Canvas* canvas, const char* name, tvg::BlendMethod method, float x, float y, uint32_t* data)
     {
         auto text = tvg::Text::gen();
-        text->font("Arial", 15);
+        text->font("Arial");
+        text->size(15);
         text->text(name);
         text->fill(255, 255, 255);
         text->translate(x + 20, y);

--- a/examples/BoundingBox.cpp
+++ b/examples/BoundingBox.cpp
@@ -83,7 +83,8 @@ struct UserExample : tvgexam::Example
         {
             if (!tvgexam::verify(tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf"))) return false;
             auto text = tvg::Text::gen();
-            text->font("Arial", 30);
+            text->font("Arial");
+            text->size(30);
             text->text("Text Test");
             text->fill(255, 255, 0);
             text->translate(100, 20);
@@ -289,7 +290,8 @@ struct UserExample : tvgexam::Example
             scene->scale(0.7f);
 
             auto text = tvg::Text::gen();
-            text->font("Arial", 50);
+            text->font("Arial");
+            text->size(50);
             text->text("Text Test");
             text->fill(255, 255, 0);
             text->translate(0, 0);

--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -213,7 +213,8 @@ void contents()
         }
 
         Tvg_Paint *text = tvg_text_new();
-        tvg_text_set_font(text, "SentyCloud", 25.0f, "");
+        tvg_text_set_font(text, "SentyCloud");
+        tvg_text_set_size(text, 25.0f);
         tvg_text_set_fill_color(text, 200, 200, 255);
         tvg_text_set_text(text, "\xE7\xB4\xA2\xE5\xB0\x94\x56\x47\x20\xE6\x98\xAF\xE6\x9C\x80\xE5\xA5\xBD\xE7\x9A\x84");
         tvg_paint_translate(text, 50.0f, 380.0f);
@@ -247,7 +248,9 @@ void contents()
         tvg_gradient_set_spread(grad, TVG_STROKE_FILL_REFLECT);
 
         Tvg_Paint *text = tvg_text_new();
-        tvg_text_set_font(text, "Arial", 40.0f, "italic");
+        tvg_text_set_font(text, "Arial");
+        tvg_text_set_size(text, 40.0f);
+        tvg_text_set_italic(text, 0.18f);
         tvg_text_set_gradient(text, grad);
         tvg_text_set_text(text, "ThorVG is the best");
         tvg_paint_translate(text, 20.0f, 420.0f);

--- a/examples/Duplicate.cpp
+++ b/examples/Duplicate.cpp
@@ -143,7 +143,8 @@ struct UserExample : tvgexam::Example
         {
             auto text = tvg::Text::gen();
             if (!tvgexam::verify(text->load(EXAMPLE_DIR"/font/Arial.ttf"))) return false;
-            text->font("Arial", 50);
+            text->font("Arial");
+            text->size(50);
             text->translate(0, 650);
             text->text("ThorVG Text");
             text->fill(100, 100, 255);

--- a/examples/Intersects.cpp
+++ b/examples/Intersects.cpp
@@ -81,7 +81,8 @@ struct UserExample : tvgexam::Example
         {
             if (!tvgexam::verify(tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf"))) return false;
             text = tvg::Text::gen();
-            text->font("Arial", 100);
+            text->font("Arial");
+            text->size(100);
             text->text("Intersect?!");
             text->translate(25, 800);
             text->fill(255, 255, 255);

--- a/examples/Text.cpp
+++ b/examples/Text.cpp
@@ -58,48 +58,56 @@ struct UserExample : tvgexam::Example
         free(data);
 
         auto text = tvg::Text::gen();
-        text->font("Arial", 80);
+        text->font("Arial");
+        text->size(80);
         text->text("THORVG Text");
         text->fill(255, 255, 255);
         canvas->push(text);
 
         auto text2 = tvg::Text::gen();
-        text2->font("Arial", 30, "italic");
-        text2->text("Font = \"Arial\", Size = 40, Style=Italic");
+        text2->font("Arial");
+        text2->size(30);
+        text2->italic();
+        text2->text("Font = \"Arial\", Size = 40, Style = Italic");
         text2->translate(0, 150);
         text2->fill(255, 255, 255);
         canvas->push(text2);
 
         auto text3 = tvg::Text::gen();
-        text3->font(nullptr, 40);  //Use any font
+        text3->font(nullptr);  //Use any font
+        text3->size(40);
         text3->text("Kerning Test: VA, AV, TJ, JT");
         text3->fill(255, 255, 255);
         text3->translate(0, 225);
         canvas->push(text3);
 
         auto text4 = tvg::Text::gen();
-        text4->font("Arial", 25);
+        text4->font("Arial");
+        text4->size(25);
         text4->text("Purple Text");
         text4->fill(255, 0, 255);
         text4->translate(0, 310);
         canvas->push(text4);
 
         auto text5 = tvg::Text::gen();
-        text5->font("Arial", 25);
+        text5->font("Arial");
+        text5->size(25);
         text5->text("Gray Text");
         text5->fill(150, 150, 150);
         text5->translate(220, 310);
         canvas->push(text5);
 
         auto text6 = tvg::Text::gen();
-        text6->font("Arial", 25);
+        text6->font("Arial");
+        text6->size(25);
         text6->text("Yellow Text");
         text6->fill(255, 255, 0);
         text6->translate(400, 310);
         canvas->push(text6);
 
         auto text7 = tvg::Text::gen();
-        text7->font("NOTO-SANS-KR", 15);
+        text7->font("NOTO-SANS-KR");
+        text7->size(15);
         text7->text("Transformed Text - 30'");
         text7->fill(0, 0, 0);
         text7->translate(600, 400);
@@ -107,7 +115,8 @@ struct UserExample : tvgexam::Example
         canvas->push(text7);
 
         auto text8 = tvg::Text::gen();
-        text8->font("NOTO-SANS-KR", 15);
+        text8->font("NOTO-SANS-KR");
+        text8->size(15);
         text8->fill(0, 0, 0);
         text8->text("Transformed Text - 90'");
         text8->translate(600, 400);
@@ -115,7 +124,8 @@ struct UserExample : tvgexam::Example
         canvas->push(text8);
 
         auto text9 = tvg::Text::gen();
-        text9->font("NOTO-SANS-KR", 15);
+        text9->font("NOTO-SANS-KR");
+        text9->size(15);
         text9->fill(0, 0, 0);
         text9->text("Transformed Text - 180'");
         text9->translate(800, 400);
@@ -126,7 +136,8 @@ struct UserExample : tvgexam::Example
         float x, y, w2, h2;
 
         auto text10 = tvg::Text::gen();
-        text10->font("NOTO-SANS-KR", 50);
+        text10->font("NOTO-SANS-KR");
+        text10->size(50);
         text10->text("Linear Text");
         text10->bounds(&x, &y, &w2, &h2);
 
@@ -147,7 +158,8 @@ struct UserExample : tvgexam::Example
         canvas->push(text10);
 
         auto text11 = tvg::Text::gen();
-        text11->font("NanumGothicCoding", 40);
+        text11->font("NanumGothicCoding");
+        text11->size(40);
         text11->text("\xeb\x82\x98\xeb\x88\x94\xea\xb3\xa0\xeb\x94\x95\xec\xbd\x94\xeb\x94\xa9\x28\x55\x54\x46\x2d\x38\x29");
         text11->bounds(&x, &y, &w2, &h2);
 
@@ -170,7 +182,8 @@ struct UserExample : tvgexam::Example
         canvas->push(text11);
 
         auto text12 = tvg::Text::gen();
-        text12->font("SentyCloud", 50);
+        text12->font("SentyCloud");
+        text12->size(50);
         text12->fill(255, 25, 25);
         text12->text("\xe4\xb8\x8d\xe5\x88\xb0\xe9\x95\xbf\xe5\x9f\x8e\xe9\x9d\x9e\xe5\xa5\xbd\xe6\xb1\x89\xef\xbc\x81");
         text12->translate(0, 525);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1666,30 +1666,44 @@ class TVG_API Text : public Paint
 {
 public:
     /**
-     * @brief Sets the font properties for the text.
+     * @brief Sets the font family for the text.
      *
-     * This function allows you to define the font characteristics used for text rendering.
-     * It sets the font name, size and optionally the style.
+     * This function specifies the name of the font to be used when rendering text.
      *
-     * @param[in] name The name of the font. This should correspond to a font available in the canvas.
-     *                 If set to @c nullptr, ThorVG will attempt to select a fallback font available on the system.
-     * @param[in] size The size of the font in points. This determines how large the text will appear.
-     * @param[in] style The style of the font. It can be used to set the font to 'italic'.
-     *                  If not specified, the default style is used. Only 'italic' style is supported currently.
+     * @param[in] name The name of the font. This should match a font available through the canvas backend.
+     *                 If set to @c nullptr, ThorVG will attempt to select a fallback font available on the engine.
      *
      * @retval Result::InsufficientCondition when the specified @p name cannot be found.
      *
-     * @note If the @p name is not specified, ThorVG will select any available font candidate.
-     * @since 1.0
+     * @note This function only sets the font family name. Use @ref size() to define the font size.
+     * @note If the @p name is not specified, ThorVG will select an available fallback font.
      *
-     * @code
-     * // Tip for fallback support to use any available font.
-     * if (text->font("Arial", 24) != tvg::Result::Success) {
-     *     text->font(nullptr, 24);
-     * }
-     * @endcode
+     * @see Text::size()
+     * @see Text::load()
+     *
+     * @since 1.0
      */
-    Result font(const char* name, float size, const char* style = nullptr) noexcept;
+    Result font(const char* name) noexcept;
+
+    /**
+     * @brief Sets the font size for the text.
+     *
+     * This function sets the font size used during text rendering.
+     * The size is specified in point units, and supports floating-point precision
+     * for smooth scaling and animation effects.
+     *
+     * @param[in] size The font size in points. Must be greater than 0.0.
+     *
+     * @retval Result::InvalidArguments if the @p size is less than or equal to 0.
+     *
+     * @note Use this function in combination with @ref font() to fully define text appearance.
+     * @note Fractional sizes (e.g., 12.5) are supported for sub-pixel rendering and animations.
+     *
+     * @see Text::font()
+     *
+     * @since 1.0
+     */
+    Result size(float size) noexcept;
 
     /**
      * @brief Assigns the given unicode text to be rendered.
@@ -1702,6 +1716,28 @@ public:
      * @since 1.0
      */
     Result text(const char* text) noexcept;
+
+    /**
+     * @brief Apply an italic (slant) transformation to the text.
+     *
+     * This function applies a shear transformation to simulate an italic (oblique) style
+     * for the current text object. The shear factor determines the degree of slant
+     * applied along the X-axis.
+     *
+     * @param[in] shear The shear factor to apply. A value of 0.0 applies no slant, while values around 0.5 result in a strong slant.
+     *                  Must be in the range [0.0, 0.5]. Default value is 0.18.
+     *
+     * @note The @p shear factor will be clamped to the valid range if it exceeds the limits.
+     * @note This does not require the font itself to be italic.
+     *       It visually simulates the effect by applying a transformation matrix.
+     *
+     * @warning Excessive slanting may cause visual distortion depending on the font and size.
+     *
+     * @see Text::font()
+     *
+     * @since 1.0
+     */
+    Result italic(float shear = 0.18f) noexcept;
 
     /**
      * @brief Sets the text color.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2149,31 +2149,49 @@ TVG_API Tvg_Paint* tvg_text_new(void);
 
 
 /**
-* @brief Sets the font properties for the text.
-*
-* This function allows you to define the font characteristics used for text rendering.
-* It sets the font name, size and optionally the style.
-*
-* @param[in] paint A Tvg_Paint pointer to the text object.
-* @param[in] name The name of the font. This should correspond to a font available in the canvas.
-*                 If set to @c nullptr, ThorVG will attempt to select a fallback font available on the system.
-* @param[in] size The size of the font in points.
-* @param[in] style The style of the font. If empty, the default style is used. Currently only 'italic' style is supported.
-*
-* @retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the @p paint argument.
-* @retval TVG_RESULT_INSUFFICIENT_CONDITION  The specified @p name cannot be found.
-*
-* @note If the @p name is not specified, ThorVG will select any available font candidate.
-* @since 1.0
-*
-* @code
-* // Fallback example: Try a specific font, then fallback to any available one.
-* if (tvg_text_set_font(text, "Arial", 24, nullptr) != TVG_RESULT_SUCCESS) {
-*     tvg_text_set_font(text, nullptr, 24, nullptr);
-* }
-* @endcode
-*/
-TVG_API Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name, float size, const char* style);
+ * @brief Sets the font family for the text.
+ *
+ * This function specifies the name of the font to be used when rendering text.
+ *
+ * @param[in] paint A Tvg_Paint pointer to the text object.
+ * @param[in] name The name of the font. This should match a font available through the canvas backend.
+ *                 If set to @c nullptr, ThorVG will attempt to select a fallback font available on the engine.
+ *
+ * @retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the @p paint argument.
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION  The specified @p name cannot be found.
+ *
+ * @note This function only sets the font family name. Use @ref size() to define the font size.
+ * @note If the @p name is not specified, ThorVG will select an available fallback font.
+ *
+ * @see tvg_text_set_size()
+ * @see tvg_font_load()
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name);
+
+
+/**
+ * @brief Sets the font size for the text.
+ *
+ * This function sets the font size used during text rendering.
+ * The size is specified in point units, and supports floating-point precision
+ * for smooth scaling and animation effects.
+ *
+ * @param[in] paint A Tvg_Paint pointer to the text object.
+ * @param[in] size The font size in points. Must be greater than 0.0.
+ *
+ * @retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the @p paint argument.
+ * @retval TVG_RESULT_INVALID_ARGUMENT if the @p size is less than or equal to 0.
+ *
+ * @note Use this function in combination with @ref font() to fully define text appearance.
+ * @note Fractional sizes (e.g., 12.5) are supported for sub-pixel rendering and animations.
+ *
+ * @see tvg_text_set_font()
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_text_set_size(Tvg_Paint* paint, float size);
 
 
 /**
@@ -2185,11 +2203,35 @@ TVG_API Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name, float s
 * @param[in] paint A Tvg_Paint pointer to the text object.
 * @param[in] text The multi-byte text encoded with utf8 string to be rendered.
 *
-* @retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the @p paint argument.
-*
 * @since 1.0
 */
 TVG_API Tvg_Result tvg_text_set_text(Tvg_Paint* paint, const char* text);
+
+
+/**
+ * @brief Apply an italic (slant) transformation to the text.
+ *
+ * This function applies a shear transformation to simulate an italic (oblique) style
+ * for the current text object. The shear factor determines the degree of slant
+ * applied along the X-axis.
+ *
+ * @param[in] paint A Tvg_Paint pointer to the text object.
+ * @param[in] shear The shear factor to apply. A value of 0.0 applies no slant, while values around 0.5 result in a strong slant.
+ *                  Must be in the range [0.0, 0.5]. Recommended value is 0.18.
+ *
+ * @note The @p shear factor will be clamped to the valid range if it exceeds the limits.
+ * @note This does not require the font itself to be italic.
+ *       It visually simulates the effect by applying a transformation matrix.
+ *
+ * @warning Excessive slanting may cause visual distortion depending on the font and size.
+ *
+ * @see tvg_text_set_font()
+ *
+ * @retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the @p paint argument.
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_text_set_italic(Tvg_Paint* paint, float shear);
 
 
 /**

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -852,9 +852,16 @@ TVG_API Tvg_Paint* tvg_text_new()
 }
 
 
-TVG_API Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name, float size, const char* style)
+TVG_API Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name)
 {
-    if (paint) return (Tvg_Result) reinterpret_cast<Text*>(paint)->font(name, size, style);
+    if (paint) return (Tvg_Result) reinterpret_cast<Text*>(paint)->font(name);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
+TVG_API Tvg_Result tvg_text_set_size(Tvg_Paint* paint, float size)
+{
+    if (paint) return (Tvg_Result) reinterpret_cast<Text*>(paint)->size(size);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
@@ -872,6 +879,11 @@ TVG_API Tvg_Result tvg_text_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t 
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
+TVG_API Tvg_Result tvg_text_set_italic(Tvg_Paint* paint, float shear)
+{
+    if (paint) return (Tvg_Result) reinterpret_cast<Text*>(paint)->italic(shear);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
 
 TVG_API Tvg_Result tvg_text_set_gradient(Tvg_Paint* paint, Tvg_Gradient* gradient)
 {

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -910,11 +910,10 @@ static void _fontText(TextDocument& doc, Scene* scene)
     auto cnt = 0;
     while (token) {
         auto txt = Text::gen();
-        if (txt->font(doc.name, size) != Result::Success) {
-            //fallback to any available font
-            txt->font(nullptr, size);
+        if (txt->font(doc.name) != Result::Success) {
+            txt->font(nullptr);  //fallback to any available font
         }
-
+        txt->size(size);
         txt->text(token);
         txt->fill(doc.color.r, doc.color.g, doc.color.b);
 

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -867,10 +867,10 @@ static Paint* _textBuildHelper(SvgLoaderData& loaderData, const SvgNode* node, c
 
     //TODO: handle def values of font and size as used in a system?
     auto size = textNode->fontSize * 0.75f; //1 pt = 1/72; 1 in = 96 px; -> 72/96 = 0.75
-    if (text->font(textNode->fontFamily, size) != Result::Success) {
-        //fallback to any available font
-        text->font(nullptr, size);
+    if (text->font(textNode->fontFamily) != Result::Success) {
+        text->font(nullptr);         //fallback to any available font
     }
+    text->size(size);
     text->text(textNode->text);
 
     _applyTextFill(node->style, text, vBox);

--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -221,13 +221,11 @@ void TtfLoader::clear()
 /************************************************************************/
 
 
-float TtfLoader::transform(Paint* paint, FontMetrics& metrics, float fontSize, bool italic)
+float TtfLoader::transform(Paint* paint, FontMetrics& metrics, float fontSize, float italicShear)
 {
-    auto shift = 0.0f;
     auto dpi = 96.0f / 72.0f;   //dpi base?
     auto scale = fontSize * dpi / reader.metrics.unitsPerEm;
-    if (italic) shift = -scale * 0.18f;  //experimental decision.
-    Matrix m = {scale, shift, -(shift * metrics.minw), 0, scale, 0, 0, 0, 1};
+    Matrix m = {scale, -italicShear * scale, italicShear * metrics.minw * scale, 0, scale, 0, 0, 0, 1};
     paint->transform(m);
 
     return scale;

--- a/src/loaders/ttf/tvgTtfLoader.h
+++ b/src/loaders/ttf/tvgTtfLoader.h
@@ -47,7 +47,7 @@ struct TtfLoader : public FontLoader
 
     bool open(const char* path) override;
     bool open(const char *data, uint32_t size, const char* rpath, bool copy) override;
-    float transform(Paint* paint, FontMetrics& metrices, float fontSize, bool italic) override;
+    float transform(Paint* paint, FontMetrics& metrices, float fontSize, float italicShear) override;
     bool read(Shape* shape, char* text, FontMetrics& out) override;
     void clear();
 };

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -117,7 +117,7 @@ struct FontLoader : LoadModule
     using LoadModule::read;
 
     virtual bool read(Shape* shape, char* text, FontMetrics& out) = 0;
-    virtual float transform(Paint* paint, FontMetrics& mertrics, float fontSize, bool italic) = 0;
+    virtual float transform(Paint* paint, FontMetrics& mertrics, float fontSize, float italicShear) = 0;
 };
 
 #endif //_TVG_LOAD_MODULE_H_

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -33,9 +33,19 @@ Result Text::text(const char* text) noexcept
 }
 
 
-Result Text::font(const char* name, float size, const char* style) noexcept
+Result Text::font(const char* name) noexcept
 {
-    return TEXT(this)->font(name, size, style);
+    return TEXT(this)->font(name);
+}
+
+
+Result Text::size(float size) noexcept
+{
+    if (size > 0.0f) {
+        TEXT(this)->fontSize = size;
+        return Result::Success;
+    }
+    return Result::InvalidArguments;
 }
 
 
@@ -94,6 +104,15 @@ Result Text::fill(uint8_t r, uint8_t g, uint8_t b) noexcept
 Result Text::fill(Fill* f) noexcept
 {
     return TEXT(this)->shape->fill(f);
+}
+
+
+Result Text::italic(float shear) noexcept
+{
+    if (shear < 0.0f) shear = 0.0f;
+    else if (shear > 0.5f) shear = 0.5f;
+    TEXT(this)->italicShear = shear;
+    return Result::Success;
 }
 
 

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -40,7 +40,7 @@ struct TextImpl : Text
     FontMetrics metrics;
     char* utf8 = nullptr;
     float fontSize;
-    bool italic = false;
+    float italicShear = 0.0f;
 
     TextImpl() : impl(Paint::Impl(this)), shape(Shape::gen())
     {
@@ -65,15 +65,10 @@ struct TextImpl : Text
         return Result::Success;
     }
 
-    Result font(const char* name, float size, const char* style)
+    Result font(const char* name)
     {
         auto loader = name ? LoaderMgr::font(name) : LoaderMgr::anyfont();
         if (!loader) return Result::InsufficientCondition;
-
-        if (style && strstr(style, "italic")) italic = true;
-        else italic = false;
-
-        fontSize = size;
 
         //Same resource has been loaded.
         if (this->loader == loader) {
@@ -108,7 +103,7 @@ struct TextImpl : Text
         //reload
         if (impl.marked(RenderUpdateFlag::Path)) loader->read(shape, utf8, metrics);
 
-        return loader->transform(shape, metrics, fontSize, italic);
+        return loader->transform(shape, metrics, fontSize, italicShear);
     }
 
     bool skip(RenderUpdateFlag flag)
@@ -172,7 +167,7 @@ struct TextImpl : Text
         }
 
         dup->utf8 = tvg::duplicate(utf8);
-        dup->italic = italic;
+        dup->italicShear = italicShear;
         dup->fontSize = fontSize;
 
         return text;

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -209,7 +209,8 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
         REQUIRE(text->bounds(&x, &y, &w, &h) == Result::InsufficientCondition);
 
         //Case 1
-        REQUIRE(text->font("Arial", 32) == Result::Success);
+        REQUIRE(text->font("Arial") == Result::Success);
+        REQUIRE(text->size(32) == Result::Success);
         REQUIRE(text->text("TEST") == Result::Success);
         REQUIRE(text->translate(100.0f, 111.0f) == Result::Success);
         REQUIRE(text->bounds(&x, &y, &w, &h) == Result::Success);
@@ -302,7 +303,8 @@ TEST_CASE("Duplication", "[tvgPaint]")
     REQUIRE(Text::load(TEST_DIR"/Arial.ttf") == Result::Success);
     auto text = unique_ptr<Text>(Text::gen());
     REQUIRE(text);
-    REQUIRE(text->font("Arial", 32) == Result::Success);
+    REQUIRE(text->font("Arial") == Result::Success);
+    REQUIRE(text->size(32) == Result::Success);
     REQUIRE(text->text("Original Text") == Result::Success);
     REQUIRE(text->fill(255, 0, 0) == Result::Success);
     paints.push_back(std::move(text));

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -1500,7 +1500,8 @@ TEST_CASE("Text draw", "[tvgSwEngine]")
 
         auto text = Text::gen();
         REQUIRE(text);
-        REQUIRE(text->font("Arial", 32) == Result::Success);
+        REQUIRE(text->font("Arial") == Result::Success);
+        REQUIRE(text->size(32) == Result::Success);
         REQUIRE(text->text("TEST") == Result::Success);
         REQUIRE(text->fill(255, 0, 0) == Result::Success);
         REQUIRE(canvas->push(text) == Result::Success);

--- a/test/testText.cpp
+++ b/test/testText.cpp
@@ -106,11 +106,13 @@ TEST_CASE("Text Font", "[tvgText]")
 
         REQUIRE(Text::load(TEST_DIR"/Arial.ttf") == tvg::Result::Success);
 
-        REQUIRE(text->font("Arial", 80) == tvg::Result::Success);
-        REQUIRE(text->font("Arial", 1) == tvg::Result::Success);
-        REQUIRE(text->font("Arial", 50) == tvg::Result::Success);
-        REQUIRE(text->font(nullptr, 50) == tvg::Result::Success);
-        REQUIRE(text->font("InvalidFont", 80) == tvg::Result::InsufficientCondition);
+        REQUIRE(text->font("Arial") == tvg::Result::Success);
+        REQUIRE(text->size(80) == tvg::Result::Success);
+        REQUIRE(text->font("Arial") == tvg::Result::Success);
+        REQUIRE(text->size(1) == tvg::Result::Success);
+        REQUIRE(text->size(50) == tvg::Result::Success);
+        REQUIRE(text->font(nullptr) == tvg::Result::Success);
+        REQUIRE(text->font("InvalidFont") == tvg::Result::InsufficientCondition);
     }
     Initializer::term();
 }
@@ -127,7 +129,8 @@ TEST_CASE("Text Basic", "[tvgText]")
         REQUIRE(text);
 
         REQUIRE(Text::load(TEST_DIR"/Arial.ttf") == tvg::Result::Success);
-        REQUIRE(text->font("Arial", 80) == tvg::Result::Success);
+        REQUIRE(text->font("Arial") == tvg::Result::Success);
+        REQUIRE(text->size(80) == tvg::Result::Success);
 
         REQUIRE(text->text(nullptr) == tvg::Result::Success);
         REQUIRE(text->text("") == tvg::Result::Success);
@@ -153,7 +156,8 @@ TEST_CASE("Text with composite glyphs", "[tvgText]")
         REQUIRE(text);
 
         REQUIRE(Text::load(TEST_DIR"/Arial.ttf") == tvg::Result::Success);
-        REQUIRE(text->font("Arial", 80) == tvg::Result::Success);
+        REQUIRE(text->font("Arial") == tvg::Result::Success);
+        REQUIRE(text->size(80) == tvg::Result::Success);
 
         REQUIRE(text->text("\xc5\xbb\x6f\xc5\x82\xc4\x85\x64\xc5\xba \xc8\xab") == tvg::Result::Success);
 


### PR DESCRIPTION
- Introduced a dedicated API to apply italic (slant) transformations
  by specifying a custom shear factor. The style parameter has been
  removed from the font() interface to decouple italic styling from font loading.

  This change provides users with more control and flexibility
  when applying italic effects via transformation matrices.

- When animating the font size or adjusting it dynamically at runtime,
  user only need to call font size set. Also, a structure that changes
  both the name and size at the same time can cause unnecessary process.
```
C++ API:
 * Result Text::font(const char* name, float size, const char* style)
  -> Result Text::font(const char* name, float size)
 * Result Text::font(const char* name, float size)
  -> Result Text::font(const char* name)
 + Result Text::size(float size)
 + Result Text::italic(float shear=0.18)

C API:
 * Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name, float size, const char * style)
  -> Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name, float size)
 * Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name, float size)
  -> Tvg_Result tvg_text_set_font(Tvg_Paint* paint, const char* name)
 + Tvg_Result tvg_text_set_italic(Tvg_Paint* paint, float shear)
 + Tvg_Result tvg_text_set_size(Tvg_Paint* paint, float size)
```
issue: https://github.com/thorvg/thorvg/issues/3116