### PR TITLE
api: added Picture::origin() support for user covenience

### DIFF
--- a/examples/Animation.cpp
+++ b/examples/Animation.cpp
@@ -38,6 +38,7 @@ struct UserExample : tvgexam::Example
         //Animation Controller
         animation = unique_ptr<tvg::Animation>(tvg::Animation::gen());
         auto picture = animation->picture();
+        picture->origin(0.5f, 0.5f);  //center origin
 
         //Background
         auto shape = tvg::Shape::gen();
@@ -49,21 +50,11 @@ struct UserExample : tvgexam::Example
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/sample.json"))) return false;
 
         //image scaling preserving its aspect ratio
-        float scale;
-        float shiftX = 0.0f, shiftY = 0.0f;
         float w2, h2;
         picture->size(&w2, &h2);
-
-        if (w2 > h2) {
-            scale = w / w2;
-            shiftY = (h - h2 * scale) * 0.5f;
-        } else {
-            scale = h / h2;
-            shiftX = (w - w2 * scale) * 0.5f;
-        }
-
+        auto scale = (w2 > h2) ? w / w2 : h / h2;
         picture->scale(scale);
-        picture->translate(shiftX, shiftY);
+        picture->translate(float(w) * 0.5f, float(h) * 0.5f);
 
         canvas->push(picture);
 

--- a/examples/ImageRotation.cpp
+++ b/examples/ImageRotation.cpp
@@ -40,6 +40,8 @@ struct UserExample : tvgexam::Example
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
         picture = tvg::Picture::gen();
+        picture->origin(0.5f, 0.5f);  //center origin
+        picture->translate(w/2, h/2);
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/image/scale.jpg"))) return false;
 
@@ -50,31 +52,8 @@ struct UserExample : tvgexam::Example
 
     bool update(tvg::Canvas* canvas, uint32_t elapsed) override
     {
-        tvg::Matrix m = {1.0f, 0.0f, 0.0f, 0.0f, 0.1f, 0.0f, 0.0f, 0.0f, 1.0f};
-
-        //center pivoting
-        m.e13 += 480;
-        m.e23 += 480;
-
-        //rotation
-        auto degree = tvgexam::progress(elapsed, 4.0f) * 360.0f;
-        auto radian = deg2rad(degree);
-        m.e11 = cosf(radian);
-        m.e12 = -sinf(radian);
-        m.e21 = sinf(radian);
-        m.e22 = cosf(radian);
-
-        //scaling
-        m.e11 *= 0.8f;
-        m.e21 *= 0.8f;
-        m.e22 *= 0.8f;
-        m.e12 *= 0.8f;
-
-        //center pivoting
-        m.e13 += (-400 * m.e11 + -400 * m.e12);
-        m.e23 += (-400 * m.e21 + -400 * m.e22);
-
-        picture->transform(m);
+        picture->scale(0.8f);
+        picture->rotate(tvgexam::progress(elapsed, 4.0f) * 360.0f);
 
         canvas->update();
 

--- a/examples/ImageScaling.cpp
+++ b/examples/ImageScaling.cpp
@@ -37,6 +37,8 @@ struct UserExample : tvgexam::Example
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/image/scale.jpg"))) return false;
 
+        picture->origin(0.5f, 0.5f);  //center origin
+        picture->translate(w/2, h/2);
         picture->scale(1.5f);
 
         canvas->push(picture);

--- a/examples/Lottie.cpp
+++ b/examples/Lottie.cpp
@@ -48,25 +48,15 @@ struct UserExample : tvgexam::Example
         //Animation Controller
         auto animation = tvg::Animation::gen();
         auto picture = animation->picture();
+        picture->origin(0.5f, 0.5f);
 
         if (!tvgexam::verify(picture->load(path))) return;
 
         //image scaling preserving its aspect ratio
-        float scale;
-        float shiftX = 0.0f, shiftY = 0.0f;
         float w, h;
         picture->size(&w, &h);
-
-        if (w > h) {
-            scale = size / w;
-            shiftY = (size - h * scale) * 0.5f;
-        } else {
-            scale = size / h;
-            shiftX = (size - w * scale) * 0.5f;
-        }
-
-        picture->scale(scale);
-        picture->translate((counter % NUM_PER_ROW) * size + shiftX, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + shiftY);
+        picture->scale((w > h) ? size / w : size / h);
+        picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + size / 2);
 
         animations.push_back(unique_ptr<tvg::Animation>(animation));
 

