### PR TITLE
loader/jpg: fine tune optimization++

### DIFF
--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -38,11 +38,11 @@ void JpgLoader::clear()
 
 void JpgLoader::run(unsigned tid)
 {
-    surface.buf8 = jpgdDecompress(decoder);
+    surface.cs = ImageLoader::cs;
+    surface.buf8 = jpgdDecompress(decoder, surface.cs);
     surface.stride = static_cast<uint32_t>(w);
     surface.w = static_cast<uint32_t>(w);
     surface.h = static_cast<uint32_t>(h);
-    surface.cs = ColorSpace::ARGB8888;
     surface.channelSize = sizeof(uint32_t);
     surface.premultiplied = true;
 

--- a/src/loaders/jpg/tvgJpgd.h
+++ b/src/loaders/jpg/tvgJpgd.h
@@ -29,7 +29,7 @@ class jpeg_decoder;
 
 jpeg_decoder* jpgdHeader(const char* data, int size, int* width, int* height);
 jpeg_decoder* jpgdHeader(const char* filename, int* width, int* height);
-unsigned char* jpgdDecompress(jpeg_decoder* decoder);
+unsigned char* jpgdDecompress(jpeg_decoder* decoder, ColorSpace cs);
 void jpgdDelete(jpeg_decoder* decoder);
 
 #endif //_TVG_JPGD_H_


### PR DESCRIPTION
- skip colospace conversion if the canvas and image source is matched.
- removed unused logic.