### PR TITLE
loader/jpg: remove unused s_max_rc variable

### DIFF
--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -1328,15 +1328,6 @@ void jpeg_decoder::transform_mcu(int mcu_row)
 }
 
 
-static const uint8_t s_max_rc[64] =
-{
-    17, 18, 34, 50, 50, 51, 52, 52, 52, 68, 84, 84, 84, 84, 85, 86, 86, 86, 86, 86,
-    102, 118, 118, 118, 118, 118, 118, 119, 120, 120, 120, 120, 120, 120, 120, 136,
-    136, 136, 136, 136, 136, 136, 136, 136, 136, 136, 136, 136, 136, 136, 136, 136,
-    136, 136, 136, 136, 136, 136, 136, 136, 136, 136, 136, 136
-};
-
-
 // Loads and dequantizes the next row of (already decoded) coefficients.
 // Progressive images only.
 void jpeg_decoder::load_next_row()


### PR DESCRIPTION
Removed the unused static const array `s_max_rc[64]` that was causing a compiler warning [-Wunused-const-variable]. The variable was defined but never referenced anywhere in the codebase.

<img width="1844" height="498" alt="CleanShot 2025-10-30 at 16 19 48@2x" src="https://github.com/user-attachments/assets/6406f25c-4bbc-4bec-92a1-2a3d98c6aa1b" />
