### PR TITLE
svg_loader: Prevent duplicate declared classes from overwriting already applied classes

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3606,9 +3606,23 @@ static bool _cssApplyClass(SvgNode* node, const char* classString, SvgNode* styl
 
     char* tokPtr = nullptr;
     auto name = _parseName(classes, " ", &tokPtr);
+    tvg::Array<const char*> applyClasses;
 
     while (name) {
-        bool found = false;
+        auto isDuplicate = false;
+        ARRAY_FOREACH(p, applyClasses) {
+            if (STR_AS(*p, name)) {
+                isDuplicate = true;
+                break;
+            }
+        }
+        if (isDuplicate) {
+            name = _parseName(nullptr, " ", &tokPtr);
+            continue;
+        }
+        applyClasses.push(name);
+
+        auto found = false;
         //css styling: tag.name has higher priority than .name
         if (auto cssNode = cssFindStyleNode(styleRoot, name)) {
             cssCopyStyleAttr(tempNode, cssNode, true);


### PR DESCRIPTION
Manages a list of applied class names. Once a class is applied,
it will not be applied again even if the class is parsed again.

related issue: https://github.com/thorvg/thorvg/issues/4017