### PR TITLE
wg_engine: update webgpu lib to v25

### DIFF
--- a/cross/wasm32.txt
+++ b/cross/wasm32.txt
@@ -11,8 +11,8 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
-cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--use-port=emdawnwebgpu']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3', '--use-port=emdawnwebgpu']
 
 [host_machine]
 system = 'emscripten'

--- a/cross/wasm32_wg.txt
+++ b/cross/wasm32_wg.txt
@@ -11,8 +11,8 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
-cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sUSE_WEBGPU=1']
+cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--use-port=emdawnwebgpu']
+cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '--use-port=emdawnwebgpu']
 
 [host_machine]
 system = 'emscripten'

--- a/src/renderer/wg_engine/tvgWgBindGroups.cpp
+++ b/src/renderer/wg_engine/tvgWgBindGroups.cpp
@@ -162,8 +162,8 @@ void WgBindGroupLayouts::initialize(WGPUDevice device)
     this->device = device;
 
     // common bind group settings
-    const WGPUShaderStageFlags visibility_vert = WGPUShaderStage_Vertex | WGPUShaderStage_Fragment | WGPUShaderStage_Compute;
-    const WGPUShaderStageFlags visibility_frag = WGPUShaderStage_Fragment | WGPUShaderStage_Compute;
+    const WGPUShaderStage visibility_vert = WGPUShaderStage_Vertex | WGPUShaderStage_Fragment | WGPUShaderStage_Compute;
+    const WGPUShaderStage visibility_frag = WGPUShaderStage_Fragment | WGPUShaderStage_Compute;
     const WGPUSamplerBindingLayout sampler = { .type = WGPUSamplerBindingType_Filtering };
     const WGPUTextureBindingLayout texture = { .sampleType = WGPUTextureSampleType_Float, .viewDimension = WGPUTextureViewDimension_2D };
     const WGPUStorageTextureBindingLayout storageTextureWO { .access = WGPUStorageTextureAccess_WriteOnly, .format = WGPUTextureFormat_RGBA8Unorm, .viewDimension = WGPUTextureViewDimension_2D };

