### PR TITLE
svg_loader: Refactor the logic for skipping white space

### DIFF
--- a/src/loaders/svg/tvgSvgPath.cpp
+++ b/src/loaders/svg/tvgSvgPath.cpp
@@ -28,6 +28,7 @@
 #include "tvgSvgLoaderCommon.h"
 #include "tvgSvgPath.h"
 #include "tvgStr.h"
+#include "tvgSvgUtil.h"
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -35,9 +36,7 @@
 
 static char* _skipComma(const char* content)
 {
-    while (*content && isspace(*content)) {
-        content++;
-    }
+    content = svgUtilSkipWhiteSpace(content, nullptr);
     if (*content == ',') return (char*)content + 1;
     return (char*)content;
 }

--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -869,8 +869,7 @@ static char* _processText(const char* text, SvgXmlSpace space)
         *dst = '\0';
     } else {
         auto spaceFound = false;
-        // Skip leading spaces
-        while (*src && isspace((unsigned char)*src)) src++;
+        src = svgUtilSkipWhiteSpace(src, nullptr);
 
         while (*src) {
             if (isspace((unsigned char)*src)) {
@@ -884,8 +883,7 @@ static char* _processText(const char* text, SvgXmlSpace space)
             }
             src++;
         }
-        // Remove trailing space
-        if (dst > processed && isspace((unsigned char)*(dst - 1))) dst--;
+        dst = (char*)svgUtilUnskipWhiteSpace(dst, processed);
         *dst = '\0';
     }
     return processed;

--- a/src/loaders/svg/tvgSvgUtil.cpp
+++ b/src/loaders/svg/tvgSvgUtil.cpp
@@ -38,6 +38,34 @@ static uint8_t _hexCharToDec(const char c)
 /* External Class Implementation                                        */
 /************************************************************************/
 
+
+const char* svgUtilSkipWhiteSpace(const char* itr, const char* itrEnd)
+{
+    while ((itrEnd && itr < itrEnd) || (!itrEnd && *itr != '\0')) {
+        if (!isspace((unsigned char)*itr)) break;
+        itr++;
+    }
+    return itr;
+}
+
+
+const char* svgUtilUnskipWhiteSpace(const char* itr, const char* itrStart)
+{
+    for (itr--; itr > itrStart; itr--) {
+        if (!isspace((unsigned char)*itr)) break;
+    }
+    return itr + 1;
+}
+
+
+const char* svgUtilSkipWhiteSpaceAndComma(const char* content)
+{
+    content = svgUtilSkipWhiteSpace(content, nullptr);
+    if (*content == ',') return content + 1;
+    return content;
+}
+
+
 size_t svgUtilURLDecode(const char *src, char** dst)
 {
     if (!src) return 0;

--- a/src/loaders/svg/tvgSvgUtil.h
+++ b/src/loaders/svg/tvgSvgUtil.h
@@ -25,6 +25,9 @@
 
 #include "tvgCommon.h"
 
+const char* svgUtilSkipWhiteSpace(const char* itr, const char* itrEnd);
+const char* svgUtilUnskipWhiteSpace(const char* itr, const char* itrStart);
+const char* svgUtilSkipWhiteSpaceAndComma(const char* content);
 size_t svgUtilURLDecode(const char *src, char** dst);
 
 #endif //_TVG_SVG_UTIL_H_

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -23,6 +23,7 @@
 #include <ctype.h>
 #include "tvgStr.h"
 #include "tvgXmlParser.h"
+#include "tvgSvgUtil.h"
 
 
 /************************************************************************/
@@ -68,24 +69,6 @@ static const char* _xmlFindWhiteSpace(const char* itr, const char* itrEnd)
 }
 
 
