### PR TITLE
renderer: fix the wrong namespace of free() call at FontMetrics

### DIFF
--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -150,7 +150,7 @@ struct FontMetrics
 
     ~FontMetrics()
     {
-        free(engine);
+        tvg::free(engine);
     }
 };
 


### PR DESCRIPTION
Hi @hermet 

As per discussed from https://github.com/thorvg/thorvg/pull/3892, this is the separate PR for fixing the typo at `tvgLoadModule.h` to make sure it uses correct `free()` function. 

Regards,
Jackson