### PR TITLE
gl: Enables direct rendering to the back buffer

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGl.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGl.cpp
@@ -467,7 +467,11 @@ PFNGLGENVERTEXARRAYSPROC                     glGenVertexArrays;
 //PFNGLCHECKFRAMEBUFFERSTATUSPROC              glCheckFramebufferStatus;
 //PFNGLFRAMEBUFFERTEXTURE1DPROC                glFramebufferTexture1D;
 //PFNGLFRAMEBUFFERTEXTURE3DPROC                glFramebufferTexture3D;
-//PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC glGetFramebufferAttachmentParameteriv;
+#if defined(THORVG_GL_DESKTOP_ATTACHMENT_QUERY)
+// Only non-Apple desktop GL needs this entry point. GLES uses the existing
+// glGetIntegerv path, and Apple deliberately keeps the offscreen target.
+PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC glGetFramebufferAttachmentParameteriv;
+#endif
 //PFNGLGENERATEMIPMAPPROC                      glGenerateMipmap;
 //PFNGLFRAMEBUFFERTEXTURELAYERPROC             glFramebufferTextureLayer;
 //PFNGLMAPBUFFERRANGEPROC                      glMapBufferRange;
@@ -805,7 +809,9 @@ bool glInit()
     GL_FUNCTION_FETCH(glFramebufferTexture2D, PFNGLFRAMEBUFFERTEXTURE2DPROC);
     // GL_FUNCTION_FETCH(glFramebufferTexture3D, PFNGLFRAMEBUFFERTEXTURE3DPROC);
     GL_FUNCTION_FETCH(glFramebufferRenderbuffer, PFNGLFRAMEBUFFERRENDERBUFFERPROC);
-    // GL_FUNCTION_FETCH(glGetFramebufferAttachmentParameteriv, PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC);
+#if defined(THORVG_GL_DESKTOP_ATTACHMENT_QUERY)
+    GL_FUNCTION_FETCH(glGetFramebufferAttachmentParameteriv, PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC);
+#endif
     // GL_FUNCTION_FETCH(glGenerateMipmap, PFNGLGENERATEMIPMAPPROC);
     GL_FUNCTION_FETCH(glBlitFramebuffer, PFNGLBLITFRAMEBUFFERPROC);
     GL_FUNCTION_FETCH(glRenderbufferStorageMultisample, PFNGLRENDERBUFFERSTORAGEMULTISAMPLEPROC);

--- a/src/renderer/gpu_engine/gl/tvgGl.h
+++ b/src/renderer/gpu_engine/gl/tvgGl.h
@@ -23,6 +23,12 @@
  #ifndef _TVG_GL_H_
  #define _TVG_GL_H_
 
+// Only non-Apple desktop GL needs the attachment query. GLES can inspect the
+// default framebuffer with glGetIntegerv, while Apple keeps the offscreen path.
+#if defined(THORVG_GL_TARGET_GL) && !defined(__APPLE__) && !defined(__MACH__)
+    #define THORVG_GL_DESKTOP_ATTACHMENT_QUERY 1
+#endif
+
 #ifdef __EMSCRIPTEN__
     #include <GLES3/gl3.h>
     #include <emscripten/html5_webgl.h>
@@ -142,6 +148,10 @@
         #define GL_DEPTH_WRITEMASK                0x0B72
         #define GL_DEPTH_CLEAR_VALUE              0x0B73
         #define GL_DEPTH_FUNC                     0x0B74
+#if defined(THORVG_GL_TARGET_GLES)
+        #define GL_DEPTH_BITS                     0x0D56
+        #define GL_STENCIL_BITS                   0x0D57
+#endif
         #define GL_STENCIL_TEST                   0x0B90
         #define GL_STENCIL_CLEAR_VALUE            0x0B91
         #define GL_STENCIL_FUNC                   0x0B92
@@ -1080,7 +1090,9 @@
         //typedef GLenum (*PFNGLCHECKFRAMEBUFFERSTATUSPROC)(GLenum target);
         //typedef void (*PFNGLFRAMEBUFFERTEXTURE1DPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
         //typedef void (*PFNGLFRAMEBUFFERTEXTURE3DPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLint zoffset);
-        //typedef void (*PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC)(GLenum target, GLenum attachment, GLenum pname, GLint *params);
+#if defined(THORVG_GL_DESKTOP_ATTACHMENT_QUERY)
+        typedef void (*PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC)(GLenum target, GLenum attachment, GLenum pname, GLint *params);
+#endif
         //typedef void (*PFNGLGENERATEMIPMAPPROC)(GLenum target);
         //typedef void (*PFNGLFRAMEBUFFERTEXTURELAYERPROC)(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer);
         //typedef void *(*PFNGLMAPBUFFERRANGEPROC)(GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
