### PR TITLE
gl: Clears optimized path when trim fails

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -298,7 +298,7 @@ void GlGeometry::prepare(const RenderShape& rshape)
         if (rshape.stroke->trim.trim(optimizedPath, trimmedPath)) {
             trimmedPath.pts.move(optimizedPath.pts);
             trimmedPath.cmds.move(optimizedPath.cmds);
-        }
+        } else optimizedPath.clear();
     }
 }
 


### PR DESCRIPTION
Avoids potential issues by clearing the optimized path if the trimming operation fails. This ensures that stale or incorrect path data is not used in subsequent rendering steps, preventing visual artifacts.

Related issues: https://github.com/thorvg/thorvg/issues/3984

<img width="1537" height="1568" alt="image" src="https://github.com/user-attachments/assets/48cbb6dd-6b99-41d8-96e7-e71dc380c3f0" />
