### PR TITLE
wg: fix round join tessellation with scale and angular interpolation (fixes #3344)

### DIFF
--- a/src/renderer/wg_engine/tvgWgTessellator.cpp
+++ b/src/renderer/wg_engine/tvgWgTessellator.cpp
@@ -56,6 +56,7 @@ void WgStroker::run(const RenderPath& path, const Matrix& m)
 {
     mBuffer->vbuffer.reserve(path.pts.count * 4 + 16);
     mBuffer->ibuffer.reserve(path.pts.count * 3);
+    mScale = tvg::scaling2D(m);
 
     auto validStrokeCap = false;
     auto pts = path.pts.data;
@@ -240,27 +241,34 @@ void WgStroker::join(const Point& dir)
 
 void WgStroker::round(const Point &prev, const Point& curr, const Point& center)
 {
-    if (orientation(prev, center, curr) == Orientation::Linear) return;
+    auto orient = orientation(prev, center, curr);
+    if (orient == Orientation::Linear) return;
 
     mLeftTop.x = std::min(mLeftTop.x, std::min(center.x, std::min(prev.x, curr.x)));
     mLeftTop.y = std::min(mLeftTop.y, std::min(center.y, std::min(prev.y, curr.y)));
     mRightBottom.x = std::max(mRightBottom.x, std::max(center.x, std::max(prev.x, curr.x)));
     mRightBottom.y = std::max(mRightBottom.y, std::max(center.y, std::max(prev.y, curr.y)));
 
+    auto startAngle = tvg::atan2(prev.y - center.y, prev.x - center.x);
+    auto endAngle = tvg::atan2(curr.y - center.y, curr.x - center.x);
+
+    if (orient == Orientation::Clockwise) {
+        if (endAngle > startAngle) endAngle -= 2 * MATH_PI;
+    } else {
+        if (endAngle < startAngle) endAngle += 2 * MATH_PI;
+    }
+
     // Fixme: just use bezier curve to calculate step count
-    auto count = Bezier(prev, curr, radius()).segments();
+    auto count = Bezier(prev * mScale, curr * mScale, radius() * length(mScale)).segments();
+    if (count < 2) count = 2;
+
     auto c = mBuffer->vbuffer.count;  mBuffer->vbuffer.push(center);
     auto pi = mBuffer->vbuffer.count; mBuffer->vbuffer.push(prev);
-    auto step = 1.f / (count - 1);
-    auto dir = curr - prev;
+    auto step = (endAngle - startAngle) / (count - 1);
 
     for (uint32_t i = 1; i < static_cast<uint32_t>(count); i++) {
-        auto t = i * step;
-        auto p = prev + dir * t;
-        auto o_dir = p - center;
-        normalize(o_dir);
-
-        auto out = center + o_dir * radius();
+        auto angle = startAngle + step * i;
+        Point out = {center.x + cos(angle) * radius(), center.y + sin(angle) * radius()};
         auto oi = mBuffer->vbuffer.count; mBuffer->vbuffer.push(out);
 
         mBuffer->ibuffer.push(c);

--- a/src/renderer/wg_engine/tvgWgTessellator.h
+++ b/src/renderer/wg_engine/tvgWgTessellator.h
@@ -71,6 +71,7 @@ private:
     State mState = {};
     Point mLeftTop = {0.0f, 0.0f};
     Point mRightBottom = {0.0f, 0.0f};
+    Point mScale;
 };
 
 class WgBWTessellator


### PR DESCRIPTION
- apply stroke scale from transform before computing round joins
- use angular sweep instead of linear lerp to generate arc vertices
- clamp round join segment count to a minimum for robustness

fixes #3344

<img width="1282" height="1320" alt="Screenshot 2025-11-27 014716" src="https://github.com/user-attachments/assets/c16938a8-47d3-45c6-ba05-ee47229b16f0" />
