### PR TITLE
svg_loader: Support style class set

### DIFF
--- a/src/loaders/svg/tvgSvgCssStyle.h
+++ b/src/loaders/svg/tvgSvgCssStyle.h
@@ -28,7 +28,6 @@
 SvgNode* cssFindStyleNode(const SvgNode* style, const char* title, SvgNodeType type);
 SvgNode* cssFindStyleNode(const SvgNode* style, const char* title);
 void cssUpdateStyle(SvgNode* doc, SvgNode* style);
-bool cssApplyClass(SvgNode* node, const char* classString, SvgNode* styleRoot);
-void cssApplyStyleToPostponeds(Array<SvgNodeIdPair>& postponeds, SvgNode* style);
+void cssCopyStyleAttr(SvgNode* to, const SvgNode* from, bool overwrite = false);
 
 #endif //_TVG_SVG_CSS_STYLE_H_


### PR DESCRIPTION
A class can be declared a space-separated set of classes. https://www.w3.org/TR/SVG2/styling.html#ElementSpecificStyling https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-space-separated-tokens

```
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64" height="64">
<style>
<![CDATA[.B{clip-path:url(#B)}.C{stroke:#f54a42}.D{stroke-width:10.75}.E{stroke-miterlimit:5}.F{stroke:#FF00FF}.G{stroke-opacity:0.5}]]>
</style>

	<g class="B">
		<path clip-path="url(#F)" d="M10 10 L100 100 Z" fill="none" class="C D E F G C"/>
	</g>
</svg>
```

path's property
.C{stroke:#f54a42}
.D{stroke-width:10.75}
.E{stroke-miterlimit:5}
~~.F{stroke:#FF00FF}~~ <- overwrite
.G{stroke-opacity:0.5}

related issue : https://github.com/thorvg/thorvg/issues/2095