### PR TITLE
sw_engine: enhanced to support scalable CLAA logic

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -126,7 +126,6 @@ struct SwSpan
     }
 };
 
-
 struct SwRle
 {
     Array<SwSpan> spans;
@@ -161,6 +160,16 @@ struct SwRle
     bool valid() const { return !invalid(); }
     uint32_t size() const { return spans.count; }
     SwSpan* data() const { return spans.data; }
+};
+
+using Area = long;
+
+struct SwCell
+{
+    int32_t x;
+    int32_t cover;
+    Area area;
+    SwCell *next;
 };
 
 struct SwFill
@@ -313,12 +322,24 @@ struct SwCompositor : RenderCompositor
     bool valid;
 };
 
+struct SwCellPool
+{
+    #define DEFAULT_POOL_SIZE 16368
+
+    uint32_t size;
+    SwCell* buffer;
+
+    SwCellPool() : size(DEFAULT_POOL_SIZE), buffer(tvg::malloc<SwCell*>(DEFAULT_POOL_SIZE)) {}
+    ~SwCellPool() { tvg::free(buffer); }
+};
+
 struct SwMpool
 {
     SwOutline* outline;
     SwOutline* strokeOutline;
     SwStrokeBorder* leftBorder;
     SwStrokeBorder* rightBorder;
+    SwCellPool* cellPool;
     unsigned allocSize;
 };
 
@@ -649,7 +670,7 @@ bool mathUpdateOutlineBBox(const SwOutline* outline, const RenderRegion& clipBox
 
 void shapeReset(SwShape& shape);
 bool shapePrepare(SwShape& shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool hasComposite);
-bool shapeGenRle(SwShape& shape, const RenderRegion& bbox, bool antiAlias);
+bool shapeGenRle(SwShape& shape, const RenderRegion& bbox, SwMpool* mpool, unsigned tid, bool antiAlias);
 void shapeDelOutline(SwShape& shape, SwMpool* mpool, uint32_t tid);
 void shapeResetStroke(SwShape& shape, const RenderShape* rshape, const Matrix& transform, SwMpool* mpool, unsigned tid);
 bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid);
@@ -668,7 +689,7 @@ SwOutline* strokeExportOutline(SwStroke* stroke, SwMpool* mpool, unsigned tid);
 void strokeFree(SwStroke* stroke);
 
 bool imagePrepare(SwImage& image, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid);
-bool imageGenRle(SwImage& image, const RenderRegion& bbox, bool antiAlias);
+bool imageGenRle(SwImage& image, const RenderRegion& bbox, SwMpool* mpool, unsigned tid, bool antiAlias);
 void imageDelOutline(SwImage& image, SwMpool* mpool, uint32_t tid);
 void imageReset(SwImage& image);
 void imageFree(SwImage& image);
@@ -691,7 +712,7 @@ void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
 void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, uint8_t a);                         //blending + BlendingMethod(op2) ver.
 void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, uint8_t* cmp, SwAlpha alpha, uint8_t csize, uint8_t opacity);     //matting ver.
 
-SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox, bool antiAlias);
+SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox, SwMpool* mpool, unsigned tid, bool antiAlias);
 SwRle* rleRender(const RenderRegion* bbox);
 void rleFree(SwRle* rle);
 void rleReset(SwRle* rle);
@@ -711,6 +732,7 @@ void mpoolRetDashOutline(SwMpool* mpool, unsigned idx);
 SwStrokeBorder* mpoolReqStrokeLBorder(SwMpool* mpool, unsigned idx);
 SwStrokeBorder* mpoolReqStrokeRBorder(SwMpool* mpool, unsigned idx);
 void mpoolRetStrokeBorders(SwMpool* mpool, unsigned idx);
+SwCellPool* mpoolReqCellPool(SwMpool* mpool, unsigned idx);
 
 bool rasterCompositor(SwSurface* surface);
 bool rasterShape(SwSurface* surface, SwShape* shape, const RenderRegion& bbox, RenderColor& c);

--- a/src/renderer/sw_engine/tvgSwImage.cpp
+++ b/src/renderer/sw_engine/tvgSwImage.cpp
@@ -96,9 +96,9 @@ bool imagePrepare(SwImage& image, const Matrix& transform, const RenderRegion& c
 }
 
 
-bool imageGenRle(SwImage& image, const RenderRegion& renderBox, bool antiAlias)
+bool imageGenRle(SwImage& image, const RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool antiAlias)
 {
-    if ((image.rle = rleRender(image.rle, image.outline, renderBox, antiAlias))) return true;
+    if ((image.rle = rleRender(image.rle, image.outline, renderBox, mpool, tid, antiAlias))) return true;
 
     return false;
 }

--- a/src/renderer/sw_engine/tvgSwMemPool.cpp
+++ b/src/renderer/sw_engine/tvgSwMemPool.cpp
@@ -24,11 +24,6 @@
 
 
 /************************************************************************/
