### PR TITLE
renderer/text: support spacing function

### DIFF
--- a/examples/Text.cpp
+++ b/examples/Text.cpp
@@ -191,12 +191,21 @@ struct UserExample : tvgexam::Example
         canvas->push(text12);
 
         auto text13 = tvg::Text::gen();
-        text13->font("NOTO-SANS-KR");
+        text13->font("Arial");
         text13->size(20);
         text13->fill(255, 255, 255);
-        text13->text("Line-Feed Test. This is the first line - \nThis is the second line.");
+        text13->text("LINE-FEED TEST. THIS IS THE FIRST LINE - \nTHIS IS THE SECOND LINE.");
         text13->translate(0, 625);
         canvas->push(text13);
+
+        auto text14 = tvg::Text::gen();
+        text14->font("Arial");
+        text14->size(20);
+        text14->fill(255, 255, 255);
+        text14->spacing(1.5f, 1.5f);
+        text14->text("1.5x SPACING TEST. THIS IS THE FIRST LINE - \nTHIS IS THE SECOND LINE.");
+        text14->translate(0, 700);
+        canvas->push(text14);
 
         return true;
     }
@@ -209,5 +218,5 @@ struct UserExample : tvgexam::Example
 
 int main(int argc, char **argv)
 {
-    return tvgexam::main(new UserExample, argc, argv);
+    return tvgexam::main(new UserExample, argc, argv, false, 1024, 1024);
 }

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1901,6 +1901,7 @@ struct TVG_API Text : Paint
      * @note Experimental API
      *
      * @see align()
+     * @see spacing()
      */
     Result layout(float w, float h) noexcept;
 
@@ -1985,6 +1986,28 @@ struct TVG_API Text : Paint
      * @since 0.15
      */
     Result fill(Fill* f) noexcept;
+
+    /**
+     * @brief Set the spacing scale factors for text layout.
+     *
+     * This function adjusts the letter spacing (horizontal space between glyphs) and
+     * line spacing (vertical space between lines of text) using scale factors.
+     *
+     * Both values are relative to the font's default metrics:
+     * - The letter spacing is applied as a scale factor to the glyph's advance width.
+     * - The line spacing is applied as a scale factor to the glyph's advance height.
+     *
+     * @param[in] letter The scale factor for letter spacing.
+     *                   Values > 1.0 increase spacing, values < 1.0 decrease it.
+     *                   Must be greater than or equal to 0.0. (default: 1.0)
+     *
+     * @param[in] line The scale factor for line spacing.
+     *                 Values > 1.0 increase line spacing, values < 1.0 decrease it.
+     *                 Must be greater than or equal to 0.0. (default: 1.0)
+     *
+     * @note Experimental API
+     */
+    Result spacing(float letter, float line) noexcept;
 
     /**
      * @brief Loads a scalable font data (ttf) from a file.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2422,6 +2422,7 @@ TVG_API Tvg_Result tvg_text_align(Tvg_Paint text, float x, float y);
  * @note Experimental API
  *
  * @see tvg_text_align()
+ * @see tvg_text_spacing()
  */
 TVG_API Tvg_Result tvg_text_layout(Tvg_Paint text, float w, float h);
 
@@ -2439,6 +2440,30 @@ TVG_API Tvg_Result tvg_text_layout(Tvg_Paint text, float w, float h);
  * @note Experimental API
  */
 TVG_API Tvg_Result tvg_text_wrap_mode(Tvg_Paint text, Tvg_Text_Wrap mode);
