### PR TITLE
common: fix meson build script for msvs (min/max)

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -29,7 +29,9 @@ if cc.get_id() == 'clang-cl'
                            '/clang:-fno-stack-protector', '/clang:-fno-unwind-tables' ,
                            '/clang:-fno-asynchronous-unwind-tables']
     endif
-elif (cc.get_id() != 'msvc')
+elif (cc.get_id() == 'msvc')
+    compiler_flags += ['-DNOMINMAX']
+else
     if simd_type == 'avx'
         compiler_flags += ['-mavx']
     endif


### PR DESCRIPTION
Add pre-defined NOMINMAX in case of msvs target
Its reguired for using Windows SDK in MSVS

https://github.com/orgs/thorvg/discussions/3794