### PR TITLE
gl: fix broken Intersect example

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -136,8 +136,8 @@ struct GlShape
   ColorSpace texColorSpace = ColorSpace::ABGR8888;
   GlGeometry geometry;
   Array<RenderData> clips;
-  bool validFill;
-  bool validStroke;
+  bool validFill = false;
+  bool validStroke = false;
 };
 
 struct GlIntersector

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -1266,25 +1266,24 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
     if (!sdata) {
         sdata = new GlShape;
         sdata->rshape = &rshape;
+        flags = RenderUpdateFlag::All;
     }
-    sdata->validStroke = sdata->validFill = false;
 
     if ((opacity == 0 && !clipper) || flags == RenderUpdateFlag::None) return sdata;
 
     sdata->viewWd = static_cast<float>(surface.w);
     sdata->viewHt = static_cast<float>(surface.h);
-
-    sdata->geometry = GlGeometry();
     sdata->opacity = opacity;
+
+    if (flags & RenderUpdateFlag::Path) sdata->geometry = GlGeometry();
+    
     sdata->geometry.matrix = transform;
     sdata->geometry.viewport = vport;
-
-    if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform)) {
-        sdata->geometry.prepare(rshape);
-    }
-
+    if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform)) sdata->geometry.prepare(rshape);
+    
     //TODO: Please precisely update tessellation not to update only if the color is changed.
     if (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
+        sdata->validFill = false;
         float opacityMultiplier = 1.0f;
         if (sdata->geometry.tesselateShape(*(sdata->rshape), &opacityMultiplier)) {
             sdata->opacity *= opacityMultiplier;
@@ -1294,6 +1293,7 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
     //TODO: Please precisely update tessellation not to update only if the color is changed.
     if (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Stroke | RenderUpdateFlag::GradientStroke | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
+        sdata->validStroke = false;
         if (sdata->geometry.tesselateStroke(*(sdata->rshape))) sdata->validStroke = true;
     }
 


### PR DESCRIPTION
Fix rendering regression in Intersect example caused by improper flag management.

The regression was introduced in commit 6454b55d3 (gl: fix trimpath flickering regression) where the GLGeometry were unconditionally reset, causing incorrect rendering for shapes with composite methods like Intersect.

This commit fixes the issue by:
- Only resetting geometry when RenderUpdateFlag::Path is set
- Conditionally resetting validFill/validStroke flags based on update flags
- Properly initializing flags when creating new GlShape instances

Fixes: #4009

https://github.com/user-attachments/assets/f62cb518-ce16-491c-af71-428bda647006

*Simple performance check: Lottie example shows a frame rate at the 1000th frame of 36.90 fps compared to 36.59 fps, indicating no regression in performance.




