### PR TITLE
lottie: support asset resolver callback

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1599,6 +1599,28 @@ public:
     Result load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy = false) noexcept;
 
     /**
+     * @brief Sets the asset resolver callback for handling external resources (e.g., images and fonts).
+     *
+     * This callback is invoked when an external asset reference (such as an image source or file path)
+     * is encountered in a Picture object. It allows the user to provide a custom mechanism for loading
+     * or substituting assets, such as loading from an external source or a virtual filesystem.
+     *
+     * @param[in] func A user-defined function that handles the resolution of asset paths.
+     *                 @p resolver can return @c true if the asset was successfully resolved by the user, or @c false if it was not.
+     * @param[in] data A pointer to user-defined data that will be passed to the callback each time it is invoked.
+     *                 This can be used to maintain context or access external resources.
+     *
+     * @retval Result::InsufficientCondition If the picture is already loaded.
+     * 
+     * @note This function must be called before @ref Picture::load()
+     *       Setting the resolver after loading will have no effect on asset resolution for that asset.
+     * @note If @c false is returned by @p func, ThorVG will attempt to resolve the resource using its internal resolution mechanism as a fallback.
+     * @note To unset the resolver, pass @c nullptr as the @p func parameter.
+     * @note Experimental API
+     */
+    Result resolver(std::function<bool(Paint* paint, const char* src, void* data)> func, void* data) noexcept;
+
+    /**
      * @brief Retrieve a paint object from the Picture scene by its Unique ID.
      *
      * This function searches for a paint object within the Picture scene that matches the provided @p id.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -315,6 +315,26 @@ typedef struct
 
 
 /**
+* @brief Callback function type for resolving external assets.
+*
+* This callback is invoked when a Picture requires an external asset
+* (such as an image or font resource). Implementations should load the asset
+* into the given @p paint object.
+*
+* @param[in] paint The target paint object where the resolved asset will be loaded.
+* @param[in] src   The source path, identifier, or URI of the asset to be resolved.
+* @param[in] data  User-provided custom data passed to the callback for context.
+*
+* @return @c true if the asset was successfully resolved and loaded into @p paint, otherwise @c false.
+*
+* @see tvg_picture_set_asset_resolver()
+*
+* @since Experimental API
+*/
+typedef bool (*Tvg_Picture_Asset_Resolver)(Tvg_Paint paint, const char* src, void* data);
+
+
+/**
 * @defgroup ThorVGCapi_Initializer Initializer
 * @brief A module enabling initialization and termination of the TVG engines.
 *
@@ -1932,6 +1952,32 @@ TVG_API Tvg_Result tvg_picture_load_raw(Tvg_Paint picture, const uint32_t *data,
 * @warning: It's the user responsibility to release the @p data memory if the @p copy is @c true.
 */
 TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint picture, const char *data, uint32_t size, const char *mimetype, const char* rpath, bool copy);
