### PR TITLE
sw_engine: corrected wrong condition

### DIFF
--- a/src/renderer/sw_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/sw_engine/tvgSwPostEffect.cpp
@@ -427,7 +427,7 @@ bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffe
     TVGLOG("SW_ENGINE", "DropShadow region(%d, %d, %d, %d) params(%f %f %f), level(%d)", bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y, params->angle, params->distance, params->sigma, data->level);
 
     //no filter required
-    if (params->sigma == 0.0f)  {
+    if (data->extends == 0)  {
         if (direct) {
             _dropShadowNoFilter(cmp->recoverSfc->buf32, cmp->image.buf32, cmp->recoverSfc->stride, cmp->image.stride, cmp->recoverSfc->w, cmp->recoverSfc->h, bbox, data->offset, color, opacity, direct);
         } else {


### PR DESCRIPTION
Don't try dropshadow filter if the zero-size sigma size is given. extends zero means no-filter application.