### PR TITLE
gl: refactor matrix handling from mat4 to mat3

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -28,57 +28,28 @@
 #include "tvgRender.h"
 #include "tvgMath.h"
 
-#define MIN_GL_STROKE_WIDTH 1.0f
-#define MIN_GL_STROKE_ALPHA 0.25f
+constexpr float MIN_GL_STROKE_WIDTH = 1.0f;
+constexpr float MIN_GL_STROKE_ALPHA = 0.25f;
 
-#define MVP_MATRIX(w, h)                \
-    float mvp[4*4] = {                  \
-        2.f / w,      0.0,  0.0f, 0.0f, \
-        0.0,     -2.f / h,  0.0f, 0.0f, \
-        0.0f,        0.0f, -1.0f, 0.0f, \
-        -1.f,         1.f,  0.0f, 1.0f  \
-    };
+constexpr uint32_t GL_MAT3_STD140_SIZE = 12; // mat3 is 3 vec4 columns in std140
+constexpr uint32_t GL_MAT3_STD140_BYTES = GL_MAT3_STD140_SIZE * sizeof(float);
 
-#define MULTIPLY_MATRIX(A, B, transform)    \
-    for(auto i = 0; i < 4; ++i) {           \
-        for(auto j = 0; j < 4; ++j) {       \
-            float sum = 0.0;                \
-            for (auto k = 0; k < 4; ++k)    \
-                sum += A[k*4+i] * B[j*4+k]; \
-            transform[j*4+i] = sum;         \
-        }                                   \
-    }
-
-/**
- *  mat3x3               mat4x4
- *
- * [ e11 e12 e13 ]     [ e11 e12 0 e13 ]
- * [ e21 e22 e23 ] =>  [ e21 e22 0 e23 ]
- * [ e31 e32 e33 ]     [ 0   0   1  0  ]
- *                     [ e31 e32 0 e33 ]
- *
- */
-
-// All GPU use 4x4 matrix with column major order
-#define GET_MATRIX44(mat3, mat4) \
-    do {                         \
-        mat4[0] = mat3.e11;      \
-        mat4[1] = mat3.e21;      \
-        mat4[2] = 0;             \
-        mat4[3] = mat3.e31;      \
-        mat4[4] = mat3.e12;      \
-        mat4[5] = mat3.e22;      \
-        mat4[6] = 0;             \
-        mat4[7] = mat3.e32;      \
-        mat4[8] = 0;             \
-        mat4[9] = 0;             \
-        mat4[10] = 1;            \
-        mat4[11] = 0;            \
-        mat4[12] = mat3.e13;     \
-        mat4[13] = mat3.e23;     \
-        mat4[14] = 0;            \
-        mat4[15] = mat3.e33;     \
-    } while (false)
+// All GPU matrices use column major order. std140 mat3 packs each column into a vec4 stride.
+static inline void getMatrix3Std140(const Matrix& mat3, float* matOut)
+{
+    matOut[0] = mat3.e11;
+    matOut[1] = mat3.e21;
+    matOut[2] = mat3.e31;
+    matOut[3] = 0.0f;
+    matOut[4] = mat3.e12;
+    matOut[5] = mat3.e22;
+    matOut[6] = mat3.e32;
+    matOut[7] = 0.0f;
+    matOut[8] = mat3.e13;
+    matOut[9] = mat3.e23;
+    matOut[10] = mat3.e33;
+    matOut[11] = 0.0f;
+}
 
 
 

--- a/src/renderer/gl_engine/tvgGlRenderPass.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderPass.cpp
@@ -58,11 +58,15 @@ void GlRenderPass::getMatrix(float *dst, const Matrix &matrix) const
     const auto& vp = getViewport();
     translate(&postMatrix, {(float)-vp.sx(), (float)-vp.sy()});
 
-    auto m = postMatrix * matrix;
+    auto modelMatrix = postMatrix * matrix;
 
-    float modelMatrix[16];
-    GET_MATRIX44(m, modelMatrix);
-    MVP_MATRIX(vp.w(), vp.h());
+    Matrix mvp = tvg::identity();
+    mvp.e11 = 2.f / vp.w();
+    mvp.e22 = -2.f / vp.h();
+    mvp.e13 = -1.f;
+    mvp.e23 = 1.f;
 
-    MULTIPLY_MATRIX(mvp, modelMatrix, dst);
+    auto mvpModel = mvp * modelMatrix;
+
+    getMatrix3Std140(mvpModel, dst);
 }

--- a/src/renderer/gl_engine/tvgGlRenderPass.h
+++ b/src/renderer/gl_engine/tvgGlRenderPass.h
@@ -51,7 +51,7 @@ public:
 
     uint32_t getFboHeight() const { return mFbo->getHeight(); }
 
