### PR TITLE
wg_engine: fix clipping issue

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -737,6 +737,7 @@ void WgCompositor::blendScene(WgContext& context, WgRenderTarget* scene, WgCompo
 
 void WgCompositor::markupClipPath(WgContext& context, WgRenderDataShape* renderData)
 {
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     // markup stencil
     if (renderData->meshStrokes.vbuffer.count > 0) {


### PR DESCRIPTION
before viewport of the clipper shape was ignored
fixed by adding clipper viewport appliance

https://github.com/thorvg/thorvg/issues/3561