### PR TITLE
cross: Add macOS cross-compilation files

### DIFF
--- a/cross/macos_arm64.txt
+++ b/cross/macos_arm64.txt
@@ -1,0 +1,22 @@
+# build for macOS Apple Silicon
+
+[binaries]
+cpp = ['clang++', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk']
+ar = 'ar'
+strip = 'strip'
+
+[properties]
+root = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer'
+has_function_printf = true
+
+[built-in options]
+cpp_args = ['-mmacosx-version-min=10.14']
+cpp_link_args = ['-mmacosx-version-min=10.14']
+
+[host_machine]
+system = 'darwin'
+subsystem = 'macos'
+kernel = 'xnu'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'

--- a/cross/macos_x86_64.txt
+++ b/cross/macos_x86_64.txt
@@ -1,0 +1,22 @@
+# build for macOS Intel
+
+[binaries]
+cpp = ['clang++', '-arch', 'x86_64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk']
+ar = 'ar'
+strip = 'strip'
+
+[properties]
+root = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer'
+has_function_printf = true
+
+[built-in options]
+cpp_args = ['-mmacosx-version-min=10.14']
+cpp_link_args = ['-mmacosx-version-min=10.14']
+
+[host_machine]
+system = 'darwin'
+subsystem = 'macos'
+kernel = 'xnu'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'


### PR DESCRIPTION
## Summary
This PR adds Meson cross-compilation configuration files for macOS builds, supporting both Apple Silicon and Intel architectures.

**This PR is a prerequisite for [thorvg/thorvg.flutter#32](https://github.com/thorvg/thorvg.flutter/pull/32)**, which adds macOS platform support to the ThorVG Flutter plugin.

## Motivation
These configuration files are needed to support macOS builds in [thorvg.flutter](https://github.com/thorvg/thorvg.flutter), enabling Flutter developers to use ThorVG on macOS platforms.

## Changes
- Added `cross/macos_arm64.txt` for Apple Silicon (M1/M2/M3) builds
- Added `cross/macos_x86_64.txt` for Intel x86_64 builds

## Related
- **Enables**: [thorvg/thorvg.flutter#32 - Add macOS platform support](https://github.com/thorvg/thorvg.flutter/pull/32)
- This follows the same pattern as existing cross-compilation files (iOS, Android, WASM)
- Required for thorvg.flutter macOS platform support