### PR TITLE
API: Revised Paint destruction for v1.0

### DIFF
--- a/examples/Capi.cpp
+++ b/examples/Capi.cpp
@@ -172,7 +172,7 @@ void contents()
         Tvg_Paint pict = tvg_picture_new();
         if (tvg_picture_load(pict, EXAMPLE_DIR"/svg/tiger.svg") != TVG_RESULT_SUCCESS) {
             printf("Problem with loading an svg file\n");
-            tvg_paint_del(pict);
+            tvg_paint_rel(pict);
         } else {
             float w, h;
             tvg_picture_get_size(pict, &w, &h);

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -343,9 +343,10 @@ struct Matrix
  */
 class TVG_API Paint
 {
-public:
+protected:
     virtual ~Paint();
 
+public:
     /**
      * @brief Retrieves the parent paint object.
      *
@@ -674,6 +675,18 @@ public:
      * @note Experimental API
      */
     uint32_t id = 0;
+
+    /**
+     * @brief Safely releases a Paint object.
+     *
+     * This is the counterpart to the `gen()` API, and releases the given Paint object safely, 
+     * handling @c nullptr and managing ownership properly.
+     *
+     * @param[in] paint A Paint object to release.
+     *
+     * @since 1.0
+     */
+    static void rel(Paint* paint) noexcept;
 
     _TVG_DECLARE_PRIVATE_BASE(Paint);
 };
@@ -1463,7 +1476,12 @@ public:
     /**
      * @brief Creates a new Shape object.
      *
-     * @return A new Shape object.
+     * This function allocates and returns a new Shape instance.
+     * To properly destroy the Shape object, use @ref Paint::rel().
+     *
+     * @return A pointer to the newly created Shape object.
+     *
+     * @see Paint::rel()
      */
     static Shape* gen() noexcept;
 
@@ -1659,7 +1677,12 @@ public:
     /**
      * @brief Creates a new Picture object.
      *
-     * @return A new Picture object.
+     * This function allocates and returns a new Picture instance.
+     * To properly destroy the Picture object, use @ref Paint::rel().
+     *
+     * @return A pointer to the newly created Picture object.
+     *
+     * @see Paint::rel()
      */
     static Picture* gen() noexcept;
 
@@ -1764,7 +1787,12 @@ public:
     /**
      * @brief Creates a new Scene object.
      *
-     * @return A new Scene object.
+     * This function allocates and returns a new Scene instance.
+     * To properly destroy the Scene object, use @ref Paint::rel().
+     *
+     * @return A pointer to the newly created Scene object.
+     *
+     * @see Paint::rel()
      */
     static Scene* gen() noexcept;
 
@@ -2026,7 +2054,12 @@ public:
     /**
      * @brief Creates a new Text object.
      *
-     * @return A new Text object.
+     * This function allocates and returns a new Text instance.
+     * To properly destroy the Text object, use @ref Paint::rel().
+     *
+     * @return A pointer to the newly created Text object.
+     *
+     * @see Paint::rel()
      *
      * @since 0.15
      */

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -740,16 +740,16 @@ TVG_API Tvg_Result tvg_canvas_set_viewport(Tvg_Canvas canvas, int32_t x, int32_t
 /************************************************************************/
 /* Paint API                                                            */
 /************************************************************************/
-/*!
-* @brief Releases the given Tvg_Paint object.
-*
-* @param[in] paint The Tvg_Paint object to be released.
-*
-* @retval TVG_RESULT_INVALID_ARGUMENT An invalid Tvg_Paint pointer.
-*
-* @see tvg_canvas_remove()
-*/
-TVG_API Tvg_Result tvg_paint_del(Tvg_Paint paint);
+
+/**
+ * @brief Safely releases a Tv_Paint object.
+ *
+ * This is the counterpart to the `new()` API, and releases the given Paint object safely, 
+ * handling @c nullptr and managing ownership properly.
+ *
+ * @param[in] paint A Tvg_Paint object to release.
+ */
+TVG_API Tvg_Result tvg_paint_rel(Tvg_Paint paint);
 
 
 /**
@@ -1157,11 +1157,17 @@ TVG_API Tvg_Result tvg_paint_set_blend_method(Tvg_Paint paint, Tvg_Blend_Method 
 /************************************************************************/
 /* Shape API                                                            */
 /************************************************************************/
-/*!
-* @brief Creates a new shape object.
-*
-* @return A new shape object.
-*/
+
+/**
+ * @brief Creates a new Shape object.
+ *
+ * This function allocates and returns a new Shape instance.
+ * To properly destroy the Shape object, use @ref tvg_paint_rel().
+ *
+ * @return A pointer to the newly created Shape object.
+ *
+ * @see tvg_paint_rel()
+ */
 TVG_API Tvg_Paint tvg_shape_new(void);
 
 
@@ -1902,11 +1908,17 @@ TVG_API Tvg_Result tvg_gradient_del(Tvg_Gradient grad);
 /************************************************************************/
 /* Picture API                                                          */
 /************************************************************************/
-/*!
-* @brief Creates a new picture object.
-*
-* @return A new picture object.
-*/
+
+/**
+ * @brief Creates a new Picture object.
+ *
+ * This function allocates and returns a new Picture instance.
+ * To properly destroy the Picture object, use @ref tvg_paint_rel().
+ *
+ * @return A pointer to the newly created Picture object.
+ *
+ * @see tvg_paint_rel()
+ */
 TVG_API Tvg_Paint tvg_picture_new(void);
 
 
@@ -2109,13 +2121,17 @@ TVG_API const Tvg_Paint tvg_picture_get_paint(Tvg_Paint picture, uint32_t id);
 /************************************************************************/
 /* Scene API                                                            */
 /************************************************************************/
-/*!
-* @brief Creates a new scene object.
-*
-* A scene object is used to group many paints into one object, which can be manipulated using TVG APIs.
-*
-* @return A new scene object.
-*/
+
+/**
+ * @brief Creates a new Scene object.
+ *
+ * This function allocates and returns a new Scene instance.
+ * To properly destroy the Scene object, use @ref tvg_paint_rel().
+ *
+ * @return A pointer to the newly created Scene object.
+ *
+ * @see tvg_paint_rel()
+ */
 TVG_API Tvg_Paint tvg_scene_new(void);
 
 
@@ -2297,13 +2313,19 @@ TVG_API Tvg_Result tvg_scene_push_effect_tritone(Tvg_Paint scene, int shadow_r, 
 /************************************************************************/
 /* Text API                                                            */
 /************************************************************************/
-/*!
-* @brief Creates a new text object.
-*
-* @return A new text object.
-*
-* @since 0.15
-*/
+
+/**
+ * @brief Creates a new Text object.
+ *
+ * This function allocates and returns a new Text instance.
+ * To properly destroy the Text object, use @ref tvg_paint_rel().
+ *
+ * @return A pointer to the newly created Text object.
+ *
+ * @see tvg_paint_rel()
+ *
+ * @since 0.15
+ */
 TVG_API Tvg_Paint tvg_text_new(void);
 
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -170,13 +170,10 @@ TVG_API const Tvg_Paint tvg_paint_get_parent(const Tvg_Paint paint)
 }
 
 
-TVG_API Tvg_Result tvg_paint_del(Tvg_Paint paint)
+TVG_API Tvg_Result tvg_paint_rel(Tvg_Paint paint)
 {
-    if (paint) {
-        delete(reinterpret_cast<Paint*>(paint));
-        return TVG_RESULT_SUCCESS;
-    }
-    return TVG_RESULT_INVALID_ARGUMENT;
+    Paint::rel(reinterpret_cast<Paint*>(paint));
+    return TVG_RESULT_SUCCESS;
 }
 
 

--- a/src/common/tvgCommon.h
+++ b/src/common/tvgCommon.h
@@ -87,9 +87,6 @@ namespace tvg {
 
     uint16_t THORVG_VERSION_NUMBER();
 
-    #define TVG_DELETE(PAINT) \
-    if (PAINT->refCnt() == 0) delete(PAINT)
-
     extern int engineInit;
 }
 

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -416,7 +416,7 @@ void LottieBuilder::appendRect(Shape* shape, Point& pos, Point& size, float r, b
 
     if (ctx->offset) {
         ctx->offset->modifyRect(SHAPE(temp)->rs.path, SHAPE(shape)->rs.path);
-        delete(temp);
+        Paint::rel(temp);
     }
 }
 
@@ -1182,8 +1182,8 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
         }
     }
 
