### PR TITLE
svg: thread safey++

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -4012,7 +4012,7 @@ bool SvgLoader::read()
 {
     if (!content || size == 0) return false;
 
-    if (root || !LoadModule::read()) return true;
+    if (!LoadModule::read() || root) return true;
 
     TaskScheduler::request(this);
 


### PR DESCRIPTION
root is not thread safety resource,
must be guarded with LoadModule::read() call.

a regression 10d36c2e4d42ba1a0ba7a11f7d8f7676676c47ff during main dev.