-    void getMatrix(float dst[16], const Matrix& matrix) const;
+    void getMatrix(float dst[GL_MAT3_STD140_SIZE], const Matrix& matrix) const;
 
     template <class T>
     T* endRenderPass(GlProgram* program, GLuint targetFbo) {

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -28,14 +28,13 @@ const char* COLOR_VERT_SHADER = TVG_COMPOSE_SHADER(
     uniform float uDepth;                                           \n
     layout(location = 0) in vec2 aLocation;                         \n
     layout(std140) uniform Matrix {                                 \n
-        mat4 transform;                                             \n
+        mat3 transform;                                             \n
     } uMatrix;                                                      \n
                                                                     \n
     void main()                                                     \n
     {                                                               \n
-        vec4 pos = uMatrix.transform * vec4(aLocation, 0.0, 1.0);   \n
-        pos.z = uDepth;                                             \n
-        gl_Position = pos;                                          \n
+        vec3 pos = uMatrix.transform * vec3(aLocation, 1.0);        \n
+        gl_Position = vec4(pos.xy, uDepth, 1.0);                    \n
     }                                                               \n
 );
 
@@ -57,19 +56,18 @@ const char* GRADIENT_VERT_SHADER = TVG_COMPOSE_SHADER(
     layout(location = 0) in vec2 aLocation;                                         \n
     out vec2 vPos;                                                                  \n
     layout(std140) uniform Matrix {                                                 \n
-        mat4 transform;                                                             \n
+        mat3 transform;                                                             \n
     } uMatrix;                                                                      \n
     layout(std140) uniform InvMatrix {                                              \n
-        mat4 transform;                                                             \n
+        mat3 transform;                                                             \n
     } uInvMatrix;                                                                   \n
                                                                                     \n
     void main()                                                                     \n
     {                                                                               \n
-        vec4 glPos = uMatrix.transform * vec4(aLocation, 0.0, 1.0);                 \n
-        glPos.z = uDepth;                                                           \n
-        gl_Position = glPos;                                                        \n
-        vec4 pos =  uInvMatrix.transform * vec4(aLocation, 0.0, 1.0);               \n
-        vPos = pos.xy / pos.w;                                                      \n
+        vec3 glPos = uMatrix.transform * vec3(aLocation, 1.0);                      \n
+        gl_Position = vec4(glPos.xy, uDepth, 1.0);                                  \n
+        vec3 pos =  uInvMatrix.transform * vec3(aLocation, 1.0);                    \n
+        vPos = pos.xy;                                                              \n
     }                                                                               \n
 );
 
@@ -315,16 +313,15 @@ const char* IMAGE_VERT_SHADER = TVG_COMPOSE_SHADER(
     layout (location = 0) in vec2 aLocation;                                                \n
     layout (location = 1) in vec2 aUV;                                                      \n
     layout (std140) uniform Matrix {                                                        \n
-        mat4 transform;                                                                     \n
+        mat3 transform;                                                                     \n
     } uMatrix;                                                                              \n
     out vec2 vUV;                                                                           \n
                                                                                             \n
     void main()                                                                             \n
     {                                                                                       \n
         vUV = aUV;                                                                          \n
-        vec4 pos = uMatrix.transform * vec4(aLocation, 0.0, 1.0);                           \n
-        pos.z = uDepth;                                                                     \n
-        gl_Position = pos;                                                                  \n
+        vec3 pos = uMatrix.transform * vec3(aLocation, 1.0);                                \n
+        gl_Position = vec4(pos.xy, uDepth, 1.0);                                            \n
     }                                                                                       \n
 );
 
@@ -541,14 +538,13 @@ const char* STENCIL_VERT_SHADER = TVG_COMPOSE_SHADER(
     uniform float uDepth;                                           \n
     layout(location = 0) in vec2 aLocation;                         \n
     layout(std140) uniform Matrix {                                 \n
-        mat4 transform;                                             \n
+        mat3 transform;                                             \n
     } uMatrix;                                                      \n
                                                                     \n
     void main()                                                     \n
     {                                                               \n
-        vec4 pos = uMatrix.transform * vec4(aLocation, 0.0, 1.0);   \n
-        pos.z = uDepth;                                             \n
-        gl_Position = pos;                                          \n
+        vec3 pos = uMatrix.transform * vec3(aLocation, 1.0);        \n
+        gl_Position = vec4(pos.xy, uDepth, 1.0);                    \n
     });
 
 const char* STENCIL_FRAG_SHADER = TVG_COMPOSE_SHADER(


### PR DESCRIPTION
This PR refactors the GL engine's matrix handling to use 3x3 matrices instead of 4x4 matrices for 2D transformations.

#### Changes

-   **Macro to modern C++**: Replaced preprocessor macros (`MVP_MATRIX`,  `MULTIPLY_MATRIX`,  `GET_MATRIX44`) with  `constexpr`  values and an inline  `getMatrix3Std140()`  function
-   **Memory optimization**: Reduced uniform buffer size from 64 bytes to 48 bytes per matrix (std140-packed mat3)
-   **Simplified shaders**: Updated vertex shaders to use `vec3`/`mat3`operations instead of  `vec4`/`mat4`
-   **Cleaner MVP calculation**: Leverages ThorVG's native `Matrix` struct and  `operator*`  instead of manual 4x4 matrix multiplication

**Impact Analysis**
In the heaviest GL example (`Blending`), the std140 `mat3` path allocates **21,757** matrices (**~1.04 MB** per frame). The previous `mat4` layout would upload **~1.39 MB** for the same frame, This **~0.35MB** reduction in uniform buffer traffic lowers the memory bus bandwidth requirement, which is critical for performance on bandwidth-constrained platforms.

#### ⚠️ Note

This implementation assumes **affine 2D transforms only** (where `e31=0`, `e32=0`, `e33=1`). The perspective divide in gradient shaders (`pos.xy / pos.w`) has been removed since it's unnecessary for affine transforms. **If ThorVG ever supports projective 2D transforms in the future, this would break and need to be revisited.**

**Verified GL rendering output across all examples**

Related issues: #3824
