### PR TITLE
wg_engine: introduce ability to combine masking and custom blend

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -30,6 +30,8 @@ struct WgCompose: RenderCompositor
 {
     BlendMethod blend{};
     RenderRegion aabb{};
+    CompositionFlag flags{};
+    bool masked{}; // indicate if composition allocates more than one render target
 };
 
 class WgCompositor


### PR DESCRIPTION
Until now, blending and masking settings couldn't be used simultaneously. 
If a mask was specified for an object, the blending settings were ignored, and the object was blended using the normal settings. 

Now it's possible to use compositions and blending in the same scene. 
This is achieved by reconfiguring the current render targets and render tree. 

This doesn't affect overall performance, but only adds functionality.

sw/ wg(before)/wg(now)
<img width="1304" height="440" alt="image" src="https://github.com/user-attachments/assets/dc05ee97-2640-4c9d-a7b6-acc822a7fc39" />


issue: https://github.com/thorvg/thorvg/issues/3793