### PR TITLE
wg_engine: trimpath optimization

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -169,18 +169,18 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
     releaseMeshes();
     strokeFirst = rshape.strokeFirst();
 
+    // trim path if necessary
+    RenderPath trimmedPath;
+    auto& path = (rshape.trimpath() && rshape.stroke->trim.trim(rshape.path, trimmedPath)) ? trimmedPath : rshape.path;
+
     // update fill shapes
     if (flag & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
         meshShape.clear();
 
         WgBWTessellator bwTess{&meshShape};
-        if (rshape.trimpath()) {
-            RenderPath trimmedPath;
-            if (rshape.stroke->trim.trim(rshape.path, trimmedPath))
-                bwTess.tessellate(trimmedPath, matrix);
-        } else bwTess.tessellate(rshape.path, matrix);
+        bwTess.tessellate(path, matrix);
 
-        if (meshShape.ibuffer.count > 0) {;
+        if (meshShape.ibuffer.count > 0) {
             auto bbox = bwTess.getBBox();
             meshShapeBBox.bbox(bbox.min, bbox.max);
             updateBBox(bbox);
@@ -201,7 +201,7 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
         //run stroking only if it's valid
         if (!tvg::zero(strokeWidth)) {
             WgStroker stroker(&meshStrokes, strokeWidth);
-            stroker.run(rshape, matrix);
+            stroker.run(rshape, path, matrix);
             if (meshStrokes.ibuffer.count > 0) {
                 auto bbox = stroker.getBBox();
                 meshStrokesBBox.bbox(bbox.min, bbox.max);

--- a/src/renderer/wg_engine/tvgWgTessellator.cpp
+++ b/src/renderer/wg_engine/tvgWgTessellator.cpp
@@ -29,7 +29,7 @@ WgStroker::WgStroker(WgMeshData* buffer, float width) : mBuffer(buffer), mWidth(
 }
 
 
-void WgStroker::run(const RenderShape& rshape, const Matrix& m)
+void WgStroker::run(const RenderShape& rshape, const RenderPath& path, const Matrix& m)
 {
     mMiterLimit = rshape.strokeMiterlimit();
     mCap = rshape.strokeCap();
@@ -37,14 +37,7 @@ void WgStroker::run(const RenderShape& rshape, const Matrix& m)
 
     RenderPath dashed;
     if (rshape.strokeDash(dashed)) run(dashed, m);
-    else if (rshape.trimpath()) {
-        RenderPath trimmedPath;
-        if (rshape.stroke->trim.trim(rshape.path, trimmedPath)) {
-            run(trimmedPath, m);
-        }
-    } else {
-        run(rshape.path, m);
-    }
+    else run(path, m);
 }
 
 

--- a/src/renderer/wg_engine/tvgWgTessellator.h
+++ b/src/renderer/wg_engine/tvgWgTessellator.h
@@ -39,7 +39,7 @@ class WgStroker
     };
 public:
     WgStroker(WgMeshData* buffer, float width);
-    void run(const RenderShape& rshape, const Matrix& m);
+    void run(const RenderShape& rshape, const RenderPath& path, const Matrix& m);
     RenderRegion bounds() const;
     BBox getBBox() const;
 private:


### PR DESCRIPTION
Current engine generate TrimPath data once for fill and stroke. 
The original path used if trimming is not necessary

issue: https://github.com/thorvg/thorvg/issues/3653