### PR TITLE
gl: handle degenerate paths as strokes

### DIFF
--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -393,6 +393,14 @@ static inline void log(const Point& pt)
 }
 
 
+static inline bool closed(const Point& lhs, const Point& rhs, float tolerance)
+{
+    float dx = lhs.x - rhs.x;
+    float dy = lhs.y - rhs.y;
+    return (dx * dx + dy * dy) < (tolerance * tolerance);
+}
+
+
 /************************************************************************/
 /* Line functions                                                       */
 /************************************************************************/

--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -29,6 +29,7 @@
 #include "tvgMath.h"
 
 #define MIN_GL_STROKE_WIDTH 1.0f
+#define MIN_GL_STROKE_ALPHA 0.25f
 
 #define MVP_MATRIX(w, h)                \
     float mvp[4*4] = {                  \
@@ -106,18 +107,23 @@ struct GlGeometryBuffer {
 
 struct GlGeometry
 {
-    bool tesselateShape(const RenderShape& rshape);
+    void prepare(const RenderShape& rshape);
+    bool tesselateShape(const RenderShape& rshape, float* opacityMultiplier = nullptr);
     bool tesselateStroke(const RenderShape& rshape);
+    bool tesselateLine(const RenderPath& path);
     void tesselateImage(const RenderSurface* image);
     bool draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag);
     GlStencilMode getStencilMode(RenderUpdateFlag flag);
     RenderRegion getBounds() const;
+    void optimizePath(const RenderPath& path, const Matrix& transform);
 
     GlGeometryBuffer fill, stroke;
     Matrix matrix = {};
     RenderRegion viewport = {};
     RenderRegion bounds = {};
     FillRule fillRule = FillRule::NonZero;
+    RenderPath optimizedPath;
+    bool optimized = false;
 };
 
 

--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -25,6 +25,153 @@
 #include "tvgGlTessellator.h"
 #include "tvgGlRenderTask.h"
 
+// Optimize path in screen space with merging collinear lines, collapsing zero length lines, and removing unnecessary cubic beziers.
+static void _optimize(const RenderPath& in, RenderPath& out, const Matrix& matrix)
+{
+    static constexpr auto PX_TOLERANCE = 0.25f;
+
+    out.cmds.reserve(in.cmds.count);
+    out.pts.reserve(in.pts.count);
+
+    auto cmds = in.cmds.data;
+    auto cmdCnt = in.cmds.count;
+    auto pts = in.pts.data;
+
+    uint32_t prevIdx = 0;
+    uint32_t prevPrevIdx = 0;
+    auto hasPrevPrev = false;
+
+    // The suffix "T" indicates that the point is transformed.
+    Point lastOutT, prevOutT;
+
+    auto isIdentity = tvg::identity(&matrix);
+
+    auto point2Line = [](const Point& point, const Point& start, const Point& vec, const float vecLenSq, float& maxDist, float& minT, float& maxT) {
+        Point offset = point - start;
+        auto area = tvg::cross(vec, offset);
+        auto dist = fabsf(area) / sqrtf(vecLenSq); // if lineVecLenSq == 0, mean closed() hasn't been called
+        if (dist > maxDist) maxDist = dist;
+
+        auto t = tvg::dot(offset, vec) / vecLenSq;
+        if (t < minT) minT = t;
+        if (t > maxT) maxT = t;
+    };
+
+    auto validateCubic = [&point2Line](const Point& start, const Point& ctrl1, const Point& ctrl2, const Point& end, float& maxDist, float& minT, float& maxT) {
+        maxDist = 0.0f;
+        minT = FLT_MAX;
+        maxT = FLT_MIN;
+        auto vec = end - start;
+        auto vecLenSq = vec.x * vec.x + vec.y * vec.y;
+        point2Line(ctrl1, start, vec, vecLenSq, maxDist, minT, maxT);
+        point2Line(ctrl2, start, vec, vecLenSq, maxDist, minT, maxT);
+    };
+
+    auto point2LineSimple = [](const Point& point, const Point& start, const Point& end, float& dist, float& t) {
+        auto vec = end - start;
+        auto vecLenSq = vec.x * vec.x + vec.y * vec.y;
+        Point offset = point - start;
+        auto area = tvg::cross(vec, offset);
+        dist = fabsf(area) / sqrtf(vecLenSq); // if lineVecLenSq == 0, mean closed() hasn't been called
+        t = tvg::dot(offset, vec) / vecLenSq;
+    };
+
+    auto addLineCmd = [&](const Point& pt, const Point& ptT) {
+        out.cmds.push(PathCommand::LineTo);
+        out.pts.push(pt);
+        prevOutT = lastOutT;
+        lastOutT = ptT;
+        prevPrevIdx = prevIdx;
+        prevIdx = out.pts.count - 1;
+        hasPrevPrev = true;
+    };
+
+    auto processLineCollinear = [&](const Point& startT, const Point& pt, const Point& ptT) {
+        if (!hasPrevPrev || out.pts.count <= 1) {
+            addLineCmd(pt, ptT);
+            return;
+        }
+
+        float dist, t;
+        point2LineSimple(ptT, prevOutT, startT, dist, t);
+
+        if (dist > PX_TOLERANCE) {
+            addLineCmd(pt, ptT);
+            return;
+        }
+
+        if (t < -PX_TOLERANCE) {
+            out.pts[prevPrevIdx] = pt;
+            lastOutT = ptT;
+        } else if (t > 1.0f + PX_TOLERANCE) {
+            out.pts[prevIdx] = pt;
+            lastOutT = ptT;
+        }
+    };
+
+    auto processCubicTo = [&](const Point* cubicPts, const Point& startT) {
+        auto endT = isIdentity ? cubicPts[2] : cubicPts[2] * matrix;
+        if (tvg::closed(startT, endT, PX_TOLERANCE)) return;
+        auto ctrl1T = isIdentity ? cubicPts[0] : cubicPts[0] * matrix;
+        auto ctrl2T = isIdentity ? cubicPts[1] : cubicPts[1] * matrix;
+        float maxDist, minT, maxT;
+        validateCubic(startT, ctrl1T, ctrl2T, endT, maxDist, minT, maxT);
+
+        bool flatEnough  = (maxDist <= PX_TOLERANCE);
+        bool inSpan = (minT >= -PX_TOLERANCE) && (maxT <= 1.0f + PX_TOLERANCE);
+        if (flatEnough && inSpan) {
+            processLineCollinear(startT, cubicPts[2], endT);
+        } else {
+            out.cmds.push(PathCommand::CubicTo);
+            out.pts.push(cubicPts[0]);
+            out.pts.push(cubicPts[1]);
+            out.pts.push(cubicPts[2]);
+            prevOutT = lastOutT;
+            lastOutT = endT;
+            prevPrevIdx = prevIdx;
+            prevIdx = out.pts.count - 1;
+            hasPrevPrev = true;
+        }
+    };
+
+    for (uint32_t i = 0; i < cmdCnt; i++) {
+        switch (cmds[i]) {
+            case PathCommand::MoveTo: {
+                out.cmds.push(PathCommand::MoveTo);
+                out.pts.push(*pts);
+                lastOutT = isIdentity ? *pts : *pts * matrix;
+                prevIdx = out.pts.count - 1;
+                hasPrevPrev = false;
+                pts++;
+                break;
+            }
+            case PathCommand::LineTo: {
+                auto startT = lastOutT;
+                auto ptT = isIdentity ? *pts : (*pts) * matrix;
+                if (tvg::closed(startT, ptT, PX_TOLERANCE)) {
+                    pts++;
+                    break;
+                }
+                processLineCollinear(startT, *pts, ptT);
+                pts++;
+                break;
+            }
+            case PathCommand::CubicTo: {
+                processCubicTo(pts, lastOutT);
+                pts += 3;
+                break;
+            }
+            case PathCommand::Close: {
+                out.cmds.push(PathCommand::Close);
+                hasPrevPrev = false;
+                break;
+            }
+            default:
+                break;
+            }
+    }
+}
+
 bool GlIntersector::isPointInTriangle(const Point& p, const Point& a, const Point& b, const Point& c)
 {
     auto d1 = tvg::cross(p - a, p - b);
@@ -134,22 +281,68 @@ bool GlIntersector::intersectImage(const RenderRegion region, const GlShape* ima
 }
 
 
-bool GlGeometry::tesselateShape(const RenderShape& rshape)
+void GlGeometry::optimizePath(const RenderPath& path, const Matrix& transform)
+{
+    optimizedPath.cmds.clear();
+    optimizedPath.pts.clear();
+    _optimize(path, optimizedPath, transform);
+    optimized = true;
+}
+
+
+void GlGeometry::prepare(const RenderShape& rshape)
+{
+    optimizePath(rshape.path, matrix);
+}
+
+
+bool GlGeometry::tesselateShape(const RenderShape& rshape, float* opacityMultiplier)
 {
     fill.clear();
+    const auto& path2Use = optimized ? optimizedPath : rshape.path;
+
+    // When the CTM scales a filled path so small that its device-space
+    // World:  [========]     // normal-sized filled path
+    // After CTM:  [.]        // thinner than 1 px in device space
+    // Handling: two points   // collapse to a 2-point handle for stability
+    if (path2Use.pts.count == 2 && tvg::zero(rshape.strokeWidth())) {
+        if (tesselateLine(path2Use)) {
+            // The time spent is similar to subtituting buffers in tessellation, so we just move the buffers to keep the code simple.
+            stroke.index.move(fill.index);
+            stroke.vertex.move(fill.vertex);
+            if (opacityMultiplier) *opacityMultiplier = MIN_GL_STROKE_ALPHA;
+            fillRule = rshape.rule;
+            return true;
+        }
+        return false;
+    }
+
+    // Handle normal shapes with more than 2 points
     BWTessellator bwTess{&fill};
+
     if (rshape.trimpath()) {
         RenderPath trimmedPath;
-        if (rshape.stroke->trim.trim(rshape.path, trimmedPath)) {
+        if (rshape.stroke->trim.trim(path2Use, trimmedPath)) {
             bwTess.tessellate(trimmedPath, matrix);
         }
     } else {
-        bwTess.tessellate(rshape.path, matrix);
+        bwTess.tessellate(path2Use, matrix);
     }
 
     fillRule = rshape.rule;
     bounds = bwTess.bounds();
+    if (opacityMultiplier) *opacityMultiplier = 1.0f;
+    return true;
+}
 
+
+bool GlGeometry::tesselateLine(const RenderPath& path)
+{
+    stroke.clear();
+    if (path.pts.count != 2) return false;
+    Stroker stroker(&stroke, MIN_GL_STROKE_WIDTH / scaling(matrix), StrokeCap::Butt, StrokeJoin::Bevel);
+    stroker.run(path, matrix);
+    bounds = stroker.bounds();
     return true;
 }
 
@@ -167,8 +360,9 @@ bool GlGeometry::tesselateStroke(const RenderShape& rshape)
     }
     //run stroking only if it's valid
     if (!tvg::zero(strokeWidth)) {
-        Stroker stroker(&stroke, strokeWidth);
-        stroker.run(rshape, matrix);
+        const RenderPath& pathToUse = optimized ? optimizedPath : rshape.path;
+        Stroker stroker(&stroke, strokeWidth, rshape.strokeCap(), rshape.strokeJoin());
+        stroker.run(rshape, pathToUse, matrix);
         bounds = stroker.bounds();
         return true;
     }

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -1279,14 +1279,22 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
     sdata->geometry.matrix = transform;
     sdata->geometry.viewport = vport;
 
+    if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform)) {
+        sdata->geometry.prepare(rshape);
+    }
+
     //TODO: Please precisely update tessellation not to update only if the color is changed.
     if (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
-        if (sdata->geometry.tesselateShape(rshape)) sdata->validFill = true;
+        float opacityMultiplier = 1.0f;
+        if (sdata->geometry.tesselateShape(*(sdata->rshape), &opacityMultiplier)) {
+            sdata->opacity *= opacityMultiplier;
+            sdata->validFill = true;
+        }
     }
 
     //TODO: Please precisely update tessellation not to update only if the color is changed.
     if (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Stroke | RenderUpdateFlag::GradientStroke | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
-        if (sdata->geometry.tesselateStroke(rshape)) sdata->validStroke = true;
+        if (sdata->geometry.tesselateStroke(*(sdata->rshape))) sdata->validStroke = true;
     }
 
     if (flags & RenderUpdateFlag::Clip) {

--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -33,25 +33,23 @@ static uint32_t _pushVertex(Array<float>& array, float x, float y)
 }
 
 
