### PR TITLE
svg: share the loader using paint reference.

### DIFF
--- a/examples/PictureSvg.cpp
+++ b/examples/PictureSvg.cpp
@@ -30,24 +30,36 @@ struct UserExample : tvgexam::Example
 {
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        //default font for fallback in case
-        tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf");
+        auto opacity = 36;
 
-        //Background
-        auto bg = tvg::Shape::gen();
-        bg->appendRect(0, 0, w, h);    //x, y, w, h
-        bg->fill(255, 255, 255);       //r, g, b
-        canvas->push(bg);
+        //Load svg file from path
+        for (int i = 0; i < 7; ++i) {
+            auto picture = tvg::Picture::gen();
+            if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/svg/logo.svg"))) return false;
+            picture->translate(i* 150, i * 150);
+            picture->rotate(30 * i);
+            picture->size(200, 200);
+            picture->opacity(opacity + opacity * i);
+            canvas->push(picture);
+        }
+
+        //Open file manually
+        ifstream file(EXAMPLE_DIR"/svg/logo.svg", ios::binary);
+        if (!file.is_open()) return false;
+        auto begin = file.tellg();
+        file.seekg(0, std::ios::end);
+        auto size = file.tellg() - begin;
+        auto data = (char*)malloc(size);
+        file.seekg(0, std::ios::beg);
+        file.read(data, size);
+        file.close();
 
         auto picture = tvg::Picture::gen();
-        if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/svg/logo.svg"))) return false;
+        if (!tvgexam::verify(picture->load(data, size, "svg", "", true))) return false;
 
-        float w2, h2;
-        picture->size(&w2, &h2);
-        picture->origin(0.5f, 0.5f);
-        picture->scale((w2 > h2) ? w / w2 : h / h2);
-        picture->translate(w / 2, h / 2);
-
+        free(data);
+        picture->translate(400, 0);
+        picture->scale(0.4);
         canvas->push(picture);
 
         return true;

--- a/src/renderer/tvgAccessor.cpp
+++ b/src/renderer/tvgAccessor.cpp
@@ -60,7 +60,7 @@ Result Accessor::set(Paint* paint, function<bool(const Paint* paint, void* data)
 
     //Root
     if (!func(paint, data)) {
-        paint->unref();
+        paint->unref(false);
         return Result::Success;
     }
 

--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -277,10 +277,10 @@ LoadModule* LoaderMgr::loader(const char* filename, bool* invalid)
 #ifdef THORVG_FILE_IO_SUPPORT
     *invalid = false;
 
-    //TODO: svg & lottie is not sharable.
+    //TODO: make lottie sharable.
     auto allowCache = true;
     auto ext = fileext(filename);
-    if (ext && (!strcmp(ext, "svg") || !strcmp(ext, "json") || !strcmp(ext, "lot"))) allowCache = false;
+    if (ext && (!strcmp(ext, "json") || !strcmp(ext, "lot"))) allowCache = false;
 
     if (allowCache) {
         if (auto loader = _findFromCache(filename)) return loader;
@@ -333,7 +333,7 @@ LoadModule* LoaderMgr::loader(const char* data, uint32_t size, const char* mimeT
     //Thus caching is only valid for shareable.
     auto allowCache = !copy;
 
-    //TODO: lottie is not sharable.
+    //TODO: make lottie shareable.
     if (allowCache) {
         auto type = _convert(mimeType);
         if (type == FileType::Lot) allowCache = false;

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -76,7 +76,7 @@ struct PictureImpl : Picture
     {
         LoaderMgr::retrieve(loader);
         tvg::free(resolver);
-        Paint::rel(vector);
+        if (vector) vector->unref();
     }
 
     bool skip(RenderUpdateFlag flag)
@@ -249,6 +249,7 @@ struct PictureImpl : Picture
             if (vector) {
                 loader->sync();
             } else if ((vector = loader->paint())) {
+                vector->ref();
                 PAINT(vector)->parent = this;
                 if (w != loader->w || h != loader->h) {
                     if (!resizing) {

--- a/test/testAccessor.cpp
+++ b/test/testAccessor.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Set", "[tvgAccessor]")
         uint32_t buffer[100*100];
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
-        auto picture = unique_ptr<Picture>(Picture::gen());
+        auto picture = Picture::gen();
         REQUIRE(picture);
         REQUIRE(picture->load(TEST_DIR"/logo.svg") == Result::Success);
 
@@ -56,7 +56,7 @@ TEST_CASE("Set", "[tvgAccessor]")
         REQUIRE(accessor);
 
         //Case 1
-        REQUIRE(accessor->set(picture.get(), nullptr, nullptr) == Result::InvalidArguments);
+        REQUIRE(accessor->set(picture, nullptr, nullptr) == Result::InvalidArguments);
 
         //Case 2
         Shape* ret = nullptr;
@@ -77,9 +77,10 @@ TEST_CASE("Set", "[tvgAccessor]")
             return true;
         };
 
-        REQUIRE(accessor->set(picture.get(), f, &ret) == Result::Success);
-
+        REQUIRE(accessor->set(picture, f, &ret) == Result::Success);
         REQUIRE((ret && ret->id == Accessor::id("TestAccessor")));
+
+        Picture::rel(picture);
     }
     REQUIRE(Initializer::term() == Result::Success);
 }

--- a/test/testAnimation.cpp
+++ b/test/testAnimation.cpp
@@ -257,7 +257,7 @@ TEST_CASE("Animation Lottie11", "[tvgAnimation]")
         file.seekg(0, ios::beg);
         file.read(data, size);
         file.close();
-        REQUIRE(picture->load(data, size, "json", "", true) == Result::Success);
+        REQUIRE(picture->load(data, size, "lot", "", true) == Result::Success);
 
         free(data);
     }


### PR DESCRIPTION
Now we have paint reference count, duplicate
svg scene in case of shareable svg.

No need to same svg load from the scratch, much better.