### PR TITLE
wg/gl: fix blur direction param usage

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -538,7 +538,7 @@ void GlGaussianBlurTask::run()
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, mDstFbo->getFboId()));
 
     GL_CHECK(glDisable(GL_BLEND));
-    if (effect->direction == 0) {
+    if ((effect->direction != 1) && (effect->direction != 2)) { // both
         GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, mDstFbo->getFboId()));
         GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mDstCopyFbo1->getResolveFboId()));
         GL_CHECK(glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST));

--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -849,7 +849,7 @@ bool WgCompositor::gaussianBlur(WgContext& context, WgRenderTarget* dst, const R
     auto aabb = compose->aabb;
 
     copyTexture(&targetTemp0, dst);
-    if (params->direction == 0) { // both
+    if ((params->direction != 1) && (params->direction != 2)) { // both
         beginRenderPass(commandEncoder, &targetTemp0); {
             wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
             wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, dst->bindGroupTexture, 0, nullptr);


### PR DESCRIPTION
Currently, the direction parameter, which controls Gaussian blur, can take three values: 0: both, 1: horizontal, 2: vertical

However, in lottie animations, values other than those specified are encountered, for example 255.
We will assume that any value other than 1 or 2 means bidirectional blurring.

issue: https://github.com/thorvg/thorvg/issues/3889