--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -79,18 +79,18 @@ bool WgContext::allocateTexture(WGPUTexture& texture, uint32_t width, uint32_t h
 {
     if ((texture) && (wgpuTextureGetWidth(texture) == width) && (wgpuTextureGetHeight(texture) == height)) {
         // update texture data
-        const WGPUImageCopyTexture imageCopyTexture{ .texture = texture };
-        const WGPUTextureDataLayout textureDataLayout{ .bytesPerRow = 4 * width, .rowsPerImage = height };
+        const WGPUTexelCopyTextureInfo copyTextureInfo{ .texture = texture };
+        const WGPUTexelCopyBufferLayout copyBufferLayout{ .bytesPerRow = 4 * width, .rowsPerImage = height };
         const WGPUExtent3D writeSize{ .width = width, .height = height, .depthOrArrayLayers = 1 };
-        wgpuQueueWriteTexture(queue, &imageCopyTexture, data, 4 * width * height, &textureDataLayout, &writeSize);
+        wgpuQueueWriteTexture(queue, &copyTextureInfo, data, 4 * width * height, &copyBufferLayout, &writeSize);
     } else {
         releaseTexture(texture);
         texture = createTexture(width, height, format);
         // update texture data
-        const WGPUImageCopyTexture imageCopyTexture{ .texture = texture };
-        const WGPUTextureDataLayout textureDataLayout{ .bytesPerRow = 4 * width, .rowsPerImage = height };
+        const WGPUTexelCopyTextureInfo copyTextureInfo{ .texture = texture };
+        const WGPUTexelCopyBufferLayout copyBufferLayout{ .bytesPerRow = 4 * width, .rowsPerImage = height };
         const WGPUExtent3D writeSize{ .width = width, .height = height, .depthOrArrayLayers = 1 };
-        wgpuQueueWriteTexture(queue, &imageCopyTexture, data, 4 * width * height, &textureDataLayout, &writeSize);
+        wgpuQueueWriteTexture(queue, &copyTextureInfo, data, 4 * width * height, &copyBufferLayout, &writeSize);
         return true;
     }
     return false;

--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -140,8 +140,8 @@ void WgCompositor::copyTexture(const WgRenderTarget* dst, const WgRenderTarget* 
     assert(dst);
     assert(src);
     assert(commandEncoder);
-    const WGPUImageCopyTexture texSrc { .texture = src->texture, .origin = { .x = region.x(), .y = region.y() } };
-    const WGPUImageCopyTexture texDst { .texture = dst->texture, .origin = { .x = region.x(), .y = region.y() } };
+    const WGPUTexelCopyTextureInfo texSrc { .texture = src->texture, .origin = { .x = (uint32_t)region.min.x, .y = (uint32_t)region.min.y } };
+    const WGPUTexelCopyTextureInfo texDst { .texture = dst->texture, .origin = { .x = (uint32_t)region.min.x, .y = (uint32_t)region.min.y } };
     const WGPUExtent3D copySize { .width = region.w(), .height = region.h(), .depthOrArrayLayers = 1 };
     wgpuCommandEncoderCopyTextureToTexture(commandEncoder, &texSrc, &texDst, &copySize);
 }

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -113,7 +113,7 @@ private:
         const WGPUShaderModule shaderModule, const char* vsEntryPoint, const char* fsEntryPoint,
         const WGPUPipelineLayout pipelineLayout,
         const WGPUVertexBufferLayout *vertexBufferLayouts, const uint32_t vertexBufferLayoutsCount,
-        const WGPUColorWriteMaskFlags writeMask, const WGPUTextureFormat colorTargetFormat, const WGPUBlendState blendState,
+        const WGPUColorWriteMask writeMask, const WGPUTextureFormat colorTargetFormat, const WGPUBlendState blendState,
         const WGPUDepthStencilState depthStencilState, const WGPUMultisampleState multisampleState);
     WGPUComputePipeline createComputePipeline(
         WGPUDevice device, const char* pipelineLabel,
@@ -125,10 +125,10 @@ private:
     void releaseShaderModule(WGPUShaderModule& shaderModule);
 
     WGPUDepthStencilState makeDepthStencilState(
-        const WGPUCompareFunction depthCompare, WGPUBool depthWriteEnabled,
+        const WGPUCompareFunction depthCompare, WGPUOptionalBool depthWriteEnabled,
         const WGPUCompareFunction stencilFunctionFrnt, const WGPUStencilOperation stencilOperationFrnt);
     WGPUDepthStencilState makeDepthStencilState(
-        const WGPUCompareFunction depthCompare, WGPUBool depthWriteEnabled,
+        const WGPUCompareFunction depthCompare, WGPUOptionalBool depthWriteEnabled,
         const WGPUCompareFunction stencilFunctionFrnt, const WGPUStencilOperation stencilOperationFrnt,
         const WGPUCompareFunction stencilFunctionBack, const WGPUStencilOperation stencilOperationBack);
 public:

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -106,12 +106,10 @@ bool WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint3
         .device = context.device,
         .format = context.preferredFormat,
         .usage = WGPUTextureUsage_RenderAttachment,
-    #ifdef __EMSCRIPTEN__
-        .alphaMode = WGPUCompositeAlphaMode_Premultiplied,
-    #endif
         .width = width,
         .height = height,
     #ifdef __EMSCRIPTEN__
+        .alphaMode = WGPUCompositeAlphaMode_Premultiplied,
         .presentMode = WGPUPresentMode_Fifo
     #elif __linux__
     #else


### PR DESCRIPTION
A migration to a new, more modern version has been introduced.
The transition from version 22 to version 24/25, which have new headers that are incompatible with the previous version, has been completed.

Emscripten cross files for compiling for the new header version have also been updated.
Used **_'--use-port=emdawnwebgpu'_** flag for compilation and linking

no changes in performance or memory consumption are expected

you can find latest (v25) webgpu library files there:
https://github.com/gfx-rs/wgpu-native/releases

how to setup it, see there:
https://github.com/thorvg/thorvg/wiki/WebGPU-Engine-Development

https://github.com/thorvg/thorvg/issues/3422
https://github.com/thorvg/thorvg/issues/3835