### PR TITLE
renderer: add custom allocator option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,14 @@ if get_option('file') == true
 endif
 
 
+#Custom Allocator
+custom_allocator_header = get_option('custom_allocator_header')
+if custom_allocator_header != ''
+    config_h.set10('THORVG_CUSTOM_ALLOCATOR', true)
+    config_h.set_quoted('TVG_CUSTOM_ALLOCATOR_HEADER', custom_allocator_header)
+endif
+
+
 #Extra
 lottie_expressions = lottie_loader and get_option('extra').contains('lottie_expressions')
 
@@ -182,6 +190,7 @@ summary(
     'Log Message': get_option('log'),
     'Tests': get_option('tests'),
     'Examples': get_option('examples'),
+    'Custom Allocator': get_option('custom_allocator_header'),
   },
   bool_yn: true,
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -73,3 +73,8 @@ option('extra',
    choices: ['', 'opengl_es', 'lottie_expressions'],
    value: ['lottie_expressions'],
    description: 'Enable support for extra options')
+
+option('custom_allocator_header',
+   type: 'string',
+   value: '',
+   description: 'Path to a header file that overrides malloc/free for ThorVG')

--- a/src/renderer/tvgAllocator.h
+++ b/src/renderer/tvgAllocator.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY  KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_ALLOCATOR_H_
+#define _TVG_ALLOCATOR_H_
+
+#include "config.h"
+
+#ifdef TVG_CUSTOM_ALLOCATOR_HEADER
+#  include TVG_CUSTOM_ALLOCATOR_HEADER
+#endif
+
+#if !defined(TVG_MALLOC) || !defined(TVG_CALLOC) || !defined(TVG_REALLOC) || !defined(TVG_FREE)
+#  include <cstdlib>
+#endif
+
+#ifndef TVG_MALLOC
+#  define TVG_MALLOC(sz)       std::malloc(sz)
+#endif
+
+#ifndef TVG_CALLOC
+#  define TVG_CALLOC(n,sz)     std::calloc(n,sz)
+#endif
+
+#ifndef TVG_REALLOC
+#  define TVG_REALLOC(p,sz)    std::realloc(p,sz)
+#endif
+
+#ifndef TVG_FREE
+#  define TVG_FREE(p)          std::free(p)
+#endif
+
+#endif //_TVG_ALLOCATOR_H_

--- a/src/renderer/tvgCommon.h
+++ b/src/renderer/tvgCommon.h
@@ -36,6 +36,7 @@
 #include <cstring>
 #include "config.h"
 #include "thorvg.h"
+#include "tvgAllocator.h"
 
 using namespace std;
 using namespace tvg;
@@ -94,25 +95,25 @@ namespace tvg {
     template<typename T = void*>
     static inline T malloc(size_t size)
     {
-        return static_cast<T>(std::malloc(size));
+        return static_cast<T>(TVG_MALLOC(size));
     }
 
     template<typename T = void*>
     static inline T calloc(size_t nmem, size_t size)
     {
-        return static_cast<T>(std::calloc(nmem, size));
+        return static_cast<T>(TVG_CALLOC(nmem, size));
     }
 
     template<typename T = void*>
     static inline T realloc(void* ptr, size_t size)
     {
-        return static_cast<T>(std::realloc(ptr, size));
+        return static_cast<T>(TVG_REALLOC(ptr, size));
     }
 
     template<typename T = void*>
     static inline void free(void* ptr)
     {
-        std::free(ptr);
+        TVG_FREE(ptr);
     }
 
     extern int engineInit;


### PR DESCRIPTION
Hi all,

This commit resolves the first part of the feature request https://github.com/thorvg/thorvg/issues/3857 . Now users can bring their own allocator by using `meson setup builddir -Dcustom_allocator_header=/path/to/your_own_alloc.h`, and then provide the TVG_{MALLOC|CALLOC|REALLOC} macros.

However I haven't got a chance to override the allocator for the 3rd party libraries like those JPG and PNG loaders. I will implement those later when I have some time.

Regards,
Jackson

