### PR TITLE
lottie: separate build and update logic for better flexibility

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1571,8 +1571,6 @@ void LottieBuilder::build(LottieComposition* comp)
 
     _buildComposition(comp, comp->root);
 
-    if (!update(comp, 0)) return;
-
     //viewport clip
     auto clip = Shape::gen();
     clip->appendRect(0, 0, comp->w, comp->h);

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -111,6 +111,7 @@ private:
     float startFrame();
     void run(unsigned tid) override;
     void release();
+    bool prepare();
 };
 
 

--- a/test/testAnimation.cpp
+++ b/test/testAnimation.cpp
@@ -115,14 +115,15 @@ TEST_CASE("Animation Lottie2", "[tvgAnimation]")
 
         REQUIRE(picture->load(TEST_DIR"/test2.json") == Result::Success);
 
+        //specify the lottie scene first
+        REQUIRE(animation->frame(20.0f) == Result::Success);
+
         //Find specific paint nodes
         REQUIRE(!picture->paint(Accessor::id("test1")));
         REQUIRE(!picture->paint(Accessor::id("abcd")));
         REQUIRE(!picture->paint(Accessor::id("abcd")));
         REQUIRE(picture->paint(Accessor::id("bar")));
         REQUIRE(picture->paint(Accessor::id("pad1")));
-
-        REQUIRE(animation->frame(20.0f) == Result::Success);
     }
     REQUIRE(Initializer::term() == Result::Success);
 }


### PR DESCRIPTION
Separate the build and update processes to allow more flexible control between threaded and non-threaded parsing sequences. This change helps support proper asset resolver injection timing.

issue: https://github.com/thorvg/thorvg/issues/3851