### PR TITLE
lottie/slot: fixed slot parsing for non-existent slots

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -365,11 +365,15 @@ uint32_t LottieLoader::gen(const char* slots, bool byDefault)
     //Generates list of the custom slot overriding
     while (auto sid = djb2Encode(parser.sid(idx == 0))) {
         //Associates the overrding target to apply for the current custom slot
+        auto found = false;
         ARRAY_FOREACH(p, comp->slots) {
             if ((*p)->sid != sid) continue;  //find target
             if (auto prop = parser.parse(*p)) custom->props.push({prop, *p});
+            found = true;
             break;
         }
+
+        if (!found) parser.skip(); //skip the value if the target slot is not found
         ++idx;
     }
 


### PR DESCRIPTION
Skip parser when the target slot ID is not found in the animation. Previously, parser would fail to continue when encountering slot overrides that don't exist in the animation, causing parsing to halt.

file: [sample.json](https://github.com/user-attachments/files/22648896/sample.json)

| Before | After |
|--------|-------|
| <img width="2052" height="1888" alt="Before" src="https://github.com/user-attachments/assets/e5f6f81f-dffa-417a-9e95-a736763810e8" /> | <img width="2050" height="1886" alt="After" src="https://github.com/user-attachments/assets/10a44a40-5328-4d53-acbd-c1c3ee829747" /> |

<img width="1256" height="1386" alt="CleanShot 2025-10-02 at 05 51 18@2x" src="https://github.com/user-attachments/assets/221520b1-d56a-4176-9478-d29b659ba4dd" />