-/* Internal Class Implementation                                        */
-/************************************************************************/
-
-
-/************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
@@ -53,6 +48,17 @@ SwOutline* mpoolReqStrokeOutline(SwMpool* mpool, unsigned idx)
 }
 
 
+void mpoolRetStrokeOutline(SwMpool* mpool, unsigned idx)
+{
+    mpool->strokeOutline[idx].pts.clear();
+    mpool->strokeOutline[idx].cntrs.clear();
+    mpool->strokeOutline[idx].types.clear();
+    mpool->strokeOutline[idx].closed.clear();
+
+    mpoolRetStrokeBorders(mpool, idx);
+}
+
+
 SwStrokeBorder* mpoolReqStrokeLBorder(SwMpool* mpool, unsigned idx)
 {
     return &mpool->leftBorder[idx];
@@ -74,14 +80,9 @@ void mpoolRetStrokeBorders(SwMpool* mpool, unsigned idx)
 }
 
 
-void mpoolRetStrokeOutline(SwMpool* mpool, unsigned idx)
+SwCellPool* mpoolReqCellPool(SwMpool* mpool, unsigned idx)
 {
-    mpool->strokeOutline[idx].pts.clear();
-    mpool->strokeOutline[idx].cntrs.clear();
-    mpool->strokeOutline[idx].types.clear();
-    mpool->strokeOutline[idx].closed.clear();
-
-    mpoolRetStrokeBorders(mpool, idx);
+    return &mpool->cellPool[idx];
 }
 
 
@@ -94,6 +95,8 @@ SwMpool* mpoolInit(uint32_t threads)
     mpool->strokeOutline = new SwOutline[allocSize];
     mpool->leftBorder = new SwStrokeBorder[allocSize];
     mpool->rightBorder = new SwStrokeBorder[allocSize];
+    mpool->cellPool = new SwCellPool[allocSize];
+
     mpool->allocSize = allocSize;
 
     return mpool;
@@ -108,6 +111,8 @@ bool mpoolTerm(SwMpool* mpool)
     delete[](mpool->strokeOutline);
     delete[](mpool->leftBorder);
     delete[](mpool->rightBorder);
+    delete[](mpool->cellPool);
+
     tvg::free(mpool);
 
     return true;

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -130,7 +130,7 @@ struct SwShapeTask : SwTask
             shapeReset(shape);
             if (rshape->fill || rshape->color.a > 0 || clipper) {
                 if (shapePrepare(shape, rshape, transform, clipBox, curBox, mpool, tid, clips.count > 0 ? true : false)) {
-                    if (!shapeGenRle(shape, curBox, antialiasing(strokeWidth))) goto err;
+                    if (!shapeGenRle(shape, curBox, mpool, tid, antialiasing(strokeWidth))) goto err;
                 } else {
                     updateFill = false;
                     curBox.reset();
@@ -224,7 +224,7 @@ struct SwImageTask : SwTask
             if (!imagePrepare(image, transform, clipBox, curBox, mpool, tid)) goto err;
             valid = true;
             if (clips.count > 0) {
-                if (!imageGenRle(image, curBox, false)) goto err;
+                if (!imageGenRle(image, curBox, mpool, tid, false)) goto err;
                 if (image.rle) {
                     //Clear current task memorypool here if the clippers would use the same memory pool
                     imageDelOutline(image, mpool, tid);

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -447,13 +447,13 @@ bool shapePrepare(SwShape& shape, const RenderShape* rshape, const Matrix& trans
 }
 
 
-bool shapeGenRle(SwShape& shape, const RenderRegion& bbox, bool antiAlias)
+bool shapeGenRle(SwShape& shape, const RenderRegion& bbox, SwMpool* mpool, unsigned tid, bool antiAlias)
 {
     //Case A: Fast Track Rectangle Drawing
     if (shape.fastTrack) return true;
 
     //Case B: Normal Shape RLE Drawing
-    if ((shape.rle = rleRender(shape.rle, shape.outline, bbox, antiAlias))) return true;
+    if ((shape.rle = rleRender(shape.rle, shape.outline, bbox, mpool, tid, antiAlias))) return true;
 
     return false;
 }
@@ -531,7 +531,7 @@ bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& 
     auto strokeOutline = strokeExportOutline(shape.stroke, mpool, tid);
 
     auto ret = mathUpdateOutlineBBox(strokeOutline, clipBox, renderBox, false);
-    if (ret) shape.strokeRle = rleRender(shape.strokeRle, strokeOutline, renderBox, true);
+    if (ret) shape.strokeRle = rleRender(shape.strokeRle, strokeOutline, renderBox, mpool, tid, true);
     mpoolRetStrokeOutline(mpool, tid);
     return ret;
 }


### PR DESCRIPTION
Previously, a fixed-size RLE cell memory buffer was used, which could cause issues when handling large outlines, particularly for CLAA gridding.

This update introduces dynamic memory pooling with an experimental size scaling strategy to better accommodate varying input sizes.

issue: https://github.com/thorvg/thorvg/issues/3307