### PR TITLE
Fix division by zero in `_updateColorTable()`

### DIFF
--- a/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/src/renderer/sw_engine/tvgSwFill.cpp
@@ -163,7 +163,8 @@ static bool _updateColorTable(SwFill* fill, const Fill* fdata, const SwSurface* 
 
         auto curr = colors + j;
         auto next = curr + 1;
-        auto delta = 1.0f / (next->offset - curr->offset);
+        auto div = next->offset - curr->offset;
+        auto delta = div != 0.0f ? (1.0f / div) : 0.0f;
         auto a2 = MULTIPLY(next->a, opacity);
 
         if (!fill->translucent && a2 < 255) fill->translucent = true;


### PR DESCRIPTION
thorvg compiled with `ubsan` complains about float division by zero here. 

While this is technically undefined behavior, nearly all implementations will return `inf`, which will eventually result in an alpha value of `255` (since alpha is a uint8_t); Setting it to `0.0` in case of a divide by zero here will result in the same behavior.