### PR TITLE
text: ++exception handling for edge cases crashes

### DIFF
--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -103,6 +103,7 @@ struct TextImpl : Text
 
     RenderRegion bounds()
     {
+        if (!load()) return {};
         return SHAPE(shape)->bounds();
     }
 
@@ -149,7 +150,6 @@ struct TextImpl : Text
         if (!load()) return true;
 
         auto scale = fm.scale;
-        if (tvg::zero(scale)) return true;
 
         //transform the gradient coordinates based on the final scaled font.
         auto fill = SHAPE(shape)->rs.fill;


### PR DESCRIPTION
- update text properly when the scale is zero-sized, text must be refreshed with the invalid visual.
- don't access Shape with the invalid condition when text is not properly loaded.