### PR TITLE
wg/gl: stabilize arc tessellation tolerance

### DIFF
--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -134,14 +134,6 @@ static inline float scaling(const Matrix& m)
 }
 
 
-static inline Point scaling2D(const Matrix& m)
-{
-    auto sx = sqrtf(m.e11 * m.e11 + m.e21 * m.e21);
-    auto sy = sqrtf(m.e12 * m.e12 + m.e22 * m.e22);
-    return {sx, sy};
-}
-
-
 static inline void scale(Matrix* m, const Point& p)
 {
     m->e11 *= p.x;
@@ -429,6 +421,16 @@ struct BBox
         max = {-FLT_MAX, -FLT_MAX};
     }
 };
+
+
+static inline uint32_t arcSegmentsCnt(float arcAngle, float pixelRadius) 
+{
+    if (pixelRadius < FLOAT_EPSILON) return 2;
+    static constexpr auto PX_TOLERANCE = 0.25f;
+    // Sagitta-based formula Approximation: 1 - cos(θ/2) ≈ (θ/2)²/2, so θ ≈ 2 * sqrt(2 * s/r)
+    auto segmentAngle = 2.0f * sqrtf(2.0f * PX_TOLERANCE / pixelRadius);
+    return static_cast<uint32_t>(ceilf(fabsf(arcAngle) / segmentAngle)) + 1;
+}
 
 
 /************************************************************************/

--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -58,7 +58,7 @@ void Stroker::run(const RenderPath& path, const Matrix& m)
 {
     mBuffer->vertex.reserve(path.pts.count * 4 + 16);
     mBuffer->index.reserve(path.pts.count * 3);
-    mScale = tvg::scaling2D(m);
+    mScale = tvg::scaling(m);
 
     auto validStrokeCap = false;
     auto pts = path.pts.data;
@@ -254,9 +254,8 @@ void Stroker::round(const Point &prev, const Point& curr, const Point& center)
         if (endAngle < startAngle) endAngle += 2 * MATH_PI;
     }
 
-    // Fixme: just use bezier curve to calculate step count
-    auto count = Bezier(prev * mScale, curr * mScale, radius() * length(mScale)).segments();
-    if (count < 2) count = 2;
+    auto arcAngle = endAngle - startAngle;
+    auto count = arcSegmentsCnt(arcAngle, radius() * mScale);
 
     auto c = _pushVertex(mBuffer->vertex, center.x, center.y);
     auto pi = _pushVertex(mBuffer->vertex, prev.x, prev.y);