+
+
+/**
+ * @brief Set the spacing scale factors for text layout.
+ *
+ * This function adjusts the letter spacing (horizontal space between glyphs) and
+ * line spacing (vertical space between lines of text) using scale factors.
+ *
+ * Both values are relative to the font's default metrics:
+ * - The letter spacing is applied as a scale factor to the glyph's advance width.
+ * - The line spacing is applied as a scale factor to the glyph's advance height.
+ *
+ * @param[in] text A Tvg_Paint pointer to the text object.
+ * @param[in] letter The scale factor for letter spacing.
+ *                   Values > 1.0 increase spacing, values < 1.0 decrease it.
+ *                   Must be greater than or equal to 0.0. (default: 1.0)
+ *
+ * @param[in] line The scale factor for line spacing.
+ *                 Values > 1.0 increase line spacing, values < 1.0 decrease it.
+ *                 Must be greater than or equal to 0.0. (default: 1.0)
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_text_spacing(Tvg_Paint text, float letter, float line);
 
 
 /**

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -944,6 +944,13 @@ TVG_API Tvg_Result tvg_text_wrap_mode(Tvg_Paint text, Tvg_Text_Wrap mode)
 }
 
 
+TVG_API Tvg_Result tvg_text_spacing(Tvg_Paint text, float letter, float line)
+{
+    if (text) return (Tvg_Result) reinterpret_cast<Text*>(text)->spacing(letter, line);
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
 TVG_API Tvg_Result tvg_font_load(const char* path)
 {
     return (Tvg_Result) Text::load(path);

--- a/src/loaders/ttf/tvgTtfLoader.h
+++ b/src/loaders/ttf/tvgTtfLoader.h
@@ -61,12 +61,12 @@ struct TtfLoader : public FontLoader
     void release(FontMetrics& fm) override;
 
 private:
-    float height(uint32_t loc)
+    float height(uint32_t loc, float spacing)
     {
-        return reader.metrics.hhea.advance * loc - reader.metrics.hhea.lineGap;
+        return (reader.metrics.hhea.advance * loc - reader.metrics.hhea.lineGap) * spacing;
     }
 
-    uint32_t feedLine(float align, float box, float x, uint32_t begin, uint32_t end, Point& cursor, uint32_t& loc, RenderPath& out);
+    uint32_t feedLine(FontMetrics& fm, float box, float x, uint32_t begin, uint32_t end, Point& cursor, uint32_t& loc, RenderPath& out);
     void wrapNone(FontMetrics& fm, const Point& box, char* utf8, RenderPath& out);
     void wrapChar(FontMetrics& fm, const Point& box, char* utf8, RenderPath& out);
     void wrapWord(FontMetrics& fm, const Point& box, char* utf8, RenderPath& out, bool smart);

--- a/src/renderer/tvgLoadModule.h
+++ b/src/renderer/tvgLoadModule.h
@@ -142,7 +142,7 @@ struct FontMetrics
 {
     Point size;  //text width, height
     float scale;
-    Point align{}, box{};
+    Point align{}, box{}, spacing{1.0f, 1.0f};
     float fontSize = 0.0f;
     TextWrap wrap = TextWrap::None;
 

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -137,6 +137,12 @@ Result Text::italic(float shear) noexcept
 }
 
 
+Result Text::spacing(float letter, float line) noexcept
+{
+    return to<TextImpl>(this)->spacing(letter, line);
+}
+
+
 Result Text::wrap(TextWrap mode) noexcept
 {
     to<TextImpl>(this)->wrapping(mode);

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -145,6 +145,16 @@ struct TextImpl : Text
         updated = true;
     }
 
+    Result spacing(float letter, float line)
+    {
+        if (letter < 0.0f || line < 0.0f) return Result::InvalidArguments;
+
+        fm.spacing = {letter, line};
+        updated = true;
+
+        return Result::Success;
+    }
+
     bool update(RenderMethod* renderer, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flag, TVG_UNUSED bool clipper)
     {
         if (!load()) return true;


### PR DESCRIPTION
Text::spacing() adjusts the letter spacing (horizontal space between glyphs) and line spacing (vertical space between lines of text) using scale factors.

C++ API:
+ Result Text::spacing(float letter, float line)

C API:
+ Tvg_Result tvg_text_spacing(Tvg_Paint text, float letter, float line)

issue: https://github.com/thorvg/thorvg/issues/3397

<img width="1275" height="805" alt="image" src="https://github.com/user-attachments/assets/f2dd4b99-d565-425f-ac0d-6ec102a63548" />