### PR TITLE
saver/gif: support an external gif saver

### DIFF
--- a/src/savers/external_gif/meson.build
+++ b/src/savers/external_gif/meson.build
@@ -1,0 +1,27 @@
+source_file = [
+   'tvgGifSaver.h',
+   'tvgGifSaver.cpp',
+   'tvgGifEncoder.h',
+   'tvgGifEncoder.cpp',
+]
+
+gif_dep_found = false
+gif_dep = dependency('gif', required: false)
+
+if not gif_dep.found()
+    gif_dep = cc.find_library('gif', required: false)
+endif
+
+gif_dep_found = gif_dep.found()
+
+if gif_dep_found 
+    if not cc.has_function('GifQuantizeBuffer', dependencies: gif_dep)
+        gif_dep_found = false
+    else
+        subsaver_dep += [declare_dependency(
+            include_directories : include_directories('.'),
+            dependencies : gif_dep,
+            sources : source_file
+        )]
+    endif
+endif

--- a/src/savers/external_gif/tvgGifEncoder.cpp
+++ b/src/savers/external_gif/tvgGifEncoder.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2023 - 2025 the ThorVG project. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "tvgGifEncoder.h"
+#include "tvgCommon.h"
+#include <cstring>
+
+#define TRANSPARENT_THRESHOLD 127
+#define BIT_DEPTH 8
+#define MAX_PALETTESIZE 256
+
+static ColorMapObject* _quantize(std::vector<GifByteType>& r, std::vector<GifByteType>& g, std::vector<GifByteType>& b, GifByteType* outputBuffer)
+{
+    int paletteSize = MAX_PALETTESIZE - 1;
+    std::vector<GifColorType> palette(paletteSize, {0, 0, 0});
+    std::vector<GifByteType> tempIndex;
+    if (outputBuffer == nullptr) {
+        tempIndex.resize(r.size(), 0);
+        outputBuffer = tempIndex.data();
+    }
+    if (r.size() > 0 && GifQuantizeBuffer((int)r.size(), 1, &paletteSize, r.data(), g.data(), b.data(), outputBuffer, palette.data()) == GIF_ERROR) {
+        return nullptr;
+    }
+
+    int colorMapSize = 1 << GifBitSize(paletteSize + 1); // +1: transparent index
+    auto* colorMap = GifMakeMapObject(colorMapSize, nullptr);
+    if (colorMap) memcpy(colorMap->Colors, palette.data(), paletteSize * sizeof(GifColorType));
+
+    return colorMap;
+}
+
+static int _getClosestPaletteColor(uint8_t r, uint8_t g, uint8_t b, const GifColorType* cols, int colorCount)
+{
+    int bestInd = 0;
+    int bestDiff = INT32_MAX;
+    for (int i = 0; i < colorCount; ++i) {
+        int rd = (int)cols[i].Red - (int)r;
+        int gd = (int)cols[i].Green - (int)g;
+        int bd = (int)cols[i].Blue - (int)b;
+        int d2 = rd * rd + gd * gd + bd * bd;
+
+        if (d2 < bestDiff) {
+            bestDiff = d2;
+            bestInd = i;
+            if (d2 == 0)
+                break;
+        }
+    }
+    return bestInd;
+}
+
+bool GifEncoder::useLocalPalette()
+{
+    return gif->SColorMap == nullptr;
+}
+
+bool GifEncoder::writeLoop()
+{
+    unsigned char netscapeStr[] = "NETSCAPE2.0";
+    GifByteType loopData[] = {/*control loop*/ 0x01, /*low loop count*/ 0x00, /*high loop count*/ 0x00}; // low == high == 0: infinite loop
+    if (GifAddExtensionBlock(&gif->ExtensionBlockCount, &gif->ExtensionBlocks, APPLICATION_EXT_FUNC_CODE, sizeof(netscapeStr) - 1, netscapeStr) == GIF_ERROR)
+        return false;
+    if (GifAddExtensionBlock(&gif->ExtensionBlockCount, &gif->ExtensionBlocks, CONTINUE_EXT_FUNC_CODE, sizeof(loopData), loopData) == GIF_ERROR)
+        return false;
+    return true;
+}
+
+bool GifEncoder::writeGCE(SavedImage* image, int delayTime, int disposalMode, int transparentIndex)
+{
+    GraphicsControlBlock gcb{.DisposalMode = disposalMode, .UserInputFlag = false, .DelayTime = delayTime, .TransparentColor = transparentIndex};
+    GifByteType ext[4];
+    const auto extSize = EGifGCBToExtension(&gcb, ext);
+    if (0 < extSize)
+        return GifAddExtensionBlock(&image->ExtensionBlockCount, &image->ExtensionBlocks, GRAPHICS_EXT_FUNC_CODE, extSize, ext) != GIF_ERROR;
+    return false;
+}
+
+SavedImage* GifEncoder::makeSavedImage(uint8_t* buffer)
+{
+    SavedImage* img = GifMakeSavedImage(gif, nullptr);
+    if (img) {
+        img->RasterBits = (GifByteType*)calloc(numPixels, sizeof(GifByteType));
+        img->ImageDesc.Left = 0;
+        img->ImageDesc.Top = 0;
+        img->ImageDesc.Width = gif->SWidth;
+        img->ImageDesc.Height = gif->SHeight;
+        img->ImageDesc.Interlace = false;
+        img->ImageDesc.ColorMap = nullptr;
+
+        if (useLocalPalette()) {
+            hasTransparent = false;
+            clearSample();
+            forEach(buffer, numPixels, [&](int index, uint8_t a, uint8_t r, uint8_t g, uint8_t b) {
+                pushSample(r, g, b);
+                hasTransparent |= (a < TRANSPARENT_THRESHOLD);
+            });
+
+            img->ImageDesc.ColorMap = _quantize(sampleR, sampleG, sampleB, img->RasterBits);
+            if (img->ImageDesc.ColorMap == nullptr)
+                return nullptr;
+        }
+        if (!img->RasterBits) return nullptr;
+
+        return img;
+    }
+    return nullptr;
+}
+
+void GifEncoder::pushSample(uint8_t r, uint8_t g, uint8_t b)
+{
+    sampleR.push_back(r);
+    sampleG.push_back(g);
+    sampleB.push_back(b);
+}
+
+void GifEncoder::clearSample()
+{
+    sampleR.clear();
+    sampleG.clear();
+    sampleB.clear();
+    sampleR.reserve(numPixels);
+    sampleG.reserve(numPixels);
+    sampleB.reserve(numPixels);
+}
+
+bool GifEncoder::begin(const char* path, uint32_t w, uint32_t h)
+{
+    int err = 0;
+    gif = EGifOpenFileName(path, false, &err);
+    if (!gif) {
+        TVGERR("GIF_SAVER", "Failed gif begin: %s", GifErrorString(err));
+        return false;
+    }
+    gif->SWidth = static_cast<GifWord>(w);
+    gif->SHeight = static_cast<GifWord>(h);
+    gif->SColorResolution = BIT_DEPTH;
+    gif->AspectByte = 0;
+    gif->SColorMap = nullptr;
+
+    if (!writeLoop()) {
+        EGifCloseFile(gif, &err);
+        return false;
+    }
+    numPixels = w * h;
+    beforeR.resize(numPixels, 0);
+    beforeG.resize(numPixels, 0);
+    beforeB.resize(numPixels, 0);
+    clearSample();
+    return true;
+}
+
+void GifEncoder::writeGlobalPalette(uint8_t* buffer, size_t size)
+{
+    forEach(buffer, size, [&](int index, uint8_t a, uint8_t r, uint8_t g, uint8_t b) {
+        if (a < TRANSPARENT_THRESHOLD || (beforeR[index] == r && beforeG[index] == g && beforeB[index] == b))
+            return;
+
+        pushSample(r, g, b);
+
+        beforeR[index] = r;
+        beforeG[index] = g;
+        beforeB[index] = b;
+    });
+}
+
+void GifEncoder::buildGlobalPalette()
+{
+    gif->SColorMap = _quantize(sampleR, sampleG, sampleB, nullptr);
+    gif->SBackGroundColor = gif->SColorMap->ColorCount - 1;
+    clearSample();
+}
+
+bool GifEncoder::writeFrame(uint8_t* buffer, int delayTime)
+{
+    auto* img = makeSavedImage(buffer);
+
+    if (img == nullptr || (img->ImageDesc.ColorMap == nullptr && gif->SColorMap == nullptr))
+        return false;
+
+    const bool isGlobal = !useLocalPalette();
+    const auto* const colorMap = isGlobal ? gif->SColorMap : img->ImageDesc.ColorMap;
+    const auto transparentIdx = colorMap->ColorCount - 1;
+
+    if (hasTransparent || isGlobal) {
+        auto* paletteIndex = img->RasterBits;
+        hasTransparent = false;
+
+        forEach(buffer, numPixels, [&](int index, uint8_t a, uint8_t r, uint8_t g, uint8_t b) {
+            if (a >= TRANSPARENT_THRESHOLD) {
+                if (paletteIndex[index] == 0)
+                    paletteIndex[index] = _getClosestPaletteColor(r, g, b, colorMap->Colors, colorMap->ColorCount - 1);
+            } else {
+                paletteIndex[index] = transparentIdx;
+                hasTransparent = true;
+            }
+        });
+    }
+
+    if (img != nullptr && !writeGCE(img, delayTime, hasTransparent ? DISPOSE_BACKGROUND : DISPOSE_DO_NOT, transparentIdx))
+        return false;
+
+    return true;
+}
+
+bool GifEncoder::end()
+{
+    bool success = (EGifSpew(gif) != GIF_ERROR);
+    GifFreeSavedImages(gif);
+    return success;
+}

