### PR TITLE
wasm: remove unused rpath parameter from load()

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -304,7 +304,7 @@ public:
         return animation->curFrame();
     }
 
-    bool load(string data, string mimetype, int width, int height, string rpath = "")
+    bool load(string data, string mimetype, int width, int height)
     {
         errorMsg = NoError;
 
@@ -326,7 +326,7 @@ public:
             filetype = "lottie+json";
         }
 
-        if (animation->picture()->load(data.c_str(), data.size(), filetype.c_str(), rpath.c_str(), false) != Result::Success) {
+        if (animation->picture()->load(data.c_str(), data.size(), filetype.c_str()) != Result::Success) {
             errorMsg = "load() fail";
             return false;
         }


### PR DESCRIPTION
This patch removes the unused `rpath` parameter from the load() function.
This simplifies the WASM binding while keeping the API aligned with current usage in thorvg.web.

For context, my initial intent was to handle default parameters via overload, but since rpath is not used, I simplified the API as requested.