### PR TITLE
renderer: fix std::min() and std::max() type mismatch issues on ESP-IDF

### DIFF
--- a/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -804,8 +804,8 @@ bool rasterTexmapPolygon(SwSurface* surface, const SwImage& image, const Matrix&
         if (vertices[i].pt.y > ye) ye = vertices[i].pt.y;
     }
 
-    auto yStart = std::max(static_cast<int>(ys), bbox.min.y);
-    auto yEnd = std::min(static_cast<int>(ye), bbox.max.y);
+    auto yStart = std::max(static_cast<int32_t>(ys), bbox.min.y);
+    auto yEnd = std::min(static_cast<int32_t>(ye), bbox.max.y);
     auto aaSpans = rightAngle(transform) ?  nullptr : _AASpans(yStart, yEnd);
 
     Polygon polygon;

--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -944,7 +944,7 @@ bool rleClip(SwRle *rle, const RenderRegion* clip)
         if (p->y < min.y || p->x >= max.x || (p->x + p->len) <= min.x) continue;
         if (p->x < min.x) {
             x = min.x;
-            len = std::min((p->len - (x - p->x)), (max.x - x));
+            len = std::min(uint16_t(p->len - (x - p->x)), uint16_t(max.x - x));
         } else {
             x = p->x;
             len = std::min(p->len, uint16_t(max.x - x));


### PR DESCRIPTION
Hi @hermet 

This is another PR for fixing type mismatch issue on ESP-IDF (ESP32) build environment. It seems like the GCC compiler they provided is very strict on these type checks. Without this fix, the compiler will complain stuff like this:

```
In file included from ../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRaster.cpp:241:
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h: In function 'bool rasterTexmapPolygon(SwSurface*, const SwImage&, const tvg::Matrix&, const tvg::RenderRegion&, uint8_t)':
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h:807:27: error: no matching function for call to 'max(int, const int32_t&)'
  807 |     auto yStart = std::max(static_cast<int>(ys), bbox.min.y);
      |                   ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/string:51,
                 from ../../../../components/esp-thorvg/thorvg/src/common/tvgCommon.h:33,
                 from ../../../../components/esp-thorvg/thorvg/src/common/tvgMath.h:30,
                 from ../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRaster.cpp:23:
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algobase.h:257:5: note: candidate: 'template<class _Tp> constexpr const _Tp& std::max(const _Tp&, const _Tp&)'
  257 |     max(const _Tp& __a, const _Tp& __b)
      |     ^~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algobase.h:257:5: note:   template argument deduction/substitution failed:
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h:807:27: note:   deduced conflicting types for parameter 'const _Tp' ('int' and 'int32_t' {aka 'long int'})
  807 |     auto yStart = std::max(static_cast<int>(ys), bbox.min.y);
      |                   ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algobase.h:303:5: note: candidate: 'template<class _Tp, class _Compare> constexpr const _Tp& std::max(const _Tp&, const _Tp&, _Compare)'
  303 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algobase.h:303:5: note:   candidate expects 3 arguments, 2 provided
In file included from /home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/algorithm:61,
                 from ../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwCommon.h:26,
                 from ../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRaster.cpp:25:
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algo.h:5705:5: note: candidate: 'template<class _Tp> constexpr _Tp std::max(initializer_list<_Tp>)'
 5705 |     max(initializer_list<_Tp> __l)
      |     ^~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algo.h:5705:5: note:   candidate expects 1 argument, 2 provided
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algo.h:5715:5: note: candidate: 'template<class _Tp, class _Compare> constexpr _Tp std::max(initializer_list<_Tp>, _Compare)'
 5715 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algo.h:5715:5: note:   template argument deduction/substitution failed:
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h:807:27: note:   mismatched types 'std::initializer_list<_Tp>' and 'int'
  807 |     auto yStart = std::max(static_cast<int>(ys), bbox.min.y);
      |                   ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h:808:25: error: no matching function for call to 'min(int, const int32_t&)'
  808 |     auto yEnd = std::min(static_cast<int>(ye), bbox.max.y);
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algobase.h:233:5: note: candidate: 'template<class _Tp> constexpr const _Tp& std::min(const _Tp&, const _Tp&)'
  233 |     min(const _Tp& __a, const _Tp& __b)
      |     ^~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algobase.h:233:5: note:   template argument deduction/substitution failed:
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h:808:25: note:   deduced conflicting types for parameter 'const _Tp' ('int' and 'int32_t' {aka 'long int'})
  808 |     auto yEnd = std::min(static_cast<int>(ye), bbox.max.y);
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algobase.h:281:5: note: candidate: 'template<class _Tp, class _Compare> constexpr const _Tp& std::min(const _Tp&, const _Tp&, _Compare)'
  281 |     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algobase.h:281:5: note:   candidate expects 3 arguments, 2 provided
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algo.h:5685:5: note: candidate: 'template<class _Tp> constexpr _Tp std::min(initializer_list<_Tp>)'
 5685 |     min(initializer_list<_Tp> __l)
      |     ^~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algo.h:5685:5: note:   candidate expects 1 argument, 2 provided
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algo.h:5695:5: note: candidate: 'template<class _Tp, class _Compare> constexpr _Tp std::min(initializer_list<_Tp>, _Compare)'
 5695 |     min(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
/home/jackson/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/xtensa-esp-elf/include/c++/14.2.0/bits/stl_algo.h:5695:5: note:   template argument deduction/substitution failed:
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h:808:25: note:   mismatched types 'std::initializer_list<_Tp>' and 'int'
  808 |     auto yEnd = std::min(static_cast<int>(ye), bbox.max.y);
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h: At global scope:
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h:727:13: warning: 'void _apply(SwSurface*, AASpans*)' defined but not used [-Wunused-function]
  727 | static void _apply(SwSurface* surface, AASpans* aaSpans)
      |             ^~~~~~
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h:522:17: warning: 'AASpans* _AASpans(int, int)' defined but not used [-Wunused-function]
  522 | static AASpans* _AASpans(int yStart, int yEnd)
      |                 ^~~~~~~~
../../../../components/esp-thorvg/thorvg/src/renderer/sw_engine/tvgSwRasterTexmap.h:346:13: warning: 'void _rasterPolygonImage(SwSurface*, const SwImage&, const tvg::RenderRegion&, Polygon&, AASpans*, uint8_t)' defined but not used [-Wunused-function]
  346 | static void _rasterPolygonImage(SwSurface* surface, const SwImage& image, const RenderRegion& bbox, Polygon& polygon, AASpans* aaSpans, uint8_t opacity)
      |             ^~~~~~~~~~~~~~~~~~~
[32/46] Compiling C++ object src/libthorvg.a.p/loaders_svg_tvgSvgLoader.cpp.o
ninja: build stopped: subcommand failed.
ninja: build stopped: subcommand failed.
```

However it doesn't show up on my macOS host or Linux host, with host's LLVM or GCC. 

I've also seen other RISC-V chips have similar stricter rules on `std::min()` and `std::max()`, and this fix shouldn't cause other side effects, so I decide to push this as a PR to fix in the upstream.

Regards,
Jackson 