--- a/src/savers/external_gif/tvgGifEncoder.h
+++ b/src/savers/external_gif/tvgGifEncoder.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 - 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TVG_GIF_ENCODER_H
+#define TVG_GIF_ENCODER_H
+
+#include <gif_lib.h>
+#include <stdint.h>
+#include <vector>
+
+class GifEncoder
+{
+public:
+    bool begin(const char* path, uint32_t w, uint32_t h);
+    void writeGlobalPalette(uint8_t* buffer, size_t size);
+    void buildGlobalPalette();
+    bool writeFrame(uint8_t* buffer, int delayTime);
+    bool end();
+
+private:
+    bool useLocalPalette();
+    bool writeLoop();
+    bool writeGCE(SavedImage* image, int delayTime, int disposalMode, int transparentIndex);
+    SavedImage* makeSavedImage(uint8_t* buffer);
+    void pushSample(uint8_t r, uint8_t g, uint8_t b);
+    void clearSample();
+
+    template <typename Function>
+    void forEach(uint8_t* buffer, size_t size, Function&& f)
+    {
+        for (size_t i = 0; i < size; i++) {
+            const auto a = buffer[i * 4 + 3];
+            const auto r = buffer[i * 4];
+            const auto g = buffer[i * 4 + 1];
+            const auto b = buffer[i * 4 + 2];
+            f(i, a, r, g, b);
+        }
+    }
+
+    GifFileType* gif = nullptr;
+    std::vector<GifByteType> sampleR, sampleG, sampleB;
+    std::vector<GifByteType> beforeR, beforeG, beforeB;
+    size_t numPixels = 0;
+    bool hasTransparent = false;
+};
+
+#endif // TVG_GIF_ENCODER_H

