### PR TITLE
wg_engine: crash with a PictureSVG (effects)

### DIFF
--- a/src/renderer/wg_engine/tvgWgCompositor.cpp
+++ b/src/renderer/wg_engine/tvgWgCompositor.cpp
@@ -119,7 +119,7 @@ void WgCompositor::resize(WgContext& context, uint32_t width, uint32_t height) {
 }
 
 
-RenderRegion WgCompositor::shrinkRenderRegion(RenderRegion& rect)
+RenderRegion WgCompositor::shrinkRenderRegion(const RenderRegion& rect)
 {
     return {
         {std::max(0, std::min((int32_t)width, rect.min.x)), std::max(0, std::min((int32_t)height, rect.min.y))},
@@ -846,7 +846,7 @@ bool WgCompositor::gaussianBlur(WgContext& context, WgRenderTarget* dst, const R
     assert(!renderPassEncoder);
 
     auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
-    auto aabb = compose->aabb;
+    auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst);
     if (params->direction == 0) { // both
@@ -894,7 +894,7 @@ bool WgCompositor::dropShadow(WgContext& context, WgRenderTarget* dst, const Ren
     assert(!renderPassEncoder);
 
     auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
-    auto aabb = compose->aabb;
+    auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst);
     copyTexture(&targetTemp1, dst);
@@ -938,7 +938,7 @@ bool WgCompositor::fillEffect(WgContext& context, WgRenderTarget* dst, const Ren
     assert(!renderPassEncoder);
 
     auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
-    auto aabb = compose->aabb;
+    auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst, aabb);
     beginRenderPass(commandEncoder, dst); {
@@ -961,7 +961,7 @@ bool WgCompositor::tintEffect(WgContext& context, WgRenderTarget* dst, const Ren
     assert(!renderPassEncoder);
 
     auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
-    auto aabb = compose->aabb;
+    auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst, aabb);
     beginRenderPass(commandEncoder, dst); {
@@ -983,7 +983,7 @@ bool WgCompositor::tritoneEffect(WgContext& context, WgRenderTarget* dst, const 
     assert(!renderPassEncoder);
 
     auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
-    auto aabb = compose->aabb;
+    auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst, aabb);
     beginRenderPass(commandEncoder, dst); {

--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -68,7 +68,7 @@ private:
     uint32_t height{};
     
     // viewport utilities
-    RenderRegion shrinkRenderRegion(RenderRegion& rect);
+    RenderRegion shrinkRenderRegion(const RenderRegion& rect);
     void copyTexture(const WgRenderTarget* dst, const WgRenderTarget* src);
     void copyTexture(const WgRenderTarget* dst, const WgRenderTarget* src, const RenderRegion& region);
 


### PR DESCRIPTION
when scenes are transformed while applying post-effects, the bounding buffer may extend beyond the screen's borders. 
we've added functionality to prevent this by aligning the scene viewport and the target buffer.

<img width="802" height="827" alt="image" src="https://github.com/user-attachments/assets/415b1316-d6f3-482c-8a54-2da748a23526" />

https://github.com/thorvg/thorvg/issues/4037