@@ -1478,7 +1490,9 @@
     //extern PFNGLCHECKFRAMEBUFFERSTATUSPROC              glCheckFramebufferStatus;
     //extern PFNGLFRAMEBUFFERTEXTURE1DPROC                glFramebufferTexture1D;
     //extern PFNGLFRAMEBUFFERTEXTURE3DPROC                glFramebufferTexture3D;
-    //extern PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC glGetFramebufferAttachmentParameteriv;
+#if defined(THORVG_GL_DESKTOP_ATTACHMENT_QUERY)
+    extern PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC glGetFramebufferAttachmentParameteriv;
+#endif
     //extern PFNGLGENERATEMIPMAPPROC                      glGenerateMipmap;
     //extern PFNGLFRAMEBUFFERTEXTURELAYERPROC             glFramebufferTextureLayer;
     //extern PFNGLMAPBUFFERRANGEPROC                      glMapBufferRange;

--- a/src/renderer/gpu_engine/gl/tvgGl.h
+++ b/src/renderer/gpu_engine/gl/tvgGl.h
@@ -23,6 +23,12 @@
  #ifndef _TVG_GL_H_
  #define _TVG_GL_H_
 
+// Only non-Apple desktop GL needs the attachment query. GLES can inspect the
+// default framebuffer with glGetIntegerv, while Apple keeps the offscreen path.
+#if defined(THORVG_GL_TARGET_GL) && !defined(__APPLE__) && !defined(__MACH__)
+    #define THORVG_GL_DESKTOP_ATTACHMENT_QUERY 1
+#endif
+
 #ifdef __EMSCRIPTEN__
     #include <GLES3/gl3.h>
     #include <emscripten/html5_webgl.h>
@@ -143,6 +149,10 @@
         #define GL_DEPTH_WRITEMASK                0x0B72
         #define GL_DEPTH_CLEAR_VALUE              0x0B73
         #define GL_DEPTH_FUNC                     0x0B74
+#if defined(THORVG_GL_TARGET_GLES)
+        #define GL_DEPTH_BITS                     0x0D56
+        #define GL_STENCIL_BITS                   0x0D57
+#endif
         #define GL_STENCIL_TEST                   0x0B90
         #define GL_STENCIL_CLEAR_VALUE            0x0B91
         #define GL_STENCIL_FUNC                   0x0B92
@@ -1081,7 +1091,9 @@
         //typedef GLenum (*PFNGLCHECKFRAMEBUFFERSTATUSPROC)(GLenum target);
         //typedef void (*PFNGLFRAMEBUFFERTEXTURE1DPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
         //typedef void (*PFNGLFRAMEBUFFERTEXTURE3DPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLint zoffset);
-        //typedef void (*PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC)(GLenum target, GLenum attachment, GLenum pname, GLint *params);
+#if defined(THORVG_GL_DESKTOP_ATTACHMENT_QUERY)
+        typedef void (*PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC)(GLenum target, GLenum attachment, GLenum pname, GLint *params);
+#endif
         //typedef void (*PFNGLGENERATEMIPMAPPROC)(GLenum target);
         //typedef void (*PFNGLFRAMEBUFFERTEXTURELAYERPROC)(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer);
         //typedef void *(*PFNGLMAPBUFFERRANGEPROC)(GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
@@ -1479,7 +1491,9 @@
     //extern PFNGLCHECKFRAMEBUFFERSTATUSPROC              glCheckFramebufferStatus;
     //extern PFNGLFRAMEBUFFERTEXTURE1DPROC                glFramebufferTexture1D;
     //extern PFNGLFRAMEBUFFERTEXTURE3DPROC                glFramebufferTexture3D;
-    //extern PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC glGetFramebufferAttachmentParameteriv;
+#if defined(THORVG_GL_DESKTOP_ATTACHMENT_QUERY)
+    extern PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVPROC glGetFramebufferAttachmentParameteriv;
+#endif
     //extern PFNGLGENERATEMIPMAPPROC                      glGenerateMipmap;
     //extern PFNGLFRAMEBUFFERTEXTURELAYERPROC             glFramebufferTextureLayer;
     //extern PFNGLMAPBUFFERRANGEPROC                      glMapBufferRange;

--- a/src/renderer/gpu_engine/gl/tvgGlCommon.h
+++ b/src/renderer/gpu_engine/gl/tvgGlCommon.h
@@ -31,6 +31,7 @@
 
 constexpr float MIN_GL_STROKE_WIDTH = 1.0f;
 constexpr float MIN_GL_STROKE_ALPHA = 0.25f;