-static const char* _xmlSkipWhiteSpace(const char* itr, const char* itrEnd)
-{
-    for (; itr < itrEnd; itr++) {
-        if (!isspace((unsigned char)*itr)) break;
-    }
-    return itr;
-}
-
-
-static const char* _xmlUnskipWhiteSpace(const char* itr, const char* itrStart)
-{
-    for (itr--; itr > itrStart; itr--) {
-        if (!isspace((unsigned char)*itr)) break;
-    }
-    return itr + 1;
-}
-
-
 static const char* _xmlSkipXmlEntities(const char* itr, const char* itrEnd)
 {
     auto p = itr;
@@ -123,12 +106,12 @@ static const char* _xmlUnskipXmlEntities(const char* itr, const char* itrStart)
 
 static const char* _skipWhiteSpacesAndXmlEntities(const char* itr, const char* itrEnd)
 {
-    itr = _xmlSkipWhiteSpace(itr, itrEnd);
+    itr = svgUtilSkipWhiteSpace(itr, itrEnd);
     auto p = itr;
     while (true) {
         if (p != (itr = _xmlSkipXmlEntities(itr, itrEnd))) p = itr;
         else break;
-        if (p != (itr = _xmlSkipWhiteSpace(itr, itrEnd))) p = itr;
+        if (p != (itr = svgUtilSkipWhiteSpace(itr, itrEnd))) p = itr;
         else break;
     }
     return itr;
@@ -137,12 +120,12 @@ static const char* _skipWhiteSpacesAndXmlEntities(const char* itr, const char* i
 
 static const char* _unskipWhiteSpacesAndXmlEntities(const char* itr, const char* itrStart)
 {
-    itr = _xmlUnskipWhiteSpace(itr, itrStart);
+    itr = svgUtilUnskipWhiteSpace(itr, itrStart);
     auto p = itr;
     while (true) {
         if (p != (itr = _xmlUnskipXmlEntities(itr, itrStart))) p = itr;
         else break;
-        if (p != (itr = _xmlUnskipWhiteSpace(itr, itrStart))) p = itr;
+        if (p != (itr = svgUtilUnskipWhiteSpace(itr, itrStart))) p = itr;
         else break;
     }
     return itr;
@@ -497,10 +480,10 @@ bool xmlParseW3CAttribute(const char* buf, unsigned bufLength, xmlAttributeCb fu
             key[next - buf] = '\0';
         }
         if (key[0]) {
-            key = const_cast<char*>(_xmlSkipWhiteSpace(key, key + strlen(key)));
-            key[_xmlUnskipWhiteSpace(key + strlen(key) , key) - key] = '\0';
-            val = const_cast<char*>(_xmlSkipWhiteSpace(val, val + strlen(val)));
-            val[_xmlUnskipWhiteSpace(val + strlen(val) , val) - val] = '\0';
+            key = const_cast<char*>(svgUtilSkipWhiteSpace(key, key + strlen(key)));
+            key[svgUtilUnskipWhiteSpace(key + strlen(key) , key) - key] = '\0';
+            val = const_cast<char*>(svgUtilSkipWhiteSpace(val, val + strlen(val)));
+            val[svgUtilUnskipWhiteSpace(val + strlen(val) , val) - val] = '\0';
 
             if (!func((void*)data, key, val)) {
                 if (!_unsupported(key, val)) {
@@ -530,7 +513,7 @@ const char* xmlParseCSSAttribute(const char* buf, unsigned bufLength, char** tag
     *tag = *name = nullptr;
     *attrsLength = 0;
 
-    auto itr = _xmlSkipWhiteSpace(buf, buf + bufLength);
+    auto itr = svgUtilSkipWhiteSpace(buf, buf + bufLength);
     auto itrEnd = (const char*)memchr(buf, '{', bufLength);
 
     if (!itrEnd || itr == itrEnd) return nullptr;
@@ -543,7 +526,7 @@ const char* xmlParseCSSAttribute(const char* buf, unsigned bufLength, char** tag
 
     const char *p;
 
-    itrEnd = _xmlUnskipWhiteSpace(itrEnd, itr);
+    itrEnd = svgUtilUnskipWhiteSpace(itrEnd, itr);
     if (*(itrEnd - 1) == '.') return nullptr;
 
     for (p = itr; p < itrEnd; p++) {


### PR DESCRIPTION
There is some duplicate logic to skip whitespace, so I'll clean it up.

https://github.com/thorvg/thorvg/pull/4031#discussion_r2580124909