--- a/src/savers/external_gif/tvgGifSaver.cpp
+++ b/src/savers/external_gif/tvgGifSaver.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2023 - 2025 the ThorVG project. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "tvgGifSaver.h"
+#include "tvgStr.h"
+#include "tvgGifEncoder.h"
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
+void GifSaver::run(unsigned)
+{
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+    if (!canvas) return;
+
+    const auto w = static_cast<uint32_t>(vsize[0]);
+    const auto h = static_cast<uint32_t>(vsize[1]);
+    const auto duration = animation->duration();
+
+    buffer = tvg::realloc<uint32_t*>(buffer, sizeof(uint32_t) * w * h);
+    canvas->target(buffer, w, w, h, ColorSpace::ABGR8888S);
+    canvas->push(bg);
+    canvas->push(animation->picture());
+
+    //use the default fps
+    if (fps > 60.0f) fps = 60.0f;   // just in case
+    else if (tvg::zero(fps) || fps < 0.0f) {
+        fps = (animation->totalFrame() / duration);
+    }
+    const float delay = 1.0f / fps;
+    const int delayTime = std::max(1,static_cast<int>(delay * 100.0f));
+
+    GifEncoder encoder;
+    if(encoder.begin(path, w, h) == false) {
+        TVGERR("GIF_SAVER", "Failed gif encoding");
+        return;
+    }
+    const bool useGlobalPalette = this->quality == 0;
+
+    if (useGlobalPalette) 
+    {
+        for (float fno = 0.0f; fno < animation->totalFrame(); fno += fps*0.5f) {
+            animation->frame(fno);
+            canvas->update();
+            if (canvas->draw(true) == tvg::Result::Success)
+                canvas->sync();
+            encoder.writeGlobalPalette(reinterpret_cast<uint8_t *>(buffer), w*h);
+        }
+        encoder.buildGlobalPalette();
+    }
+
+    for (auto p = 0.0f; p < duration; p += delay) {
+        auto frameNo = animation->totalFrame() * (p / duration);
+        animation->frame(frameNo);
+        canvas->update();
+        if (canvas->draw(true) == tvg::Result::Success) {
+            canvas->sync();
+        }
+        if(!encoder.writeFrame(reinterpret_cast<uint8_t*>(buffer), delayTime)) {
+            TVGERR("GIF_SAVER", "Failed gif encoding");
+            break;
+        }
+    }
+
+    if (!encoder.end()) {
+        TVGERR("GIF_SAVER", "Failed gif encoding");
+    }
+
+    if (bg) {
+        bg->unref();
+        bg = nullptr;
+    }
+}
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
+GifSaver::~GifSaver()
+{
+    close();
+}
+
+bool GifSaver::close()
+{
+    this->done();
+
+    if (bg) bg->unref();
+    bg = nullptr;
+
+    //animation holds the picture, it must be 1 at the bottom.
+    if (animation && animation->picture()->refCnt() <= 1) delete(animation);
+    animation = nullptr;
+
+    tvg::free(path);
+    path = nullptr;
+
+    tvg::free(buffer);
+    buffer = nullptr;
+
+    return true;
+}
+
+bool GifSaver::save(TVG_UNUSED Paint* paint, TVG_UNUSED Paint* bg, TVG_UNUSED const char* filename, TVG_UNUSED uint32_t quality)
+{
+    TVGLOG("GIF_SAVER", "Paint is not supported.");
+    return false;
+}
+
+bool GifSaver::save(Animation* animation, Paint* bg, const char* filename, uint32_t quality, uint32_t fps)
+{
+    close();
+
+    this->quality = quality;
+    auto picture = animation->picture();
+    auto x = 0.0f, y = 0.0f;
+    picture->bounds(&x, &y, &vsize[0], &vsize[1]);
+
+    //cut off the negative space
+    if (x < 0) vsize[0] += x;
+    if (y < 0) vsize[1] += y;
+
+    if (vsize[0] < FLOAT_EPSILON || vsize[1] < FLOAT_EPSILON) {
+        TVGLOG("GIF_SAVER", "Saving animation(%p) has zero view size.", animation);
+        return false;
+    }
+
+    if (!filename) return false;
+    this->path = duplicate(filename);
+
+    this->animation = animation;
+
+    if (bg) {
+        bg->ref();
+        this->bg = bg;
+    }
+    this->fps = static_cast<float>(fps);
+
+    TaskScheduler::request(this);
+
+    return true;
+}