-    delete(scene);
-    delete(textGroup);
+    Paint::rel(scene);
+    Paint::rel(textGroup);
 }
 
 
@@ -1259,7 +1259,7 @@ bool LottieBuilder::updateMatte(LottieComposition* comp, float frameNo, Scene* s
         layer->scene->mask(target->scene, layer->matteType);
     } else if (layer->matteType == MaskMethod::Alpha || layer->matteType == MaskMethod::Luma) {
         //matte target is not exist. alpha blending definitely bring an invisible result
-        delete(layer->scene);
+        Paint::rel(layer->scene);
         layer->scene = nullptr;
         return false;
     }

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -707,7 +707,7 @@ bool LottieLayer::assign(const char* layer, uint32_t ix, const char* var, float 
 
 LottieComposition::~LottieComposition()
 {
-    if (!initiated && root) delete(root->scene);
+    if (!initiated && root) Paint::rel(root->scene);
 
     delete(root);
     tvg::free(version);

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3824,7 +3824,7 @@ void SvgLoader::clear(bool all)
 
     if (copy) tvg::free((char*)content);
 
-    delete(root);
+    Paint::rel(root);
     root = nullptr;
 
     size = 0;

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -266,7 +266,7 @@ static bool _applyClip(SvgLoaderData& loaderData, Paint* paint, const SvgNode* n
         clipper->transform(finalTransform);
         paint->clip(clipper);
     } else {
-        delete(clipper);
+        Paint::rel(clipper);
     }
 
     node->style->clipPath.applying = false;
@@ -286,7 +286,7 @@ static Paint* _applyComposition(SvgLoaderData& loaderData, Paint* paint, const S
 
     if (!clipNode && !maskNode) return paint;
     if ((clipNode && clipNode->child.empty()) || (maskNode && maskNode->child.empty())) {
-        delete(paint);
+        Paint::rel(paint);
         return nullptr;
     }
 
@@ -295,7 +295,7 @@ static Paint* _applyComposition(SvgLoaderData& loaderData, Paint* paint, const S
 
     if (clipNode) {
         if (!_applyClip(loaderData, scene, node, clipNode, vBox, svgPath)) {
-            delete(scene);
+            Paint::rel(scene);
             return nullptr;
         }
     }

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -300,6 +300,12 @@ Paint :: Paint() = default;
 Paint :: ~Paint() = default;
 
 
+void Paint::rel(Paint* paint) noexcept
+{
+    if (paint && paint->refCnt() <= 0) delete(paint);
+}
+
+
 Result Paint::rotate(float degree) noexcept
 {
     if (pImpl->rotate(degree)) return Result::Success;

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -76,7 +76,7 @@ struct PictureImpl : Picture
     {
         LoaderMgr::retrieve(loader);
         tvg::free(resolver);
-        delete(vector);
+        Paint::rel(vector);
     }
 
     bool skip(RenderUpdateFlag flag)

--- a/src/renderer/tvgSaver.cpp
+++ b/src/renderer/tvgSaver.cpp
@@ -107,7 +107,7 @@ Result Saver::save(Paint* paint, const char* filename, uint32_t quality) noexcep
 
     //Already on saving another resource.
     if (pImpl->saveModule) {
-        TVG_DELETE(paint);
+        Paint::rel(paint);
         return Result::InsufficientCondition;
     }
 
@@ -116,12 +116,12 @@ Result Saver::save(Paint* paint, const char* filename, uint32_t quality) noexcep
             pImpl->saveModule = saveModule;
             return Result::Success;
         } else {
-            TVG_DELETE(paint);
+            Paint::rel(paint);
             delete(saveModule);
             return Result::Unknown;
         }
     }
-    TVG_DELETE(paint);
+    Paint::rel(paint);
     return Result::NonSupport;
 }
 

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -55,7 +55,7 @@ struct TextImpl : Text
             loader->release(fm);
             LoaderMgr::retrieve(loader);
         }
-        delete(shape);
+        Paint::rel(shape);
     }
 
     Result text(const char* utf8)

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -321,20 +321,20 @@ TEST_CASE("Intersection", "[tvgPaint]")
 
 TEST_CASE("Duplication", "[tvgPaint]")
 {
-    vector<unique_ptr<Paint>> paints;
+    vector<Paint*> paints;
 
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
-    paints.push_back(std::move(shape));
+    paints.push_back(shape);
 
     REQUIRE(Text::load(TEST_DIR"/Arial.ttf") == Result::Success);
-    auto text = unique_ptr<Text>(Text::gen());
+    auto text = Text::gen();
     REQUIRE(text);
     REQUIRE(text->font("Arial") == Result::Success);
     REQUIRE(text->size(32) == Result::Success);
     REQUIRE(text->text("Original Text") == Result::Success);
     REQUIRE(text->fill(255, 0, 0) == Result::Success);
-    paints.push_back(std::move(text));
+    paints.push_back(text);
 
     for (auto& paint : paints) {
         //Setup paint properties
@@ -348,7 +348,7 @@ TEST_CASE("Duplication", "[tvgPaint]")
         REQUIRE(paint->clip(comp) == Result::Success);
 
         //Duplication
-        auto dup = unique_ptr<Paint>(paint->duplicate());
+        auto dup = paint->duplicate();
         REQUIRE(dup);
 
         //Compare properties
@@ -364,6 +364,13 @@ TEST_CASE("Duplication", "[tvgPaint]")
         REQUIRE(m.e31 == Approx(0.0f).margin(0.000001));
         REQUIRE(m.e32 == Approx(0.0f).margin(0.000001));
         REQUIRE(m.e33 == Approx(1.0f).margin(0.000001));
+
+        Paint::rel(dup);
+    }
+
+    //release
+    for (auto p : paints) {
+        Paint::rel(p);
     }
 }
 


### PR DESCRIPTION
ThorVG APIs had a weakness where users could delete Paint objects directly using C++ delete(), bypassing internal canvas management. To ensure consistent and safe management of Paint instances, a dedicated API Paint::rel() has been introduced. This API safely
releases Paint objects and handles nullptr gracefully. Direct use of delete on Paint instances is now prohibited.

**C++ API:**
 \+ void Paint::rel(Paint* paint)

**C API:**
 \* Tvg_Result tvg_paint_del(Tvg_Paint paint) -> Tvg_Result tvg_paint_rel(Tvg_Paint paint)

issue: https://github.com/thorvg/thorvg/issues/3116
issue: https://github.com/thorvg/thorvg/issues/3782