### PR TITLE
lottie: fixed a crash of image slot overriding.

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -899,16 +899,15 @@ void LottieBuilder::updateSolid(LottieLayer* layer)
 void LottieBuilder::updateImage(LottieGroup* layer)
 {
     auto image = static_cast<LottieImage*>(layer->children.first());
-    auto picture = image->pooling(true);
+    auto picture = image->data.picture;
     layer->scene->push(picture);
-    if (image->updated) return;
 
-    if (image->data.size > 0) picture->load((const char*)image->data.b64Data, image->data.size, image->data.mimeType);
-    else if (resolver && resolver->func(picture, image->data.path, resolver->data)) {}
-    else picture->load(image->data.path);
-
-    picture->size(image->data.width, image->data.height);
-    image->updated = true;
+    //resolve an image asset if need
+    if (resolver && !image->resolved) {
+        resolver->func(picture, image->data.path, resolver->data);
+        picture->size(image->data.width, image->data.height);
+        image->resolved = true;
+    }
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -354,20 +354,13 @@ void LottieImage::prepare()
 {
     LottieObject::type = LottieObject::Image;
 
+    //Prepare the Picture image
     auto picture = Picture::gen();
+    auto result = (data.size > 0) ? picture->load((const char*)data.b64Data, data.size, data.mimeType) : picture->load(data.path);
+    if (result == Result::Success) resolved = true;
+    picture->size(data.width, data.height);
+    data.picture = picture;
     picture->ref();
-    pooler.push(picture);
-}
-
-
-void LottieImage::update()
-{
-    //Update the picture data
-    ARRAY_FOREACH(p, pooler) {
-        if (data.size > 0) (*p)->load((const char*)data.b64Data, data.size, data.mimeType);
-        else (*p)->load(data.path);
-        (*p)->size(data.width, data.height);
-    }
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -867,20 +867,18 @@ struct LottieGradientStroke : LottieGradient, LottieStroke
 };
 
 
-struct LottieImage : LottieObject, LottieRenderPooler<tvg::Picture>
+struct LottieImage : LottieObject
 {
     LottieBitmap data;
-    bool updated = false;
+    bool resolved = false;
 
     void override(LottieProperty* prop, bool release = false) override
     {
         if (release) data.release();
         data.copy(*static_cast<LottieBitmap*>(prop), false);
-        update();
     }
 
     void prepare();
-    void update();
 };
 
 

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -973,6 +973,7 @@ struct LottieBitmap : LottieProperty
         char* b64Data = nullptr;
         char* path;
     };
+    Picture *picture = nullptr;
     char* mimeType = nullptr;
     uint32_t size = 0;
     float width = 0.0f;
@@ -992,6 +993,11 @@ struct LottieBitmap : LottieProperty
 
     void release()
     {
+        if (picture) {
+            picture->unref();
+            picture = nullptr;
+        }
+
         tvg::free(b64Data);
         tvg::free(mimeType);
 
@@ -1008,18 +1014,13 @@ struct LottieBitmap : LottieProperty
     {
         if (LottieProperty::copy(&rhs, shallow)) return;
 
-        if (shallow) {
-            b64Data = rhs.b64Data;
-            mimeType = rhs.mimeType;
-            rhs.b64Data = nullptr;
-            rhs.mimeType = nullptr;
-        } else {
-            //TODO: optimize here by avoiding data copy
-            TVGLOG("LOTTIE", "Shallow copy of the image data!");
-            b64Data = duplicate(rhs.b64Data);
-            if (rhs.mimeType) mimeType = duplicate(rhs.mimeType);
+        release();
+
+        if (rhs.picture) {
+            picture = rhs.picture;
+            picture->ref();
         }
-        size = rhs.size;
+
         width = rhs.width;
         height = rhs.height;
     }


### PR DESCRIPTION
Replaced the image object with a Picture object to
efficiently support bitmap data sharing among instances.

This change removes the image pooler entirely.
Now, each bitmap is managed 1:1 with a Picture,
resulting in a cleaner and more straightforward design.