+constexpr GLint GL_MSAA_SAMPLES = 4;
 
 constexpr uint32_t GL_MAT3_STD140_SIZE = 12; // mat3 is 3 vec4 columns in std140
 constexpr uint32_t GL_MAT3_STD140_BYTES = GL_MAT3_STD140_SIZE * sizeof(float);

--- a/src/renderer/gpu_engine/gl/tvgGlCommon.h
+++ b/src/renderer/gpu_engine/gl/tvgGlCommon.h
@@ -35,6 +35,7 @@ struct GlRenderer;
 
 constexpr float MIN_GL_STROKE_WIDTH = 1.0f;
 constexpr float MIN_GL_STROKE_ALPHA = 0.25f;
+constexpr GLint GL_MSAA_SAMPLES = 4;
 
 constexpr uint32_t GL_MAT3_STD140_SIZE = 12; // mat3 is 3 vec4 columns in std140
 constexpr uint32_t GL_MAT3_STD140_BYTES = GL_MAT3_STD140_SIZE * sizeof(float);

--- a/src/renderer/gpu_engine/gl/tvgGlRenderTarget.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTarget.cpp
@@ -29,27 +29,34 @@ GlRenderTarget::~GlRenderTarget()
     reset();
 }
 
-void GlRenderTarget::init(uint32_t width, uint32_t height, GLint resolveId)
+void GlRenderTarget::init(uint32_t width, uint32_t height, GLint resolveId, bool external)
 {
     if (width == 0 || height == 0) return;
 
     this->width = width;
     this->height = height;
+    this->external = external;
+    this->valid = true;
 
-    //TODO: fbo is used. maybe we can consider the direct rendering with resolveId as well.
+    if (external) {
+        fbo = static_cast<GLuint>(resolveId);
+        colorBuffer = depthStencilBuffer = resolvedFbo = colorTex = 0;
+        return;
+    }
+
     GL_CHECK(glGenFramebuffers(1, &fbo));
 
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, fbo));
 
     GL_CHECK(glGenRenderbuffers(1, &colorBuffer));
     GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, colorBuffer));
-    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_RGBA8, width, height));
+    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, GL_MSAA_SAMPLES, GL_RGBA8, width, height));
 
     GL_CHECK(glGenRenderbuffers(1, &depthStencilBuffer));
 
     GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, depthStencilBuffer));
 
-    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, width, height));
+    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, GL_MSAA_SAMPLES, GL_DEPTH24_STENCIL8, width, height));
 
     GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, 0));
 
@@ -78,16 +85,22 @@ void GlRenderTarget::init(uint32_t width, uint32_t height, GLint resolveId)
 
 void GlRenderTarget::reset()
 {
-    if (fbo == 0) return;
+    if (!valid) return;
 
-    GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
-    GL_CHECK(glDeleteFramebuffers(1, &fbo));
-    GL_CHECK(glDeleteRenderbuffers(1, &colorBuffer));
-    GL_CHECK(glDeleteRenderbuffers(1, &depthStencilBuffer));
-    GL_CHECK(glDeleteFramebuffers(1, &resolvedFbo));
-    GL_CHECK(glDeleteTextures(1, &colorTex));
+    if (!external) {
+        GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+        if (fbo != 0) GL_CHECK(glDeleteFramebuffers(1, &fbo));
+        if (colorBuffer != 0) GL_CHECK(glDeleteRenderbuffers(1, &colorBuffer));
+        if (depthStencilBuffer != 0) GL_CHECK(glDeleteRenderbuffers(1, &depthStencilBuffer));
+        if (resolvedFbo != 0) GL_CHECK(glDeleteFramebuffers(1, &resolvedFbo));
+        if (colorTex != 0) GL_CHECK(glDeleteTextures(1, &colorTex));
+    }
 
     fbo = colorBuffer = depthStencilBuffer = resolvedFbo = colorTex = 0;
+    width = height = 0;
+    viewport = {};
+    valid = false;
+    external = false;
 }
 
 GlRenderTargetPool::GlRenderTargetPool(uint32_t maxWidth, uint32_t maxHeight): maxWidth(maxWidth), maxHeight(maxHeight), pool() {}

--- a/src/renderer/gpu_engine/gl/tvgGlRenderTarget.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTarget.cpp
@@ -30,28 +30,35 @@ GlRenderTarget::~GlRenderTarget()
     reset();
 }
 