-Stroker::Stroker(GlGeometryBuffer* buffer, float width) : mBuffer(buffer), mWidth(width)
+Stroker::Stroker(GlGeometryBuffer* buffer, float width, StrokeCap cap, StrokeJoin join) : mBuffer(buffer), mWidth(width), mCap(cap), mJoin(join)
 {
 }
 
 
-void Stroker::run(const RenderShape& rshape, const Matrix& m)
+void Stroker::run(const RenderShape& rshape, const RenderPath& path, const Matrix& m)
 {
     mMiterLimit = rshape.strokeMiterlimit();
-    mCap = rshape.strokeCap();
-    mJoin = rshape.strokeJoin();
 
     RenderPath dashed;
     if (rshape.strokeDash(dashed)) run(dashed, m);
     else if (rshape.trimpath()) {
         RenderPath trimmedPath;
-        if (rshape.stroke->trim.trim(rshape.path, trimmedPath)) {
+        if (rshape.stroke->trim.trim(path, trimmedPath)) {
             run(trimmedPath, m);
         }
-    } else run(rshape.path, m);
+    } else run(path, m);
 }
 
 

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -38,12 +38,12 @@ class Stroker
         Point prevPtDir;
     };
 public:
-    Stroker(GlGeometryBuffer* buffer, float strokeWidth);
-    void run(const RenderShape& rshape, const Matrix& m);
+    Stroker(GlGeometryBuffer* buffer, float strokeWidth, StrokeCap cap, StrokeJoin join);
+    void run(const RenderShape& rshape, const RenderPath& path, const Matrix& m);
+    void run(const RenderPath& path, const Matrix& m);
     RenderRegion bounds() const;
 
 private:
