### PR TITLE
text: support linewrap feature

### DIFF
--- a/examples/TextLineWrap.cpp
+++ b/examples/TextLineWrap.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "Example.h"
+
+/************************************************************************/
+/* ThorVG Drawing Contents                                              */
+/************************************************************************/
+
+struct UserExample : tvgexam::Example
+{
+    tvg::Point size = {230.0f, 120.0f};
+
+    void guide(tvg::Canvas* canvas, const char* title, float x, float y)
+    {
+        auto txt = tvg::Text::gen();
+        txt->font("NOTO-SANS-KR");
+        txt->translate(x, y);
+        txt->size(12);
+        txt->text(title);
+        txt->fill(200, 200, 200);
+        canvas->push(txt);
+
+        auto lines = tvg::Shape::gen();
+        lines->strokeFill(100, 100, 100);
+        lines->strokeWidth(1);
+        lines->appendRect(x, y + 30.0f, size.x, size.y);
+        canvas->push(lines);
+    }
+
+    void text(tvg::Canvas* canvas, const char* content, const tvg::Point& pos, const tvg::Point& align, tvg::TextWrap wrapMode)
+    {
+        auto txt = tvg::Text::gen();
+        txt->font("NOTO-SANS-KR");
+        txt->translate(pos.x, pos.y + 30.0f);
+        txt->layout(size.x, size.y);
+        txt->size(14.5f);
+        txt->text(content);
+        txt->align(align.x, align.y);
+        txt->wrap(wrapMode);
+        txt->fill(255, 255, 255);
+        canvas->push(txt);
+    }
+
+    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    {
+        if (!tvgexam::verify(tvg::Text::load(EXAMPLE_DIR"/font/NOTO-SANS-KR.ttf"))) return false;
+
+        auto character = "TextWrap::Character";
+        guide(canvas, character, 25.0f, 25.0f);
+        text(canvas, "This is a lengthy text used to test line wrapping with top-left.", {25.0f, 25.0f}, {0.0f, 0.0f}, tvg::TextWrap::Character);
+
+        guide(canvas, character, 290.0f, 25.0f);
+        text(canvas, "This is a lengthy text used to test line wrapping with middle-center.", {290.0f, 25.0f}, {0.5f, 0.5f}, tvg::TextWrap::Character);
+
+        guide(canvas, character, 550.0f, 25.0f);
+        text(canvas, "This is a lengthy text used to test line wrapping with bottom-right.", {550.0f, 25.0f}, {1.0f, 1.0f}, tvg::TextWrap::Character);
+
+        auto word = "TextWrap::Word";
+        guide(canvas, word, 25.0f, 195.0f);
+        text(canvas, "An extreame-long-length-word to test with top-left.", {25.0f, 195.0f}, {0.0f, 0.0f}, tvg::TextWrap::Word);
+
+        guide(canvas, word, 290.0f, 195.0f);
+        text(canvas, "An extreame-long-length-word to test with middle-center.", {290.0f, 195.0f}, {0.5f, 0.5f}, tvg::TextWrap::Word);
+
+        guide(canvas, word, 550.0f, 195.0f);
+        text(canvas, "An extreame-long-length-word to test with bottom-right.", {550.0f, 195.0f}, {1.0f, 1.0f}, tvg::TextWrap::Word);
+
+        auto smart = "TextWrap::Smart";
+        guide(canvas, smart, 25.0f, 365.0f);
+        text(canvas, "An extreame-long-length-word to test with top-left.", {25.0f, 365.0f}, {0.0f, 0.0f}, tvg::TextWrap::Smart);
+
+        guide(canvas, smart, 290.0f, 365.0f);
+        text(canvas, "An extreame-long-length-word to test with middle-center.", {290.0f, 365.0f}, {0.5f, 0.5f}, tvg::TextWrap::Smart);
+
+        guide(canvas, smart, 550.0f, 365.0f);
+        text(canvas, "An extreame-long-length-word to test with bottom-right.", {550.0f, 365.0f}, {1.0f, 1.0f}, tvg::TextWrap::Smart);
+
+        auto ellipsis = "TextWrap::Ellipsis";
+        guide(canvas, ellipsis, 25.0f, 535.0f);
+        text(canvas, "This is a lengthy text used to test line wrapping with top-left.", {25.0f, 535.0f}, {0.0f, 0.0f}, tvg::TextWrap::Ellipsis);
+
+        guide(canvas, ellipsis, 290.0f, 535.0f);
+        text(canvas, "This is a lengthy text used to test line wrapping with middle-center.", {290.0f, 535.0f}, {0.5f, 0.5f}, tvg::TextWrap::Ellipsis);
+
+        guide(canvas, ellipsis, 550.0f, 535.0f);
+        text(canvas, "This is a lengthy text used to test line wrapping with bottom-right.", {550.0f, 535.0f}, {1.0f, 1.0f}, tvg::TextWrap::Ellipsis);
+
+        return true;
+    }
+};
+
+
+/************************************************************************/
+/* Entry Point                                                          */
+/************************************************************************/
+
+int main(int argc, char **argv)
+{
+    return tvgexam::main(new UserExample, argc, argv);
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -65,6 +65,7 @@ source_file = [
     'Svg.cpp',
     'Text.cpp',
     'TextLayout.cpp',
+    'TextLineWrap.cpp',
     'Transform.cpp',
     'TrimPath.cpp',
     'Update.cpp',

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -262,6 +262,27 @@ enum class SceneEffect : uint8_t
 
 
 /**
+ * @brief Enumeration that defines methods used for wrapping text.
+ *
+ * This enum provides options to control how text is wrapped when it exceeds the available space.
+ * Wrapping affects the layout and flow of text in the rendering area.
+ *
+ * @see Text::wrap(TextWrap mode)
+ *
+ * @note Experimental API
+ */
+enum class TextWrap : uint8_t
+{
+    None = 0,      ///< Do not wrap text. Text is rendered on a single line and may overflow the bounding area.
+    Character,     ///< Wrap at the character level. If a word cannot fit, it is broken into individual characters to fit the line.
+    Word,          ///< Wrap at the word level. Words that do not fit are moved to the next line.
+    Smart,         ///< Smart choose wrapping method: word wrap first, falling back to character wrap if a word does not fit.
+    Ellipsis,      ///< Truncate overflowing text and append an ellipsis ("...") at the end. Typically used for single-line labels.
+    Hyphenation    ///< Reserved. No Support.
+};
+
+
+/**
  * @brief Enumeration specifying the ThorVG class type value.
  *
  * ThorVG's drawing objects can return class type values, allowing you to identify the specific class of each object.
@@ -1858,6 +1879,20 @@ public:
      * @see align()
      */
     Result layout(float w, float h) noexcept;
+
+    /**
+     * @brief Sets the text wrapping mode for this text object.
+     *
+     * This method controls how the text is laid out when it exceeds the available space.
+     * The wrapping mode determines whether text is truncated, wrapped by character or word,
+     * or adjusted automatically. An ellipsis mode is also available for truncation with "...".
+     *
+     * @param[in] mode The wrapping strategy to apply. Default is @c TextWrap::None
+     *
+     * @see TextWrap
+     * @note Experimental API
+     */
+    Result wrap(TextWrap mode) noexcept;
 
     /**
      * @brief Apply an italic (slant) transformation to the text.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -278,8 +278,7 @@ typedef enum {
 /*!
 * @brief A data structure storing the information about the color and its relative position inside the gradient bounds.
 */
-typedef struct
-{
+typedef struct {
     float offset; /**< The relative position of the color. */
     uint8_t r;    /**< The red color channel value in the range [0 ~ 255]. */
     uint8_t g;    /**< The green color channel value in the range [0 ~ 255]. */
@@ -290,11 +289,29 @@ typedef struct
 /** \} */   // end addtogroup ThorVGCapi_Gradient
 
 
+/*!
+* @addtogroup ThorVGCapi_Text
+* \{
+*/
+
+/*!
+* @brief A data structure storing the information about the color and its relative position inside the gradient bounds.
+*/
+typedef enum {
+    TVG_TEXT_WRAP_NONE = 0,      ///< Do not wrap text. Text is rendered on a single line and may overflow the bounding area.
+    TVG_TEXT_WRAP_CHARACTER,     ///< Wrap at the character level. If a word cannot fit, it is broken into individual characters to fit the line.
+    TVG_TEXT_WRAP_WORD,          ///< Wrap at the word level. Words that do not fit are moved to the next line.
+    TVG_TEXT_WRAP_SMART,         ///< Smart choose wrapping method: word wrap first, falling back to character wrap if a word does not fit.
+    TVG_TEXT_WRAP_ELLIPSIS,      ///< Truncate overflowing text and append an ellipsis ("...") at the end. Typically used for single-line labels.
+    TVG_TEXT_WRAP_HYPHENATION    ///< Reserved. No Support.
+} Tvg_Text_Wrap;
+
+/** \} */  // end addtogroup ThorVGCapi_Text
+
 /**
  * @brief A data structure representing a point in two-dimensional space.
  */
-typedef struct
-{
+typedef struct {
     float x, y;
 } Tvg_Point;
 
@@ -306,8 +323,7 @@ typedef struct
  * The elements e13 and e23 determine the translation of the object along the x and y-axis, respectively.
  * The elements e31 and e32 are set to 0, e33 is set to 1.
  */
-typedef struct
-{
+typedef struct {
     float e11, e12, e13;
     float e21, e22, e23;
     float e31, e32, e33;
@@ -2386,6 +2402,21 @@ TVG_API Tvg_Result tvg_text_align(Tvg_Paint text, float x, float y);
  * @see tvg_text_align()
  */
 TVG_API Tvg_Result tvg_text_layout(Tvg_Paint text, float w, float h);
+
+/**
+ * @brief Sets the text wrapping mode for this text object.
+ *
+ * This method controls how the text is laid out when it exceeds the available space.
+ * The wrapping mode determines whether text is truncated, wrapped by character or word,
+ * or adjusted automatically. An ellipsis mode is also available for truncation with "...".
+ *
+ * @param[in] text A Tvg_Paint pointer to the text object.
+ * @param[in] mode The wrapping strategy to apply. Default is @c TVG_TEXT_WRAP_NONE.
+ *
+ * @see Tvg_Text_Wrap
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_text_wrap_mode(Tvg_Paint text, Tvg_Text_Wrap mode);
 
 
 /**

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -925,15 +925,24 @@ TVG_API Tvg_Result tvg_text_set_color(Tvg_Paint text, uint8_t r, uint8_t g, uint
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
+
 TVG_API Tvg_Result tvg_text_set_italic(Tvg_Paint text, float shear)
 {
     if (text) return (Tvg_Result) reinterpret_cast<Text*>(text)->italic(shear);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
+
 TVG_API Tvg_Result tvg_text_set_gradient(Tvg_Paint text, Tvg_Gradient gradient)
 {
     if (text) return (Tvg_Result) reinterpret_cast<Text*>(text)->fill((Fill*)(gradient));
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
+TVG_API Tvg_Result tvg_text_wrap_mode(Tvg_Paint text, Tvg_Text_Wrap mode)
+{
+    if (text) return (Tvg_Result) reinterpret_cast<Text*>(text)->wrap(TextWrap(mode));
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 

--- a/src/loaders/ttf/tvgTtfLoader.h
+++ b/src/loaders/ttf/tvgTtfLoader.h
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 #ifndef _TVG_TTF_LOADER_H_
 #define _TVG_TTF_LOADER_H_
 
@@ -34,8 +33,6 @@ using namespace std;
 struct TtfMetrics : FontMetrics
 {
     float baseWidth;  //Use as the reference glyph width for italic transform
-
-    FontMetrics* duplicate() override { return new TtfMetrics(*this); }
 };
 
 
@@ -58,9 +55,22 @@ struct TtfLoader : public FontLoader
 
     bool open(const char* path) override;
     bool open(const char *data, uint32_t size, const char* rpath, bool copy) override;
-    void transform(Paint* paint, FontMetrics* metrices, float fontSize, float italicShear) override;
-    bool read(RenderPath& path, char* text, FontMetrics* out) override;
-    FontMetrics* metrics() override { return new TtfMetrics; }
+    void transform(Paint* paint, FontMetrics& fm, float italicShear) override;
+    bool get(FontMetrics& fm, char* text, RenderPath& out) override;
+    void copy(const FontMetrics& in, FontMetrics& out) override;
+    void release(FontMetrics& fm) override;
+
+private:
+    float height(uint32_t loc)
+    {
+        return reader.metrics.hhea.advance * loc - reader.metrics.hhea.lineGap;
+    }
+
+    void wrapNone(FontMetrics& fm, const Point& box, char* utf8, RenderPath& out);
+    void wrapChar(FontMetrics& fm, const Point& box, char* utf8, RenderPath& out);
+    void wrapWord(FontMetrics& fm, const Point& box, char* utf8, RenderPath& out, bool smart);
+    void wrapEllipsis(FontMetrics& fm, const Point& box, char* utf8, RenderPath& out);
+    TtfGlyphMetrics* request(uint32_t code);
     void clear();
 };
 

--- a/src/loaders/ttf/tvgTtfReader.cpp
+++ b/src/loaders/ttf/tvgTtfReader.cpp
@@ -314,6 +314,7 @@ bool TtfReader::header()
     metrics.hhea.ascent = _i16(data, hhea + 4);
     metrics.hhea.descent = _i16(data, hhea + 6);
     metrics.hhea.lineGap = _i16(data, hhea + 8);
+    metrics.hhea.advance = metrics.hhea.ascent - metrics.hhea.descent + metrics.hhea.lineGap;
     metrics.numHmtx = _u16(data, hhea + 34);
 
     //kerning
@@ -573,8 +574,6 @@ bool TtfReader::kerning(uint32_t lglyph, uint32_t rglyph, Point& out)
     if (!kern) return false;
 
     auto kern = this->kern.load();
-
-    out.x = out.y = 0.0f;
 
     //kern tables
     auto tableCnt = _u16(data, kern + 2);

--- a/src/loaders/ttf/tvgTtfReader.h
+++ b/src/loaders/ttf/tvgTtfReader.h
@@ -52,9 +52,9 @@ public:
     {
         //horizontal header info
         struct {
-            float ascent;
-            float descent;
+            float ascent, descent;
             float lineGap;
+            float advance;
         } hhea;
 
         uint16_t unitsPerEm;

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -111,11 +111,18 @@ struct ImageLoader : LoadModule
 
 struct FontMetrics
 {
-    float w, h;  //text width, height
+    Point size;  //text width, height
     float scale;
+    Point align{}, box{};
+    float fontSize = 0.0f;
+    TextWrap wrap = TextWrap::None;
 
-    virtual ~FontMetrics() {}
-    virtual FontMetrics* duplicate() = 0;
+    void *engine = nullptr;  //engine extension
+
+    ~FontMetrics()
+    {
+        free(engine);
+    }
 };
 
 
@@ -127,9 +134,10 @@ struct FontLoader : LoadModule
 
     using LoadModule::read;
 
-    virtual bool read(RenderPath& path, char* text, FontMetrics* out) = 0;
-    virtual void transform(Paint* paint, FontMetrics* mertrics, float fontSize, float italicShear) = 0;
-    virtual FontMetrics* metrics() = 0;
+    virtual bool get(FontMetrics& fm, char* text, RenderPath& out) = 0;
+    virtual void transform(Paint* paint, FontMetrics& fm, float italicShear) = 0;
+    virtual void release(FontMetrics& fm) = 0;
+    virtual void copy(const FontMetrics& in, FontMetrics& out) = 0;
 };
 
 #endif //_TVG_LOAD_MODULE_H_

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -93,7 +93,7 @@ Result Text::unload(const char* filename) noexcept
 
 Result Text::align(float x, float y) noexcept
 {
-    TEXT(this)->align = {x, y};
+    TEXT(this)->fm.align = {x, y};
     PAINT(this)->mark(RenderUpdateFlag::Transform);
     return Result::Success;
 }
@@ -133,6 +133,13 @@ Result Text::italic(float shear) noexcept
     else if (shear > 0.5f) shear = 0.5f;
     TEXT(this)->italicShear = shear;
     TEXT(this)->updated = true;
+    return Result::Success;
+}
+
+
+Result Text::wrap(TextWrap mode) noexcept
+{
+    TEXT(this)->wrapping(mode);
     return Result::Success;
 }
 


### PR DESCRIPTION
Text linewrap method controls how the text is laid out
when it exceeds the available space. The wrapping mode
determines whether text is truncated, wrapped by character
or word,or adjusted automatically. An ellipsis mode is
also available for truncation with "..."

C++ API
 + enum TextWrap [None, Character, Word, Smart, Ellipsis, Hyphenation]
 + Result Text::wrap(TextWrap mode)

C API
 + enum Tvg_Text_Wrap [TVG_TEXT_WRAP_NONE, TVG_TEXT_WRAP_CHARACTER, TVG_TEXT_WRAP_SMART ...]
 + Tvg_Result tvg_text_wrap_mode(Tvg_Paint text, Tvg_Text_Wrap mode)

issue: https://github.com/thorvg/thorvg/issues/3397

<img width="774" height="690" alt="image" src="https://github.com/user-attachments/assets/112fcb11-b6c4-480c-a90e-c30733b69b4d" />