### PR TITLE
lottie/jerryscript: fix debug build on MSVC

### DIFF
--- a/src/loaders/lottie/jerryscript/jerry-core/jrt/jrt.h
+++ b/src/loaders/lottie/jerryscript/jerry-core/jrt/jrt.h
@@ -93,10 +93,6 @@ void JERRY_ATTR_NORETURN jerry_unreachable (const char *file, const char *functi
 #define JERRY_ASSERT(x) \
   do                    \
   {                     \
-    if (false)          \
-    {                   \
-      JERRY_UNUSED (x); \
-    }                   \
   } while (0)
 
 #if defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
## Issue: #3821

<img width="539" height="346" alt="image" src="https://github.com/user-attachments/assets/292b2a89-7e1e-4a64-b0e6-c42e8a604dfc" />

Linking error occurs when building with `extra=lottie_expressions` enabled(build examples):

```
2>libthorvg.a(loaders_lottie_jerryscript_jerry-core_jmem_jmem-allocator.cpp.obj) : error LNK2019: unresolved external symbol "bool __cdecl jmem_is_heap_pointer(void const *)" (?jmem_is_heap_pointer@@YA_NPEBX@Z) referenced in function "unsigned short __cdecl jmem_compress_pointer(void const *)" (?jmem_compress_pointer@@YAGPEBX@Z)
2>libthorvg.a(loaders_lottie_jerryscript_jerry-core_jmem_jmem-heap.cpp.obj) : error LNK2001: unresolved external symbol "bool __cdecl jmem_is_heap_pointer(void const *)" (?jmem_is_heap_pointer@@YA_NPEBX@Z)
2>.\Animation.exe : fatal error LNK1120: 1 unresolved externals
```



## History/ Problem

In commit [#2198](https://github.com/thorvg/thorvg/pull/2198/commits/9d6a12bf248457ceb96da18055df731d9ac53bb7#diff-d0d9eb0da9b37d46d57d81c1e4d130cc53471b8eed3a9251a5a624d248b4e262R26-R28)
, the build defines `JERRY_NDEBUG`, which disables the implementation of `jmem_is_heap_pointer()` because it is wrapped in:

```cpp
// jmem-heap.cpp
#ifndef JERRY_NDEBUG
/**
 * Check whether the pointer points to the heap
 *
 * Note:
 *      the routine should be used only for assertion checks
 *
 * @return true - if pointer points to the heap,
 *         false - otherwise
 */
bool
jmem_is_heap_pointer (const void *pointer) /**< pointer */
{
#if !JERRY_SYSTEM_ALLOCATOR
  return ((uint8_t *) pointer >= JERRY_HEAP_CONTEXT (area)
          && (uint8_t *) pointer <= (JERRY_HEAP_CONTEXT (area) + JMEM_HEAP_AREA_SIZE));
#else /* JERRY_SYSTEM_ALLOCATOR */
  JERRY_UNUSED (pointer);
  return true;
#endif /* !JERRY_SYSTEM_ALLOCATOR */
} /* jmem_is_heap_pointer */
#endif /* !JERRY_NDEBUG */

```


However, this function is still referenced inside `JERRY_ASSERT()` calls, such as:

<img width="383" height="310" alt="image" src="https://github.com/user-attachments/assets/0824e5e9-c38c-4288-ab3e-4bcf3fd5bf6a" />

`JERRY_ASSERT` does not completely remove the argument reference, causing the linker to look for the missing symbol and fail.

```cpp
#define JERRY_UNUSED(x) ((void) (x))
```