-    void run(const RenderPath& path, const Matrix& m);
 
     float radius() const
     {


### PR DESCRIPTION
### Add support for rendering degenerate paths (2-point paths) as strokes in GL engine:
- Add RenderPath::optimize() to simplify paths by merging close points and flattening curves
- Add math utilities: shouldMergePts(), checkLine(), validateCubic(), checkLinePts()
- Add tesselateLineOnly() to handle 2-point paths with MIN_GL_STROKE_ALPHA opacity
- Update GlRenderer::prepare() to detect and handle degenerate paths

<figure>
<img width="852" height="201" alt="Screenshot 2025-11-03 at 1 19 45 AM" src="https://github.com/user-attachments/assets/adc2d7f0-8f42-4742-97ed-9f06c5cd7699" />
<figcaption>Some pixels dropped</figcaption>
</figure>
<figure>
<img width="850" height="202" alt="Screenshot 2025-11-03 at 1 14 09 AM" src="https://github.com/user-attachments/assets/a419c59b-0558-424f-a77e-1858f5d26cad" />
<figcaption>Resolved</figcaption>
</figure>

### Test
- Native System: The FPS of Feature branch is consistently **~+4.1%** above Main branch overall, peaking in the early section (**~+5.2%** around 60–200), tapering to **~+3.7%** by the 700–1000 range, while startup is roughly **+1.1%** slower on Feature branch
<figure>
<img width="1979" height="1180" alt="output" src="https://github.com/user-attachments/assets/c7504b12-7dd7-4d66-a339-631c602b8d81" />
<figcaption>Lottie Example 1000 Frames Comparison</figcaption>
</figure>

- WebGL: I haven't collected the exact performance data yet, but I haven't found any critical issues.

Related Issue: #2920


