### PR TITLE
lottie/slot: handle colorStops input deep-copy properly

### DIFF
--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -675,6 +675,8 @@ struct LottieColorStop : LottieProperty
 
         ARRAY_FOREACH(p, *frames) {
             tvg::free((*p).value.data);
+            delete((*p).value.input);
+            (*p).value.input = nullptr;
         }
         tvg::free(frames->data);
         tvg::free(frames);
@@ -812,6 +814,14 @@ struct LottieColorStop : LottieProperty
             } else {
                 frames = tvg::calloc<Array<LottieScalarFrame<ColorStop>>*>(1, sizeof(Array<LottieScalarFrame<ColorStop>>));
                 *frames = *rhs.frames;
+
+                for (uint32_t i = 0; i < rhs.frames->count; ++i) {
+                    auto& srcInput = (*rhs.frames)[i].value.input;
+                    if (srcInput) {
+                        auto& dstInput = (*frames)[i].value.input;
+                        dstInput = new Array<float>(*srcInput);
+                    }
+                }
             }
         } else {
             frames = nullptr;


### PR DESCRIPTION
There is a missing copy/free pair in frame handling.

Resolve potential memory leak and runtime crash caused by missing copy/free handling in animated value and in cases with multiple overriding.


| Memory Leak | Runtime Crash |
| --- | --- |
| <img width="2514" height="1434" alt="image" src="https://github.com/user-attachments/assets/2f9e3449-055c-42e3-9664-812f6c47a61f" /> | <img width="2260" height="1004" alt="image" src="https://github.com/user-attachments/assets/52004435-3a69-4a2b-8d5b-8ea0f246fdf6" /> |


issue: https://github.com/thorvg/thorvg/issues/3766