### PR TITLE
text: add outline style support

### DIFF
--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -215,7 +215,7 @@ void contents()
         Tvg_Paint *text = tvg_text_new();
         tvg_text_set_font(text, "SentyCloud");
         tvg_text_set_size(text, 25.0f);
-        tvg_text_set_fill_color(text, 200, 200, 255);
+        tvg_text_set_color(text, 200, 200, 255);
         tvg_text_set_text(text, "\xE7\xB4\xA2\xE5\xB0\x94\x56\x47\x20\xE6\x98\xAF\xE6\x9C\x80\xE5\xA5\xBD\xE7\x9A\x84");
         tvg_paint_translate(text, 50.0f, 380.0f);
         tvg_canvas_push(canvas, text);

--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -250,6 +250,7 @@ void contents()
         Tvg_Paint *text = tvg_text_new();
         tvg_text_set_font(text, "Arial");
         tvg_text_set_size(text, 40.0f);
+        tvg_text_set_outline(text, 2, 255, 0, 0);
         tvg_text_set_italic(text, 0.18f);
         tvg_text_set_gradient(text, grad);
         tvg_text_set_text(text, "ThorVG is the best");

--- a/examples/Text.cpp
+++ b/examples/Text.cpp
@@ -185,6 +185,7 @@ struct UserExample : tvgexam::Example
         text12->font("SentyCloud");
         text12->size(50);
         text12->fill(255, 25, 25);
+        text12->outline(3, 255, 200, 200);
         text12->text("\xe4\xb8\x8d\xe5\x88\xb0\xe9\x95\xbf\xe5\x9f\x8e\xe9\x9d\x9e\xe5\xa5\xbd\xe6\xb1\x89\xef\xbc\x81");
         text12->translate(0, 525);
         canvas->push(text12);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1157,21 +1157,37 @@ public:
     Result appendPath(const PathCommand* cmds, uint32_t cmdCnt, const Point* pts, uint32_t ptsCnt) noexcept;
 
     /**
-     * @brief Sets the stroke width for all of the figures from the path.
+     * @brief Sets the stroke width for the path.
      *
-     * @param[in] width The width of the stroke. The default value is 0.
+     * This function defines the thickness of the stroke applied to all figures
+     * in the path object. A stroke is the outline drawn along the edges of the
+     * path's geometry.
      *
+     * @param[in] width The width of the stroke in pixels. Must be positive value. (The default is 0)
+     *
+     * @note A value of @p width 0 disables the stroke.
+     *
+     * @see strokeFill()
      */
     Result strokeWidth(float width) noexcept;
 
     /**
-     * @brief Sets the color of the stroke for all of the figures from the path.
+     * @brief Sets the stroke color for the path.
+     *
+     * This function defines the RGBA color of the stroke applied to all figures
+     * in the path object. The stroke color is used when rendering the outline
+     * of the path geometry.
      *
      * @param[in] r The red color channel value in the range [0 ~ 255]. The default value is 0.
      * @param[in] g The green color channel value in the range [0 ~ 255]. The default value is 0.
      * @param[in] b The blue color channel value in the range [0 ~ 255]. The default value is 0.
      * @param[in] a The alpha channel value in the range [0 ~ 255], where 0 is completely transparent and 255 is opaque. The default value is 0.
      *
+     * @note If the stroke width is 0 (default), the stroke will not be visible regardless of the color.
+     * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
+     *
+     * @see strokeWidth()
+     * @see strokeFill(Fill* f)
      */
     Result strokeFill(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255) noexcept;
 
@@ -1180,7 +1196,12 @@ public:
      *
      * @param[in] f The gradient fill.
      *