--- a/examples/LottieExpressions.cpp
+++ b/examples/LottieExpressions.cpp
@@ -48,25 +48,15 @@ struct UserExample : tvgexam::Example
         //Animation Controller
         auto animation = tvg::Animation::gen();
         auto picture = animation->picture();
+        picture->origin(0.5f, 0.5f);
 
         if (!tvgexam::verify(picture->load(path))) return;
 
         //image scaling preserving its aspect ratio
-        float scale;
-        float shiftX = 0.0f, shiftY = 0.0f;
         float w, h;
         picture->size(&w, &h);
-
-        if (w > h) {
-            scale = size / w;
-            shiftY = (size - h * scale) * 0.5f;
-        } else {
-            scale = size / h;
-            shiftX = (size - w * scale) * 0.5f;
-        }
-
-        picture->scale(scale);
-        picture->translate((counter % NUM_PER_ROW) * size + shiftX, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + shiftY);
+        picture->scale((w > h) ? size / w : size / h);
+        picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + size / 2);
 
         animations.push_back(unique_ptr<tvg::Animation>(animation));
 

--- a/examples/LottieInteraction.cpp
+++ b/examples/LottieInteraction.cpp
@@ -114,14 +114,7 @@ struct UserExample : tvgexam::Example
         //LottieAnimation Controller
         lottie = unique_ptr<tvg::LottieAnimation>(tvg::LottieAnimation::gen());
         auto picture = lottie->picture();
-
-        //Background
-        {
-            auto shape = tvg::Shape::gen();
-            shape->appendRect(0, 0, w, h);
-            shape->fill(0, 0, 0);
-            canvas->push(std::move(shape));
-        }
+        picture->origin(0.5f, 0.5f);
 
         //Lottie Boundary
         {
@@ -134,23 +127,11 @@ struct UserExample : tvgexam::Example
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/spin.json"))) return false;
 
         //image scaling preserving its aspect ratio
-        float scale;
-        float shiftX = 0.0f, shiftY = 0.0f;
         float w2, h2;
         picture->size(&w2, &h2);
-
-        if (w2 > h2) {
-            scale = w / w2 * 0.8f;
-            shiftX = w2 * 0.2f;
-            shiftY = (h - h2 * scale) * 0.5f;
-        } else {
-            scale = h / h2 * 0.8f;
-            shiftX = (w - w2 * scale) * 0.5f;
-            shiftY = h2 * 0.2f;
-        }
-
+        auto scale = ((w2 > h2) ? w / w2 : h / h2) * 0.8f;
         picture->scale(scale);
-        picture->translate(shiftX, shiftY);
+        picture->translate(float(w) * 0.5f, float(h) * 0.5f);
 
         canvas->push(picture);
 

--- a/examples/LottieTweening.cpp
+++ b/examples/LottieTweening.cpp
@@ -116,6 +116,7 @@ struct UserExample : tvgexam::Example
         //Animation Controller
         lottie = tvg::LottieAnimation::gen();
         auto picture = lottie->picture();
+        picture->origin(0.5f, 0.5f);  //center origin
 
         //Background
         auto shape = tvg::Shape::gen();
@@ -127,21 +128,12 @@ struct UserExample : tvgexam::Example
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/emoji.json"))) return false;
 
         //image scaling preserving its aspect ratio
-        float scale;
-        float shiftX = 0.0f, shiftY = 0.0f;
         float w2, h2;
         picture->size(&w2, &h2);
-
-        if (w2 > h2) {
-            scale = w / w2;
-            shiftY = (h - h2 * scale) * 0.5f;
-        } else {
-            scale = h / h2;
-            shiftX = (w - w2 * scale) * 0.5f;
-        }
-
+        auto scale = (w2 > h2) ? w / w2 : h / h2;
         picture->scale(scale);
-        picture->translate(shiftX, shiftY);
+        picture->translate(float(w) * 0.5f, float(h) * 0.5f);
+
 
         canvas->push(picture);
 

--- a/examples/MultiCanvas.cpp
+++ b/examples/MultiCanvas.cpp
@@ -44,21 +44,14 @@ void content(tvg::Canvas* canvas)
     canvas->push(bg);
 
     auto picture = tvg::Picture::gen();
+    picture->origin(0.5f, 0.5f);
     if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/svg/logo.svg"))) return;
 
-    float scale;
-    float shiftX = 0.0f, shiftY = 0.0f;
     float w2, h2;
     picture->size(&w2, &h2);
-    if (w2 > h2) {
-        scale = SIZE / w2;
-        shiftY = (SIZE - h2 * scale) * 0.5f;
-    } else {
-        scale = SIZE / h2;
-        shiftX = (SIZE - w2 * scale) * 0.5f;
-    }
-    picture->translate(shiftX, shiftY);
+    auto scale = (w2 > h2) ? SIZE / w2 : SIZE / h2;
     picture->scale(scale);
+    picture->translate(SIZE * 0.5f, SIZE * 0.5f);
 
     canvas->push(picture);
 }

