### PR TITLE
common: ++window portability

### DIFF
--- a/src/common/tvgStr.cpp
+++ b/src/common/tvgStr.cpp
@@ -232,8 +232,8 @@ char* dirname(const char* path)
 {
     auto ptr = strrchr(path, '/');
 #ifdef _WIN32
-    auto backslash = strrchr(ptr ? ptr : path, '\\');
-    if (backslash > ptr) ptr = backslash;
+    auto ptr2 = strrchr(ptr ? ptr : path, '\\');
+    if (ptr2) ptr = ptr2;
 #endif
     auto len = ptr ? size_t(ptr - path + 1) : SIZE_MAX;
     return duplicate(path, len);


### PR DESCRIPTION
compare the size with a pointer is invalid.
aligned the logic with filename()

issue: https://github.com/thorvg/thorvg/issues/3807