### PR TITLE
api: add missing const qualifier to user data parameter

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1574,7 +1574,7 @@ public:
      *
      * @since 0.9
      */
-    Result load(uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy = false) noexcept;
+    Result load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy = false) noexcept;
 
     /**
      * @brief Retrieve a paint object from the Picture scene by its Unique ID.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1881,7 +1881,7 @@ TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* picture, const char* path);
 *
 * @since 0.9
 */
-TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* picture, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy);
+TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* picture, const uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -612,7 +612,7 @@ TVG_API Tvg_Result tvg_picture_load(Tvg_Paint* picture, const char* path)
 }
 
 
-TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* picture, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy)
+TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint* picture, const uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy)
 {
     if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->load(data, w, h, static_cast<ColorSpace>(cs), copy);
     return TVG_RESULT_INVALID_ARGUMENT;

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -56,7 +56,7 @@ Result Picture::load(const char* data, uint32_t size, const char* mimeType, cons
 }
 
 
-Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy) noexcept
+Result Picture::load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy) noexcept
 {
     return PICTURE(this)->load(data, w, h, cs, copy);
 }

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -164,7 +164,7 @@ struct PictureImpl : Picture
         return load(loader);
     }
 
-    Result load(uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
+    Result load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
     {
         if (!data || w <= 0 || h <= 0 || cs == ColorSpace::Unknown)  return Result::InvalidArguments;
         if (vector || bitmap) return Result::InsufficientCondition;


### PR DESCRIPTION
explicitly state that user data is not modifiable, this also keeps the api consistency.

C++ API
* Result Picture::load(uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy = false) -> Result Picture::load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy = false)

C API
* Tvg_Result tvg_picture_load_raw(Tvg_Paint* picture, uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy) -> Tvg_Result tvg_picture_load_raw(Tvg_Paint* picture, const uint32_t *data, uint32_t w, uint32_t h, Tvg_Colorspace cs, bool copy)