### PR TITLE
wg/gl: support stroke bounding box

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -897,11 +897,25 @@ bool GlRenderer::sync()
 }
 
 
-bool GlRenderer::bounds(RenderData data, TVG_UNUSED Point* pt4, TVG_UNUSED const Matrix& m)
+bool GlRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
 {
     if (data) {
-        //TODO: stroking bounding box is required
-        TVGLOG("GL_ENGINE", "bounds() is not supported!");
+        auto sdata = static_cast<GlShape*>(data);
+        if (sdata->validStroke) {
+            tvg::BBox bbox;
+            bbox.init();
+            auto& vertexes = sdata->geometry.stroke.vertex;
+            for (uint32_t i = 0; i < vertexes.count / 2; i++) {
+                Point vert = Point{vertexes[i*2+0], vertexes[i*2+1]} * m;
+                bbox.min = min(bbox.min, vert);
+                bbox.max = max(bbox.max, vert);
+            }
+            pt4[0] = bbox.min;
+            pt4[1] = {bbox.max.x, bbox.min.y};
+            pt4[2] = bbox.max;
+            pt4[3] = {bbox.min.x, bbox.max.y};
+            return true;
+        }
     }
     return false;
 }

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -268,11 +268,28 @@ void WgRenderer::dispose(RenderData data) {
 }
 
 
-bool WgRenderer::bounds(RenderData data, Point* pt4, TVG_UNUSED const Matrix& m)
+bool WgRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
 {
     if (data) {
-        //TODO: stroking bounding box is required
-        TVGLOG("WG_ENGINE", "bounds() is not supported!");
+        auto renderDataPaint = (WgRenderDataPaint*)data;
+        if (renderDataPaint->type() == Type::Shape) {
+            auto renderData = (WgRenderDataShape*)data;
+            if (!renderData->renderSettingsStroke.skip) {
+                tvg::BBox bbox;
+                bbox.init();
+                auto& vertexes = renderData->meshStrokes.vbuffer;
+                for (uint32_t i = 0; i < vertexes.count; i++) {
+                    Point vert = vertexes[i] * m;
+                    bbox.min = min(bbox.min, vert);
+                    bbox.max = max(bbox.max, vert);
+                }
+                pt4[0] = bbox.min;
+                pt4[1] = {bbox.max.x, bbox.min.y};
+                pt4[2] = bbox.max;
+                pt4[3] = {bbox.min.x, bbox.max.y};
+                return true;
+            }
+        }
     }
     return false;
 }


### PR DESCRIPTION
generated geometry of strokes is taken into account in the calculation of aabb pre-calculated strokes mesh geometry is used and transformation is applied

https://github.com/thorvg/thorvg/issues/3725

<img width="902" height="932" alt="image" src="https://github.com/user-attachments/assets/73b9f244-3f6a-49bc-af31-950dc65657c3" />
