### PR TITLE
example: fix compilation errors on win/mingw

### DIFF
--- a/examples/Example.h
+++ b/examples/Example.h
@@ -21,6 +21,7 @@
  */
 #include "config.h"
 
+#include <cmath>
 #include <memory>
 #include <vector>
 #include <fstream>


### PR DESCRIPTION
added missed include

<img width="545" height="119" alt="image" src="https://github.com/user-attachments/assets/8e8b73a6-5c39-4f25-a402-d2859d8cd99c" />
