### PR TITLE
common: separate memory allocators

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,3 +48,4 @@ SoonGeon Noh <nors.nsg@gmail.com>
 Giseong Ji <jiggyjiggy0323@gmail.com>
 KunYoung Park <rjsdud3263@gmail.com>
 Wang SiMiao 王思淼 <wangsimiao1@xiaomi.com>
+Jackson Hu <huming2207@gmail.com>

--- a/src/common/tvgAllocator.h
+++ b/src/common/tvgAllocator.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_ALLOCATOR_H_
+#define _TVG_ALLOCATOR_H_
+
+#include <cstdlib>
+#include <cstddef>
+
+//separate memory alloators for clean customization
+namespace tvg
+{
+    template<typename T = void*>
+    static inline T malloc(size_t size)
+    {
+        return static_cast<T>(std::malloc(size));
+    }
+
+    template<typename T = void*>
+    static inline T calloc(size_t nmem, size_t size)
+    {
+        return static_cast<T>(std::calloc(nmem, size));
+    }
+
+    template<typename T = void*>
+    static inline T realloc(void* ptr, size_t size)
+    {
+        return static_cast<T>(std::realloc(ptr, size));
+    }
+
+    template<typename T = void*>
+    static inline void free(void* ptr)
+    {
+        std::free(ptr);
+    }
+}
+
+#endif //_TVG_ALLOCATOR_H_

--- a/src/common/tvgCommon.h
+++ b/src/common/tvgCommon.h
@@ -90,32 +90,9 @@ namespace tvg {
     #define TVG_DELETE(PAINT) \
     if (PAINT->refCnt() == 0) delete(PAINT)
 
-    //custom memory allocators
-    template<typename T = void*>
-    static inline T malloc(size_t size)
-    {
-        return static_cast<T>(std::malloc(size));
-    }
-
-    template<typename T = void*>
-    static inline T calloc(size_t nmem, size_t size)
-    {
-        return static_cast<T>(std::calloc(nmem, size));
-    }
-
-    template<typename T = void*>
-    static inline T realloc(void* ptr, size_t size)
-    {
-        return static_cast<T>(std::realloc(ptr, size));
-    }
-
-    template<typename T = void*>
-    static inline void free(void* ptr)
-    {
-        std::free(ptr);
-    }
-
     extern int engineInit;
 }
+
+#include "tvgAllocator.h"
 
 #endif //_TVG_COMMON_H_


### PR DESCRIPTION
Make the memory allocators more visible so that
users can easily replace them with a custom file.