--- a/src/savers/external_gif/tvgGifSaver.h
+++ b/src/savers/external_gif/tvgGifSaver.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 - 2025 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_GIFSAVER_H_
+#define _TVG_GIFSAVER_H_
+
+#include "tvgSaveModule.h"
+#include "tvgTaskScheduler.h"
+
+namespace tvg
+{
+
+class GifSaver : public SaveModule, public Task
+{
+private:
+    uint32_t* buffer = nullptr;
+    Animation* animation = nullptr;
+    Paint* bg = nullptr;
+    char *path = nullptr;
+    float vsize[2] = {0.0f, 0.0f};
+    float fps = 0.0f;
+    uint32_t quality;
+
+    void run(unsigned tid) override;
+
+public:
+    ~GifSaver();
+
+    bool save(Paint* paint, Paint* bg, const char* filename, uint32_t quality) override;
+    bool save(Animation* animation, Paint* bg, const char* filename, uint32_t quality, uint32_t fps) override;
+    bool close() override;
+};
+
+}
+
+#endif  //_TVG_GIFSAVER_H_

--- a/src/savers/meson.build
+++ b/src/savers/meson.build
@@ -1,7 +1,14 @@
 subsaver_dep = []
 
 if gif_saver
-    subdir('gif')
+    if get_option('static')
+        subdir('gif')
+    else 
+        subdir('external_gif')
+        if not gif_dep_found
+            subdir('gif')
+        endif
+    endif
 endif
 
 saver_dep = declare_dependency(


### PR DESCRIPTION
### Support External GIF (giflib)

This patch adds support for external GIF encoding using [giflib](https://giflib.sourceforge.net/)

- issue: https://github.com/thorvg/thorvg/issues/2166

### Implementation Details

This patch integrates **giflib** as an optional external dependency.  
We can control the palette behavior via the **quality** parameter:

Quality Value | Behavior | Description
-- | -- | --
=0 | Global Palette | Use a single global color palette for all frames
!= 0 | Local Palette | Use individual local palettes per frame

The implementation of `tvgGifSaver.h` and `tvgGifSaver.cpp` is mostly identical to the static version,  
except for the parts handling the `quality` setting and global palette generation.  

Additionally,  `tvgGifEncoder.h` and `tvgGifEncoder.cpp` have been added.  
They share a similar interface with the static encoder but include an option to generate a global palette.


### **giflib Quantization**

giflib provides an color quantization API, but it's deprecated. (see [source code reference](https://sourceforge.net/p/giflib/code/ci/5.0.5/tree/lib/gif_lib.h#l216), [This doesn't really belong in the core library, was undocumented,
 and was removed in 4.2](https://sourceforge.net/p/giflib/code/ci/5.0.5/tree/lib/quantize.c#l8))
 
 [Coomplee the removal of GifQuantizeBuffer().](https://sourceforge.net/p/giflib/code/ci/befe188771035de7acbc2ad46bea22ea73ab09cd/)


```
Version 5.2.0
=============

The undocumented and deprecated GifQuantizeBuffer() entry point
has been moved to the util library to reduce libgif size and attack
surface. Applications needing this function are couraged to link the
util library or make their own copy.

The following obsolete utility programs are no longer installed:
gifecho, giffilter, gifinto, gifsponge. These were either installed in
error or have been obsolesced by modern image-transformation tools
like ImageMagick convert. They may be removed entirely in a future
release.

* Address SourceForge issue #136: Stack-buffer-overflow in gifcolor.c:84

* Address SF bug #134: Giflib fails to slurp significant number of gifs

* Apply SPDX convention for license tagging.

```

### Comparison

#### 1. Binary Size

```sh
meson setup builddir --wipe -Dloaders=all -Dsavers=gif -Dtests=true -Dlog=false -Dengines=sw,gl -Dextra=lottie_expressions -Dstatic=false  -Dbuildtype=release -Dtools=all 

meson compile -C builddir
```

Version | Binary Size 
-- | -- 
static (gif-h) | 1520144
external_gif  | 1512048(-8096) 



#### 2. Performance

```sh
./builddir/tools/lottie2gif/tvg-lottie2gif ./examples/resources/lottie/ -r 200x200

find examples/resources/lottie -type f -iname "*.gif" -printf '%s\n' | awk '{sum+=$1} END {print sum/1024/1024 " MB"}'
```

Mode | Encode Time | gif file size
-- | -- | --
global palette (quality = 0) |   81380.06 ms  | 52.102 MB
local palette (quality != 0) |  21256.928 ms |  63.4543 MB
static (gif-h) |  53286.036  ms |  77.3191 MB

> AMD Ryzen 5 7600, 64GB ram, wsl2 ubuntu 

#### 3. Result

(no bg, 200x200)

| static(gif-h) |  giflib (global) | giflib (local)  | [gifenc](https://codepen.io/lottiefiles/pen/EaPXgRJ?editors=0010) |
|:------:|:----------------:|:---------------:|:--------:|
| ![Image](https://github.com/user-attachments/assets/7f6cd4a5-ef77-47ff-a11e-786c0635bb14) | ![Image](https://github.com/user-attachments/assets/baa67784-8756-472b-9ca1-7808042a3500) | ![Image](https://github.com/user-attachments/assets/e9891a7f-23db-4a04-9fe0-e9b2a119ec0b) | ![Image](https://github.com/user-attachments/assets/067512e6-b5d9-4053-9a7f-7d584b3d2139) |
| ![Image](https://github.com/user-attachments/assets/51b67b10-e48f-4b68-85a7-a57381402c4d) | ![Image](https://github.com/user-attachments/assets/93b99d46-f6a6-4917-89b1-140d939f983f) | ![Image](https://github.com/user-attachments/assets/d21c8271-474e-455a-81f4-226ae267856a) | ![Image](https://github.com/user-attachments/assets/6bfee5c5-a795-4c41-94a9-94a01dc1b1a0) |
| ![Image](https://github.com/user-attachments/assets/7914d167-eab9-4ec8-9bbf-cebcc9783ec8) | ![Image](https://github.com/user-attachments/assets/24f22afc-3e33-4f28-b586-c31f57ce5456) | ![Image](https://github.com/user-attachments/assets/b8468cb1-090d-4a53-9442-7cd822fbc676) | ![Image](https://github.com/user-attachments/assets/c9042d62-fcc6-4cb9-b017-9e174d676b1f) |
| ![Image](https://github.com/user-attachments/assets/e04ad5a0-e34f-4b5b-9983-5e6a4c1fffd6) | ![Image](https://github.com/user-attachments/assets/f345dffe-393a-4dff-8023-d832fe66771d) | ![Image](https://github.com/user-attachments/assets/b0207d61-640b-461f-ab18-c2a90e3100ad) | ![Image](https://github.com/user-attachments/assets/716249a0-9702-4048-a7e1-99edfe9aaf30) |
| ![Image](https://github.com/user-attachments/assets/e1582d2f-f0e0-4478-9d27-059e2c642be4) | ![Image](https://github.com/user-attachments/assets/e8b36d19-ad67-4c26-89fd-dfa5ab28bd54) | ![Image](https://github.com/user-attachments/assets/e173bfef-4ce7-4a74-ba85-aed871e929e8) | ![Image](https://github.com/user-attachments/assets/98262eba-9279-4030-a0dc-652248c33064) |
| ![Image](https://github.com/user-attachments/assets/87f6ac9b-d93c-4caa-a1ca-3aa198b4d63a) | ![Image](https://github.com/user-attachments/assets/d90eb5ab-4bb4-4c7b-83a9-94e4c5b8323a) | ![Image](https://github.com/user-attachments/assets/c0846752-eabe-42ae-b923-53bf6652695b) | ![Image](https://github.com/user-attachments/assets/7aa42541-b43a-4f50-8fe4-528f734a6e80) |
| ![Image](https://github.com/user-attachments/assets/baf006ff-7d16-44e4-b8c0-c071959db7c5) | ![Image](https://github.com/user-attachments/assets/f24a2d02-6881-4256-bd04-096adef5766a) | ![Image](https://github.com/user-attachments/assets/50ce0b31-5088-460c-af61-60fb6f052521) | ![Image](https://github.com/user-attachments/assets/b9dddbe7-a79a-4d39-9089-c4ee4b0b2935) |
| ![Image](https://github.com/user-attachments/assets/af6ad506-a755-467c-9ba4-46efa5d0516b) | ![Image](https://github.com/user-attachments/assets/f538848f-2415-4b7b-b023-6a849e9d67df) | ![Image](https://github.com/user-attachments/assets/abee8d30-9809-4333-ae12-0b4924f0d619) | ![Image](https://github.com/user-attachments/assets/29029508-dc4e-4c20-8111-6e5423def927) |
| ![Image](https://github.com/user-attachments/assets/8b24adae-c3db-4179-807e-c6b8aced74cf) | ![Image](https://github.com/user-attachments/assets/c949aced-dc61-4e2f-9426-163c540f26ba) | ![Image](https://github.com/user-attachments/assets/6c47a987-6b33-4b79-be01-f643a416a830) | ![Image](https://github.com/user-attachments/assets/409d0c03-a4ca-4218-87b2-9ce899e876ca) |
| ![Image](https://github.com/user-attachments/assets/35161abc-47f4-41e5-8a9f-f0c644efb175) | ![Image](https://github.com/user-attachments/assets/09c709e4-9b80-4fe3-ac4c-e8e4bf068639) | ![Image](https://github.com/user-attachments/assets/c57c2f82-4c46-4b1f-bbb2-663f4a8dc910) | ![Image](https://github.com/user-attachments/assets/4d75cab8-58af-4696-9a59-e1b547258431) |
| ![Image](https://github.com/user-attachments/assets/1ceb3a10-be3e-4734-ac93-9b06ce92c338) | ![Image](https://github.com/user-attachments/assets/deb13027-6bd2-43ea-9e6a-15de020eff10) | ![Image](https://github.com/user-attachments/assets/4550e984-b3db-4b2a-9edd-3a07bf372cd4) | ![Image](https://github.com/user-attachments/assets/bc832e6a-138b-4a81-a096-54798426b2bb) |


