### PR TITLE
api: introduced EngineOption to specify engine behavior

### DIFF
--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -287,7 +287,7 @@ int main(int argc, char **argv)
     SDL_Surface* surface = SDL_GetWindowSurface(window);
 
     //create the canvas
-    canvas = tvg_swcanvas_create();
+    canvas = tvg_swcanvas_create(TVG_ENGINE_OPTION_DEFAULT);
     tvg_swcanvas_set_target(canvas, (uint32_t*)surface->pixels, surface->w, surface->pitch / 4, surface->h, TVG_COLORSPACE_ARGB8888);
 
     contents();

--- a/examples/Example.h
+++ b/examples/Example.h
@@ -321,7 +321,7 @@ struct SwWindow : Window
 
         window = SDL_CreateWindow("ThorVG Example (Software)", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE);
 
-        //Create a Canvas
+        //Create a Canvas. Use Smart Rendering by default.
         canvas = tvg::SwCanvas::gen();
         if (!canvas) {
             cout << "SwCanvas is not supported. Did you enable the SwEngine?" << endl;

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -109,6 +109,28 @@ enum class ColorSpace : uint8_t
 
 
 /**
+ * @brief Enumeration to specify rendering engine behavior.
+ *
+ * @note The availability or behavior of @c SmartRender may vary depending on platform or backend support.
+ *       It attempts to optimize rendering performance by updating only the regions  of the canvas that have
+ *       changed between frames (partial redraw). This can be highly effective in scenarios  where most of the
+ *       canvas remains static and only small portions are updated—such as simple animations or GUI interactions.
+ *       However, in complex scenes where a large portion of the canvas changes frequently (e.g., full-screen animations
+ *       or heavy object movements), the overhead of tracking changes and managing update regions may outweigh the benefits,
+ *       resulting in decreased performance compared to the default rendering mode. Thus, it is recommended to benchmark
+ *       both modes in your specific use case to determine the optimal setting.
+ *
+ * @note Experimental API
+ */
+enum class EngineOption : uint8_t
+{
+    None = 0,                   /**< No engine options are enabled. This may be used to explicitly disable all optional behaviors. */
+    Default = 1 << 0,           /**< Uses the default rendering mode. */
+    SmartRender = 1 << 1        /**< Enables automatic partial (smart) rendering optimizations. */
+};
+
+
+/**
  * @brief Enumeration specifying the values of the path commands accepted by ThorVG.
  */
 enum class PathCommand : uint8_t
@@ -2001,10 +2023,18 @@ public:
     Result target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs) noexcept;
 
     /**
-     * @brief Creates a new SwCanvas object.
+     * @brief Creates a new SwCanvas object with optional rendering engine settings.
+     *
+     * This method generates a software canvas instance that can be used for drawing vector graphics.
+     * It accepts an optional parameter @p op to choose between different rendering engine behaviors.
+     *
+     * @param[in] op The rendering engine option. Default is @c EngineOption::Default.
+     *
      * @return A new SwCanvas object.
+     *
+     * @see enum EngineOption
      */
