### PR TITLE
test: replace direct destructors with Paint::rel() calls

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -54,6 +54,11 @@ protected: \
 public: \
     Impl* pImpl
 
+#define _TVG_DECLARE_PRIVATE_DERIVE(A) \
+    _TVG_DECLARE_PRIVATE(A); \
+protected: \
+    ~A() {}
+
 #define _TVG_DISABLE_CTOR(A) \
     A() = delete; \
     ~A() = delete
@@ -1496,7 +1501,7 @@ public:
      */
     Type type() const noexcept override;
 
-    _TVG_DECLARE_PRIVATE(Shape);
+    _TVG_DECLARE_PRIVATE_DERIVE(Shape);
 };
 
 
@@ -1698,7 +1703,7 @@ public:
     Type type() const noexcept override;
 
     _TVG_DECLARE_ACCESSOR(Animation);
-    _TVG_DECLARE_PRIVATE(Picture);
+    _TVG_DECLARE_PRIVATE_DERIVE(Picture);
 };
 
 
@@ -1807,7 +1812,7 @@ public:
      */
     Type type() const noexcept override;
 
-    _TVG_DECLARE_PRIVATE(Scene);
+    _TVG_DECLARE_PRIVATE_DERIVE(Scene);
 };
 
 
@@ -2076,7 +2081,7 @@ public:
      */
     Type type() const noexcept override;
 
-    _TVG_DECLARE_PRIVATE(Text);
+    _TVG_DECLARE_PRIVATE_DERIVE(Text);
 };
 
 

