### PR TITLE
text: perform precise update only if necessary

### DIFF
--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -205,14 +205,14 @@ void TtfLoader::clear()
 /************************************************************************/
 
 
-float TtfLoader::transform(Paint* paint, FontMetrics* metrics, float fontSize, float italicShear)
+void TtfLoader::transform(Paint* paint, FontMetrics* metrics, float fontSize, float italicShear)
 {
     auto dpi = 96.0f / 72.0f;   //dpi base?
     auto scale = fontSize * dpi / reader.metrics.unitsPerEm;
     Matrix m = {scale, -italicShear * scale, italicShear * static_cast<TtfMetrics*>(metrics)->baseWidth * scale, 0, scale, reader.metrics.hhea.ascent * scale, 0, 0, 1};
     paint->transform(m);
 
-    return scale;
+    metrics->scale = scale / 1.0f;
 }
 
 

--- a/src/loaders/ttf/tvgTtfLoader.h
+++ b/src/loaders/ttf/tvgTtfLoader.h
@@ -58,7 +58,7 @@ struct TtfLoader : public FontLoader
 
     bool open(const char* path) override;
     bool open(const char *data, uint32_t size, const char* rpath, bool copy) override;
-    float transform(Paint* paint, FontMetrics* metrices, float fontSize, float italicShear) override;
+    void transform(Paint* paint, FontMetrics* metrices, float fontSize, float italicShear) override;
     bool read(RenderPath& path, char* text, FontMetrics* out) override;
     FontMetrics* metrics() override { return new TtfMetrics; }
     void clear();

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -104,6 +104,7 @@ struct ImageLoader : LoadModule
 struct FontMetrics
 {
     float w, h;  //text width, height
+    float scale;
 
     virtual ~FontMetrics() {}
     virtual FontMetrics* duplicate() = 0;
@@ -119,7 +120,7 @@ struct FontLoader : LoadModule
     using LoadModule::read;
 
     virtual bool read(RenderPath& path, char* text, FontMetrics* out) = 0;
-    virtual float transform(Paint* paint, FontMetrics* mertrics, float fontSize, float italicShear) = 0;
+    virtual void transform(Paint* paint, FontMetrics* mertrics, float fontSize, float italicShear) = 0;
     virtual FontMetrics* metrics() = 0;
 };
 

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -41,11 +41,7 @@ Result Text::font(const char* name) noexcept
 
 Result Text::size(float size) noexcept
 {
-    if (size > 0.0f) {
-        TEXT(this)->fontSize = size;
-        return Result::Success;
-    }
-    return Result::InvalidArguments;
+    return TEXT(this)->size(size);
 }
 
 
@@ -136,6 +132,7 @@ Result Text::italic(float shear) noexcept
     if (shear < 0.0f) shear = 0.0f;
     else if (shear > 0.5f) shear = 0.5f;
     TEXT(this)->italicShear = shear;
+    TEXT(this)->updated = true;
     return Result::Success;
 }
 


### PR DESCRIPTION
improve the efficiency by adding an update flag
to process the text only when its properties have changed.