### PR TITLE
svg_loader: Improve CSS class declaration

### DIFF
--- a/src/common/tvgCommon.h
+++ b/src/common/tvgCommon.h
@@ -47,6 +47,7 @@ using namespace tvg;
     #define TVG_UNUSED
     #define strncasecmp _strnicmp
     #define strcasecmp _stricmp
+    #define strtok_r strtok_s
 #else
     #define TVG_UNUSED __attribute__ ((__unused__))
 #endif

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -21,7 +21,6 @@
  */
 
 #include <fstream>
-#include <cstring>
 #include "tvgStr.h"
 #include "tvgMath.h"
 #include "tvgColor.h"
@@ -3518,15 +3517,26 @@ static void _svgLoaderParserXmlCssStyle(SvgLoaderData* loader, const char* conte
         } else if (STR_AS(tag, "stop")) {
             TVGLOG("SVG", "Unsupported elements used in the internal CSS style sheets [Elements: %s]", tag);
         } else if (STR_AS(tag, "all")) {
-            char *pch = strtok(name, ",");
+            char* tokPtr = nullptr;
+            auto pch = strtok_r(name, ",", &tokPtr);
             while (pch != nullptr) {
                 while (*pch && isspace(*pch)) pch++;
 
-                char* id = pch;
+                auto id = pch;
                 if (*id == '.') id++;
 
-                char* end = id + strlen(id) - 1;
-                while(end > id && isspace(*end)) *end-- = '\0';
+                if (*id == '\0') {
+                    pch = strtok_r(nullptr, ",", &tokPtr);
+                    continue;
+                }
+
+                auto end = id + strlen(id) - 1;
+                while (end > id && isspace(*end)) *end-- = '\0';
+
+                if (*id == '\0') {
+                    pch = strtok_r(nullptr, ",", &tokPtr);
+                    continue;
+                }
 
                 if (auto cssNode = cssFindStyleNode(loader->cssStyle, id)) {
                     auto oldNode = loader->svgParse->node;
@@ -3535,10 +3545,10 @@ static void _svgLoaderParserXmlCssStyle(SvgLoaderData* loader, const char* conte
                     loader->svgParse->node = oldNode;
                 } else {
                     if ((node = _createCssStyleNode(loader, loader->cssStyle, attrs, attrsLength, xmlParseW3CAttribute))) {
-                         node->id = _copyId(id);
+                        node->id = _copyId(id);
                     }
                 }
-                pch = strtok(nullptr, ",");
+                pch = strtok_r(nullptr, ",", &tokPtr);
             }
         } else if (STR_AS(tag, "@font-face")) { //css at-rule specifying font
             _createFontFace(loader, attrs, attrsLength, xmlParseW3CAttribute);


### PR DESCRIPTION
Improve two issues related to class declarations in style.
- When declaring same class multiple times, fix it so that later declared attributes are not omitted.
- When declaring nested classes, fix to prevent classes from being omitted

related issues:  https://github.com/thorvg/thorvg/issues/3662 / https://github.com/thorvg/thorvg/issues/2096