--- a/examples/PictureSvg.cpp
+++ b/examples/PictureSvg.cpp
@@ -42,19 +42,11 @@ struct UserExample : tvgexam::Example
         auto picture = tvg::Picture::gen();
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/svg/logo.svg"))) return false;
 
-        float scale;
-        float shiftX = 0.0f, shiftY = 0.0f;
         float w2, h2;
         picture->size(&w2, &h2);
-        if (w2 > h2) {
-            scale = w / w2;
-            shiftY = (h - h2 * scale) * 0.5f;
-        } else {
-            scale = h / h2;
-            shiftX = (w - w2 * scale) * 0.5f;
-        }
-        picture->translate(shiftX, shiftY);
-        picture->scale(scale);
+        picture->origin(0.5f, 0.5f);
+        picture->scale((w2 > h2) ? w / w2 : h / h2);
+        picture->translate(w / 2, h / 2);
 
         canvas->push(picture);
 

--- a/examples/Svg.cpp
+++ b/examples/Svg.cpp
@@ -46,25 +46,15 @@ struct UserExample : tvgexam::Example
         if (strcmp(ext, "svg")) return;
 
         auto picture = tvg::Picture::gen();
+        picture->origin(0.5f, 0.5f);
 
         if (!tvgexam::verify(picture->load(path))) return;
 
         //image scaling preserving its aspect ratio
-        float scale;
-        float shiftX = 0.0f, shiftY = 0.0f;
         float w, h;
         picture->size(&w, &h);
-
-        if (w > h) {
-            scale = size / w;
-            shiftY = (size - h * scale) * 0.5f;
-        } else {
-            scale = size / h;
-            shiftX = (size - w * scale) * 0.5f;
-        }
-
-        picture->scale(scale);
-        picture->translate((counter % NUM_PER_ROW) * size + shiftX, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + shiftY);
+        picture->scale((w > h) ? size / w : size / h);
+        picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + size / 2);
 
         pictures.push_back(picture);
 

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1515,6 +1515,50 @@ public:
     Result size(float* w, float* h) const noexcept;
 
     /**
+     * @brief Sets the normalized origin point of the Picture object.
+     *
+     * This method defines the origin point of the Picture using normalized coordinates.
+     * Unlike a typical pivot point used only for transformations, this origin affects both
+     * the transformation behavior and the actual rendering position of the Picture.
+     *
+     * The specified origin becomes the reference point for positioning the Picture on the canvas.
+     * For example, setting the origin to (0.5f, 0.5f) moves the visual center of the picture
+     * to the position specified by Paint::translate().
+     *
+     * The coordinates are given in a normalized range relative to the picture's bounds:
+     * - (0.0f, 0.0f): top-left corner
+     * - (0.5f, 0.5f): center
+     * - (1.0f, 1.0f): bottom-right corner
+     *
+     * @param[in] x The normalized x-coordinate of the origin point (range: 0.0f to 1.0f).
+     * @param[in] y The normalized y-coordinate of the origin point (range: 0.0f to 1.0f).
+     *
+     * @note This origin directly affects how the Picture is placed on the canvas when using
+     *       transformations such as translate(), rotate(), or scale().
+     *
+     * @see Paint::translate()
+     * @see Paint::rotate()
+     * @see Paint::scale()
+     *
+     * @since 1.0
+     */
+    Result origin(float x, float y) noexcept;
+
+    /**
+     * @brief Gets the normalized origin point of the Picture object.
+     *
+     * This method retrieves the current origin point of the Picture, expressed
+     * in normalized coordinates relative to the picture’s bounds.
+     *
+     * @param[out] x The normalized x-coordinate of the origin (range: 0.0f to 1.0f).
+     * @param[out] y The normalized y-coordinate of the origin (range: 0.0f to 1.0f).
+     *
+     * @see origin()
+     * @since 1.0
+     */
+    Result origin(float* x, float* y) const noexcept;
+
+    /**
      * @brief Loads raw image data in a specific format from a memory block of the given size.
      *
      * ThorVG efficiently caches the loaded data, using the provided @p data address as a key

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1853,13 +1853,13 @@ TVG_API Tvg_Paint* tvg_picture_new(void);
 * This means that loading the same file again will not result in duplicate operations;
 * instead, ThorVG will reuse the previously loaded picture data.
 *
-* @param[in] paint A Tvg_Paint pointer to the picture object.
+* @param[in] picture A Tvg_Paint pointer to the picture object.
 * @param[in] path The absolute path to the image file.
 *
 * @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer or an empty @p path.
 * @retval TVG_RESULT_NOT_SUPPORTED A file with an unknown extension.
 */
-TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path);
+TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* picture, const char* path);
 
 
 /*!
@@ -1870,6 +1870,7 @@ TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path);
  * by reusing the previously loaded picture data for the same sharable @p data,
  * rather than duplicating the load process.
  *
+ * @param[in] picture A Tvg_Paint pointer to the picture object.
  * @param[in] data A pointer to the memory block where the raw image data is stored.
  * @param[in] w The width of the image in pixels.
  * @param[in] h The height of the image in pixels.
@@ -1880,7 +1881,7 @@ TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path);
 *
 * @since 0.9
 */
-TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy);
+TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* picture, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy);
 
 
 /*!
@@ -1890,7 +1891,7 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32
 * when the @p copy has @c false. This means that loading the same data again will not result in duplicate operations
 * for the sharable @p data. Instead, ThorVG will reuse the previously loaded picture data.
 *
-* @param[in] paint A Tvg_Paint pointer to the picture object.
+* @param[in] picture A Tvg_Paint pointer to the picture object.
 * @param[in] data A pointer to a memory location where the content of the picture file is stored. A null-terminated string is expected for non-binary data if @p copy is @c false
 * @param[in] size The size in bytes of the memory occupied by the @p data.
 * @param[in] mimetype Mimetype or extension of data such as "jpg", "jpeg", "svg", "svg+xml", "lot", "lottie+json", "png", etc. In case an empty string or an unknown type is provided, the loaders will be tried one by one.
@@ -1902,7 +1903,7 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32
 *
 * @warning: It's the user responsibility to release the @p data memory if the @p copy is @c true.
 */
-TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, const char* rpath, bool copy);
+TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* picture, const char *data, uint32_t size, const char *mimetype, const char* rpath, bool copy);
 
 
 /*!
@@ -1911,33 +1912,86 @@ TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uin
 * The picture content is resized while keeping the default size aspect ratio.
 * The scaling factor is established for each of dimensions and the smaller value is applied to both of them.
 *
-* @param[in] paint A Tvg_Paint pointer to the picture object.
+* @param[in] picture A Tvg_Paint pointer to the picture object.
 * @param[in] w A new width of the image in pixels.
 * @param[in] h A new height of the image in pixels.
 *
 * @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
-TVG_API Tvg_Result tvg_picture_set_size(Tvg_Paint* paint, float w, float h);
+TVG_API Tvg_Result tvg_picture_set_size(Tvg_Paint* picture, float w, float h);
 
 
 /*!
 * @brief Gets the size of the loaded picture.
 *
-* @param[in] paint A Tvg_Paint pointer to the picture object.
+* @param[in] picture A Tvg_Paint pointer to the picture object.
 * @param[out] w A width of the image in pixels.
 * @param[out] h A height of the image in pixels.
 *
 * @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
 */
