### PR TITLE
lottie/slot: fix colorstop memory access crash with animated value

### DIFF
--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -828,9 +828,9 @@ struct LottieColorStop : LottieProperty
                     *value.input = *rhs.value.input;
                 }
             }
-            populated = rhs.populated;
-            count = rhs.count;
         }
+        populated = rhs.populated;
+        count = rhs.count;
     }
 
     void prepare() {}


### PR DESCRIPTION
populated and count fields were not properly initialized during frames-based deep copy operations.

issue: https://github.com/thorvg/thorvg/issues/3766