### PR TITLE
gl: Apply trim path during preparation instead of tessellation

### DIFF
--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -44,12 +44,7 @@ void Stroker::run(const RenderShape& rshape, const RenderPath& path, const Matri
 
     RenderPath dashed;
     if (rshape.strokeDash(dashed)) run(dashed, m);
-    else if (rshape.trimpath()) {
-        RenderPath trimmedPath;
-        if (rshape.stroke->trim.trim(path, trimmedPath)) {
-            run(trimmedPath, m);
-        }
-    } else run(path, m);
+    else run(path, m);
 }
 
 


### PR DESCRIPTION
Moves trim path operations from the tessellation phase to the preparation phase, where the trimmed path replaces the optimized path. This ensures the trimmed geometry is available throughout the rendering pipeline and prevents geometry loss during trim path operations.

The trim path is now applied once in GlGeometry::prepare() and reused by both fill and stroke tessellation, eliminating duplicate trim operations.

Related issues:
https://github.com/thorvg/thorvg/issues/3653