### PR TITLE
gl_engine/tessellator: Improve stroke tessellation quality

### DIFF
--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -134,6 +134,14 @@ static inline float scaling(const Matrix& m)
 }
 
 
+static inline Point scaling2D(const Matrix& m)
+{
+    auto sx = sqrtf(m.e11 * m.e11 + m.e21 * m.e21);
+    auto sy = sqrtf(m.e12 * m.e12 + m.e22 * m.e22);
+    return {sx, sy};
+}
+
+
 static inline void scale(Matrix* m, const Point& p)
 {
     m->e11 *= p.x;

--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -65,6 +65,7 @@ void Stroker::run(const RenderPath& path, const Matrix& m)
 {
     mBuffer->vertex.reserve(path.pts.count * 4 + 16);
     mBuffer->index.reserve(path.pts.count * 3);
+    mScale = tvg::scaling2D(m);
 
     auto validStrokeCap = false;
     auto pts = path.pts.data;
@@ -251,7 +252,7 @@ void Stroker::round(const Point &prev, const Point& curr, const Point& center)
     mRightBottom.y = std::max(mRightBottom.y, std::max(center.y, std::max(prev.y, curr.y)));
 
     // Fixme: just use bezier curve to calculate step count
-    auto count = Bezier(prev, curr, radius()).segments();
+    auto count = Bezier(prev * mScale, curr * mScale, radius() * length(mScale)).segments();
     auto c = _pushVertex(mBuffer->vertex, center.x, center.y);
     auto pi = _pushVertex(mBuffer->vertex, prev.x, prev.y);
     auto step = 1.f / (count - 1);

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -71,6 +71,7 @@ private:
     State mState = {};
     Point mLeftTop = {0.0f, 0.0f};
     Point mRightBottom = {0.0f, 0.0f};
+    Point mScale;
 };
 
 class BWTessellator


### PR DESCRIPTION
## Summary
This patch partially resolves issue [#3665](https://github.com/thorvg/thorvg/issues/3665)
 by improving stroke tessellation quality in the GL engine.
The updated algorithm produces smoother and more accurate stroke rendering, achieving visual results closer to the WebGPU engine.
<img width="456" height="403.5" alt="Screenshot 2025-10-21 at 1 47 19 AM" src="https://github.com/user-attachments/assets/e963ce31-ffbf-4cea-ac8d-0907b51c8adb" />

### Changes

- Improved segment count calculation in the tessellation join process.

- Updated the member function `lineTo` and `close` to imitate `cubicTo` logic, passing the Transform matrix as a parameter to `round` to ensure proper segment computation.

### Current Status

Fixes the basic stroke quality problem described in #3665.

The odd–even rendering issue mentioned in [#3668](https://github.com/thorvg/thorvg/issues/3668)
 remains and will be addressed in a future patch.

### Related Issues

Partially resolves: #3665 (GL/WG: poor stroke quality)

Related: #3668 (Engines: excessive stroke width causes visual inconsistency)