### PR TITLE
loader/jpg: fix double free

### DIFF
--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -2468,7 +2468,6 @@ jpeg_decoder* jpgdHeader(const char* filename, int* width, int* height)
 
     auto decoder = new jpeg_decoder(fileStream);
     if (decoder->get_error_code() != JPGD_SUCCESS) {
-        delete(fileStream);
         delete(decoder);
         return nullptr;
     }


### PR DESCRIPTION

jpeg_decoder takes ownership of fileStream and frees it, so deleting it again caused a double free.
- issue: #3872



<img width="1075" height="365" alt="image" src="https://github.com/user-attachments/assets/e4a30a88-cb09-41ba-bf38-56c17d49ab05" />



```cpp
void jpeg_decoder::decode_init(jpeg_decoder_stream *pStream)
{
    init(pStream);
    locate_sof_marker();
}

void jpeg_decoder::init(jpeg_decoder_stream *pStream)
{
    m_pMem_blocks = nullptr;
    m_error_code = JPGD_SUCCESS;
    m_ready_flag = false;
    m_image_x_size = m_image_y_size = 0;
    m_pStream = pStream;
    m_progressive_flag = false
```

```cpp
void jpeg_decoder::free_all_blocks()
{
    delete(m_pStream);
    m_pStream = nullptr;
```
