### PR TITLE
infra: add Apple Silicon simulator CI support

### DIFF
--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  build_x86_64:
+  build_simulator_x86_64:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
@@ -38,7 +38,36 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: result_x86_64
+        name: result_simulator_x86_64
+        path: build/src/libthorvg*
+
+  build_simulator_arm64:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Unbreak Python in GitHub Actions
+      run: |
+        find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+        sudo rm -rf /Library/Frameworks/Python.framework/
+        brew install --force python3 && brew unlink python3 && brew link --overwrite python3
+
+    - name: Install Packages
+      run: |
+        export HOMEBREW_NO_INSTALL_FROM_API=1
+        brew update
+        brew install meson
+
+    - name: Build
+      run: |
+        meson setup build -Dlog=true -Dloaders=all -Dsavers=all -Dbindings=capi -Dstatic=true --cross-file ./cross/ios_simulator_arm64.txt
+        ninja -C build install
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: result_simulator_arm64
         path: build/src/libthorvg*
 
   build_arm64:


### PR DESCRIPTION
# Update iOS CI workflow to reflect cross-compilation file changes

## Summary

This PR updates the iOS build workflow to reflect the changes merged in #3939, including the file rename and adding a new build job for iOS Simulator on Apple Silicon.

## Context

PR #3939 made two key changes to iOS cross-compilation files:
1. Renamed `ios_x86_64.txt` to `ios_simulator_x86_64.txt` for consistency
2. Added new `ios_simulator_arm64.txt` for Apple Silicon iOS Simulator support

This PR updates the CI workflow to use the renamed file and adds a new build job to test the Apple Silicon simulator configuration.