### PR TITLE
svg_loader: Support for the xml:space attribute in <text>

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1104,6 +1104,14 @@ static constexpr struct
 };
 
 
+static SvgXmlSpace _toXmlSpace(const char* str)
+{
+    if (STR_AS(str, "default")) return SvgXmlSpace::Default;
+    if (STR_AS(str, "preserve")) return SvgXmlSpace::Preserve;
+    return SvgXmlSpace::None;
+}
+
+
 static bool _parseStyleAttr(void* data, const char* key, const char* value, bool style)
 {
     SvgLoaderData* loader = (SvgLoaderData*)data;
@@ -1114,6 +1122,11 @@ static bool _parseStyleAttr(void* data, const char* key, const char* value, bool
     //Trim the white space
     key = _skipSpace(key, nullptr);
     value = _skipSpace(value, nullptr);
+
+    if (!style && STR_AS(key, "xml:space")) {
+        node->xmlSpace = _toXmlSpace(value);
+        return true;
+    }
 
     sz = strlen(key);
     for (unsigned int i = 0; i < sizeof(styleTags) / sizeof(styleTags[0]); i++) {
@@ -1401,6 +1414,7 @@ static SvgNode* _createNode(SvgNode* parent, SvgNodeType type)
     node->style->display = true;
     node->parent = parent;
     node->type = type;
+    node->xmlSpace = SvgXmlSpace::None;
 
     if (parent) parent->child.push(node);
     return node;

--- a/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -234,6 +234,13 @@ enum class SvgMaskType
     Alpha
 };
 
+enum class SvgXmlSpace
+{
+    None,
+    Default,
+    Preserve
+};
+
 //Length type to recalculate %, pt, pc, mm, cm etc
 enum class SvgParserLengthType
 {
@@ -546,6 +553,7 @@ struct SvgNode
         SvgFilterNode filter;
         SvgGaussianBlurNode gaussianBlur;
     } node;
+    SvgXmlSpace xmlSpace = SvgXmlSpace::None;
     ~SvgNode();
 };
 

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -425,7 +425,7 @@ bool xmlParse(const char* buf, unsigned bufLength, bool strip, xmlCb func, const
         } else {
             const char *p, *end;
 
-            if (strip) {
+            if (strip && ((SvgLoaderData*)data)->openedTag != OpenedTagType::Text) {
                 p = itr;
                 p = _skipWhiteSpacesAndXmlEntities(p, itrEnd);
                 if (p) {
@@ -438,7 +438,7 @@ bool xmlParse(const char* buf, unsigned bufLength, bool strip, xmlCb func, const
             if (!p) p = itrEnd;
 
             end = p;
-            if (strip) end = _unskipWhiteSpacesAndXmlEntities(end, itr);
+            if (strip && ((SvgLoaderData*)data)->openedTag != OpenedTagType::Text) end = _unskipWhiteSpacesAndXmlEntities(end, itr);
 
             if (itr != end && !func((void*)data, XMLType::Data, itr, (unsigned int)(end - itr))) return false;
 


### PR DESCRIPTION
Supports `xml:space=“preserve”` and `"default"` attributes for `<text>`. The `“preserve”` attribute outputs all whitespace defined within `<text>` tag exactly as written(newline excluded). Since our XML parser removes all leading and trailing whitespace from CDATA(DATA) before passing it to the loader, it passes the text without removing whitespace when the `openedTag` is <text>.

example
```html
<svg viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
    <!-- TEST 1 -->
    <text x="0" y="100" font-family="Arial" fill="#0000ff" font-size="50" xml:space="default">     SP     ACE    <tspan></tspan>   S
    test </text>
    <rect width="330" height="60" x="0" y="50" fill="none" stroke="#ff00ff" stroke-width="2" />

    <!-- TEST 2 -->
    <text x="0" y="200" font-family="Arial" fill="#0000ff" font-size="50" xml:space="preserve">     SP     ACE    <tspan></tspan>   S
    test </text>
    <rect width="330" height="60" x="0" y="150" fill="none" stroke="#ff00ff" stroke-width="2" />
</svg>
```

related issue : https://github.com/thorvg/thorvg/issues/2710