-void GlRenderTarget::init(GlStateCache& state, uint32_t width, uint32_t height, GLint resolveId)
+void GlRenderTarget::init(GlStateCache& state, uint32_t width, uint32_t height, GLint resolveId, bool external)
 {
     if (width == 0 || height == 0) return;
 
     this->state = &state;
     this->width = width;
     this->height = height;
+    this->external = external;
+    this->valid = true;
 
-    //TODO: fbo is used. maybe we can consider the direct rendering with resolveId as well.
+    if (external) {
+        fbo = static_cast<GLuint>(resolveId);
+        colorBuffer = depthStencilBuffer = resolvedFbo = colorTex = 0;
+        return;
+    }
+
     GL_CHECK(glGenFramebuffers(1, &fbo));
 
     state.bindFramebuffer(GL_FRAMEBUFFER, fbo);
 
     GL_CHECK(glGenRenderbuffers(1, &colorBuffer));
     GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, colorBuffer));
-    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_RGBA8, width, height));
+    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, GL_MSAA_SAMPLES, GL_RGBA8, width, height));
 
     GL_CHECK(glGenRenderbuffers(1, &depthStencilBuffer));
 
     GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, depthStencilBuffer));
 
-    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_DEPTH24_STENCIL8, width, height));
+    GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, GL_MSAA_SAMPLES, GL_DEPTH24_STENCIL8, width, height));
 
     GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, 0));
 
@@ -80,16 +87,22 @@ void GlRenderTarget::init(GlStateCache& state, uint32_t width, uint32_t height, 
 
 void GlRenderTarget::reset()
 {
-    if (fbo == 0) return;
+    if (!valid) return;
 
-    state->bindFramebuffer(GL_FRAMEBUFFER, 0);
-    GL_CHECK(glDeleteFramebuffers(1, &fbo));
-    GL_CHECK(glDeleteRenderbuffers(1, &colorBuffer));
-    GL_CHECK(glDeleteRenderbuffers(1, &depthStencilBuffer));
-    GL_CHECK(glDeleteFramebuffers(1, &resolvedFbo));
-    GL_CHECK(glDeleteTextures(1, &colorTex));
+    if (!external) {
+        state->bindFramebuffer(GL_FRAMEBUFFER, 0);
+        GL_CHECK(glDeleteFramebuffers(1, &fbo));
+        GL_CHECK(glDeleteRenderbuffers(1, &colorBuffer));
+        GL_CHECK(glDeleteRenderbuffers(1, &depthStencilBuffer));
+        GL_CHECK(glDeleteFramebuffers(1, &resolvedFbo));
+        GL_CHECK(glDeleteTextures(1, &colorTex));
+    }
 
     fbo = colorBuffer = depthStencilBuffer = resolvedFbo = colorTex = 0;
+    width = height = 0;
+    viewport = {};
+    valid = false;
+    external = false;
 }
 
 GlRenderTargetPool::GlRenderTargetPool(uint32_t maxWidth, uint32_t maxHeight, GlStateCache& state) :

--- a/src/renderer/gpu_engine/gl/tvgGlRenderTarget.h
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTarget.h
@@ -30,14 +30,16 @@ struct GlRenderTarget
     GlRenderTarget();
     ~GlRenderTarget();
 
-    void init(uint32_t width, uint32_t height, GLint resolveId);
+    void init(uint32_t width, uint32_t height, GLint resolveId, bool external = false);
     void reset();
 
-    bool invalid() const { return fbo == 0; }
+    bool invalid() const { return !valid; }
 
     RenderRegion viewport{};
     uint32_t width = 0, height = 0;
     GLuint resolvedFbo = 0, fbo = 0, colorTex = 0;
+    bool valid = false;
+    bool external = false;
 
 private:
     GLuint colorBuffer = 0;

--- a/src/renderer/gpu_engine/gl/tvgGlRenderTarget.h
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTarget.h
@@ -31,13 +31,15 @@ struct GlRenderTarget
     GlRenderTarget();
     ~GlRenderTarget();
 
-    void init(GlStateCache& state, uint32_t width, uint32_t height, GLint resolveId);
+    void init(GlStateCache& state, uint32_t width, uint32_t height, GLint resolveId, bool external = false);
     void reset();
-    bool invalid() const { return fbo == 0; }
+    bool invalid() const { return !valid; }
 
     RenderRegion viewport{};
     uint32_t width = 0, height = 0;
     GLuint resolvedFbo = 0, fbo = 0, colorTex = 0;
+    bool valid = false;
+    bool external = false;
 
 private:
     GlStateCache* state = nullptr;

--- a/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
@@ -243,7 +243,9 @@ void GlComposeTask::run()
 #endif
     GL_CHECK(glDepthMask(1));
 
-    GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+    GLbitfield clearMask = GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT;
+    if (!mFbo->external || mClearBuffer) clearMask |= GL_COLOR_BUFFER_BIT;
+    GL_CHECK(glClear(clearMask));
     GL_CHECK(glDepthMask(0));
 
     GL_CHECK(glViewport(0, 0, mRenderWidth, mRenderHeight));
@@ -254,13 +256,16 @@ void GlComposeTask::run()
     }
 
 #if defined(THORVG_GL_TARGET_GLES)
