### PR TITLE
lottie: fix text clipping issue in URL font rendering

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -946,7 +946,8 @@ void LottieBuilder::updateURLFont( LottieLayer* layer, float frameNo, LottieText
     paint->fill(color.r, color.g, color.b);
     paint->size(doc.size * 75.0f); //1 pt = 1/72; 1 in = 96 px; -> 72/96 = 0.75
     paint->text(buf);
-    paint->align(-doc.justify, 0.5f);
+    paint->align(-doc.justify, 0.0f);
+    paint->translate(0.0f, doc.size * -100.0f);
     layer->scene->push(paint);
 
     //outline


### PR DESCRIPTION
Restore line height calculation and vertical positioning that was removed recently. The previous refactoring to rely on core text layout caused text to be clipped at the bottom due to missing vertical offset adjustment.

| ![Comet 2025-11-13 16 26 55](https://github.com/user-attachments/assets/0cfe6eca-578e-481e-8b9a-1bd536af0c7f) | ![Comet 2025-11-13 16 27 30](https://github.com/user-attachments/assets/48d02965-0a09-4368-8304-3c488616864f) |
|:--:|:--:|
| **Current** | **Patched** |

- restore lineHeight calculation (doc.size * 100.0f)
- change vertical alignment from middle (0.5f) to top (0.0f)

since: https://github.com/thorvg/thorvg/commit/03514dd0