-    static SwCanvas* gen() noexcept;
+    static SwCanvas* gen(EngineOption op = EngineOption::Default) noexcept;
 
     _TVG_DECLARE_PRIVATE(SwCanvas);
 };

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -121,6 +121,27 @@ typedef enum {
 
 
 /**
+ * @brief Enumeration to specify rendering engine behavior.
+ *
+ * @note The availability or behavior of @c TVG_ENGINE_OPTION_SMART_RENDER may vary depending on platform or backend support.
+ *       It attempts to optimize rendering performance by updating only the regions  of the canvas that have
+ *       changed between frames (partial redraw). This can be highly effective in scenarios  where most of the
+ *       canvas remains static and only small portions are updated—such as simple animations or GUI interactions.
+ *       However, in complex scenes where a large portion of the canvas changes frequently (e.g., full-screen animations
+ *       or heavy object movements), the overhead of tracking changes and managing update regions may outweigh the benefits,
+ *       resulting in decreased performance compared to the default rendering mode. Thus, it is recommended to benchmark
+ *       both modes in your specific use case to determine the optimal setting.
+ *
+ * @note Experimental API
+ */
+typedef enum {
+    TVG_ENGINE_OPTION_NONE = 0,                   /**< No engine options are enabled. This may be used to explicitly disable all optional behaviors. */
+    TVG_ENGINE_OPTION_DEFAULT = 1 << 0,           /**< Uses the default rendering mode. */
+    TVG_ENGINE_OPTION_SMART_RENDER = 1 << 1       /**< Enables automatic partial (smart) rendering optimizations. */
+} Tvg_Engine_Option;
+
+
+/**
  * @brief Enumeration indicating the method used in the masking of two objects - the target and the source.
  *
  * @ingroup ThorVGCapi_Paint
@@ -330,7 +351,7 @@ TVG_API Tvg_Result tvg_engine_init(unsigned threads);
 * @note The initializer maintains a reference count for safe repeated use. Only the final call to tvg_engine_term() will fully shut down the engine.
 * @see tvg_engine_init()
 */
-TVG_API Tvg_Result tvg_engine_term();
+TVG_API Tvg_Result tvg_engine_term(void);
 
 
 /**
@@ -375,12 +396,19 @@ TVG_API Tvg_Result tvg_engine_version(uint32_t* major, uint32_t* minor, uint32_t
 /* SwCanvas API                                                         */
 /************************************************************************/
 
-/*!
-* @brief Creates a Canvas object.
-*
-* @return A new Tvg_Canvas object.
-*/
-TVG_API Tvg_Canvas* tvg_swcanvas_create(void);
+/**
+ * @brief Creates a new SwCanvas object with optional rendering engine settings.
+ *
+ * This method generates a software canvas instance that can be used for drawing vector graphics.
+ * It accepts an optional parameter @p op to choose between different rendering engine behaviors.
+ *
+ * @param[in] op The rendering engine option.
+ *
+ * @return A new Tvg_Canvas object.
+ *
+ * @see enum Tvg_Engine_Option
+ */
+TVG_API Tvg_Canvas* tvg_swcanvas_create(Tvg_Engine_Option op);
 
 
 /*!
@@ -2718,7 +2746,7 @@ TVG_API Tvg_Result tvg_animation_del(Tvg_Animation* animation);
 *
 * @note Experimental API
 */
-TVG_API Tvg_Accessor* tvg_accessor_new();
+TVG_API Tvg_Accessor* tvg_accessor_new(void);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -62,9 +62,9 @@ TVG_API Tvg_Result tvg_engine_version(uint32_t* major, uint32_t* minor, uint32_t
 /* Canvas API                                                           */
 /************************************************************************/
 
-TVG_API Tvg_Canvas* tvg_swcanvas_create()
+TVG_API Tvg_Canvas* tvg_swcanvas_create(Tvg_Engine_Option op)
 {
-    return (Tvg_Canvas*) SwCanvas::gen();
+    return (Tvg_Canvas*) SwCanvas::gen(static_cast<EngineOption>(op));
 }
 
 

--- a/src/bindings/wasm/tvgWasmLottieAnimation.cpp
+++ b/src/bindings/wasm/tvgWasmLottieAnimation.cpp
@@ -67,7 +67,7 @@ struct TvgSwEngine : TvgEngineMethod
     {
         Initializer::init();
         loadFont();
-        return SwCanvas::gen();
+        return SwCanvas::gen(EngineOption::None);
     }
 
     void resize(Canvas* canvas, int w, int h) override

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -257,21 +257,6 @@ struct SwImageTask : SwTask
 /* External Class Implementation                                        */
 /************************************************************************/
 
-SwRenderer::SwRenderer()
-{
-    if (TaskScheduler::onthread()) {
-        TVGLOG("SW_RENDERER", "Running on a non-dominant thread!, Renderer(%p)", this);
-        mpool = mpoolInit(threadsCnt);
-        sharedMpool = false;
-    } else {
-        mpool = globalMpool;
-        sharedMpool = true;
-    }
-
-    ++rendererCnt;
-}
-
-
 SwRenderer::~SwRenderer()
 {
     clearCompositors();
@@ -925,7 +910,7 @@ bool SwRenderer::term()
 }
 
 
-SwRenderer* SwRenderer::gen(uint32_t threads)
+SwRenderer::SwRenderer(uint32_t threads, EngineOption op)
 {
     //initialize engine
     if (rendererCnt == -1) {
@@ -938,5 +923,16 @@ SwRenderer* SwRenderer::gen(uint32_t threads)
         rendererCnt = 0;
     }
 
-    return new SwRenderer;
+    if (TaskScheduler::onthread()) {
+        TVGLOG("SW_RENDERER", "Running on a non-dominant thread!, Renderer(%p)", this);
+        mpool = mpoolInit(threadsCnt);
+        sharedMpool = false;
+    } else {
+        mpool = globalMpool;
+        sharedMpool = true;
+    }
+
+    if (op == EngineOption::None) dirtyRegion.support = false;
+
+    ++rendererCnt;
 }

--- a/src/renderer/sw_engine/tvgSwRenderer.h
+++ b/src/renderer/sw_engine/tvgSwRenderer.h
@@ -74,7 +74,7 @@ public:
     void damage(RenderData rd, const RenderRegion& region) override;
     bool partial(bool disable) override;
 
-    static SwRenderer* gen(uint32_t threads);
+    SwRenderer(uint32_t threads, EngineOption op);
     static bool term();
 
 private:
@@ -86,7 +86,6 @@ private:
     bool                 sharedMpool;                 //memory-pool behavior policy
     bool                 fulldraw = true;             //buffer is cleared (need to redraw full screen)
 
-    SwRenderer();
     ~SwRenderer();
 
     RenderData prepareCommon(SwTask* task, const Matrix& transform, const Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags);

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -160,6 +160,7 @@ struct RenderRegion
     {
     public:
         static constexpr const int PARTITIONING = 16;   //must be N*N
+        bool support = true;
 
         void init(uint32_t w, uint32_t h);
         void commit();
@@ -175,7 +176,7 @@ struct RenderRegion
 
         bool deactivated()
         {
-            return disabled;
+            return (!support || disabled);
         }
 
         const RenderRegion& partition(int idx)
@@ -206,6 +207,7 @@ struct RenderRegion
     struct RenderDirtyRegion
     {
         static constexpr const int PARTITIONING = 16;   //must be N*N
+        bool support = true;
 
         void init(uint32_t w, uint32_t h) {}
         void commit() {}

--- a/src/renderer/tvgSwCanvas.cpp
+++ b/src/renderer/tvgSwCanvas.cpp
@@ -69,11 +69,11 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
 }
 
 
-SwCanvas* SwCanvas::gen() noexcept
+SwCanvas* SwCanvas::gen(EngineOption op) noexcept
 {
 #ifdef THORVG_SW_RASTER_SUPPORT
     if (engineInit > 0) {
-        auto renderer = SwRenderer::gen(TaskScheduler::threads());
+        auto renderer = new SwRenderer(TaskScheduler::threads(), op);
         renderer->ref();
         auto ret = new SwCanvas;
         ret->pImpl->renderer = renderer;


### PR DESCRIPTION
C++ API
 + enum EngineOption [None, Default, SmartRender]
 * SwCanvas* SwCanvas::gen() -> SwCanvas* SwCanvas::gen(EngineOption op = EngineOption::Default)

C API
 + enum [TVG_ENGINE_OPTION_NONE, TVG_ENGINE_OPTION_DEFAULT, TVG_ENGINE_OPTION_SMART_RENDER]
 * Tvg_Canvas* tvg_swcanvas_create() -> Tvg_Canvas* tvg_swcanvas_create(Tvg_Engine_Option op)

Note: SmartRender is still an experimental feature and may not be fully matured. For product stability, use EngineOption::None. (SmartRender is applied by default.)