+
+
+/**
+ * @brief Sets the asset resolver callback for handling external resources (e.g., images and fonts).
+ *
+ * This callback is invoked when an external asset reference (such as an image source or file path)
+ * is encountered in a Picture object. It allows the user to provide a custom mechanism for loading
+ * or substituting assets, such as loading from an external source or a virtual filesystem.
+ *
+ * @param[in] resolver A user-defined function that handles the resolution of asset paths.
+ *                     The function should return @c true if the asset was successfully resolved by the user, or @c false if it was not.
+ * @param[in] data A pointer to user-defined data that will be passed to the callback each time it is invoked.
+ *                 This can be used to maintain context or access external resources.
+ *
+ * @retval TVG_RESULT_INVALID_ARGUMENT A @c nullptr passed as the @p picture argument.
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the @p picture is already loaded.
+ *
+ * @note This function must be called before @ref tvg_picture_load()
+ *       Setting the resolver after loading will have no effect on asset resolution for that asset.
+ * @note If @c false is returned by @p resolver, ThorVG will attempt to resolve the resource using its internal resolution mechanism as a fallback.
+ * @note To unset the resolver, pass @c nullptr as the @p resolver parameter.
+ * @note Experimental API
+ *
+ * @see Tvg_Picture_Asset_Resolver
+ */
+TVG_API Tvg_Result tvg_picture_set_asset_resolver(Tvg_Paint picture, Tvg_Picture_Asset_Resolver resolver, void* data);
 
 
 /*!

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -628,6 +628,15 @@ TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint picture, const char *data, ui
 }
 
 
+TVG_API Tvg_Result tvg_picture_set_asset_resolver(Tvg_Paint picture, Tvg_Picture_Asset_Resolver resolver, void* data)
+{
+    if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->resolver([resolver](Paint* paint, const char* src, void* data) -> bool {
+        return resolver(reinterpret_cast<Tvg_Paint>(paint), src, data);
+    }, data);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
 TVG_API Tvg_Result tvg_picture_set_size(Tvg_Paint picture, float w, float h)
 {
     if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->size(w, h);

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -24,6 +24,7 @@
 #include "tvgCommon.h"
 #include "tvgMath.h"
 #include "tvgScene.h"
+#include "tvgLoadModule.h"
 #include "tvgLottieModel.h"
 #include "tvgLottieBuilder.h"
 #include "tvgLottieExpressions.h"
@@ -899,7 +900,15 @@ void LottieBuilder::updateSolid(LottieLayer* layer)
 void LottieBuilder::updateImage(LottieGroup* layer)
 {
     auto image = static_cast<LottieImage*>(layer->children.first());
-    layer->scene->push(image->pooling(true));
+    auto picture = image->pooling(true);
+    layer->scene->push(picture);
+    if (image->updated) return;
+
+    if (image->data.size > 0) picture->load((const char*)image->data.b64Data, image->data.size, image->data.mimeType);
+    else if (resolver && resolver->func(picture, image->data.path, resolver->data)) {}
+    else picture->load(image->data.path);
+
+    image->updated = true;
 }
 
 

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -30,6 +30,7 @@
 #include "tvgLottieModifier.h"
 
 struct LottieComposition;
+struct AssetResolver;
 
 struct RenderRepeater
 {
@@ -140,6 +141,8 @@ struct LottieBuilder
 
     bool update(LottieComposition* comp, float progress);
     void build(LottieComposition* comp);
+
+    const AssetResolver* resolver = nullptr;  //do not free this
 
 private:
     void appendRect(Shape* shape, Point& pos, Point& size, float r, bool clockwise, RenderContext* ctx);

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -539,3 +539,9 @@ bool LottieLoader::quality(uint8_t value)
     }
     return true;
 }
+
+
+void LottieLoader::set(const AssetResolver* resolver)
+{
+    builder->resolver = resolver;
+}

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -102,6 +102,7 @@ public:
     bool tween(float from, float to, float progress);
     bool assign(const char* layer, uint32_t ix, const char* var, float val);
     bool quality(uint8_t value);
+    void set(const AssetResolver* resolver) override;
 
 private:
     bool ready();

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -355,14 +355,8 @@ void LottieImage::prepare()
     LottieObject::type = LottieObject::Image;
 
     auto picture = Picture::gen();
-
-    //force to load a picture on the same thread
-    if (data.size > 0) picture->load((const char*)data.b64Data, data.size, data.mimeType);
-    else picture->load(data.path);
-
     picture->size(data.width, data.height);
     picture->ref();
-
     pooler.push(picture);
 }
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -870,6 +870,7 @@ struct LottieGradientStroke : LottieGradient, LottieStroke
 struct LottieImage : LottieObject, LottieRenderPooler<tvg::Picture>
 {
     LottieBitmap data;
+    bool updated = false;
 
     void override(LottieProperty* prop, bool release = false) override
     {

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -29,6 +29,13 @@
 #include "tvgInlist.h"
 
 
+struct AssetResolver
+{
+    std::function<bool(Paint* paint, const char* src, void* data)> func;
+    void* data;
+};
+
+
 struct LoadModule
 {
     INLIST_ITEM(LoadModule);
@@ -92,6 +99,7 @@ struct ImageLoader : LoadModule
 
     virtual bool animatable() { return false; }  //true if this loader supports animation.
     virtual Paint* paint() { return nullptr; }
+    virtual void set(const AssetResolver* resolver) {}
 
     virtual RenderSurface* bitmap()
     {

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -62,6 +62,12 @@ Result Picture::load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs
 }
 
 
+Result Picture::resolver(std::function<bool(Paint* paint, const char* src, void* data)> func, void* data) noexcept
+{
+    return PICTURE(this)->set(func, data);
+}
+
+
 Result Picture::size(float w, float h) noexcept
 {
     PICTURE(this)->size(w, h);


### PR DESCRIPTION
This PR implements an asset resolver callback mechanism for Lottie animations. It enables applications to provide custom image loading logic with the following benefits:
- Eliminates unnecessary base64 encoding/decoding steps for dotLottie use cases
- Provides flexible image asset handling for users who want to resolve assets in their own way

## Usage 

```cpp
auto animation = tvg::LottieAnimation::gen();
char* data = "hello, world";
// ...
animation->resolve([](tvg::Paint* p, const char* src, void* user_data) {
    ifstream file(TEST_DIR"/test.webp", ios::in | ios::binary);
    auto size = sizeof(uint32_t) * (1000*1000);
    auto data = (char*)malloc(size);
    file.read(data, size);
    file.close();
            
    auto ret = static_cast<tvg::Picture*>(p)->load(data, size, "webp", nullptr, true);
    return ret == Result::Success;
}, (void*)data);
```

<img width="2044" height="1890" alt="CleanShot 2025-09-10 at 01 56 33@2x" src="https://github.com/user-attachments/assets/5678f3d5-686b-4cb4-878f-351a3016cabd" />


issue: https://github.com/thorvg/thorvg/issues/3533