-    // only OpenGLES has tiled base framebuffer and discard function
-    GLenum attachments[2] = {GL_STENCIL_ATTACHMENT, GL_DEPTH_ATTACHMENT };
+    // OpenGL ES uses different attachment enums for default and user framebuffers.
+    GLenum attachments[2] = {
+        static_cast<GLenum>(mFbo->external ? GL_STENCIL : GL_STENCIL_ATTACHMENT),
+        static_cast<GLenum>(mFbo->external ? GL_DEPTH : GL_DEPTH_ATTACHMENT),
+    };
     GL_CHECK(glInvalidateFramebuffer(GL_FRAMEBUFFER, 2, attachments));
 #endif
     // reset scissor box
     GL_CHECK(glScissor(0, 0, mFbo->width, mFbo->height));
-    onResolve();
+    if (!mFbo->external) onResolve();
 }
 
 

--- a/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
@@ -222,7 +222,9 @@ void GlComposeTask::run(GlStateCache& state)
     state.clearDepth(0.0);
     state.depthMask(GL_TRUE);
 
-    GL_CHECK(glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
+    GLbitfield clearMask = GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT;
+    if (!fbo->external || clearBuffer) clearMask |= GL_COLOR_BUFFER_BIT;
+    GL_CHECK(glClear(clearMask));
     state.depthMask(GL_FALSE);
     state.viewport(0, 0, renderWidth, renderHeight);
     state.scissor(0, 0, renderWidth, renderHeight);
@@ -230,13 +232,16 @@ void GlComposeTask::run(GlStateCache& state)
     ARRAY_FOREACH(p, tasks) (*p)->run(state);
 
 #if defined(THORVG_GL_TARGET_GLES)
-    // only OpenGLES has tiled base framebuffer and discard function
-    GLenum attachments[2] = {GL_STENCIL_ATTACHMENT, GL_DEPTH_ATTACHMENT };
+    // OpenGL ES uses different attachment enums for default and user framebuffers.
+    GLenum attachments[2] = {
+        static_cast<GLenum>(fbo->external ? GL_STENCIL : GL_STENCIL_ATTACHMENT),
+        static_cast<GLenum>(fbo->external ? GL_DEPTH : GL_DEPTH_ATTACHMENT),
+    };
     GL_CHECK(glInvalidateFramebuffer(GL_FRAMEBUFFER, 2, attachments));
 #endif
     // reset scissor box
     state.scissor(0, 0, fbo->width, fbo->height);
-    onResolve(state);
+    if (!fbo->external) onResolve(state);
 }
 
 

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -84,6 +84,7 @@ void GlRenderer::flush()
     clearDisposes();
 
     mRootTarget.reset();
+    mDirectTarget = false;
 
     ARRAY_FOREACH(p, mComposePool) delete(*p);
     mComposePool.clear();
