### PR TITLE
engines: add missing colorspace information

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -721,7 +721,6 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
             case MaskMethod::Darken: program = mPrograms[RT_MaskDarken]; break;
             default: break;
         }
-
         if (program && !selfPass->isEmpty() && !maskPass->isEmpty()) {
             auto prev_task = maskPass->endRenderPass<GlComposeTask>(nullptr, currentPass()->getFboId());
             prev_task->setDrawDepth(currentPass()->nextDrawDepth());
@@ -741,11 +740,9 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
             compose_task->setParentSize(currentPass()->getViewport().w(), currentPass()->getViewport().h());
             currentPass()->addRenderTask(compose_task);
         }
-
         delete(selfPass);
         delete(maskPass);
-    } else
-    if (glCmp->blendMethod != BlendMethod::Normal) {
+    } else if (glCmp->blendMethod != BlendMethod::Normal) {
         auto renderPass = mRenderPassStack.last();
         mRenderPassStack.pop();
 
@@ -774,8 +771,7 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
             currentPass()->addRenderTask(std::move(task));
         }
         delete(renderPass);
-    } else
-    {
+    } else {
         auto renderPass = mRenderPassStack.last();
         mRenderPassStack.pop();
 
@@ -830,7 +826,7 @@ bool GlRenderer::clear()
 }
 
 
-bool GlRenderer::target(void* context, int32_t id, uint32_t w, uint32_t h)
+bool GlRenderer::target(void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs)
 {
     //assume the context zero is invalid
     if (!context || w == 0 || h == 0) return false;
@@ -842,6 +838,7 @@ bool GlRenderer::target(void* context, int32_t id, uint32_t w, uint32_t h)
     surface.stride = w;
     surface.w = w;
     surface.h = h;
+    surface.cs = cs;
 
     mContext = context;
     mTargetFboId = static_cast<GLint>(id);
@@ -1029,7 +1026,7 @@ void GlRenderer::dispose(RenderEffect* effect)
 
 ColorSpace GlRenderer::colorSpace()
 {
-    return ColorSpace::Unknown;
+    return surface.cs;
 }
 
 

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -145,7 +145,7 @@ public:
     bool clear() override;
     bool intersectsShape(RenderData data, const RenderRegion& region) override;
     bool intersectsImage(RenderData data, const RenderRegion& region) override;
-    bool target(void* context, int32_t id, uint32_t w, uint32_t h);
+    bool target(void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs);
 
     //composition
     RenderCompositor* target(const RenderRegion& region, ColorSpace cs, CompositionFlag flags) override;

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -188,7 +188,7 @@ Result GlCanvas::target(void* context, int32_t id, uint32_t w, uint32_t h, Color
     auto renderer = static_cast<GlRenderer*>(pImpl->renderer);
     if (!renderer) return Result::MemoryCorruption;
 
-    if (!renderer->target(context, id, w, h)) return Result::Unknown;
+    if (!renderer->target(context, id, w, h, cs)) return Result::Unknown;
     pImpl->vport = {{0, 0}, {(int32_t)w, (int32_t)h}};
     renderer->viewport(pImpl->vport);
 
@@ -227,7 +227,7 @@ WgCanvas::~WgCanvas()
 {
 #ifdef THORVG_WG_RASTER_SUPPORT
     auto renderer = static_cast<WgRenderer*>(pImpl->renderer);
-    renderer->target(nullptr, nullptr, nullptr, 0, 0);
+    renderer->target(nullptr, nullptr, nullptr, 0, 0, ColorSpace::Unknown);
 
     WgRenderer::term();
 #endif
@@ -247,7 +247,7 @@ Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, 
     auto renderer = static_cast<WgRenderer*>(pImpl->renderer);
     if (!renderer) return Result::MemoryCorruption;
 
-    if (!renderer->target((WGPUDevice)device, (WGPUInstance)instance, target, w, h, type)) return Result::Unknown;
+    if (!renderer->target((WGPUDevice)device, (WGPUInstance)instance, target, w, h, cs, type)) return Result::Unknown;
     pImpl->vport = {{0, 0}, {(int32_t)w, (int32_t)h}};
     renderer->viewport(pImpl->vport);
 

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -47,7 +47,7 @@ public:
     bool sync() override;
     bool intersectsImage(RenderData data, const RenderRegion& region) override;
     bool intersectsShape(RenderData data, const RenderRegion& region) override;
-    bool target(WGPUDevice device, WGPUInstance instance, void* target, uint32_t width, uint32_t height, int type = 0);
+    bool target(WGPUDevice device, WGPUInstance instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0);
 
     //composition
     RenderCompositor* target(const RenderRegion& region, ColorSpace cs, CompositionFlag flags) override;


### PR DESCRIPTION
Properly retain the requested colorspace information for each engine. Although these colorspaces are not currently utilized by gl, wg engines themselves, this information may be required by image loaders to target a specific colorspace.