-     * @retval Result::MemoryCorruption In case a @c nullptr is passed as the argument.
+     * @retval Result::InvalidArgument In case a @c nullptr is passed as the argument.
+     *
+     * @note If the stroke width is 0 (default), the stroke will not be visible regardless of the color.
+     * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
+     *
+     * @see strokeFill(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
      */
     Result strokeFill(Fill* f) noexcept;
 
@@ -1740,6 +1761,24 @@ public:
     Result italic(float shear = 0.18f) noexcept;
 
     /**
+     * @brief Sets an outline (stroke) around the text object.
+     *
+     * This function adds an outline to the text with the specified width and RGB color.
+     * The outline enhances the visibility of the text by rendering a stroke around its glyphs.
+     *
+     * @param width The width of the outline. Must be positive value. (The default is 0)
+     * @param r     Red component of the outline color (0–255).
+     * @param g     Green component of the outline color (0–255).
+     * @param b     Blue component of the outline color (0–255).
+     *
+     * @note To disable the outline, set @p width to 0.
+     * @see Text::fill() to set the main text fill color.
+     *
+     * @since 1.0
+     */
+    Result outline(float width, uint8_t r, uint8_t g, uint8_t b) noexcept;
+
+    /**
      * @brief Sets the text color.
      *
      * @param[in] r The red color channel value in the range [0 ~ 255]. The default value is 0.
@@ -1747,6 +1786,7 @@ public:
      * @param[in] b The blue color channel value in the range [0 ~ 255]. The default value is 0.
      *
      * @see Text::font()
+     * @see Text::outline()
      *
      * @since 0.15
      */

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1271,12 +1271,20 @@ TVG_API Tvg_Result tvg_shape_get_path(const Tvg_Paint* paint, const Tvg_Path_Com
 
 
 /*!
-* @brief Sets the stroke width for all of the figures from the @p paint.
+* @brief Sets the stroke width for the path.
+*
+* This function defines the thickness of the stroke applied to all figures
+* in the path object. A stroke is the outline drawn along the edges of the
+* path's geometry.
 *
 * @param[in] paint A Tvg_Paint pointer to the shape object.
-* @param[in] width The width of the stroke. The default value is 0.
+* @param[in] width The width of the stroke in pixels. Must be positive value. (The default is 0)
 *
 * @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
+*
+* @note A value of @p width 0 disables the stroke.
+*
+* @see tvg_shape_set_stroke_color()
 */
 TVG_API Tvg_Result tvg_shape_set_stroke_width(Tvg_Paint* paint, float width);
 
@@ -1303,7 +1311,11 @@ TVG_API Tvg_Result tvg_shape_get_stroke_width(const Tvg_Paint* paint, float* wid
 *
 * @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 *
+* @note If the stroke width is 0 (default), the stroke will not be visible regardless of the color.
 * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
+*
+* @see tvg_shape_set_stroke_width()
+* @see tvg_shape_set_stroke_gradient()
 */
 TVG_API Tvg_Result tvg_shape_set_stroke_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
@@ -1333,6 +1345,8 @@ TVG_API Tvg_Result tvg_shape_get_stroke_color(const Tvg_Paint* paint, uint8_t* r
 * @retval TVG_RESULT_MEMORY_CORRUPTION An invalid Tvg_Gradient pointer or an error with accessing it.
 *
 * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
+*
+* @see tvg_shape_set_stroke_color()
 */
 TVG_API Tvg_Result tvg_shape_set_stroke_gradient(Tvg_Paint* paint, Tvg_Gradient* grad);
 
@@ -2235,6 +2249,26 @@ TVG_API Tvg_Result tvg_text_set_italic(Tvg_Paint* paint, float shear);
 
 
 /**
+ * @brief Sets an outline (stroke) around the text object.
+ *
+ * This function adds an outline to the text with the specified width and RGB color.
+ * The outline enhances the visibility of the text by rendering a stroke around its glyphs.
+ *
+ * @param[in] paint A Tvg_Paint pointer to the text object.
+ * @param width The width of the outline. Must be positive value. (The default is 0)
+ * @param r     Red component of the outline color (0–255).
+ * @param g     Green component of the outline color (0–255).
+ * @param b     Blue component of the outline color (0–255).
+ *
+ * @note To disable the outline, set @p width to 0.
+ * @see tvg_text_set_fill_color() to set the main text fill color.
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_text_set_outline(Tvg_Paint* paint, float width, uint8_t r, uint8_t g, uint8_t b);
+
+
+/**
 * @brief Sets the text solid color.
 *
 * @param[in] paint A Tvg_Paint pointer to the text object.
@@ -2245,7 +2279,9 @@ TVG_API Tvg_Result tvg_text_set_italic(Tvg_Paint* paint, float shear);
 * @retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the @p paint argument.
 *
 * @note Either a solid color or a gradient fill is applied, depending on what was set as last.
+*
 * @see tvg_text_set_font()
+* @see tvg_text_set_outline()
 *
 * @since 0.15
 */

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2285,7 +2285,7 @@ TVG_API Tvg_Result tvg_text_set_outline(Tvg_Paint* paint, float width, uint8_t r
 *
 * @since 0.15
 */
-TVG_API Tvg_Result tvg_text_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b);
+TVG_API Tvg_Result tvg_text_set_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b);
 
 
 /**

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -880,7 +880,7 @@ TVG_API Tvg_Result tvg_text_set_outline(Tvg_Paint* paint, float width, uint8_t r
 }
 
 
-TVG_API Tvg_Result tvg_text_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b)
+TVG_API Tvg_Result tvg_text_set_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b)
 {
     if (paint) return (Tvg_Result) reinterpret_cast<Text*>(paint)->fill(r, g, b);
     return TVG_RESULT_INVALID_ARGUMENT;

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -873,6 +873,13 @@ TVG_API Tvg_Result tvg_text_set_text(Tvg_Paint* paint, const char* text)
 }
 
 
+TVG_API Tvg_Result tvg_text_set_outline(Tvg_Paint* paint, float width, uint8_t r, uint8_t g, uint8_t b)
+{
+    if (paint) return (Tvg_Result) reinterpret_cast<Text*>(paint)->outline(width, r, g, b);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
 TVG_API Tvg_Result tvg_text_set_fill_color(Tvg_Paint* paint, uint8_t r, uint8_t g, uint8_t b)
 {
     if (paint) return (Tvg_Result) reinterpret_cast<Text*>(paint)->fill(r, g, b);

--- a/src/renderer/tvgShape.cpp
+++ b/src/renderer/tvgShape.cpp
@@ -144,6 +144,7 @@ Result Shape::order(bool strokeFirst) noexcept
 
 Result Shape::strokeWidth(float width) noexcept
 {
+    if (width < 0.0f) width = 0.0f;
     SHAPE(this)->strokeWidth(width);
     return Result::Success;
 }

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -101,6 +101,14 @@ Result Text::fill(uint8_t r, uint8_t g, uint8_t b) noexcept
 }
 
 
+Result Text::outline(float width, uint8_t r, uint8_t g, uint8_t b) noexcept
+{
+    TEXT(this)->outlineWidth = width;
+    TEXT(this)->shape->strokeFill(r, g, b);
+    return Result::Success;
+}
+
+
 Result Text::fill(Fill* f) noexcept
 {
     return TEXT(this)->shape->fill(f);

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -40,6 +40,7 @@ struct TextImpl : Text
     FontMetrics metrics;
     char* utf8 = nullptr;
     float fontSize;
+    float outlineWidth = 0.0f;
     float italicShear = 0.0f;
 
     TextImpl() : impl(Paint::Impl(this)), shape(Shape::gen())
@@ -134,6 +135,9 @@ struct TextImpl : Text
                 RADIAL(fill)->fr *= scale;
             }
         }
+
+        if (outlineWidth > 0.0f) shape->strokeWidth(outlineWidth * scale);
+
         PAINT(shape)->update(renderer, transform, clips, opacity, flag, false);
         return true;
     }

--- a/test/testText.cpp
+++ b/test/testText.cpp
@@ -168,4 +168,38 @@ TEST_CASE("Text with composite glyphs", "[tvgText]")
     Initializer::term();
 }
 
+
+TEST_CASE("Text Styles", "[tvgText]")
+{
+    Initializer::init();
+    {
+        auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+        uint32_t buffer[100*100];
+        canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888);
+
+        auto text = Text::gen();
+        REQUIRE(text);
+
+        REQUIRE(Text::load(TEST_DIR"/Arial.ttf") == tvg::Result::Success);
+        REQUIRE(text->font("Arial") == tvg::Result::Success);
+        REQUIRE(text->size(80) == tvg::Result::Success);
+
+        REQUIRE(text->text("\xc5\xbb\x6f\xc5\x82\xc4\x85\x64\xc5\xba \xc8\xab") == tvg::Result::Success);
+
+        REQUIRE(text->fill(255, 255, 255) == tvg::Result::Success);
+
+        REQUIRE(text->outline(0, 0, 0, 0) == tvg::Result::Success);
+        REQUIRE(text->outline(3, 255, 255, 255) == tvg::Result::Success);
+        REQUIRE(text->outline(0, 0, 0, 0) == tvg::Result::Success);
+
+        REQUIRE(text->italic(-10.0f) == tvg::Result::Success);
+        REQUIRE(text->italic(10000.0f) == tvg::Result::Success);
+        REQUIRE(text->italic(0.0) == tvg::Result::Success);
+        REQUIRE(text->italic(0.18f) == tvg::Result::Success);
+
+        REQUIRE(canvas->push(text) == Result::Success);
+    }
+    Initializer::term();
+}
+
 #endif


### PR DESCRIPTION
Introduce outline support for text rendering.
The outline feature applies a stroke around text glyphs, allowing improved readability and visual emphasis.

C++:
 + Result Text::outline(float width, uint8_t r, uint8_t g, uint8_t b)

CAPI:
 + Tvg_Result tvg_text_set_outline(Tvg_Paint* paint, float width, uint8_t r, uint8_t g, uint8_t b)

CAPI:
<img width="474" height="98" alt="image" src="https://github.com/user-attachments/assets/03d500f1-1dea-4cc8-90de-2b16a67f66a7" />

Text:
<img width="558" height="96" alt="image" src="https://github.com/user-attachments/assets/0d071f3a-097f-4319-9cbb-5e1a427bd405" />

issue: https://github.com/thorvg/thorvg/issues/3397