@@ -953,11 +954,50 @@ Result GlRenderer::target(void* display, void* surface, void* context, int32_t i
     mTargetFboId = static_cast<GLint>(id);
 
     auto ret = currentContext();
+    if (!ret) return Result::InsufficientCondition;
 
+#if defined(__APPLE__) || defined(__MACH__)
+    // Direct rendering was slower or showed no benefit on tested Apple
+    mDirectTarget = false;
+#else
+    mDirectTarget = (mTargetFboId == 0);
+    if (mDirectTarget) {
+        GLint stencilSize = 0;
+        GLint depthSize = 0;
+        GLint sampleBuffers = 0;
+        GLint samples = 0;
+
+        GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+
+#if defined(THORVG_GL_TARGET_GLES)
+        // GLES exposes default framebuffer bit depths through glGetIntegerv,
+        // avoiding another GL entry point in GLES and WebAssembly binaries.
+        GL_CHECK(glGetIntegerv(GL_STENCIL_BITS, &stencilSize));
+        GL_CHECK(glGetIntegerv(GL_DEPTH_BITS, &depthSize));
+#elif defined(THORVG_GL_DESKTOP_ATTACHMENT_QUERY)
+        // GL_DEPTH_BITS and GL_STENCIL_BITS are unavailable in desktop core
+        // GL, so query the default framebuffer attachments instead.
+        GL_CHECK(glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_STENCIL, GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE, &stencilSize));
+        GL_CHECK(glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_DEPTH, GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE, &depthSize));
+#else
+    #error Unsupported GL target
+#endif
+
+        GL_CHECK(glGetIntegerv(GL_SAMPLE_BUFFERS, &sampleBuffers));
+        GL_CHECK(glGetIntegerv(GL_SAMPLES, &samples));
+
+        mDirectTarget = (stencilSize > 0 && depthSize > 0 && sampleBuffers > 0 && samples >= GL_MSAA_SAMPLES);
+#if defined(THORVG_GL_TARGET_GL)
+        if (mDirectTarget) GL_CHECK(glEnable(GL_MULTISAMPLE));
+#endif
+        TVGLOG("GL_ENGINE", "Default framebuffer stencil/depth/sample buffers/samples: %d/%d/%d/%d, rendering: %s",
+               stencilSize, depthSize, sampleBuffers, samples, mDirectTarget ? "direct" : "offscreen");
+    }
+#endif
     mRootTarget.viewport = {{0, 0}, {int32_t(this->surface.w), int32_t(this->surface.h)}};
-    mRootTarget.init(this->surface.w, this->surface.h, mTargetFboId);
+    mRootTarget.init(this->surface.w, this->surface.h, mTargetFboId, mDirectTarget);
 
-    return ret ? Result::Success : Result::InsufficientCondition;
+    return Result::Success;
 }
 
 
@@ -977,12 +1017,18 @@ bool GlRenderer::sync()
     GL_CHECK(glEnable(GL_DEPTH_TEST));
     GL_CHECK(glDepthFunc(GL_GREATER));
 
-    auto task = mRenderPassStack.first()->endRenderPass<GlBlitTask>(mPrograms[RT_Blit], mTargetFboId);
-
-    prepareBlitTask(task);
-
-    task->mClearBuffer = mClearBuffer;
-    task->setTargetViewport({{0, 0}, {int32_t(surface.w), int32_t(surface.h)}});
+    GlRenderTask* task = nullptr;
+    if (mDirectTarget) {
+        auto composeTask = mRenderPassStack.first()->endRenderPass<GlComposeTask>(nullptr, mTargetFboId);
+        composeTask->mClearBuffer = mClearBuffer;
+        task = composeTask;
+    } else {
+        auto blitTask = mRenderPassStack.first()->endRenderPass<GlBlitTask>(mPrograms[RT_Blit], mTargetFboId);
+        prepareBlitTask(blitTask);
+        blitTask->mClearBuffer = mClearBuffer;
+        blitTask->setTargetViewport({{0, 0}, {int32_t(surface.w), int32_t(surface.h)}});
+        task = blitTask;
+    }
 
     if (mGpuBuffer.flushToGPU()) {
         mGpuBuffer.bind();

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -105,6 +105,7 @@ void GlRenderer::flush()
     clearDisposes();
 
     mRootTarget.reset();
+    mDirectTarget = false;
 
     ARRAY_FOREACH(p, mComposePool) delete(*p);
     mComposePool.clear();
@@ -976,12 +977,51 @@ Result GlRenderer::target(void* display, void* surface, void* context, int32_t i
     // Cached values belong to the previous context. Numeric object ids can be
     // reused by the new context, so do not carry any binding assumptions over.
     mStateCache.invalidate();
+    if (!ret) return Result::InsufficientCondition;
 
+#if defined(__APPLE__) || defined(__MACH__)
+    // Direct rendering was slower or showed no benefit on tested Apple
+    mDirectTarget = false;
+#else
+    mDirectTarget = (mTargetFboId == 0);
+    if (mDirectTarget) {
+        GLint stencilSize = 0;
+        GLint depthSize = 0;
+        GLint sampleBuffers = 0;
+        GLint samples = 0;
+
+        mStateCache.bindFramebuffer(GL_FRAMEBUFFER, 0);
+
+#if defined(THORVG_GL_TARGET_GLES)
+        // GLES exposes default framebuffer bit depths through glGetIntegerv,
+        // avoiding another GL entry point in GLES and WebAssembly binaries.
+        GL_CHECK(glGetIntegerv(GL_STENCIL_BITS, &stencilSize));
+        GL_CHECK(glGetIntegerv(GL_DEPTH_BITS, &depthSize));
+#elif defined(THORVG_GL_DESKTOP_ATTACHMENT_QUERY)
+        // GL_DEPTH_BITS and GL_STENCIL_BITS are unavailable in desktop core
+        // GL, so query the default framebuffer attachments instead.
+        GL_CHECK(glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_STENCIL, GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE, &stencilSize));
+        GL_CHECK(glGetFramebufferAttachmentParameteriv(GL_FRAMEBUFFER, GL_DEPTH, GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE, &depthSize));
+#else
+    #error Unsupported GL target
+#endif
+
+        GL_CHECK(glGetIntegerv(GL_SAMPLE_BUFFERS, &sampleBuffers));
+        GL_CHECK(glGetIntegerv(GL_SAMPLES, &samples));
+
+        mDirectTarget = (stencilSize > 0 && depthSize > 0 && sampleBuffers > 0 && samples >= GL_MSAA_SAMPLES);
+#if defined(THORVG_GL_TARGET_GL)
+        if (mDirectTarget) GL_CHECK(glEnable(GL_MULTISAMPLE));
+#endif
+        TVGLOG("GL_ENGINE", "Default framebuffer stencil/depth/sample buffers/samples: %d/%d/%d/%d, rendering: %s",
+               stencilSize, depthSize, sampleBuffers, samples, mDirectTarget ? "direct" : "offscreen");
+    }
+#endif
     mRootTarget.viewport = {{0, 0}, {int32_t(this->surface.w), int32_t(this->surface.h)}};
-    mRootTarget.init(mStateCache, this->surface.w, this->surface.h, mTargetFboId);
+    mRootTarget.init(mStateCache, this->surface.w, this->surface.h, mTargetFboId, mDirectTarget);
     mStateCache.invalidate();
 
-    return ret ? Result::Success : Result::InsufficientCondition;
+    return Result::Success;
 }
 
 
