### PR TITLE
gl_engine: introduce ability to combine masking and custom blend

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -171,8 +171,9 @@ struct GlCompositor : RenderCompositor
 {
     RenderRegion bbox = {};
     BlendMethod blendMethod = {};
+    CompositionFlag flags = {};
 
-    GlCompositor(const RenderRegion& box) : bbox(box) {}
+    GlCompositor(const RenderRegion& box, CompositionFlag flags) : bbox(box), flags(flags) {}
 };
 
 


### PR DESCRIPTION
Until now, blending and masking settings couldn't be used simultaneously. If a mask was specified for an object, the blending settings were ignored, and the object was blended using the normal settings.

Now it's possible to use compositions and blending in the same scene. This is achieved by reconfiguring the current render targets and render tree. 

This doesn't affect overall performance, but only adds functionality.

gl(old)/sw/gl(new)
<img width="1456" height="661" alt="image" src="https://github.com/user-attachments/assets/2e5cbfe9-b79d-40f3-b711-63671a278d4a" />

issue: https://github.com/thorvg/thorvg/issues/3793