### PR TITLE
sw_engine: improve drop shadow stabilization

### DIFF
--- a/src/renderer/sw_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/sw_engine/tvgSwPostEffect.cpp
@@ -465,6 +465,7 @@ bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffe
     //draw to the intermediate surface
     rasterClear(surface[1], bbox.min.x, bbox.min.y, w, h);
     _dropShadowShift(buffer[1]->buf32, cmp->image.buf32, buffer[1]->stride, cmp->image.stride, buffer[1]->w, buffer[1]->h, bbox, data->offset, opacity, direct);
+    std::swap(cmp->image.buf32, buffer[1]->buf32);
 
     //compositing shadow and body
     auto s = buffer[0]->buf32 + (bbox.min.y * buffer[0]->stride + bbox.min.x);

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -794,7 +794,7 @@ bool SwRenderer::render(RenderCompositor* cmp, const RenderEffect* effect, bool 
         }
         case SceneEffect::DropShadow: {
             auto cmp1 = request(surface->channelSize, true);
-            cmp1->compositor->valid = false;
+            cmp1->compositor->valid = false;   //prevent a conflict with cmp2 request.
             auto cmp2 = request(surface->channelSize, true);
             SwSurface* surfaces[] = {cmp1, cmp2};
             auto ret = effectDropShadow(p, surfaces, static_cast<const RenderEffectDropShadow*>(effect), direct);


### PR DESCRIPTION
Injected missing buffer swapping to
preserve non-direct drawing operations.

issue: https://github.com/thorvg/thorvg/issues/3814