### PR TITLE
wg_engine: handle degenerate paths as strokes

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -745,7 +745,7 @@ void WgCompositor::markupClipPath(WgContext& context, WgRenderDataShape* renderD
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
         drawMesh(context, &renderData->meshStrokes);
-    } else {
+    } else if (renderData->meshShape.vbuffer.count > 0) {
         WGPURenderPipeline stencilPipeline = (renderData->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
         WgRenderSettings& settings = renderData->renderSettingsShape;
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -88,7 +88,7 @@ void WgRenderSettings::update(WgContext& context, const tvg::Matrix& transform, 
 {
     //TODO: Update separtely according to the RenderUpdateFlag
     settings.transform.update(transform);
-    settings.options.update(cs, opacity);
+    settings.options.update(cs, opacity * opacityMultiplier);
 }
 
 void WgRenderSettings::update(WgContext& context, const Fill* fill)
@@ -168,20 +168,38 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
 {
     releaseMeshes();
     strokeFirst = rshape.strokeFirst();
+    renderSettingsShape.opacityMultiplier = 1.0f;
+    renderSettingsStroke.opacityMultiplier = 1.0f;
 
-    // trim path if necessary
-    RenderPath trimmedPath;
-    auto& path = (rshape.trimpath() && rshape.stroke->trim.trim(rshape.path, trimmedPath)) ? trimmedPath : rshape.path;
+    // optimize path
+    RenderPath optPath;
+    if (rshape.trimpath()) {
+        RenderPath trimmedPath;
+        if (rshape.stroke->trim.trim(rshape.path, trimmedPath)) {
+            trimmedPath.optimize(optPath, matrix);
+        } else {
+            optPath.clear();
+        }
+    } else rshape.path.optimize(optPath, matrix);
 
     // update fill shapes
     if (flag & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
         meshShape.clear();
 
-        WgBWTessellator bwTess{&meshShape};
-        bwTess.tessellate(path, matrix);
+        BBox bbox;
+        // in a case of single line shape we must tesselate it as a single line stroke with minimal width
+        if (optPath.pts.count == 2 && tvg::zero(rshape.strokeWidth())) {
+            WgStroker stroker(&meshShape, MIN_WG_STROKE_WIDTH / scaling(matrix), StrokeCap::Butt, StrokeJoin::Bevel);
+            stroker.run(rshape, optPath, matrix);
+            bbox = stroker.getBBox();
+            renderSettingsShape.opacityMultiplier = MIN_WG_STROKE_ALPHA;
+        } else {
+            WgBWTessellator bwTess{&meshShape};
+            bwTess.tessellate(optPath, matrix);
+            bbox = bwTess.getBBox();
+        }
 
         if (meshShape.ibuffer.count > 0) {
-            auto bbox = bwTess.getBBox();
             meshShapeBBox.bbox(bbox.min, bbox.max);
             updateBBox(bbox);
         } else meshShape.clear();
@@ -200,8 +218,9 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
         }
         //run stroking only if it's valid
         if (!tvg::zero(strokeWidth)) {
-            WgStroker stroker(&meshStrokes, strokeWidth);
-            stroker.run(rshape, path, matrix);
+            WgStroker stroker(&meshStrokes, strokeWidth, rshape.strokeCap(), rshape.strokeJoin());
+            stroker.run(rshape, optPath, matrix);
+            renderSettingsStroke.opacityMultiplier = 1.0f;
             if (meshStrokes.ibuffer.count > 0) {
                 auto bbox = stroker.getBBox();
                 meshStrokesBBox.bbox(bbox.min, bbox.max);
@@ -213,7 +232,7 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
     // update shapes bbox (with empty path handling)
     if ((meshShape.vbuffer.count > 0 ) || (meshStrokes.vbuffer.count > 0)) {
         updateAABB(matrix);
-    } else aabb = {{0, 0}, {0, 0}};
+    } else bbox = aabb = {{0, 0}, {0, 0}};
     meshBBox.bbox(bbox.min, bbox.max);
 }
 

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -47,6 +47,7 @@ struct WgRenderSettings
     WgImageData gradientData;
     WgRenderSettingsType fillType{};
     WgRenderRasterType rasterType{};
+    float opacityMultiplier = 1.0f;
     bool skip{};
 
     void update(WgContext& context, const tvg::Matrix& transform, tvg::ColorSpace cs, uint8_t opacity);

--- a/src/renderer/wg_engine/tvgWgTessellator.cpp
+++ b/src/renderer/wg_engine/tvgWgTessellator.cpp
@@ -24,7 +24,8 @@
 #include "tvgMath.h"
 
 
-WgStroker::WgStroker(WgMeshData* buffer, float width) : mBuffer(buffer), mWidth(width)
+WgStroker::WgStroker(WgMeshData* buffer, float width, StrokeCap cap, StrokeJoin join) 
+    : mBuffer(buffer), mWidth(width), mCap(cap), mJoin(join)
 {
 }
 

--- a/src/renderer/wg_engine/tvgWgTessellator.h
+++ b/src/renderer/wg_engine/tvgWgTessellator.h
@@ -27,6 +27,7 @@
 #include "tvgWgGeometry.h"
 
 #define MIN_WG_STROKE_WIDTH 1.0f
+#define MIN_WG_STROKE_ALPHA 0.25f
 
 class WgStroker
 {
@@ -38,7 +39,7 @@ class WgStroker
         Point prevPtDir;
     };
 public:
-    WgStroker(WgMeshData* buffer, float width);
+    WgStroker(WgMeshData* buffer, float width, StrokeCap cap, StrokeJoin join = StrokeJoin::Bevel);
     void run(const RenderShape& rshape, const RenderPath& path, const Matrix& m);
     RenderRegion bounds() const;
     BBox getBBox() const;


### PR DESCRIPTION
- apply path optimization before tesselation stroking
- handle 2-point paths with MIN_WG_STROKE_ALPHA opacity

<img width="802" height="224" alt="image" src="https://github.com/user-attachments/assets/c3c095b1-c47e-4681-81c9-8e5492bd8aac" />


Lottie example (wg)
main: 20 fps
PR: 23 fps

https://github.com/thorvg/thorvg/issues/2920
https://github.com/thorvg/thorvg/issues/3990
https://github.com/thorvg/thorvg/issues/3991