### PR TITLE
loader: Support `img/` tag for embedded image

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -576,8 +576,8 @@ static constexpr struct
 
 
 static bool _isValidImageMimeTypeAndEncoding(const char** href, const char** mimetype, imageMimeTypeEncoding* encoding) {
-    if (strncmp(*href, "image/", sizeof("image/") - 1)) return false; //not allowed mime type
-    *href += sizeof("image/") - 1;
+    if (strncmp(*href, "image/", sizeof("image/") - 1) && strncmp(*href, "img/", sizeof("img/") - 1)) return false; //not allowed mime type
+    *href += (((*href)[3] == '/') ? sizeof("img/") : sizeof("image/")) - 1;
 
     //RFC2397 data:[<mediatype>][;base64],<data>
     //mediatype  := [ type "/" subtype ] *( ";" parameter )


### PR DESCRIPTION
Most of browser support "img/" tag for decode embedded image at svg.

Let we also allow to thorvg support it.

resvg didnt support "img/" tag also.
So, it will make thorvg is more powerful svg rendering engine rather than resvg

Example :
![embedded_rgbywb_image](https://github.com/user-attachments/assets/2795a797-3c53-40bd-9c51-50a700e49873)
Image with "image/" (standard svg)

![embedded_rgbywb_img](https://github.com/user-attachments/assets/52df86e3-9cb2-43ed-ba62-b2dd34b56d89)
Imge with "img/" (not standard, but all of web browser support)
