### PR TITLE
lottie: properly invert chained masking logic

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -48,7 +48,7 @@ public:
 private:
     RGB32 getColor(const char *str);
     FillRule getFillRule();
-    MaskMethod getMaskMethod(bool inversed);
+    MaskMethod getMaskMethod(bool inversed, bool inversedRoot);
     LottieInterpolator* getInterpolator(const char* key, Point& in, Point& out);
     LottieEffect* getEffect(int type);
     LottieExpression* getExpression(char* code, LottieComposition* comp, LottieLayer* layer, LottieObject* object, LottieProperty* property);
@@ -89,7 +89,7 @@ private:
     LottieRoundedCorner* parseRoundedCorner();
     LottieGradientFill* parseGradientFill();
     LottieLayer* parseLayers(LottieLayer* root);
-    LottieMask* parseMask();
+    LottieMask* parseMask(bool inversedRoot = false);
     LottieTrimpath* parseTrimpath();
     LottieRepeater* parseRepeater();
     LottieOffsetPath* parseOffsetPath();


### PR DESCRIPTION
Improved handling of inverted root masks (InvAlpha, InvLuma). When the root mask is inverted, subsequent mask modes are now remapped (e.g., Subtract → Add, Add → Subtract).

This resolves the issue where only the first inverted mask was applied in masks in the chain.

file: [sample.json](https://github.com/user-attachments/files/22647078/sample.json)

| Before (Second masking didn’t apply) | After (Correctly chained masks) |
|--------------------------------------|---------------------------------|
| <img width="2056" height="1890" alt="Before" src="https://github.com/user-attachments/assets/fab7121f-713d-4e01-bf7e-b6a58f8091d4" /> | <img width="2056" height="1894" alt="After" src="https://github.com/user-attachments/assets/cb6ae3c1-45ab-4854-85c3-b1d1000868f0" /> |