@@ -1010,12 +1050,18 @@ bool GlRenderer::sync()
     mStateCache.enable(GL_DEPTH_TEST);
     mStateCache.depthFunc(GL_GREATER);
 
-    auto task = mRenderPassStack.first()->endRenderPass<GlBlitTask>(mPrograms[RT_Blit], mTargetFboId);
-
-    prepareBlitTask(task);
-
-    task->clearBuffer = mClearBuffer;
-    task->targetViewport = {{0, 0}, {int32_t(surface.w), int32_t(surface.h)}};
+    GlRenderTask* task = nullptr;
+    if (mDirectTarget) {
+        auto composeTask = mRenderPassStack.first()->endRenderPass<GlComposeTask>(nullptr, mTargetFboId);
+        composeTask->clearBuffer = mClearBuffer;
+        task = composeTask;
+    } else {
+        auto blitTask = mRenderPassStack.first()->endRenderPass<GlBlitTask>(mPrograms[RT_Blit], mTargetFboId);
+        prepareBlitTask(blitTask);
+        blitTask->clearBuffer = mClearBuffer;
+        blitTask->targetViewport = {{0, 0}, {int32_t(surface.w), int32_t(surface.h)}};
+        task = blitTask;
+    }
 
     if (mGpuBuffer.flushToGPU(mStateCache)) {
         mGpuBuffer.bind(mStateCache);

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.h
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.h
@@ -241,6 +241,7 @@ private:
 
     BlendMethod mBlendMethod = BlendMethod::Normal;
     bool mClearBuffer = false;
+    bool mDirectTarget = false;
 };
 
 #endif /* _TVG_GL_RENDERER_H_ */

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.h
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.h
@@ -246,6 +246,7 @@ private:
 
     BlendMethod mBlendMethod = BlendMethod::Normal;
     bool mClearBuffer = false;
+    bool mDirectTarget = false;
 };
 
 #endif /* _TVG_GL_RENDERER_H_ */


### PR DESCRIPTION
Allows the engine to render directly to the screen's back buffer, bypassing intermediate framebuffers when possible.

This change introduces a new `mDirectTarget` flag to indicate whether the rendering target is the back buffer.  When rendering directly, it uses a compose task instead of a blit task and avoids unnecessary framebuffer operations.

This improves rendering performance and reduces memory consumption in scenarios where direct rendering is feasible.

**The WASM binding requires modification to enable this feature.**
```cpp
        attrs.depth = true;
        attrs.stencil = true;
        attrs.antialias = true;
```
Related issues: https://github.com/thorvg/thorvg/issues/3951

### Evaluation

