### PR TITLE
lottie/slot: fix TextDoc deep copy in new slot system

### DIFF
--- a/src/loaders/lottie/tvgLottieData.h
+++ b/src/loaders/lottie/tvgLottieData.h
@@ -78,6 +78,12 @@ struct TextDocument
     float tracking = 0.0f;
     float justify = 0.0f;    //horizontal alignment
     uint8_t caps = 0;        //0: Regular, 1: AllCaps, 2: SmallCaps
+
+    void copy(const TextDocument& rhs)
+    {
+        text = duplicate(rhs.text);
+        name = duplicate(rhs.name);
+    }
 };
 
 

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -947,12 +947,19 @@ struct LottieTextDoc : LottieProperty
             } else {
                 frames = new Array<LottieScalarFrame<TextDocument>>;
                 *frames = *rhs.frames;
+                for (uint32_t i = 0; i < (*rhs.frames).count; ++i) {
+                    (*frames)[i].value.copy((*rhs.frames)[i].value);
+                }
             }
         } else {
             frames = nullptr;
-            value = rhs.value;
-            rhs.value.text = nullptr;
-            rhs.value.name = nullptr;
+            if (shallow) {
+                value = rhs.value;
+                rhs.value.text = nullptr;
+                rhs.value.name = nullptr;
+            } else {
+                value.copy(rhs.value);
+            }
         }
     }
 


### PR DESCRIPTION
Fix TextDocument string pointer deep copying issue after slot API revision.

The new slot system (gen/apply/del) requires proper deep copying of TextDocument strings (text, name) in LottieTextDoc::copy() method.

[text_doc_slot.json](https://github.com/user-attachments/files/22510038/text_doc_slot.json)



<img width="2058" height="1890" alt="CleanShot 2025-09-24 at 18 00 31@2x" src="https://github.com/user-attachments/assets/3236c1e4-a3d3-4942-bfe2-c27146418c90" />
