### PR TITLE
examples: Add Windows support

### DIFF
--- a/examples/all.bat
+++ b/examples/all.bat
@@ -1,0 +1,28 @@
+@echo off
+setlocal
+
+rem Work in the folder where this .bat lives
+cd /d "%~dp0"
+
+rem Get arg; default to sw if none
+set "ARG=%~1"
+if not defined ARG set "ARG=sw"
+
+rem Validate
+if /I not "%ARG%"=="gl" if /I not "%ARG%"=="sw" if /I not "%ARG%"=="wg" (
+  echo Invalid argument: %ARG%
+  echo Usage: %~n0 [gl^|sw^|wg]
+  exit /b 1
+)
+
+for %%F in ("*.exe") do (
+  echo Launching %%~nxF %ARG%
+  start "" "%%~fF" %ARG%
+  timeout /t 2 /nobreak >nul
+  rem Try to close it, then force-close if needed
+  taskkill /im "%%~nxF" /t >nul 2>&1
+  taskkill /im "%%~nxF" /f /t >nul 2>&1
+)
+
+echo Done.
+endlocal

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -8,6 +8,8 @@ if gl_variant == 'OpenGL ES'
     examples_compiler_flags += '-DTHORVG_GL_TARGET_GLES=1'
 endif
 
+examples_compiler_flags += ['-DSDL_MAIN_HANDLED']
+
 examples_dep = [dependency('sdl2')]
 
 if all_engines or get_option('engines').contains('wg')
@@ -109,6 +111,8 @@ if get_option('bindings').contains('capi')
     endforeach
 endif
 
-execute_all_src = join_paths(meson.project_source_root(), 'examples/all.sh')
-execute_all_dst = join_paths(meson.project_build_root(), 'examples/all.sh')
-run_command('cp', execute_all_src, execute_all_dst, check: true)
+if cc.get_id() == 'msvc'
+    configure_file(input: 'all.bat', output: 'all.bat', copy: true)
+else
+    configure_file(input: 'all.sh', output: 'all.sh', copy: true)
+endif


### PR DESCRIPTION
- Add Windows batch script (all.bat) to run all examples automatically
- Configure SDL main handling for MSVC builds to prevent conflicts

This enables seamless example execution on Windows platforms