### PR TITLE
lottie/expressions: add `.value` accessor for numeric effect properties

### DIFF
--- a/src/loaders/lottie/jerryscript/jerry-core/api/jerryscript.cpp
+++ b/src/loaders/lottie/jerryscript/jerry-core/api/jerryscript.cpp
@@ -267,6 +267,21 @@ jerry_value_to_object (const jerry_value_t value) /**< input value */
 } /* jerry_value_to_object */
 
 /**
+ * Call ToPrimitive operation on the api value.
+ *
+ * Note:
+ *      returned value must be freed with jerry_value_free, when it is no longer needed.
+ *
+ * @return converted primitive value - if success
+ *         thrown error - otherwise
+ */
+jerry_value_t
+jerry_value_to_primitive (const jerry_value_t value) /**< input value */
+{
+  return jerry_return (ecma_op_to_primitive (value, ECMA_PREFERRED_TYPE_NO));
+} /* jerry_value_to_primitive */
+
+/**
  * Call the ToString ecma builtin operation on the api value.
  *
  * Note:

--- a/src/loaders/lottie/jerryscript/jerry-core/include/jerryscript-core.h
+++ b/src/loaders/lottie/jerryscript/jerry-core/include/jerryscript-core.h
@@ -32,6 +32,7 @@ bool jerry_value_is_object (const jerry_value_t value);
 bool jerry_value_is_string (const jerry_value_t value);
 bool jerry_value_is_exception (const jerry_value_t value);
 jerry_value_t jerry_value_to_object (const jerry_value_t value);
+jerry_value_t jerry_value_to_primitive (const jerry_value_t value);
 jerry_value_t jerry_value_to_string (const jerry_value_t value);
 float jerry_value_as_number (const jerry_value_t value);
 int32_t jerry_value_as_int32 (const jerry_value_t value);


### PR DESCRIPTION
This patch fixes an issue where expressions such as:

```js
effect("Slider Control")("Slider").value.toFixed(0)
```

failed because numeric effect properties (Integer, Float, Opacity) did not
expose a `.value` accessor.  
These properties are now *boxed* into Number objects with a `.value` field.

- issue: #3896


### Reference

#### Prior related work

- https://github.com/thorvg/thorvg/pull/3749

---

<details>
<summary> Effect → Property → Value lookup in After Effects </summary>


- AE treats the slider effect’s internal slider as a `Property` object.  
The `.value` accessor is required to retrieve the underlying primitive.
    - **AE documentation:** [effect](https://ae-expressions.docsforadobe.dev/objects/effect/#returns), [property-value](https://ae-expressions.docsforadobe.dev/objects/property/#value)

| Effect | Property| Value
| - | - | - |
|<img width="908" height="859" alt="Image" src="https://github.com/user-attachments/assets/80ad10e6-6dec-471c-9e1d-c0db907e17e6" />|<img width="1621" height="1110" alt="Image" src="https://github.com/user-attachments/assets/c1cf21b8-fad0-4bca-be57-4b302f03c8d2" />| <img width="620" height="436" alt="Image" src="https://github.com/user-attachments/assets/13d061e0-0e76-4326-a906-a19ce741e8e9" />|


</details>

<details>
<summary>boxing: Number → Number Object </summary>

| [legacy-and-extend-script-engine](https://helpx.adobe.com/after-effects/using/legacy-and-extend-script-engine.html)|
|-|
|<img width="1153" height="508" alt="Image" src="https://github.com/user-attachments/assets/2bb1b8cb-5740-47d9-9738-694b7ef2b627" />|

- AE’s Legacy engine requires .value, while the modern JavaScript engine automatically resolves the underlying numeric value. To support both behaviors, numeric effect properties must be boxed into a Number object and expose .value. This is done using `jerry_value_to_object()`.



```cpp
/**
 * Call ToObject operation on the api value.
 *
 * Note:
 *      returned value must be freed with jerry_value_free, when it is no longer needed.
 *
 * @return converted object value - if success
 *         thrown error - otherwise
 */
jerry_value_t
jerry_value_to_object (const jerry_value_t value) /**< input value */
{
  return jerry_return (ecma_op_to_object (value));
} /* jerry_value_to_object */

ecma_value_t
ecma_op_to_object (ecma_value_t value) /**< ecma value */
{
  ecma_check_value_type_is_spec_defined (value);
  ecma_builtin_id_t proto_id = ECMA_BUILTIN_ID_OBJECT_PROTOTYPE;
  uint8_t class_type;

  if (ecma_is_value_number (value))
  {
#if JERRY_BUILTIN_NUMBER
    proto_id = ECMA_BUILTIN_ID_NUMBER_PROTOTYPE;
#endif /* JERRY_BUILTIN_NUMBER */
    class_type = ECMA_OBJECT_CLASS_NUMBER;
  }
```

</details>


### Result

|main | fetch |
|-|-|
|![issue](https://github.com/user-attachments/assets/4347797f-8c0e-4910-82e9-1f0e3aaabdf4)|![Fetch](https://github.com/user-attachments/assets/8abc9772-9544-4523-bcc1-20a7d952315a)|


|**Note: Position and font-related issues are not yet resolved.**|
|-|
|<img width="250" alt="image" src="https://github.com/user-attachments/assets/795f839d-3936-410e-bddf-5874969d7827" />|