-TVG_API Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, float* h);
+TVG_API Tvg_Result tvg_picture_get_size(const Tvg_Paint* picture, float* w, float* h);
 
+
+/**
+ * @brief Sets the normalized origin point of the Picture object.
+ *
+ * This method defines the origin point of the Picture using normalized coordinates.
+ * Unlike a typical pivot point used only for transformations, this origin affects both
+ * the transformation behavior and the actual rendering position of the Picture.
+ *
+ * The specified origin becomes the reference point for positioning the Picture on the canvas.
+ * For example, setting the origin to (0.5f, 0.5f) moves the visual center of the picture
+ * to the position specified by Paint::translate().
+ *
+ * The coordinates are given in a normalized range relative to the picture's bounds:
+ * - (0.0f, 0.0f): top-left corner
+ * - (0.5f, 0.5f): center
+ * - (1.0f, 1.0f): bottom-right corner
+ *
+ * @param[in] picture A Tvg_Paint pointer to the picture object.
+ * @param[in] x The normalized x-coordinate of the origin point (range: 0.0f to 1.0f).
+ * @param[in] y The normalized y-coordinate of the origin point (range: 0.0f to 1.0f).
+ *
+ * @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
+ *
+ * @note This origin directly affects how the Picture is placed on the canvas when using
+ *       transformations such as translate(), rotate(), or scale().
+ *
+ * @see tvg_paint_translate()
+ * @see tvg_paint_rotate()
+ * @see tvg_paint_scale()
+ * @see tvg_paint_set_transform()
+ * @see tvg_picture_get_origin()
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_picture_set_origin(Tvg_Paint* picture, float x, float y);
+
+
+/**
+ * @brief Gets the normalized origin point of the Picture object.
+ *
+ * This method retrieves the current origin point of the Picture, expressed
+ * in normalized coordinates relative to the picture’s bounds.
+ *
+ * @param[in] picture A Tvg_Paint pointer to the picture object.
+ * @param[out] x The normalized x-coordinate of the origin (range: 0.0f to 1.0f).
+ * @param[out] y The normalized y-coordinate of the origin (range: 0.0f to 1.0f).
+ *
+ * @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
+ *
+ * @see tvg_picture_set_origin()
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_picture_get_origin(const Tvg_Paint* picture, float* x, float* y);
 
 /*!
 * @brief Retrieve a paint object from the Picture scene by its Unique ID.
 *
 * This function searches for a paint object within the Picture scene that matches the provided @p id.
 *
-* @param[in] paint A Tvg_Paint pointer to the picture object.
+* @param[in] picture A Tvg_Paint pointer to the picture object.
 * @param[in] id The Unique ID of the paint object.
 
 * @return A pointer to the paint object that matches the given identifier, or @c nullptr if no matching paint object is found.
@@ -1945,7 +1999,7 @@ TVG_API Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, float*
 * @see tvg_accessor_generate_id()
 * @note Experimental API
 */
-TVG_API const Tvg_Paint* tvg_picture_get_paint(Tvg_Paint* paint, uint32_t id);
+TVG_API const Tvg_Paint* tvg_picture_get_paint(Tvg_Paint* picture, uint32_t id);
 
 
 /** \} */   // end defgroup ThorVGCapi_Picture

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -605,45 +605,59 @@ TVG_API Tvg_Paint* tvg_picture_new()
 }
 
 
-TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* paint, const char* path)
+TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* picture, const char* path)
 {
-    if (paint) return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(path);
+    if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->load(path);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
 
-TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* paint, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy)
+TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* picture, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy)
 {
-    if (paint) return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, w, h, static_cast<ColorSpace>(cs), copy);
+    if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->load(data, w, h, static_cast<ColorSpace>(cs), copy);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
 
-TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* paint, const char *data, uint32_t size, const char *mimetype, const char* rpath, bool copy)
+TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint* picture, const char *data, uint32_t size, const char *mimetype, const char* rpath, bool copy)
 {
-    if (paint) return (Tvg_Result) reinterpret_cast<Picture*>(paint)->load(data, size, mimetype ? mimetype : "", rpath ? rpath : "", copy);
+    if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->load(data, size, mimetype ? mimetype : "", rpath ? rpath : "", copy);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
 
-TVG_API Tvg_Result tvg_picture_set_size(Tvg_Paint* paint, float w, float h)
+TVG_API Tvg_Result tvg_picture_set_size(Tvg_Paint* picture, float w, float h)
 {
-    if (paint) return (Tvg_Result) reinterpret_cast<Picture*>(paint)->size(w, h);
+    if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->size(w, h);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
 
-TVG_API Tvg_Result tvg_picture_get_size(const Tvg_Paint* paint, float* w, float* h)
+TVG_API Tvg_Result tvg_picture_get_size(const Tvg_Paint* picture, float* w, float* h)
 {
-    if (paint) return (Tvg_Result) reinterpret_cast<const Picture*>(paint)->size(w, h);
+    if (picture) return (Tvg_Result) reinterpret_cast<const Picture*>(picture)->size(w, h);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
 
-TVG_API const Tvg_Paint* tvg_picture_get_paint(Tvg_Paint* paint, uint32_t id)
+TVG_API const Tvg_Paint* tvg_picture_get_paint(Tvg_Paint* picture, uint32_t id)
 {
-    if (paint) return (Tvg_Paint*) reinterpret_cast<Picture*>(paint)->paint(id);
+    if (picture) return (Tvg_Paint*) reinterpret_cast<Picture*>(picture)->paint(id);
     return nullptr;
+}
+
+
+TVG_API Tvg_Result tvg_picture_set_origin(Tvg_Paint* picture, float x, float y)
+{
+    if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->origin(x, y);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
+TVG_API Tvg_Result tvg_picture_get_origin(const Tvg_Paint* picture, float* x, float* y)
+{
+    if (picture) return (Tvg_Result) reinterpret_cast<const Picture*>(picture)->origin(x, y);
+    return TVG_RESULT_INVALID_ARGUMENT;
 }
 
 

--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -274,6 +274,7 @@ public:
 
         animation = Animation::gen();
         if (!animation) errorMsg = "Invalid animation";
+        animation->picture()->origin(0.5f, 0.5f);  //center-aligned
     }
 
     string error()
@@ -414,17 +415,10 @@ public:
 
         engine->resize(canvas, width, height);
 
-        float scale;
-        float shiftX = 0.0f, shiftY = 0.0f;
-        if (psize[0] > psize[1]) {
-            scale = width / psize[0];
-            shiftY = (height - psize[1] * scale) * 0.5f;
-        } else {
-            scale = height / psize[1];
-            shiftX = (width - psize[0] * scale) * 0.5f;
-        }
+        auto scale = (psize[0] > psize[1]) ? width / psize[0] : height / psize[1];
         animation->picture()->scale(scale);
-        animation->picture()->translate(shiftX, shiftY);
+        animation->picture()->translate(width * 0.5f, height * 0.5f);
+
 
         updated = true;
     }

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -75,6 +75,22 @@ Result Picture::size(float* w, float* h) const noexcept
 }
 
 
+Result Picture::origin(float x, float y) noexcept
+{
+    PICTURE(this)->origin = {x, y};
+    PAINT(this)->mark(RenderUpdateFlag::Transform);
+    return Result::Success;
+}
+
+
+Result Picture::origin(float* x, float* y) const noexcept
+{
+    if (x) *x = CONST_PICTURE(this)->origin.x;
+    if (y) *y = CONST_PICTURE(this)->origin.y;
+    return Result::Success;
+}
+
+
 const Paint* Picture::paint(uint32_t id) noexcept
 {
     struct Value


### PR DESCRIPTION
This method defines the origin point of the Picture using normalized coordinates. Unlike a typical pivot point used only for transformations, this origin affects both the transformation behavior and the actual rendering position of the Picture.

C++ API
 + Result Picture::origin(float x, float y)
 + Result Picture::origin(float* x, float* y)

CAPI
 + Tvg_Result tvg_picture_set_origin(Tvg_Paint* picture, float x, float y)
 + Tvg_Result tvg_picture_get_origin(Tvg_Paint* picture, float* x, float* y)

issue: https://github.com/thorvg/thorvg/issues/1506