### PR TITLE
lottie: Support font asset resolver

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -914,7 +914,7 @@ void LottieBuilder::updateImage(LottieGroup* layer)
 
 
 //TODO: unify with the updateText() building logic
-static void _fontText(TextDocument& doc, Scene* scene)
+static void _fontText(LottieFont* font, TextDocument& doc, Scene* scene, const AssetResolver* resolver)
 {
     auto delim = "\r\n\3";
     auto size = doc.size * 75.0f; //1 pt = 1/72; 1 in = 96 px; -> 72/96 = 0.75
@@ -927,9 +927,10 @@ static void _fontText(TextDocument& doc, Scene* scene)
     auto cnt = 0;
     while (token) {
         auto txt = Text::gen();
-        if (txt->font(doc.name) != Result::Success) {
-            txt->font(nullptr);  //fallback to any available font
-        }
+        if (txt->font(doc.name) == Result::Success) {}
+        else if (resolver && resolver->func(txt, font->path, resolver->data)) {}
+        else txt->font(nullptr);  //fallback to any available font
+
         txt->size(size);
         txt->text(token);
         txt->fill(doc.color.r, doc.color.g, doc.color.b);
@@ -953,7 +954,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
     if (!p || !text->font) return;
 
     if (text->font->origin != LottieFont::Origin::Local || text->font->chars.empty()) {
-        _fontText(doc, layer->scene);
+        _fontText(text->font, doc, layer->scene, resolver);
         return;
     }
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -344,9 +344,9 @@ float LottieTextRange::factor(float frameNo, float totalLen, float idx)
 
 void LottieFont::prepare()
 {
-    if (!data.b64src || !name) return;
+    if (!b64src) return;
 
-    Text::load(name, data.b64src, data.size, "ttf", false);
+    Text::load(name, b64src, size, "ttf", false);
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -396,18 +396,19 @@ struct LottieFont
         tvg::free(style);
         tvg::free(family);
         tvg::free(name);
-        tvg::free(data.b64src);
+        tvg::free(b64src);
     }
 
-    struct {
+    union {
         char* b64src = nullptr;
-        uint32_t size = 0;
-    } data;
+        char* path;
+    };
 
     Array<LottieGlyph*> chars;
     char* name = nullptr;
     char* family = nullptr;
     char* style = nullptr;
+    uint32_t size = 0;
     float ascent = 0.0f;
     Origin origin = Local;
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1007,13 +1007,22 @@ LottieObject* LottieParser::parseAsset()
 void LottieParser::parseFontData(LottieFont* font, const char* data)
 {
     if (!data) return;
-    if (strncmp(data, "data:font/ttf;base64,", sizeof("data:font/ttf;base64,") - 1) != 0) {
-        TVGLOG("LOTTIE", "Unsupported embeded font data format");
-        return;
-    }
 
-    auto ttf = data + sizeof("data:font/ttf;base64,") - 1;
-    font->data.size = b64Decode(ttf, strlen(ttf), &font->data.b64src);
+    //handle base64 font data
+    if (!strncmp(data, "data:font/", sizeof("data:font/") - 1)) {
+        data += sizeof("data:font/") - 1;
+        if (!strncmp(data, "ttf", 3)) {
+            data += 3;
+        } else {
+            TVGLOG("LOTTIE", "TODO: Support a new font type!");
+            return;
+        }
+        data += sizeof(";base64,") - 1;
+        font->size = b64Decode(data, strlen(data), &font->b64src);
+    //external font resource
+    } else {
+        font->path = duplicate(data);
+    }
 }
 
 


### PR DESCRIPTION
This patch implements font path resolution through AssetResolver during the builder stage.

issue: #3866 

## 1. Usage
```cpp
picture->resolver([](tvg::Paint* p, const char* src, void* data) {
    // check paint type
    if (p->type() != tvg::Type::Text) return false;

    // load custom font data
    auto ret = tvg::Text::load(EXAMPLE_DIR "/font/SentyCloud.ttf");

    // set loaded font to the text object
    ret = static_cast<tvg::Text*>(p)->font("SentyCloud");

    // return true if resolving is successful
    return (ret == (tvg::Result)0) ? true : false;
}, nullptr);
```

## 2. Example
<img width="1602" height="1662" alt="CleanShot 2025-10-29 at 03 59 42@2x" src="https://github.com/user-attachments/assets/bca3c2d0-86ca-4f08-a738-7ef7724782fd" />

## 3. Design Alternatives Considered
Two primary approaches were evaluated for implementing font path resolution:
1. **Parser-stage resolution**: Invoke AssetResolver during the parsing phase
2. **Builder-stage resolution**: Invoke AssetResolver during rendering, consistent with existing image asset handling

And I have selected builder stage resolution for the reasons:

#### 1. Priority Control

Users may preload fonts via `Text::load()` before loading animations. AssetResolver should act as a **fallback**, not override user intent. Builder-stage resolution allows checking if fonts can be loaded before invoking the resolver, naturally establishing the priority: user preload > resolver > system fallback.

Parser-stage resolution would make AssetResolver the primary loading path, making it difficult to respect user preloads.

#### 2. Font Name Mapping Consistency

ThorVG's `Text::font()` matches fonts by filename(when loading via path). Lottie animations reference fonts via `doc.name`. The Lottie spec doesn't guarantee these align. (file name under the path and document name could be very different)

Thus, if we proceed font resolution in parsing, then users handle loading(`Text::load`) and engine handles `text->font` in building step, it leads:
- Users can't predict which name will be registered when resolving a path
- Loading unused fonts (_resolver is fired, but resolved font isn't referenced_)
- Mismatches name when users load custom font (_even if doc name and path are aligned, users may want to load custom font_)

This patch makes the engine attempts `doc.name` first, then invokes resolver only when needed(on failure). This unifies font loading and name mapping in user side resolution, avoiding unnecessary loads and name conflicts.

#### 3. Layering/Consistency
- In lottie builder, font is resolved at same stage as image resolver
- Since the AssetResolver lives in LoadModule, parser could create unwanted dependency (parser → loader)