### PR TITLE
common: code refactoring

### DIFF
--- a/src/common/tvgAllocator.h
+++ b/src/common/tvgAllocator.h
@@ -29,25 +29,24 @@
 //separate memory alloators for clean customization
 namespace tvg
 {
-    template<typename T = void*>
-    static inline T malloc(size_t size)
+    template<typename T = void>
+    static inline T* malloc(size_t size)
     {
-        return static_cast<T>(std::malloc(size));
+        return static_cast<T*>(std::malloc(size));
     }
 
-    template<typename T = void*>
-    static inline T calloc(size_t nmem, size_t size)
+    template<typename T = void>
+    static inline T* calloc(size_t nmem, size_t size)
     {
-        return static_cast<T>(std::calloc(nmem, size));
+        return static_cast<T*>(std::calloc(nmem, size));
     }
 
-    template<typename T = void*>
-    static inline T realloc(void* ptr, size_t size)
+    template<typename T = void>
+    static inline T* realloc(void* ptr, size_t size)
     {
-        return static_cast<T>(std::realloc(ptr, size));
+        return static_cast<T*>(std::realloc(ptr, size));
     }
 
-    template<typename T = void*>
     static inline void free(void* ptr)
     {
         std::free(ptr);

--- a/src/common/tvgArray.h
+++ b/src/common/tvgArray.h
@@ -58,7 +58,7 @@ struct Array
     {
         if (count + 1 > reserved) {
             reserved = count + (count + 2) / 2;
-            data = tvg::realloc<T*>(data, sizeof(T) * reserved);
+            data = tvg::realloc<T>(data, sizeof(T) * reserved);
         }
         data[count++] = element;
     }
@@ -75,7 +75,7 @@ struct Array
     {
         if (size > reserved) {
             reserved = size;
-            data = tvg::realloc<T*>(data, sizeof(T) * reserved);
+            data = tvg::realloc<T>(data, sizeof(T) * reserved);
         }
         return true;
     }

--- a/src/common/tvgCompressor.cpp
+++ b/src/common/tvgCompressor.cpp
@@ -48,7 +48,7 @@ size_t b64Decode(const char* encoded, const size_t len, char** decoded)
     if (!decoded || !encoded || len == 0) return 0;
 
     auto reserved = 3 * (1 + (len >> 2)) + 1;
-    auto output = tvg::malloc<char*>(reserved * sizeof(char));
+    auto output = tvg::malloc<char>(reserved * sizeof(char));
     if (!output) return 0;
     output[reserved - 1] = '\0';
 

--- a/src/common/tvgStr.cpp
+++ b/src/common/tvgStr.cpp
@@ -212,7 +212,7 @@ char* duplicate(const char *str, size_t n)
     auto len = strlen(str);
     if (len < n) n = len;
 
-    auto ret = tvg::malloc<char*>(n + 1);
+    auto ret = tvg::malloc<char>(n + 1);
     ret[n] = '\0';
 
     return (char*)memcpy(ret, str, n);
@@ -223,7 +223,7 @@ char* append(char* lhs, const char* rhs, size_t n)
 {
     if (!rhs) return lhs;
     if (!lhs) return duplicate(rhs, n);
-    lhs = tvg::realloc<char*>(lhs, strlen(lhs) + n + 1);
+    lhs = tvg::realloc<char>(lhs, strlen(lhs) + n + 1);
     return strncat(lhs, rhs, n);
 }
 
@@ -270,7 +270,7 @@ const char* fileext(const char* path)
 char* concat(const char* a, const char* b)
 {
     auto len = strlen(a) + strlen(b) + 1;
-    auto ret = tvg::malloc<char*>(len * sizeof(char));
+    auto ret = tvg::malloc<char>(len * sizeof(char));
     strcpy(ret, a);
     strcat(ret, b);
     return ret;

--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -78,7 +78,7 @@ bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpa
     if (tjDecompressHeader3(jpegDecompressor, (unsigned char *) data, size, &width, &height, &subSample, &colorSpace) < 0) return false;
 
     if (copy) {
-        this->data = tvg::malloc<unsigned char*>(size);
+        this->data = tvg::malloc<unsigned char>(size);
         if (!this->data) return false;
         memcpy((unsigned char *)this->data, data, size);
         freeData = true;

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -39,7 +39,7 @@ void PngLoader::clear()
 
 PngLoader::PngLoader() : ImageLoader(FileType::Png)
 {
-    image = tvg::calloc<png_imagep>(1, sizeof(png_image));
+    image = tvg::calloc<png_image>(1, sizeof(png_image));
     image->version = PNG_IMAGE_VERSION;
     image->opaque = nullptr;
 }
@@ -95,7 +95,7 @@ bool PngLoader::read()
         surface.cs = ColorSpace::ABGR8888S;
     }
 
-    auto buffer = tvg::malloc<png_bytep>(PNG_IMAGE_SIZE((*image)));
+    auto buffer = tvg::malloc<png_byte>(PNG_IMAGE_SIZE((*image)));
     if (!png_image_finish_read(image, NULL, buffer, 0, NULL)) {
         tvg::free(buffer);
         return false;

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -85,7 +85,7 @@ bool WebpLoader::open(const char* path)
 bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
 {
     if (copy) {
-        this->data = tvg::malloc<unsigned char*>(size);
+        this->data = tvg::malloc<unsigned char>(size);
         if (!this->data) return false;
         memcpy((unsigned char *)this->data, data, size);
         freeData = true;

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -87,7 +87,7 @@ bool JpgLoader::open(const char* path)
 bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
 {
     if (copy) {
-        this->data = tvg::malloc<char*>(size);
+        this->data = tvg::malloc<char>(size);
         if (!this->data) return false;
         memcpy((char *)this->data, data, size);
         freeData = true;

--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -808,7 +808,7 @@ void *jpeg_decoder::alloc(size_t nSize, bool zero)
     }
     if (!rv) {
         int capacity = JPGD_MAX(32768 - 256, (nSize + 2047) & ~2047);
-        auto b = tvg::malloc<mem_block*>(sizeof(mem_block) + capacity);
+        auto b = tvg::malloc<mem_block>(sizeof(mem_block) + capacity);
         b->m_pNext = m_pMem_blocks; m_pMem_blocks = b;
         b->m_used_count = nSize;
         b->m_size = capacity;
@@ -2486,7 +2486,7 @@ unsigned char* jpgdDecompress(jpeg_decoder* decoder, ColorSpace cs)
     auto height = decoder->get_height();
     //auto actual_comps = decoder->get_num_components();
     const auto stride = width * channel;
-    auto ret = tvg::malloc<uint8_t*>(stride * height);
+    auto ret = tvg::malloc<uint8_t>(stride * height);
     auto dst = ret;
 
     for (int y = 0; y < height; y++) {

--- a/src/loaders/lottie/tvgLottieData.h
+++ b/src/loaders/lottie/tvgLottieData.h
@@ -50,7 +50,7 @@ struct ColorStop
     void copy(const ColorStop& rhs, uint32_t cnt)
     {
         if (rhs.data) {
-            data = tvg::malloc<Fill::ColorStop*>(sizeof(Fill::ColorStop) * cnt);
+            data = tvg::malloc<Fill::ColorStop>(sizeof(Fill::ColorStop) * cnt);
             memcpy(data, rhs.data, sizeof(Fill::ColorStop) * cnt);
         }
         if (rhs.input) TVGERR("LOTTIE", "Must be populated!");

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -66,7 +66,7 @@ static LottieExpressions* exps = nullptr;   //singleton instance engine
 
 static ExpContent* _expcontent(LottieExpression* exp, float frameNo, void* data, size_t refCnt = 1)
 {
-    auto ret = tvg::malloc<ExpContent*>(sizeof(ExpContent));
+    auto ret = tvg::malloc<ExpContent>(sizeof(ExpContent));
     ret->exp = exp;
     ret->frameNo = frameNo;
     ret->data = data;
@@ -156,7 +156,7 @@ static char* _name(jerry_value_t args)
 {
     auto arg0 = jerry_value_to_string(args);
     auto len = jerry_string_length(arg0);
-    auto name = tvg::malloc<jerry_char_t*>(len * sizeof(jerry_char_t) + 1);
+    auto name = tvg::malloc<jerry_char_t>(len * sizeof(jerry_char_t) + 1);
     jerry_string_to_buffer(arg0, JERRY_ENCODING_UTF8, name, len);
     name[len] = '\0';
     jerry_value_free(arg0);

--- a/src/loaders/lottie/tvgLottieExpressions.h
+++ b/src/loaders/lottie/tvgLottieExpressions.h
@@ -116,7 +116,7 @@ struct LottieExpressions
 
         if (jerry_value_is_string(bm_rt)) {
             auto len = jerry_string_length(bm_rt);
-            doc.text = tvg::realloc<char*>(doc.text, (len + 1) * sizeof(jerry_char_t));
+            doc.text = tvg::realloc<char>(doc.text, (len + 1) * sizeof(jerry_char_t));
             jerry_string_to_buffer(bm_rt, JERRY_ENCODING_UTF8, (jerry_char_t*)doc.text, len);
             doc.text[len] = '\0';
         }

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -211,7 +211,7 @@ bool LottieLoader::header()
 bool LottieLoader::open(const char* data, uint32_t size, const char* rpath, bool copy)
 {
     if (copy) {
-        content = tvg::malloc<char*>(size + 1);
+        content = tvg::malloc<char>(size + 1);
         if (!content) return false;
         memcpy((char*)content, data, size);
         const_cast<char*>(content)[size] = '\0';

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -390,7 +390,7 @@ LottieInterpolator* LottieParser::getInterpolator(const char* key, Point& in, Po
 
     //new interpolator
     if (!interpolator) {
-        interpolator = tvg::malloc<LottieInterpolator*>(sizeof(LottieInterpolator));
+        interpolator = tvg::malloc<LottieInterpolator>(sizeof(LottieInterpolator));
         interpolator->set(key, in, out);
         comp->interpolators.push(interpolator);
     }
@@ -962,7 +962,7 @@ void LottieParser::parseImage(LottieImage* image, const char* data, const char* 
     //external image resource
     } else {
         auto len = strlen(dirName) + strlen(subPath) + strlen(data) + 2;
-        image->data.path = tvg::malloc<char*>(len);
+        image->data.path = tvg::malloc<char>(len);
         snprintf(image->data.path, len, "%s/%s%s", dirName, subPath, data);
     }
 
@@ -1191,7 +1191,7 @@ void LottieParser::parseTextRange(LottieText* text)
                     else if (KEY_AS("xe"))
                     {
                         parseProperty(selector->maxEase);
-                        selector->interpolator = tvg::malloc<LottieInterpolator*>(sizeof(LottieInterpolator));
+                        selector->interpolator = tvg::malloc<LottieInterpolator>(sizeof(LottieInterpolator));
                     }
                     else if (KEY_AS("ne")) parseProperty(selector->minEase);
                     else if (KEY_AS("a")) parseProperty(selector->maxAmount);
@@ -1694,7 +1694,7 @@ void LottieParser::captureSlots(const char* key)
 
     //composite '{' + slots + '}'
     auto len = (end - begin + 2);
-    slots = tvg::malloc<char*>(sizeof(char) * len + 1);
+    slots = tvg::malloc<char>(sizeof(char) * len + 1);
     slots[0] = '{';
     memcpy(slots + 1, begin, len);
     slots[len] = '\0';

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -507,7 +507,7 @@ struct LottiePathSet : LottieProperty
     LottieScalarFrame<PathSet>& newFrame()
     {
         if (!frames) {
-            frames = tvg::calloc<Array<LottieScalarFrame<PathSet>>*>(1, sizeof(Array<LottieScalarFrame<PathSet>>));
+            frames = tvg::calloc<Array<LottieScalarFrame<PathSet>>>(1, sizeof(Array<LottieScalarFrame<PathSet>>));
         }
         if (frames->count + 1 >= frames->reserved) {
             auto old = frames->reserved;
@@ -561,7 +561,7 @@ struct LottiePathSet : LottieProperty
         //interpolate 2 frames
         auto s = frame->value.pts;
         auto e = (frame + 1)->value.pts;
-        auto interpPts = tvg::malloc<Point*>(frame->value.ptsCnt * sizeof(Point));
+        auto interpPts = tvg::malloc<Point>(frame->value.ptsCnt * sizeof(Point));
         auto p = interpPts;
 
         for (auto i = 0; i < frame->value.ptsCnt; ++i, ++s, ++e, ++p) {
@@ -705,7 +705,7 @@ struct LottieColorStop : LottieProperty
     LottieScalarFrame<ColorStop>& newFrame()
     {
         if (!frames) {
-            frames = tvg::calloc<Array<LottieScalarFrame<ColorStop>>*>(1, sizeof(Array<LottieScalarFrame<ColorStop>>));
+            frames = tvg::calloc<Array<LottieScalarFrame<ColorStop>>>(1, sizeof(Array<LottieScalarFrame<ColorStop>>));
         }
         if (frames->count + 1 >= frames->reserved) {
             auto old = frames->reserved;
@@ -813,7 +813,7 @@ struct LottieColorStop : LottieProperty
                 frames = rhs.frames;
                 rhs.frames = nullptr;
             } else {
-                frames = tvg::calloc<Array<LottieScalarFrame<ColorStop>>*>(1, sizeof(Array<LottieScalarFrame<ColorStop>>));
+                frames = tvg::calloc<Array<LottieScalarFrame<ColorStop>>>(1, sizeof(Array<LottieScalarFrame<ColorStop>>));
                 *frames = *rhs.frames;
                 for (uint32_t i = 0; i < (*rhs.frames).count; ++i) {
                     (*frames)[i].value.copy((*rhs.frames)[i].value, rhs.count);

--- a/src/loaders/png/tvgLodePng.cpp
+++ b/src/loaders/png/tvgLodePng.cpp
@@ -477,7 +477,7 @@ static unsigned HuffmanTree_makeTable(HuffmanTree* tree)
     static const unsigned headsize = 1u << FIRSTBITS; /*size of the first table*/
     static const unsigned mask = (1u << FIRSTBITS) /*headsize*/ - 1u;
     size_t i, numpresent, pointer, size; /*total table size*/
-    unsigned* maxlens = tvg::malloc<unsigned*>(headsize * sizeof(unsigned));
+    unsigned* maxlens = tvg::malloc<unsigned>(headsize * sizeof(unsigned));
     if (!maxlens) return 83; /*alloc fail*/
 
     /* compute maxlens: max total bit length of symbols sharing prefix in the first table*/
@@ -497,8 +497,8 @@ static unsigned HuffmanTree_makeTable(HuffmanTree* tree)
         unsigned l = maxlens[i];
         if (l > FIRSTBITS) size += (1u << (l - FIRSTBITS));
     }
-    tree->table_len = tvg::malloc<unsigned char*>(size * sizeof(*tree->table_len));
-    tree->table_value = tvg::malloc<unsigned short*>(size * sizeof(*tree->table_value));
+    tree->table_len = tvg::malloc<unsigned char>(size * sizeof(*tree->table_len));
+    tree->table_value = tvg::malloc<unsigned short>(size * sizeof(*tree->table_value));
     if (!tree->table_len || !tree->table_value) {
         tvg::free(maxlens);
         /* freeing tree->table values is done at a higher scope */
@@ -600,9 +600,9 @@ static unsigned HuffmanTree_makeFromLengths2(HuffmanTree* tree)
     unsigned error = 0;
     unsigned bits, n;
 
-    tree->codes = tvg::malloc<unsigned*>(tree->numcodes * sizeof(unsigned));
-    blcount = tvg::malloc<unsigned*>((tree->maxbitlen + 1) * sizeof(unsigned));
-    nextcode = tvg::malloc<unsigned*>((tree->maxbitlen + 1) * sizeof(unsigned));
+    tree->codes = tvg::malloc<unsigned>(tree->numcodes * sizeof(unsigned));
+    blcount = tvg::malloc<unsigned>((tree->maxbitlen + 1) * sizeof(unsigned));
+    nextcode = tvg::malloc<unsigned>((tree->maxbitlen + 1) * sizeof(unsigned));
     if (!tree->codes || !blcount || !nextcode) error = 83; /*alloc fail*/
 
     if (!error) {
@@ -639,7 +639,7 @@ static unsigned HuffmanTree_makeFromLengths2(HuffmanTree* tree)
 static unsigned HuffmanTree_makeFromLengths(HuffmanTree* tree, const unsigned* bitlen, size_t numcodes, unsigned maxbitlen)
 {
     unsigned i;
-    tree->lengths = tvg::malloc<unsigned*>(numcodes * sizeof(unsigned));
+    tree->lengths = tvg::malloc<unsigned>(numcodes * sizeof(unsigned));
     if (!tree->lengths) return 83; /*alloc fail*/
     for (i = 0; i != numcodes; ++i) tree->lengths[i] = bitlen[i];
     tree->numcodes = (unsigned)numcodes; /*number of symbols*/
@@ -652,7 +652,7 @@ static unsigned HuffmanTree_makeFromLengths(HuffmanTree* tree, const unsigned* b
 static unsigned generateFixedLitLenTree(HuffmanTree* tree)
 {
     unsigned i, error = 0;
-    unsigned* bitlen = tvg::malloc<unsigned*>(NUM_DEFLATE_CODE_SYMBOLS * sizeof(unsigned));
+    unsigned* bitlen = tvg::malloc<unsigned>(NUM_DEFLATE_CODE_SYMBOLS * sizeof(unsigned));
     if (!bitlen) return 83; /*alloc fail*/
 
     /*288 possible codes: 0-255=literals, 256=endcode, 257-285=lengthcodes, 286-287=unused*/
@@ -672,7 +672,7 @@ static unsigned generateFixedLitLenTree(HuffmanTree* tree)
 static unsigned generateFixedDistanceTree(HuffmanTree* tree)
 {
     unsigned i, error = 0;
-    unsigned* bitlen = tvg::malloc<unsigned*>(NUM_DISTANCE_SYMBOLS * sizeof(unsigned));
+    unsigned* bitlen = tvg::malloc<unsigned>(NUM_DISTANCE_SYMBOLS * sizeof(unsigned));
     if (!bitlen) return 83; /*alloc fail*/
 
     /*there are 32 distance codes, but 30-31 are unused*/
@@ -742,7 +742,7 @@ static unsigned getTreeInflateDynamic(HuffmanTree* tree_ll, HuffmanTree* tree_d,
     /*number of code length codes. Unlike the spec, the value 4 is added to it here already*/
     HCLEN = readBits(reader, 4) + 4;
 
-    bitlen_cl = tvg::malloc<unsigned*>(NUM_CODE_LENGTH_CODES * sizeof(unsigned));
+    bitlen_cl = tvg::malloc<unsigned>(NUM_CODE_LENGTH_CODES * sizeof(unsigned));
     if(!bitlen_cl) return 83 /*alloc fail*/;
 
     HuffmanTree_init(&tree_cl);
@@ -764,8 +764,8 @@ static unsigned getTreeInflateDynamic(HuffmanTree* tree_ll, HuffmanTree* tree_d,
         if(error) break;
 
         /*now we can use this tree to read the lengths for the tree that this function will return*/
-        bitlen_ll = tvg::malloc<unsigned*>(NUM_DEFLATE_CODE_SYMBOLS * sizeof(unsigned));
-        bitlen_d = tvg::malloc<unsigned*>(NUM_DISTANCE_SYMBOLS * sizeof(unsigned));
+        bitlen_ll = tvg::malloc<unsigned>(NUM_DEFLATE_CODE_SYMBOLS * sizeof(unsigned));
+        bitlen_d = tvg::malloc<unsigned>(NUM_DISTANCE_SYMBOLS * sizeof(unsigned));
         if (!bitlen_ll || !bitlen_d) ERROR_BREAK(83 /*alloc fail*/);
         lodepng_memset(bitlen_ll, 0, NUM_DEFLATE_CODE_SYMBOLS * sizeof(*bitlen_ll));
         lodepng_memset(bitlen_d, 0, NUM_DISTANCE_SYMBOLS * sizeof(*bitlen_d));
@@ -1366,7 +1366,7 @@ static void lodepng_color_mode_alloc_palette(LodePNGColorMode* info)
     size_t i;
     /*if the palette is already allocated, it will have size 1024 so no reallocation needed in that case*/
     /*the palette must have room for up to 256 colors with 4 bytes each.*/
-    if (!info->palette) info->palette = tvg::malloc<unsigned char*>(1024);
+    if (!info->palette) info->palette = tvg::malloc<unsigned char>(1024);
     if (!info->palette) return; /*alloc fail*/
     for (i = 0; i != 256; ++i) {
         /*Initialize all unused colors with black, the value used for invalid palette indices.
@@ -1399,7 +1399,7 @@ static unsigned lodepng_color_mode_copy(LodePNGColorMode* dest, const LodePNGCol
     lodepng_color_mode_cleanup(dest);
     lodepng_memcpy(dest, source, sizeof(LodePNGColorMode));
     if (source->palette) {
-        dest->palette = tvg::malloc<unsigned char*>(1024);
+        dest->palette = tvg::malloc<unsigned char>(1024);
         if (!dest->palette && source->palettesize) return 83; /*alloc fail*/
         lodepng_memcpy(dest->palette, source->palette, source->palettesize * 4);
     }
@@ -1559,7 +1559,7 @@ static unsigned color_tree_add(ColorTree* tree, unsigned char r, unsigned char g
     for (bit = 0; bit < 8; ++bit) {
         int i = 8 * ((r >> bit) & 1) + 4 * ((g >> bit) & 1) + 2 * ((b >> bit) & 1) + 1 * ((a >> bit) & 1);
         if (!tree->children[i]) {
-            tree->children[i] = tvg::malloc<ColorTree*>(sizeof(ColorTree));
+            tree->children[i] = tvg::malloc<ColorTree>(sizeof(ColorTree));
             if (!tree->children[i]) return 83; /*alloc fail*/
             color_tree_init(tree->children[i]);
         }
@@ -2386,7 +2386,7 @@ static void decodeGeneric(unsigned char** out, unsigned* w, unsigned* h, LodePNG
     }
 
     /*the input filesize is a safe upper bound for the sum of idat chunks size*/
-    idat = tvg::malloc<unsigned char*>(insize);
+    idat = tvg::malloc<unsigned char>(insize);
     if (!idat) CERROR_RETURN(state->error, 83); /*alloc fail*/
 
     chunk = &in[33]; /*first byte of the first chunk after the header*/
@@ -2486,7 +2486,7 @@ static void decodeGeneric(unsigned char** out, unsigned* w, unsigned* h, LodePNG
 
     if (!state->error) {
         outsize = lodepng_get_raw_size(*w, *h, &state->info_png.color);
-        *out = tvg::malloc<unsigned char*>(outsize);
+        *out = tvg::malloc<unsigned char>(outsize);
         if (!*out) state->error = 83; /*alloc fail*/
     }
     if (!state->error) {
@@ -2601,7 +2601,7 @@ unsigned lodepng_decode(unsigned char** out, unsigned* w, unsigned* h, LodePNGSt
         }
 
         outsize = lodepng_get_raw_size(*w, *h, &state->info_raw);
-        *out = tvg::malloc<unsigned char*>(outsize);
+        *out = tvg::malloc<unsigned char>(outsize);
         if (!(*out)) {
             state->error = 83; /*alloc fail*/
         }

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -93,7 +93,7 @@ bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpa
     if (lodepng_inspect(&width, &height, &state, (unsigned char*)(data), size) > 0) return false;
 
     if (copy) {
-        this->data = tvg::malloc<unsigned char*>(size);
+        this->data = tvg::malloc<unsigned char>(size);
         if (!this->data) return false;
         memcpy((unsigned char *)this->data, data, size);
         freeData = true;

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -47,7 +47,7 @@ bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs
     this->copy = copy;
 
     if (copy) {
-        surface.buf32 = tvg::malloc<uint32_t*>(sizeof(uint32_t) * w * h);
+        surface.buf32 = tvg::malloc<uint32_t>(sizeof(uint32_t) * w * h);
         if (!surface.buf32) return false;
         memcpy((void*)surface.buf32, data, sizeof(uint32_t) * w * h);
     }

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -186,7 +186,7 @@ void cssCopyStyleAttr(SvgNode* to, const SvgNode* from)
 {
     //Copy matrix attribute
     if (from->transform && !(to->style->flags & SvgStyleFlags::Transform)) {
-        to->transform = tvg::malloc<Matrix*>(sizeof(Matrix));
+        to->transform = tvg::malloc<Matrix>(sizeof(Matrix));
         if (to->transform) {
             *to->transform = *from->transform;
             to->style->flags = (to->style->flags | SvgStyleFlags::Transform);

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -724,7 +724,7 @@ static Matrix* _parseTransformationMatrix(const char* value)
 {
     const int POINT_CNT = 8;
 
-    auto matrix = tvg::malloc<Matrix*>(sizeof(Matrix));
+    auto matrix = tvg::malloc<Matrix>(sizeof(Matrix));
     tvg::identity(matrix);
 
     float points[POINT_CNT];
@@ -1391,10 +1391,10 @@ static bool _attrParseGaussianBlurNode(void* data, const char* key, const char* 
 
 static SvgNode* _createNode(SvgNode* parent, SvgNodeType type)
 {
-    SvgNode* node = tvg::calloc<SvgNode*>(1, sizeof(SvgNode));
+    SvgNode* node = tvg::calloc<SvgNode>(1, sizeof(SvgNode));
 
     //Default fill property
-    node->style = tvg::calloc<SvgStyleProperty*>(1, sizeof(SvgStyleProperty));
+    node->style = tvg::calloc<SvgStyleProperty>(1, sizeof(SvgStyleProperty));
 
     //Set the default values other than 0/false: https://www.w3.org/TR/SVGTiny12/painting.html#SpecifyingPaint
     node->style->opacity = 255;
@@ -2136,7 +2136,7 @@ static bool _attrParseUseNode(void* data, const char* key, const char* value)
                 INLIST_FOREACH(loader->cloneNodes, pair) {
                     if (_checkPostponed(nodeFrom, pair->node, 1)) {
                         postpone = true;
-                        loader->cloneNodes.back(new(tvg::malloc<SvgNodeIdPair*>(sizeof(SvgNodeIdPair))) SvgNodeIdPair(node, id));
+                        loader->cloneNodes.back(new(tvg::malloc<SvgNodeIdPair>(sizeof(SvgNodeIdPair))) SvgNodeIdPair(node, id));
                         break;
                     }
                 }
@@ -2154,7 +2154,7 @@ static bool _attrParseUseNode(void* data, const char* key, const char* value)
             //some svg export software include <defs> element at the end of the file
             //if so the 'from' element won't be found now and we have to repeat finding
             //after the whole file is parsed
-            loader->cloneNodes.back(new(tvg::malloc<SvgNodeIdPair*>(sizeof(SvgNodeIdPair))) SvgNodeIdPair(node, id));
+            loader->cloneNodes.back(new(tvg::malloc<SvgNodeIdPair>(sizeof(SvgNodeIdPair))) SvgNodeIdPair(node, id));
         }
     } else {
         return _attrParseGNode(data, key, value);
@@ -2568,12 +2568,12 @@ static bool _attrParseRadialGradientNode(void* data, const char* key, const char
 
 static SvgStyleGradient* _createRadialGradient(SvgLoaderData* loader, const char* buf, unsigned bufLength)
 {
-    auto grad = tvg::calloc<SvgStyleGradient*>(1, sizeof(SvgStyleGradient));
+    auto grad = tvg::calloc<SvgStyleGradient>(1, sizeof(SvgStyleGradient));
     loader->svgParse->styleGrad = grad;
 
     grad->flags = SvgGradientFlags::None;
     grad->type = SvgGradientType::Radial;
-    grad->radial = tvg::calloc<SvgRadialGradient*>(1, sizeof(SvgRadialGradient));
+    grad->radial = tvg::calloc<SvgRadialGradient>(1, sizeof(SvgRadialGradient));
     if (!grad->radial) {
         grad->clear();
         tvg::free(grad);
@@ -2859,12 +2859,12 @@ static bool _attrParseLinearGradientNode(void* data, const char* key, const char
 
 static SvgStyleGradient* _createLinearGradient(SvgLoaderData* loader, const char* buf, unsigned bufLength)
 {
-    auto grad = tvg::calloc<SvgStyleGradient*>(1, sizeof(SvgStyleGradient));
+    auto grad = tvg::calloc<SvgStyleGradient>(1, sizeof(SvgStyleGradient));
     loader->svgParse->styleGrad = grad;
 
     grad->flags = SvgGradientFlags::None;
     grad->type = SvgGradientType::Linear;
-    grad->linear = tvg::calloc<SvgLinearGradient*>(1, sizeof(SvgLinearGradient));
+    grad->linear = tvg::calloc<SvgLinearGradient>(1, sizeof(SvgLinearGradient));
     if (!grad->linear) {
         grad->clear();
         tvg::free(grad);
@@ -2944,7 +2944,7 @@ static void _inheritGradient(SvgLoaderData* loader, SvgStyleGradient* to, SvgSty
     }
 
     if (!to->transform && from->transform) {
-        to->transform = tvg::malloc<Matrix*>(sizeof(Matrix));
+        to->transform = tvg::malloc<Matrix>(sizeof(Matrix));
         if (to->transform) *to->transform = *from->transform;
     }
 
@@ -2998,7 +2998,7 @@ static SvgStyleGradient* _cloneGradient(SvgStyleGradient* from)
 {
     if (!from) return nullptr;
 
-    auto grad = tvg::calloc<SvgStyleGradient*>(1, sizeof(SvgStyleGradient));
+    auto grad = tvg::calloc<SvgStyleGradient>(1, sizeof(SvgStyleGradient));
     if (!grad) return nullptr;
 
     grad->type = from->type;
@@ -3009,16 +3009,16 @@ static SvgStyleGradient* _cloneGradient(SvgStyleGradient* from)
     grad->flags = from->flags;
 
     if (from->transform) {
-        grad->transform = tvg::calloc<Matrix*>(1, sizeof(Matrix));
+        grad->transform = tvg::calloc<Matrix>(1, sizeof(Matrix));
         if (grad->transform) *grad->transform = *from->transform;
     }
 
     if (grad->type == SvgGradientType::Linear) {
-        grad->linear = tvg::calloc<SvgLinearGradient*>(1, sizeof(SvgLinearGradient));
+        grad->linear = tvg::calloc<SvgLinearGradient>(1, sizeof(SvgLinearGradient));
         if (!grad->linear) goto error_grad_alloc;
         memcpy(grad->linear, from->linear, sizeof(SvgLinearGradient));
     } else if (grad->type == SvgGradientType::Radial) {
-        grad->radial = tvg::calloc<SvgRadialGradient*>(1, sizeof(SvgRadialGradient));
+        grad->radial = tvg::calloc<SvgRadialGradient>(1, sizeof(SvgRadialGradient));
         if (!grad->radial) goto error_grad_alloc;
         memcpy(grad->radial, from->radial, sizeof(SvgRadialGradient));
     }
@@ -3182,7 +3182,7 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
 {
     //Copy matrix attribute
     if (from->transform) {
-        to->transform = tvg::malloc<Matrix*>(sizeof(Matrix));
+        to->transform = tvg::malloc<Matrix>(sizeof(Matrix));
         if (to->transform) *to->transform = *from->transform;
     }
     //Copy style attribute
@@ -3902,7 +3902,7 @@ bool SvgLoader::header()
     //For valid check, only <svg> tag is parsed first.
     //If the <svg> tag is found, the loaded file is valid and stores viewbox information.
     //After that, the remaining content data is parsed in order with async.
-    loaderData.svgParse = tvg::malloc<SvgParser*>(sizeof(SvgParser));
+    loaderData.svgParse = tvg::malloc<SvgParser>(sizeof(SvgParser));
     loaderData.svgParse->flags = SvgStopStyleFlags::StopDefault;
     viewFlag = SvgViewFlag::None;
 
@@ -3970,7 +3970,7 @@ bool SvgLoader::header()
 bool SvgLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
 {
     if (copy) {
-        content = tvg::malloc<char*>(size + 1);
+        content = tvg::malloc<char>(size + 1);
         if (!content) return false;
         memcpy((char*)content, data, size);
         content[size] = '\0';

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -93,7 +93,7 @@ static LinearGradient* _applyLinearGradientProperty(SvgStyleGradient* g, const B
     //Update the stops
     if (g->stops.count == 0) return fillGrad;
 
-    stops = tvg::malloc<Fill::ColorStop*>(g->stops.count * sizeof(Fill::ColorStop));
+    stops = tvg::malloc<Fill::ColorStop>(g->stops.count * sizeof(Fill::ColorStop));
     auto prevOffset = 0.0f;
     for (uint32_t i = 0; i < g->stops.count; ++i) {
         auto colorStop = &g->stops[i];
@@ -143,7 +143,7 @@ static RadialGradient* _applyRadialGradientProperty(SvgStyleGradient* g, const B
     //Update the stops
     if (g->stops.count == 0) return fillGrad;
 
-    stops = tvg::malloc<Fill::ColorStop*>(g->stops.count * sizeof(Fill::ColorStop));
+    stops = tvg::malloc<Fill::ColorStop>(g->stops.count * sizeof(Fill::ColorStop));
     auto prevOffset = 0.0f;
     for (uint32_t i = 0; i < g->stops.count; ++i) {
         auto colorStop = &g->stops[i];

--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -45,7 +45,7 @@ size_t svgUtilURLDecode(const char *src, char** dst)
     auto length = strlen(src);
     if (length == 0) return 0;
 
-    char* decoded = tvg::malloc<char*>(sizeof(char) * length + 1);
+    char* decoded = tvg::malloc<char>(sizeof(char) * length + 1);
 
     char a, b;
     int idx =0;

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -286,7 +286,7 @@ bool isIgnoreUnsupportedLogElements(TVG_UNUSED const char* tagName)
 bool xmlParseAttributes(const char* buf, unsigned bufLength, xmlAttributeCb func, const void* data)
 {
     const char *itr = buf, *itrEnd = buf + bufLength;
-    char* tmpBuf = tvg::malloc<char*>(bufLength + 1);
+    char* tmpBuf = tvg::malloc<char>(bufLength + 1);
 
     if (!buf || !func || !tmpBuf) goto error;
 

--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -137,7 +137,7 @@ static bool _map(TtfLoader* loader, const char* path)
         return false;
     }
 
-    reader.data = tvg::malloc<uint8_t*>(reader.size);
+    reader.data = tvg::malloc<uint8_t>(reader.size);
 
     fseek(f, 0, SEEK_SET);
     auto ret = fread(reader.data, sizeof(char), reader.size, f);
@@ -537,7 +537,7 @@ bool TtfLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpa
     nomap = true;
 
     if (copy) {
-        reader.data = tvg::malloc<uint8_t*>(size);
+        reader.data = tvg::malloc<uint8_t>(size);
         if (!reader.data) return false;
         memcpy((char*)reader.data, data, reader.size);
         freeData = true;
@@ -557,7 +557,7 @@ bool TtfLoader::get(FontMetrics& fm, char* text, RenderPath& out)
 
     fm.scale = reader.metrics.unitsPerEm / (fm.fontSize * DPI);
     fm.size = {};
-    if (!fm.engine) fm.engine = tvg::calloc<TtfMetrics*>(1, sizeof(TtfMetrics));
+    if (!fm.engine) fm.engine = tvg::calloc<TtfMetrics>(1, sizeof(TtfMetrics));
 
     auto box = fm.box * fm.scale;
 
@@ -583,6 +583,6 @@ void TtfLoader::copy(const FontMetrics& in, FontMetrics& out)
 {
     release(out);
     out = in;
-    if (in.engine) out.engine = tvg::calloc<TtfMetrics*>(1, sizeof(TtfMetrics));
+    if (in.engine) out.engine = tvg::calloc<TtfMetrics>(1, sizeof(TtfMetrics));
     *static_cast<TtfMetrics*>(out.engine) = *static_cast<TtfMetrics*>(in.engine);
 }

--- a/src/loaders/webp/dec/alpha.cpp
+++ b/src/loaders/webp/dec/alpha.cpp
@@ -24,7 +24,7 @@
 // ALPHDecoder object.
 
 ALPHDecoder* ALPHNew(void) {
-  ALPHDecoder* const dec = tvg::calloc<ALPHDecoder*>(1ULL, sizeof(*dec));
+  ALPHDecoder* const dec = tvg::calloc<ALPHDecoder>(1ULL, sizeof(*dec));
   return dec;
 }
 

--- a/src/loaders/webp/dec/buffer.cpp
+++ b/src/loaders/webp/dec/buffer.cpp
@@ -104,7 +104,7 @@ static VP8StatusCode AllocateBuffer(WebPDecBuffer* const buffer) {
     total_size = size + 2 * uv_size + a_size;
 
     // Security/sanity checks
-    output = tvg::malloc<uint8_t*>(total_size * sizeof(*output));
+    output = tvg::malloc<uint8_t>(total_size * sizeof(*output));
     if (output == NULL) {
       return VP8_STATUS_OUT_OF_MEMORY;
     }

--- a/src/loaders/webp/dec/vp8.cpp
+++ b/src/loaders/webp/dec/vp8.cpp
@@ -45,7 +45,7 @@ int VP8InitIoInternal(VP8Io* const io, int version) {
 }
 
 VP8Decoder* VP8New(void) {
-  VP8Decoder* const dec = tvg::calloc<VP8Decoder*>(1ULL, sizeof(*dec));
+  VP8Decoder* const dec = tvg::calloc<VP8Decoder>(1ULL, sizeof(*dec));
   if (dec != NULL) {
     SetOk(dec);
     dec->ready_ = 0;

--- a/src/loaders/webp/dec/vp8l.cpp
+++ b/src/loaders/webp/dec/vp8l.cpp
@@ -352,9 +352,9 @@ static int ReadHuffmanCodes(VP8LDecoder* const dec, int xsize, int ysize,
     }
   }
 
-  huffman_tables = tvg::malloc<HuffmanCode*>(num_htree_groups * table_size * sizeof(*huffman_tables));
+  huffman_tables = tvg::malloc<HuffmanCode>(num_htree_groups * table_size * sizeof(*huffman_tables));
   htree_groups = VP8LHtreeGroupsNew(num_htree_groups);
-  code_lengths = tvg::calloc<int*>((uint64_t)max_alphabet_size, sizeof(*code_lengths));
+  code_lengths = tvg::calloc<int>((uint64_t)max_alphabet_size, sizeof(*code_lengths));
 
   if (htree_groups == NULL || code_lengths == NULL || huffman_tables == NULL) {
     dec->status_ = VP8_STATUS_OUT_OF_MEMORY;
@@ -424,7 +424,7 @@ static int AllocateAndInitRescaler(VP8LDecoder* const dec, VP8Io* const io) {
   const uint64_t memory_size = sizeof(*dec->rescaler) +
                                work_size * sizeof(*work) +
                                scaled_data_size * sizeof(*scaled_data);
-  uint8_t* memory = tvg::calloc<uint8_t*>(memory_size, sizeof(*memory));
+  uint8_t* memory = tvg::calloc<uint8_t>(memory_size, sizeof(*memory));
   if (memory == NULL) {
     dec->status_ = VP8_STATUS_OUT_OF_MEMORY;
     return 0;
@@ -1128,7 +1128,7 @@ static void ClearTransform(VP8LTransform* const transform) {
 static int ExpandColorMap(int num_colors, VP8LTransform* const transform) {
   int i;
   const int final_num_colors = 1 << (8 >> transform->bits_);
-  uint32_t* const new_color_map = tvg::malloc<uint32_t*>((uint64_t)final_num_colors * sizeof(*new_color_map));
+  uint32_t* const new_color_map = tvg::malloc<uint32_t>((uint64_t)final_num_colors * sizeof(*new_color_map));
   if (new_color_map == NULL) {
     return 0;
   } else {
@@ -1223,7 +1223,7 @@ static void ClearMetadata(VP8LMetadata* const hdr) {
 // VP8LDecoder
 
 VP8LDecoder* VP8LNew(void) {
-  VP8LDecoder* const dec = tvg::calloc<VP8LDecoder*>(1ULL, sizeof(*dec));
+  VP8LDecoder* const dec = tvg::calloc<VP8LDecoder>(1ULL, sizeof(*dec));
   if (dec == NULL) return NULL;
   dec->status_ = VP8_STATUS_OK;
   dec->state_ = READ_DIM;
@@ -1326,7 +1326,7 @@ static int DecodeImageStream(int xsize, int ysize,
 
   {
     const uint64_t total_size = (uint64_t)transform_xsize * transform_ysize;
-    data = tvg::malloc<uint32_t*>(total_size * sizeof(*data));
+    data = tvg::malloc<uint32_t>(total_size * sizeof(*data));
     if (data == NULL) {
       dec->status_ = VP8_STATUS_OUT_OF_MEMORY;
       ok = 0;
@@ -1371,7 +1371,7 @@ static int AllocateInternalBuffers32b(VP8LDecoder* const dec, int final_width) {
       num_pixels + cache_top_pixels + cache_pixels;
 
   assert(dec->width_ <= final_width);
-  dec->pixels_ = tvg::malloc<uint32_t*>(total_num_pixels * sizeof(uint32_t));
+  dec->pixels_ = tvg::malloc<uint32_t>(total_num_pixels * sizeof(uint32_t));
   if (dec->pixels_ == NULL) {
     dec->argb_cache_ = NULL;    // for sanity check
     dec->status_ = VP8_STATUS_OUT_OF_MEMORY;
@@ -1384,7 +1384,7 @@ static int AllocateInternalBuffers32b(VP8LDecoder* const dec, int final_width) {
 static int AllocateInternalBuffers8b(VP8LDecoder* const dec) {
   const uint64_t total_num_pixels = (uint64_t)dec->width_ * dec->height_;
   dec->argb_cache_ = NULL;    // for sanity check
-  dec->pixels_ = tvg::malloc<uint32_t*>(total_num_pixels * sizeof(uint8_t));
+  dec->pixels_ = tvg::malloc<uint32_t>(total_num_pixels * sizeof(uint8_t));
   if (dec->pixels_ == NULL) {
     dec->status_ = VP8_STATUS_OUT_OF_MEMORY;
     return 0;

--- a/src/loaders/webp/tvgWebpLoader.cpp
+++ b/src/loaders/webp/tvgWebpLoader.cpp
@@ -90,7 +90,7 @@ bool WebpLoader::open(const char* path)
 bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
 {
     if (copy) {
-        this->data = tvg::malloc<uint8_t*>(size);
+        this->data = tvg::malloc<uint8_t>(size);
         if (!this->data) return false;
         memcpy((uint8_t*)this->data, data, size);
         freeData = true;

--- a/src/loaders/webp/utils/color_cache.cpp
+++ b/src/loaders/webp/utils/color_cache.cpp
@@ -23,7 +23,7 @@ int VP8LColorCacheInit(VP8LColorCache* const cc, int hash_bits) {
   const int hash_size = 1 << hash_bits;
   assert(cc != NULL);
   assert(hash_bits > 0);
-  cc->colors_ = tvg::calloc<uint32_t*>((uint64_t)hash_size, sizeof(*cc->colors_));
+  cc->colors_ = tvg::calloc<uint32_t>((uint64_t)hash_size, sizeof(*cc->colors_));
   if (cc->colors_ == NULL) return 0;
   cc->hash_shift_ = 32 - hash_bits;
   cc->hash_bits_ = hash_bits;

--- a/src/loaders/webp/utils/huffman.cpp
+++ b/src/loaders/webp/utils/huffman.cpp
@@ -22,7 +22,7 @@
 #define MAX_HTREE_GROUPS    0x10000
 
 HTreeGroup* VP8LHtreeGroupsNew(int num_htree_groups) {
-  HTreeGroup* const htree_groups = tvg::malloc<HTreeGroup*>(num_htree_groups * sizeof(*htree_groups));
+  HTreeGroup* const htree_groups = tvg::malloc<HTreeGroup>(num_htree_groups * sizeof(*htree_groups));
   if (htree_groups == NULL) {
     return NULL;
   }
@@ -112,7 +112,7 @@ int VP8LBuildHuffmanTable(HuffmanCode* const root_table, int root_bits,
     offset[len + 1] = offset[len] + count[len];
   }
 
-  sorted = tvg::malloc<int*>(code_lengths_size * sizeof(*sorted));
+  sorted = tvg::malloc<int>(code_lengths_size * sizeof(*sorted));
   if (sorted == NULL) {
     return 0;
   }

--- a/src/loaders/webp/utils/quant_levels_dec.cpp
+++ b/src/loaders/webp/utils/quant_levels_dec.cpp
@@ -213,7 +213,7 @@ static int InitParams(uint8_t* const data, int width, int height,
   const size_t size_m =  width * sizeof(*p->average_);
   const size_t size_lut = (1 + 2 * LUT_SIZE) * sizeof(*p->correction_);
   const size_t total_size = size_scratch_m + size_m + size_lut;
-  uint8_t* mem = tvg::malloc<uint8_t*>(1U * total_size);
+  uint8_t* mem = tvg::malloc<uint8_t>(1U * total_size);
 
   if (mem == NULL) return 0;
   p->mem_ = (void*)mem;

--- a/src/renderer/gl_engine/tvgGlEffect.cpp
+++ b/src/renderer/gl_engine/tvgGlEffect.cpp
@@ -58,7 +58,7 @@ bool GlEffect::region(RenderEffectGaussianBlur* effect)
 void GlEffect::update(RenderEffectGaussianBlur* effect, const Matrix& transform)
 {
     GlGaussianBlur* blur = (GlGaussianBlur*)effect->rd;
-    if (!blur) blur = tvg::malloc<GlGaussianBlur*>(sizeof(GlGaussianBlur));
+    if (!blur) blur = tvg::malloc<GlGaussianBlur>(sizeof(GlGaussianBlur));
     blur->sigma = effect->sigma;
     blur->scale = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
     blur->extend = 2 * blur->sigma * blur->scale;
@@ -126,7 +126,7 @@ bool GlEffect::region(RenderEffectDropShadow* effect)
 void GlEffect::update(RenderEffectDropShadow* effect, const Matrix& transform)
 {
     GlDropShadow* dropShadow = (GlDropShadow*)effect->rd;
-    if (!dropShadow) dropShadow = tvg::malloc<GlDropShadow*>(sizeof(GlDropShadow));
+    if (!dropShadow) dropShadow = tvg::malloc<GlDropShadow>(sizeof(GlDropShadow));
     const auto scale = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
     const auto radian = tvg::deg2rad(90.0f - effect->angle) - tvg::radian(transform);
     const Point offset = {-effect->distance * cosf(radian) * scale, -effect->distance * sinf(radian) * scale};
@@ -203,7 +203,7 @@ struct GlEffectParams {
 void GlEffect::update(RenderEffectFill* effect, const Matrix& transform)
 {
     auto params = (GlEffectParams*)effect->rd;
-    if (!params) params = tvg::malloc<GlEffectParams*>(sizeof(GlEffectParams));
+    if (!params) params = tvg::malloc<GlEffectParams>(sizeof(GlEffectParams));
     params->params[0] = effect->color[0] / 255.0f;
     params->params[1] = effect->color[1] / 255.0f;
     params->params[2] = effect->color[2] / 255.0f;
@@ -219,7 +219,7 @@ void GlEffect::update(RenderEffectTint* effect, const Matrix& transform)
     if (!effect->valid) return;
 
     auto params = (GlEffectParams*)effect->rd;
-    if (!params) params = tvg::malloc<GlEffectParams*>(sizeof(GlEffectParams));
+    if (!params) params = tvg::malloc<GlEffectParams>(sizeof(GlEffectParams));
     params->params[0] = effect->black[0] / 255.0f;
     params->params[1] = effect->black[1] / 255.0f;
     params->params[2] = effect->black[2] / 255.0f;
@@ -239,7 +239,7 @@ void GlEffect::update(RenderEffectTritone* effect, const Matrix& transform)
     if (!effect->valid) return;
 
     auto params = (GlEffectParams*)effect->rd;
-    if (!params) params = tvg::malloc<GlEffectParams*>(sizeof(GlEffectParams));
+    if (!params) params = tvg::malloc<GlEffectParams>(sizeof(GlEffectParams));
     params->params[0] = effect->shadow[0] / 255.0f;
     params->params[1] = effect->shadow[1] / 255.0f;
     params->params[2] = effect->shadow[2] / 255.0f;

--- a/src/renderer/gl_engine/tvgGlProgram.cpp
+++ b/src/renderer/gl_engine/tvgGlProgram.cpp
@@ -56,7 +56,7 @@ GlProgram::GlProgram(const char* vertSrc, const char* fragSrc)
         glGetProgramiv(progObj, GL_INFO_LOG_LENGTH, &infoLen);
         if (infoLen > 0)
         {
-            auto infoLog = tvg::malloc<char*>(sizeof(char) * infoLen);
+            auto infoLog = tvg::malloc<char>(sizeof(char) * infoLen);
             glGetProgramInfoLog(progObj, infoLen, NULL, infoLog);
             TVGERR("GL_ENGINE", "Error linking shader: %s", infoLog);
             tvg::free(infoLog);

--- a/src/renderer/gl_engine/tvgGlShader.cpp
+++ b/src/renderer/gl_engine/tvgGlShader.cpp
@@ -66,7 +66,7 @@ uint32_t GlShader::compileShader(uint32_t type, char* shaderSrc)
 
         if (infoLen > 0)
         {
-            auto infoLog = tvg::malloc<char*>(sizeof(char)*infoLen);
+            auto infoLog = tvg::malloc<char>(sizeof(char)*infoLen);
             glGetShaderInfoLog(shader, infoLen, NULL, infoLog);
             TVGERR("GL_ENGINE", "Error compiling shader: %s", infoLog);
             tvg::free(infoLog);

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -329,7 +329,7 @@ struct SwCellPool
     uint32_t size;
     SwCell* buffer;
 
-    SwCellPool() : size(DEFAULT_POOL_SIZE), buffer(tvg::malloc<SwCell*>(DEFAULT_POOL_SIZE)) {}
+    SwCellPool() : size(DEFAULT_POOL_SIZE), buffer(tvg::malloc<SwCell>(DEFAULT_POOL_SIZE)) {}
     ~SwCellPool() { tvg::free(buffer); }
 };
 

--- a/src/renderer/sw_engine/tvgSwMemPool.cpp
+++ b/src/renderer/sw_engine/tvgSwMemPool.cpp
@@ -90,7 +90,7 @@ SwMpool* mpoolInit(uint32_t threads)
 {
     auto allocSize = threads + 1;
 
-    auto mpool = tvg::malloc<SwMpool*>(sizeof(SwMpool));
+    auto mpool = tvg::malloc<SwMpool>(sizeof(SwMpool));
     mpool->outline = new SwOutline[allocSize];
     mpool->strokeOutline = new SwOutline[allocSize];
     mpool->leftBorder = new SwStrokeBorder[allocSize];

--- a/src/renderer/sw_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/sw_engine/tvgSwPostEffect.cpp
@@ -155,7 +155,7 @@ bool effectGaussianBlurRegion(RenderEffectGaussianBlur* params)
 
 void effectGaussianBlurUpdate(RenderEffectGaussianBlur* params, const Matrix& transform)
 {
-    if (!params->rd) params->rd = tvg::malloc<SwGaussianBlur*>(sizeof(SwGaussianBlur));
+    if (!params->rd) params->rd = tvg::malloc<SwGaussianBlur>(sizeof(SwGaussianBlur));
     auto rd = static_cast<SwGaussianBlur*>(params->rd);
 
     //compute box kernel sizes
@@ -375,7 +375,7 @@ bool effectDropShadowRegion(RenderEffectDropShadow* params)
 
 void effectDropShadowUpdate(RenderEffectDropShadow* params, const Matrix& transform)
 {
-    if (!params->rd) params->rd = tvg::malloc<SwDropShadow*>(sizeof(SwDropShadow));
+    if (!params->rd) params->rd = tvg::malloc<SwDropShadow>(sizeof(SwDropShadow));
     auto rd = static_cast<SwDropShadow*>(params->rd);
 
     //compute box kernel sizes

--- a/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -524,14 +524,14 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage& image, const 
 
 static AASpans* _AASpans(int yStart, int yEnd)
 {
-    auto aaSpans = tvg::malloc<AASpans*>(sizeof(AASpans));
+    auto aaSpans = tvg::malloc<AASpans>(sizeof(AASpans));
     aaSpans->yStart = yStart;
     aaSpans->yEnd = yEnd;
 
     //Initialize X range
     auto height = yEnd - yStart;
 
-    aaSpans->lines = tvg::malloc<AALine*>(height * sizeof(AALine));
+    aaSpans->lines = tvg::malloc<AALine>(height * sizeof(AALine));
 
     for (int32_t i = 0; i < height; i++) {
         aaSpans->lines[i].x[0] = INT32_MAX;

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -627,7 +627,7 @@ SwSurface* SwRenderer::request(int channelSize, bool square)
         //Inherits attributes from main surface
         cmp = new SwSurface(surface);
         cmp->compositor = new SwCompositor;
-        cmp->compositor->image.data = tvg::malloc<pixel_t*>(channelSize * w * h);
+        cmp->compositor->image.data = tvg::malloc<pixel_t>(channelSize * w * h);
         cmp->w = cmp->compositor->image.w = w;
         cmp->h = cmp->compositor->image.h = h;
         cmp->stride = cmp->compositor->image.stride = w;

--- a/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/src/renderer/sw_engine/tvgSwRle.cpp
@@ -735,7 +735,7 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox,
     if (reqSize > cellPool->size) {
         cellPool->size = ((reqSize + (reqSize >> 2)) / sizeof(SwCell)) * sizeof(SwCell);
         tvg::free(cellPool->buffer);
-        cellPool->buffer = tvg::malloc<SwCell*>(cellPool->size);
+        cellPool->buffer = tvg::malloc<SwCell>(cellPool->size);
     }
 
     //Init Cells
@@ -847,7 +847,7 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox,
 
 SwRle* rleRender(const RenderRegion* bbox)
 {
-    auto rle = tvg::calloc<SwRle*>(sizeof(SwRle), 1);
+    auto rle = tvg::calloc<SwRle>(sizeof(SwRle), 1);
     rle->spans.reserve(bbox->h());
     rle->spans.count = bbox->h();
 

--- a/src/renderer/sw_engine/tvgSwShape.cpp
+++ b/src/renderer/sw_engine/tvgSwShape.cpp
@@ -502,7 +502,7 @@ void shapeDelStroke(SwShape& shape)
 
 void shapeResetStroke(SwShape& shape, const RenderShape* rshape, const Matrix& transform, SwMpool* mpool, unsigned tid)
 {
-    if (!shape.stroke) shape.stroke = tvg::calloc<SwStroke*>(1, sizeof(SwStroke));
+    if (!shape.stroke) shape.stroke = tvg::calloc<SwStroke>(1, sizeof(SwStroke));
     auto stroke = shape.stroke;
     strokeReset(stroke, rshape, transform, mpool, tid);
     rleReset(shape.strokeRle);
@@ -552,7 +552,7 @@ bool shapeGenStrokeFillColors(SwShape& shape, const Fill* fill, const Matrix& tr
 void shapeResetFill(SwShape& shape)
 {
     if (!shape.fill) {
-        shape.fill = tvg::calloc<SwFill*>(1, sizeof(SwFill));
+        shape.fill = tvg::calloc<SwFill>(1, sizeof(SwFill));
         if (!shape.fill) return;
     }
     fillReset(shape.fill);
@@ -562,7 +562,7 @@ void shapeResetFill(SwShape& shape)
 void shapeResetStrokeFill(SwShape& shape)
 {
     if (!shape.stroke->fill) {
-        shape.stroke->fill = tvg::calloc<SwFill*>(1, sizeof(SwFill));
+        shape.stroke->fill = tvg::calloc<SwFill>(1, sizeof(SwFill));
         if (!shape.stroke->fill) return;
     }
     fillReset(shape.stroke->fill);

--- a/src/renderer/sw_engine/tvgSwStroke.cpp
+++ b/src/renderer/sw_engine/tvgSwStroke.cpp
@@ -48,7 +48,7 @@ static void _growBorder(SwStrokeBorder* border, uint32_t newPts)
 {
     if (border->pts.count + newPts <= border->pts.reserved) return;
     border->pts.grow(newPts * 20);
-    border->tags = tvg::realloc<uint8_t*>(border->tags, border->pts.reserved);      //align the pts / tags memory size
+    border->tags = tvg::realloc<uint8_t>(border->tags, border->pts.reserved);      //align the pts / tags memory size
 }
 
 

--- a/src/renderer/tvgFill.h
+++ b/src/renderer/tvgFill.h
@@ -48,7 +48,7 @@ struct Fill::Impl
     {
         cnt = dup.cnt;
         spread = dup.spread;
-        colorStops = tvg::malloc<ColorStop*>(sizeof(ColorStop) * dup.cnt);
+        colorStops = tvg::malloc<ColorStop>(sizeof(ColorStop) * dup.cnt);
         if (dup.cnt > 0) memcpy(colorStops, dup.colorStops, sizeof(ColorStop) * dup.cnt);
         transform = dup.transform;
     }
@@ -67,7 +67,7 @@ struct Fill::Impl
         }
 
         if (cnt != this->cnt) {
-            this->colorStops = tvg::realloc<ColorStop*>(this->colorStops, cnt * sizeof(ColorStop));
+            this->colorStops = tvg::realloc<ColorStop>(this->colorStops, cnt * sizeof(ColorStop));
         }
 
         this->cnt = cnt;

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -103,7 +103,7 @@ struct LoadModule
             return nullptr;
         }
 
-        auto content = tvg::malloc<char*>(sizeof(char) * (text ? size + 1 : size));
+        auto content = tvg::malloc<char>(sizeof(char) * (text ? size + 1 : size));
         fseek(f, 0, SEEK_SET);
         size = fread(content, sizeof(char), size, f);
         if (text) content[size] = '\0';

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -212,7 +212,7 @@ struct Paint::Impl
 
         if (!target && method == MaskMethod::None) return Result::Success;
 
-        maskData = tvg::malloc<Mask*>(sizeof(Mask));
+        maskData = tvg::malloc<Mask>(sizeof(Mask));
         target->ref();
         maskData->target = target;
         PAINT(target)->parent = parent;

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -187,7 +187,7 @@ struct PictureImpl : Picture
             return Result::Success;
         }
 
-        if (!this->resolver) this->resolver = tvg::calloc<AssetResolver*>(1, sizeof(AssetResolver));
+        if (!this->resolver) this->resolver = tvg::calloc<AssetResolver>(1, sizeof(AssetResolver));
         *(this->resolver) = {resolver, data};
         return Result::Success;
     }

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -359,7 +359,7 @@ struct RenderStroke
         tvg::free(dash.pattern);
         dash = rhs.dash;
         if (rhs.dash.count > 0) {
-            dash.pattern = tvg::malloc<float*>(sizeof(float) * rhs.dash.count);
+            dash.pattern = tvg::malloc<float>(sizeof(float) * rhs.dash.count);
             memcpy(dash.pattern, rhs.dash.pattern, sizeof(float) * rhs.dash.count);
         }
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -286,7 +286,7 @@ struct ShapeImpl : Shape
             dash.pattern = nullptr;
         }
         if (cnt > 0) {
-            if (!dash.pattern) dash.pattern = tvg::malloc<float*>(sizeof(float) * cnt);
+            if (!dash.pattern) dash.pattern = tvg::malloc<float>(sizeof(float) * cnt);
             dash.length = 0.0f;
             for (uint32_t i = 0; i < cnt; ++i) {
                 dash.pattern[i] = pattern[i] < 0.0f ? 0.0f : pattern[i];

--- a/src/savers/gif/tvgGifEncoder.cpp
+++ b/src/savers/gif/tvgGifEncoder.cpp
@@ -464,7 +464,7 @@ static void _writeLzwImage(GifWriter* writer, uint32_t width, uint32_t height, u
 
     fputc(minCodeSize, f); // min code size 8 bits
 
-    GifLzwNode* codetree = tvg::malloc<GifLzwNode*>(sizeof(GifLzwNode)*4096);
+    GifLzwNode* codetree = tvg::malloc<GifLzwNode>(sizeof(GifLzwNode)*4096);
 
     memset(codetree, 0, sizeof(GifLzwNode)*4096);
     int32_t curCode = -1;
@@ -552,8 +552,8 @@ bool gifBegin(GifWriter* writer, const char* filename, uint32_t width, uint32_t 
     writer->firstFrame = true;
 
     // allocate
-    writer->oldImage = tvg::malloc<uint8_t*>(width*height*4);
-    writer->tmpImage = tvg::malloc<uint8_t*>(width*height*4);
+    writer->oldImage = tvg::malloc<uint8_t>(width*height*4);
+    writer->tmpImage = tvg::malloc<uint8_t>(width*height*4);
 
     fputs("GIF89a", writer->f);
 

--- a/src/savers/gif/tvgGifSaver.cpp
+++ b/src/savers/gif/tvgGifSaver.cpp
@@ -38,7 +38,7 @@ void GifSaver::run(unsigned tid)
     auto w = static_cast<uint32_t>(vsize[0]);
     auto h = static_cast<uint32_t>(vsize[1]);
 
-    buffer = tvg::realloc<uint32_t*>(buffer, sizeof(uint32_t) * w * h);
+    buffer = tvg::realloc<uint32_t>(buffer, sizeof(uint32_t) * w * h);
     canvas->target(buffer, w, w, h, ColorSpace::ABGR8888S);
     canvas->push(bg);
     canvas->push(animation->picture());


### PR DESCRIPTION
removed the * specifier from memory allocator types. since all memory allocators mandatorily use pointers, specifying * is redundant and omitting it improves code clarity.