### PR TITLE
svg_loader: When trimming id url string, trim it with single quotes as well

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -367,8 +367,8 @@ static char* _idFromUrl(const char* url)
     ++open;
     --close;
 
-    //trim the rest of the spaces if any
-    while (open < close && *close == ' ') --close;
+    //trim the rest of the spaces and the quote marks if any
+    while (open < close && (*close == ' ' || *close == '\'' || *close == '\"')) --close;
 
     //quick verification
     for (auto id = open; id < close; id++) {


### PR DESCRIPTION
IdFromUrl starts with the # symbol.(Therefore, the single quote preceding # is ignored.)
Previously, only whitespace was trimmed. If the string ends with a single quote, it is trimmed as well.

related issue : https://github.com/thorvg/thorvg/issues/3834