--- a/test/testFill.cpp
+++ b/test/testFill.cpp
@@ -83,11 +83,13 @@ TEST_CASE("Common Filling", "[tvgFill]")
     REQUIRE(fill->colorStops(&cs) == 0);
 
     //Set to Shape
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     REQUIRE(shape->fill(fill) == Result::Success);
     REQUIRE(shape->fill() == fill);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Fill Transformation", "[tvgFill]")

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 TEST_CASE("Custom Transformation", "[tvgPaint]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     //Verify default transform
@@ -75,12 +75,14 @@ TEST_CASE("Custom Transformation", "[tvgPaint]")
     REQUIRE(m2.e31 == Approx(m4.e31).margin(0.000001));
     REQUIRE(m2.e32 == Approx(m4.e32).margin(0.000001));
     REQUIRE(m2.e33 == Approx(m4.e33).margin(0.000001));
+
+    Paint::rel(shape);
 }
 
 
 TEST_CASE("Basic Transformation", "[tvgPaint]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     REQUIRE(shape->translate(155.0f, -155.0f) == Result::Success);
@@ -97,11 +99,13 @@ TEST_CASE("Basic Transformation", "[tvgPaint]")
     REQUIRE(m.e31 == Approx(0).margin(0.000001));
     REQUIRE(m.e32 == Approx(0).margin(0.000001));
     REQUIRE(m.e33 == Approx(1).margin(0.000001));
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Opacity", "[tvgPaint]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     REQUIRE(shape->opacity() == 255);
@@ -114,11 +118,13 @@ TEST_CASE("Opacity", "[tvgPaint]")
 
     REQUIRE(shape->opacity(0) == Result::Success);
     REQUIRE(shape->opacity() == 0);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Visibility", "[tvgPaint]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     REQUIRE(shape->visible() == true);
@@ -131,6 +137,8 @@ TEST_CASE("Visibility", "[tvgPaint]")
 
     REQUIRE(shape->visible(true) == Result::Success);
     REQUIRE(shape->visible() == true);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Bounding Box", "[tvgPaint]")
@@ -376,7 +384,7 @@ TEST_CASE("Duplication", "[tvgPaint]")
 
 TEST_CASE("Composition", "[tvgPaint]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     //Negative
@@ -416,11 +424,13 @@ TEST_CASE("Composition", "[tvgPaint]")
 
     REQUIRE(shape->mask(&comp2) == MaskMethod::InvLuma);
     REQUIRE(comp == comp2);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Blending", "[tvgPaint]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     //Add
@@ -458,6 +468,8 @@ TEST_CASE("Blending", "[tvgPaint]")
 
     //SoftLight
     REQUIRE(shape->blend(BlendMethod::SoftLight) == Result::Success);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Refernce Count", "[tvgPaint]")

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -32,15 +32,17 @@ using namespace std;
 
 TEST_CASE("Picture Creation", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     REQUIRE(picture->type() == Type::Picture);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Load RAW Data", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     ifstream file(TEST_DIR"/rawimage_200x300.raw");
@@ -64,6 +66,8 @@ TEST_CASE("Load RAW Data", "[tvgPicture]")
 
     REQUIRE(w == 200);
     REQUIRE(h == 300);
+
+    Paint::rel(picture);
 
     free(data);
 }
@@ -99,7 +103,7 @@ TEST_CASE("Load RAW file and render", "[tvgPicture]")
 
 TEST_CASE("Picture Size", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     float w, h;
@@ -135,11 +139,13 @@ TEST_CASE("Picture Size", "[tvgPicture]")
     REQUIRE(picture->size(w, h) == Result::Success);
 
     free(data);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Picture Duplication", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     //Primary
@@ -152,7 +158,7 @@ TEST_CASE("Picture Duplication", "[tvgPicture]")
     REQUIRE(picture->load(data, 200, 300, ColorSpace::ARGB8888, false) == Result::Success);
     REQUIRE(picture->size(100, 100) == Result::Success);
 
-    auto dup = unique_ptr<Picture>((Picture*)picture->duplicate());
+    auto dup = (Picture*)picture->duplicate();
     REQUIRE(dup);
 
     float w, h;
@@ -161,13 +167,16 @@ TEST_CASE("Picture Duplication", "[tvgPicture]")
     REQUIRE(h == 100);
 
     free(data);
+
+    Paint::rel(dup);
+    Paint::rel(picture);
 }
 
 #ifdef THORVG_SVG_LOADER_SUPPORT
 
 TEST_CASE("Load SVG file", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     //Invalid file
@@ -178,13 +187,15 @@ TEST_CASE("Load SVG file", "[tvgPicture]")
 
     float w, h;
     REQUIRE(picture->size(&w, &h) == Result::Success);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Load SVG Data", "[tvgPicture]")
 {
     static const char* svg = "<svg height=\"1000\" viewBox=\"0 0 1000 1000\" width=\"1000\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M.10681413.09784845 1000.0527.01592069V1000.0851L.06005738 999.9983Z\" fill=\"#ffffff\" stroke-width=\"3.910218\"/><g fill=\"#252f35\"><g stroke-width=\"3.864492\"><path d=\"M256.61221 100.51736H752.8963V386.99554H256.61221Z\"/><path d=\"M201.875 100.51736H238.366478V386.99554H201.875Z\"/><path d=\"M771.14203 100.51736H807.633508V386.99554H771.14203Z\"/></g><path d=\"M420.82388 380H588.68467V422.805317H420.82388Z\" stroke-width=\"3.227\"/><path d=\"m420.82403 440.7101v63.94623l167.86079 25.5782V440.7101Z\"/><path d=\"M420.82403 523.07258V673.47362L588.68482 612.59701V548.13942Z\"/></g><g fill=\"#222f35\"><path d=\"M420.82403 691.37851 588.68482 630.5019 589 834H421Z\"/><path d=\"m420.82403 852.52249h167.86079v28.64782H420.82403v-28.64782 0 0\"/><path d=\"m439.06977 879.17031c0 0-14.90282 8.49429-18.24574 15.8161-4.3792 9.59153 0 31.63185 0 31.63185h167.86079c0 0 4.3792-22.04032 0-31.63185-3.34292-7.32181-18.24574-15.8161-18.24574-15.8161z\"/></g><g fill=\"#ffffff\"><path d=\"m280 140h15v55l8 10 8-10v-55h15v60l-23 25-23-25z\"/><path d=\"m335 140v80h45v-50h-25v10h10v30h-15v-57h18v-13z\"/></g></svg>";
 
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     //Negative cases
@@ -198,6 +209,8 @@ TEST_CASE("Load SVG Data", "[tvgPicture]")
     REQUIRE(picture->size(&w, &h) == Result::Success);
     REQUIRE(w == 1000);
     REQUIRE(h == 1000);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Load SVG file and render", "[tvgPicture]")
@@ -233,7 +246,7 @@ TEST_CASE("Load SVG file and render", "[tvgPicture]")
 
 TEST_CASE("Load PNG file from path", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     //Invalid file
@@ -246,11 +259,13 @@ TEST_CASE("Load PNG file from path", "[tvgPicture]")
 
     REQUIRE(w == 512);
     REQUIRE(h == 512);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Load PNG file from data", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     //Open file
@@ -270,6 +285,8 @@ TEST_CASE("Load PNG file from data", "[tvgPicture]")
     REQUIRE(h == 512);
 
     free(data);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Load PNG file and render", "[tvgPicture]")
@@ -300,7 +317,7 @@ TEST_CASE("Load PNG file and render", "[tvgPicture]")
 
 TEST_CASE("Load JPG file from path", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     //Invalid file
@@ -313,11 +330,13 @@ TEST_CASE("Load JPG file from path", "[tvgPicture]")
 
     REQUIRE(w == 512);
     REQUIRE(h == 512);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Load JPG file from data", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     //Open file
@@ -340,6 +359,8 @@ TEST_CASE("Load JPG file from data", "[tvgPicture]")
     REQUIRE(h == 512);
 
     free(data);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Load JPG file and render", "[tvgPicture]")
@@ -369,7 +390,7 @@ TEST_CASE("Load JPG file and render", "[tvgPicture]")
 
 TEST_CASE("Load WEBP file from path", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     //Invalid file
@@ -382,11 +403,13 @@ TEST_CASE("Load WEBP file from path", "[tvgPicture]")
 
     REQUIRE(w == 512);
     REQUIRE(h == 512);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Load WEBP file from data", "[tvgPicture]")
 {
-    auto picture = unique_ptr<Picture>(Picture::gen());
+    auto picture = Picture::gen();
     REQUIRE(picture);
 
     //Open file
@@ -406,6 +429,8 @@ TEST_CASE("Load WEBP file from data", "[tvgPicture]")
     REQUIRE(h == 512);
 
     free(data);
+
+    Paint::rel(picture);
 }
 
 TEST_CASE("Load WEBP file and render", "[tvgPicture]")

--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -29,15 +29,17 @@ using namespace std;
 
 TEST_CASE("Scene Creation", "[tvgScene]")
 {
-    auto scene = unique_ptr<Scene>(Scene::gen());
+    auto scene = Scene::gen();
     REQUIRE(scene);
 
     REQUIRE(scene->type() == Type::Scene);
+
+    Paint::rel(scene);
 }
 
 TEST_CASE("Pushing Paints Into Scene", "[tvgScene]")
 {
-    auto scene = unique_ptr<Scene>(Scene::gen());
+    auto scene = Scene::gen();
     REQUIRE(scene);
     REQUIRE(scene->parent() == nullptr);
 
@@ -47,32 +49,36 @@ TEST_CASE("Pushing Paints Into Scene", "[tvgScene]")
     paints[0] = Shape::gen();
     REQUIRE(paints[0]->parent() == nullptr);
     REQUIRE(scene->push(paints[0]) == Result::Success);
-    REQUIRE(paints[0]->parent() == scene.get());
+    REQUIRE(paints[0]->parent() == scene);
 
     paints[1] = Picture::gen();
     REQUIRE(paints[1]->parent() == nullptr);
     REQUIRE(scene->push(paints[1]) == Result::Success);
-    REQUIRE(paints[1]->parent() == scene.get());
+    REQUIRE(paints[1]->parent() == scene);
 
     paints[2] = Picture::gen();
     REQUIRE(paints[2]->parent() == nullptr);
     REQUIRE(scene->push(paints[2]) == Result::Success);
-    REQUIRE(paints[2]->parent() == scene.get());
+    REQUIRE(paints[2]->parent() == scene);
 
     //Pushing Null Pointer
     REQUIRE(scene->push(nullptr) == Result::InvalidArguments);
 
     //Pushing Invalid Paint
     REQUIRE(scene->push(nullptr) == Result::InvalidArguments);
+
+    Paint::rel(scene);
 }
 
 TEST_CASE("Scene Clear", "[tvgScene]")
 {
-    auto scene = unique_ptr<Scene>(Scene::gen());
+    auto scene = Scene::gen();
     REQUIRE(scene);
 
     REQUIRE(scene->push(Shape::gen()) == Result::Success);
     REQUIRE(scene->remove() == Result::Success);
+
+    Paint::rel(scene);
 }
 
 TEST_CASE("Scene Clear And Reuse Shape", "[tvgScene]")

--- a/test/testShape.cpp
+++ b/test/testShape.cpp
@@ -29,15 +29,17 @@ using namespace std;
 
 TEST_CASE("Shape Creation", "[tvgShape]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     REQUIRE(shape->type() == Type::Shape);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Appending Commands", "[tvgShape]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     REQUIRE(shape->close() == Result::Success);
@@ -59,11 +61,13 @@ TEST_CASE("Appending Commands", "[tvgShape]")
 
     REQUIRE(shape->reset() == Result::Success);
     REQUIRE(shape->reset() == Result::Success);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Appending Shapes", "[tvgShape]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     REQUIRE(shape->moveTo(100, 100) == Result::Success);
@@ -78,11 +82,13 @@ TEST_CASE("Appending Shapes", "[tvgShape]")
     REQUIRE(shape->appendCircle(0, 0, 0, 0) == Result::Success);
     REQUIRE(shape->appendCircle(-99999999.0f, 99999999.0f, 0, 0, true) == Result::Success);
     REQUIRE(shape->appendCircle(-99999999.0f, 99999999.0f, -99999999.0f, 99999999.0f, false) == Result::Success);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Appending Paths", "[tvgShape]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     //Negative cases
@@ -127,11 +133,13 @@ TEST_CASE("Appending Paths", "[tvgShape]")
     REQUIRE(shape->path(nullptr, &cmds2Cnt, nullptr, &pts2Cnt) == Result::Success);
     REQUIRE(cmds2Cnt == 0);
     REQUIRE(pts2Cnt == 0);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Stroking", "[tvgShape]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     //Stroke Order Before Stroke Setting
@@ -210,11 +218,13 @@ TEST_CASE("Stroking", "[tvgShape]")
     //Stroke Order After Stroke Setting
     REQUIRE(shape->order(true) == Result::Success);
     REQUIRE(shape->order(false) == Result::Success);
+
+    Paint::rel(shape);
 }
 
 TEST_CASE("Shape Filling", "[tvgShape]")
 {
-    auto shape = unique_ptr<Shape>(Shape::gen());
+    auto shape = Shape::gen();
     REQUIRE(shape);
 
     //Fill Color
@@ -231,4 +241,6 @@ TEST_CASE("Shape Filling", "[tvgShape]")
     REQUIRE(shape->fillRule() == FillRule::NonZero);
     REQUIRE(shape->fillRule(FillRule::EvenOdd) == Result::Success);
     REQUIRE(shape->fillRule() == FillRule::EvenOdd);
+
+    Paint::rel(shape);
 }

--- a/test/testText.cpp
+++ b/test/testText.cpp
@@ -33,17 +33,19 @@ using namespace std;
 
 TEST_CASE("Text Creation", "[tvgText]")
 {
-    auto text = unique_ptr<Text>(Text::gen());
+    auto text = Text::gen();
     REQUIRE(text);
 
     REQUIRE(text->type() == Type::Text);
+
+    Paint::rel(text);
 }
 
 TEST_CASE("Load TTF Data from a file", "[tvgText]")
 {
     Initializer::init();
     {
-        auto text = unique_ptr<Text>(Text::gen());
+        auto text = Text::gen();
         REQUIRE(text);
 
         REQUIRE(Text::unload(TEST_DIR"/invalid.ttf") == tvg::Result::InsufficientCondition);
@@ -53,6 +55,8 @@ TEST_CASE("Load TTF Data from a file", "[tvgText]")
         REQUIRE(Text::unload(TEST_DIR"/Arial.ttf") == tvg::Result::Success);
         REQUIRE(Text::load("") == tvg::Result::InvalidArguments);
         REQUIRE(Text::load(TEST_DIR"/NanumGothicCoding.ttf") == tvg::Result::Success);
+
+        Paint::rel(text);
     }
     Initializer::term();
 }
@@ -71,7 +75,7 @@ TEST_CASE("Load TTF Data from a memory", "[tvgText]")
         file.read(data, size);
         file.close();
 
-        auto text = unique_ptr<Text>(Text::gen());
+        auto text = Text::gen();
         REQUIRE(text);
 
         static const char* svg = "<svg height=\"1000\" viewBox=\"0 0 600 600\" ></svg>";
@@ -93,6 +97,8 @@ TEST_CASE("Load TTF Data from a memory", "[tvgText]")
         REQUIRE(Text::load("Arial", nullptr, 111) == Result::Success);
 
         free(data);
+
+        Paint::rel(text);
     }
     Initializer::term();
 }
@@ -101,7 +107,7 @@ TEST_CASE("Text Font", "[tvgText]")
 {
     Initializer::init();
     {
-        auto text = unique_ptr<Text>(Text::gen());
+        auto text = Text::gen();
         REQUIRE(text);
 
         REQUIRE(Text::load(TEST_DIR"/Arial.ttf") == tvg::Result::Success);
@@ -113,6 +119,8 @@ TEST_CASE("Text Font", "[tvgText]")
         REQUIRE(text->size(50) == tvg::Result::Success);
         REQUIRE(text->font(nullptr) == tvg::Result::Success);
         REQUIRE(text->font("InvalidFont") == tvg::Result::InsufficientCondition);
+
+        Paint::rel(text);
     }
     Initializer::term();
 }


### PR DESCRIPTION
now thorvg don't allow destroy paints with manual destructors.