### PR TITLE
gl: fix trimpath flickering regression

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -123,7 +123,6 @@ struct GlGeometry
     RenderRegion bounds = {};
     FillRule fillRule = FillRule::NonZero;
     RenderPath optimizedPath;
-    bool optimized = false;
 };
 
 


### PR DESCRIPTION
Fix trimpath flickering during animation by reordering path optimization.

The regression was caused by applying path optimization before trimming, which resulted in incorrect geometry for trimmed paths. This commit fixes the issue by:
- Moving optimizePath() call to after trimming operation
- Applying optimization only to the trimmed path when trimpath is active
- Ensuring optimizedPath is properly cleared when trimming fails

Fixes: #3999