### PR TITLE
wasm: fix WG context registration issue with remove() timing

### DIFF
--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -271,9 +271,6 @@ public:
             errorMsg = "Unsupported!";
             return;
         }
-
-        animation = Animation::gen();
-        if (!animation) errorMsg = "Invalid animation";
     }
 
     string error()
@@ -315,10 +312,17 @@ public:
             return false;
         }
 
-        canvas->remove();
+        if (animation) {
+            canvas->remove();
+            delete(animation);
+        }
 
-        delete(animation);
         animation = Animation::gen();
+        if (!animation) {
+            errorMsg = "Invalid animation";
+            return false;
+        }
+
         animation->picture()->origin(0.5f, 0.5f);  //center-aligned
 
         string filetype = mimetype;


### PR DESCRIPTION
Since the last change (a5be644b50415d37947adf41e3ee18b0c319e38a), the `canvas::remove()` function now sets the status to Painting.

<img width="2640" height="1050" alt="CleanShot 2025-09-02 at 01 16 13@2x" src="https://github.com/user-attachments/assets/22db8427-5d1e-477c-9fd3-f80bbb045298" />

When remove() function changes status to Painting mode, WebGPU instance and adapter may not be properly targeted by the target method if WG context is not ready.

To prevent incorrect state transitions, canvas.remove() is now only called when an existing animation is present, ensuring WG context is prepared (after resize) before any status changes that could affect context registration.

This resolves the issue where WG context registration fails due to premature status changes during animation lifecycle management.