@@ -283,10 +282,9 @@ void Stroker::round(const Point &prev, const Point& curr, const Point& center)
 
 void Stroker::roundPoint(const Point &p)
 {
-    // Fixme: just use bezier curve to calculate step count
-    auto count = Bezier(p, p, radius()).segments() * 2;
+    auto count = arcSegmentsCnt(2.0f * MATH_PI, radius() * mScale);
     auto c = _pushVertex(mBuffer->vertex, p.x, p.y);
-    auto step = 2 * MATH_PI / (count - 1);
+    auto step = 2.0f * MATH_PI / (count - 1);
 
     for (uint32_t i = 1; i <= static_cast<uint32_t>(count); i++) {
         float angle = i * step;

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -71,7 +71,7 @@ private:
     State mState = {};
     Point mLeftTop = {0.0f, 0.0f};
     Point mRightBottom = {0.0f, 0.0f};
-    Point mScale;
+    float mScale;
 };
 
 class BWTessellator

--- a/src/renderer/wg_engine/tvgWgTessellator.cpp
+++ b/src/renderer/wg_engine/tvgWgTessellator.cpp
@@ -56,7 +56,7 @@ void WgStroker::run(const RenderPath& path, const Matrix& m)
 {
     mBuffer->vbuffer.reserve(path.pts.count * 4 + 16);
     mBuffer->ibuffer.reserve(path.pts.count * 3);
-    mScale = tvg::scaling2D(m);
+    mScale = tvg::scaling(m);
 
     auto validStrokeCap = false;
     auto pts = path.pts.data;
@@ -258,9 +258,8 @@ void WgStroker::round(const Point &prev, const Point& curr, const Point& center)
         if (endAngle < startAngle) endAngle += 2 * MATH_PI;
     }
 
-    // Fixme: just use bezier curve to calculate step count
-    auto count = Bezier(prev * mScale, curr * mScale, radius() * length(mScale)).segments();
-    if (count < 2) count = 2;
+    auto arcAngle = endAngle - startAngle;
+    auto count = tvg::arcSegmentsCnt(arcAngle, radius() * mScale);
 
     auto c = mBuffer->vbuffer.count;  mBuffer->vbuffer.push(center);
     auto pi = mBuffer->vbuffer.count; mBuffer->vbuffer.push(prev);
@@ -287,10 +286,9 @@ void WgStroker::round(const Point &prev, const Point& curr, const Point& center)
 
 void WgStroker::roundPoint(const Point &p)
 {
-    // Fixme: just use bezier curve to calculate step count
-    auto count = Bezier(p, p, radius()).segments() * 2;
+    auto count = tvg::arcSegmentsCnt(2.0f * MATH_PI, radius() * mScale);
     auto c = mBuffer->vbuffer.count; mBuffer->vbuffer.push(p);
-    auto step = 2 * MATH_PI / (count - 1);
+    auto step = 2.0f * MATH_PI / (count - 1);
 
     for (uint32_t i = 1; i <= static_cast<uint32_t>(count); i++) {
         float angle = i * step;

--- a/src/renderer/wg_engine/tvgWgTessellator.h
+++ b/src/renderer/wg_engine/tvgWgTessellator.h
@@ -71,7 +71,7 @@ private:
     State mState = {};
     Point mLeftTop = {0.0f, 0.0f};
     Point mRightBottom = {0.0f, 0.0f};
-    Point mScale;
+    float mScale;
 };
 
 class WgBWTessellator


### PR DESCRIPTION
## Summary:

- add `arcSegmentsCnt `helper to size round joins/caps by pixel tolerance
- switch GL/WG strokers to scalar stroke scale and reuse the helper
- remove the unused `scaling2D `helper from tvgMath

## Purpose:

### Existing Bezier-based 
***Tiny joints positioned in small gaps provide an excessive level of detail.***
<img width="359" height="296" alt="image" src="https://github.com/user-attachments/assets/59a5e4a1-c4ba-4537-a7c8-aa16c4eced99" />

## Result
### 📊 Performance Comparison (Sampling at Frame 1000 in the example `Lottie`)

Build | WG FPS (Recent / Accumulated) | GL FPS (Recent / Accumulated)
-- | -- | --
Feature branch | 36.80 / 36.31 | 36.20 / 36.67
Original | 37.16 / 35.42 | 34.56 / 35.44

- WG backend
  - Recent FPS slightly decreased on the feature branch (36.80 from 37.16 : **−0.97%**).
  - Accumulated FPS improved (36.31 from 35.42 : **+2.51%**).
- GL backend
  - Recent FPS improved (36.20 form 34.56 : **+4.74%**).
  - Accumulated FPS improved (36.67 from 35.44 : **+3.47%**).

The feature branch shows **overall better** long-term stability,

### New resolution dependant tesselation
As the resolution increases, the level of detail is enhanced **appropriately**.
- 1x scale
<img width="1347" height="750" alt="Screenshot 2025-11-28 185821" src="https://github.com/user-attachments/assets/6fae46d5-2943-45e7-8c4a-26d151216b26" />

- 4x scale
<img width="1316" height="802" alt="image" src="https://github.com/user-attachments/assets/157db984-4389-4e11-94d5-fe8e2f8daf1f" />