#### Summary
- No regressions in any example.
- **Large animation**: +0.3% overall FPS, +1.2% steady-state FPS.
- **Lottie animations**: +3.4% overall FPS, +4.6% steady-state FPS (with higher jitter).
- **Simple animation (normal resolution)**: +3.0% overall FPS, steady-state is the same.
- **Simple animation (4K)**: +44% overall FPS, +36% steady-state FPS (with slightly lower jitter).
- **WebGL multi-animation test**: After a 1-minute run, both builds stabilize at 60 FPS with similar memory ranges. No meaningful difference observed.

Overall, the feature branch is performance-safe and shows significant improvements at high resolutions, especially in 4K scenarios.

---

### 1. Large Animation
<img width="769" height="785" alt="image" src="https://github.com/user-attachments/assets/76b795a6-a656-4a39-91b1-2510f735e3fd" />

**Overall FPS**  
- Origin: 25.66  
- Feature: 25.74  
- Change: **+0.31%**

**Steady-State FPS (last 20 intervals)**  
- Origin: 25.49  
- Feature: 25.79  
- Change: **+1.18%**

**Jitter (stddev/mean)**  
- Origin: 1.71%  
- Feature: 2.18%  
- Relative change: **+27%**

**Conclusion:** Tiny gain, effectively identical to origin. No regression.

---

### 2. Lottie Animation
<img width="961" height="800" alt="image" src="https://github.com/user-attachments/assets/bfea140d-f0e6-4d6d-832f-acf500eb1539" />

**Overall FPS**  
- Origin: 34.28  
- Feature: 35.45  
- Change: **+3.41%**

**Steady-State FPS**  
- Origin: 34.75  
- Feature: 36.36  
- Change: **+4.62%**

**Jitter**  
- Origin: 3.21%  
- Feature: 5.51%  
- Relative change: **+72%**

**Conclusion:** Clear 3–5% FPS gain with higher variability. Still stable.

---

### 3. Small Animation (Normal Resolution)
<img width="1026" height="1056" alt="image" src="https://github.com/user-attachments/assets/4237e1cf-72c9-401f-9b77-80ea1fc55d28" />

**Overall FPS**  
- Origin: 187.20  
- Feature: 192.72  
- Change: **+2.95%**

**Steady-State FPS**  
- Origin: 239.55  
- Feature: 239.33  
- Change: **−0.09%**

**Jitter**  
- Origin: 0.10%  
- Feature: 0.14%  
- Relative change: **+43%**

**Conclusion:** +3% overall from faster warm-up; steady-state identical.

---

### 4. Small Animation (4K Resolution)
<img width="3841" height="2160" alt="Screenshot 2025-11-23 011229" src="https://github.com/user-attachments/assets/497ea795-dcf9-4c45-acb1-6720043edc8a" />

**Overall FPS**  
- Origin: 120.01  
- Feature: 173.07  
- Change: **+44.21%**

**Steady-State FPS**  
- Origin: 119.04  
- Feature: 161.46  
- Change: **+35.64%**

**Jitter**  
- Origin: 0.85%  
- Feature: 0.67%  
- Change: **−21%**

**Conclusion:** Major performance uplift at 4K — both average and steady-state FPS improve significantly.

---

### 5. Resolution Scaling (Normal → 4K)

#### Origin Branch
- Overall FPS: −35.89%  
- Steady-State FPS: −50.31%

#### Feature Branch
- Overall FPS: −10.20%  
- Steady-State FPS: −32.54%

**Conclusion:** The feature branch is far more resolution-robust.  
Origin loses half its steady-state FPS, while the feature retains much more performance.

---

### 6. WebGL Multi-Animation Test (Qualitative)
<img width="4064" height="2160" alt="Screenshot 2025-11-22 at 8 48 52 PM" src="https://github.com/user-attachments/assets/30f2b311-35ed-490f-90d6-bfda7aabbb51" />

Tested using the WebGL/DevTools HUD for 1 minute.

**Feature Build**
- FPS: 60 (range 29–60)
- Memory counter: ~20 MB (range 19–25 MB)

**Origin Build**
- FPS: 60 (range 29–60)
- Memory counter: ~23 MB (range 19–25 MB)

**Conclusion:**
- FPS stabilizes at 60 on both builds.
- The HUD memory number fluctuates and stays in the same range for both builds.
- Treat this as **no meaningful difference** and, importantly, **no regression**.

**Notes**
- I also make sure that direct rendering is enabled in WebGL with a tool, but the performance remains exactly the same.
<p>
<img width="1016" height="540" alt="image" src="https://github.com/user-attachments/assets/722d3122-d6fb-4308-80dd-eb17822aa571" />
<img width="1016" height="540" alt="image" src="https://github.com/user-attachments/assets/31863db6-7503-4595-8ebe-28dccb1fbfe8" />
</p>

---


