### PR TITLE
wg_engine: fix shape aabb transfrom

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -137,6 +137,12 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
         renderDataShape->updateMeshes(rshape, flags, transform);
     }
 
+    // update transform
+    if ((!data) || (flags & RenderUpdateFlag::Transform)) {
+        renderDataShape->transform = transform;
+        renderDataShape->updateAABB(transform);
+    }
+
     // update paint settings
     if ((!data) || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Blend | RenderUpdateFlag::Color))) {
         renderDataShape->renderSettingsShape.update(mContext, transform, mTargetSurface.cs, opacity);
@@ -146,7 +152,6 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
     // setup fill settings
     renderDataShape->viewport = vport;
-    renderDataShape->transform = transform;
     renderDataShape->updateVisibility(rshape, opacity);
     // update shape render settings
     if (!renderDataShape->renderSettingsShape.skip) {


### PR DESCRIPTION
Each shape has two types of bounding boxes: one from the original path and one from its transformed version. If the transformation changed, the aabb wasn't updated, which resulted in effects being applied to the wrong area of he screen. 
Now, if the transformation changes, the aabb is recalculated.

https://github.com/thorvg/thorvg/issues/3762