### PR TITLE
example: Resize example size to fit the window size

### DIFF
--- a/examples/Accessor.cpp
+++ b/examples/Accessor.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //load the tvg file
         auto picture = tvg::Picture::gen();
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
             shape->strokeWidth(5);
         }
 
-        canvas->push(picture);
+        root->push(picture);
 
         return true;
     }

--- a/examples/Animation.cpp
+++ b/examples/Animation.cpp
@@ -30,7 +30,7 @@ struct UserExample : tvgexam::Example
 {
     unique_ptr<tvg::Animation> animation;
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //The default font for fallback in case
         tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf");
@@ -45,7 +45,7 @@ struct UserExample : tvgexam::Example
         shape->appendRect(0, 0, w, h);
         shape->fill(50, 50, 50);
 
-        canvas->push(shape);
+        root->push(shape);
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/sample.json"))) return false;
 
@@ -56,12 +56,12 @@ struct UserExample : tvgexam::Example
         picture->scale(scale);
         picture->translate(float(w) * 0.5f, float(h) * 0.5f);
 
-        canvas->push(picture);
+        root->push(picture);
 
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         auto progress = tvgexam::progress(elapsed, animation->duration());
 

--- a/examples/Blending.cpp
+++ b/examples/Blending.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    void blender(tvg::Canvas* canvas, const char* name, tvg::BlendMethod method, float x, float y, uint32_t* data)
+    void blender(tvg::Scene* root, const char* name, tvg::BlendMethod method, float x, float y, uint32_t* data)
     {
         auto text = tvg::Text::gen();
         text->font("Arial");
@@ -36,20 +36,20 @@ struct UserExample : tvgexam::Example
         text->text(name);
         text->fill(255, 255, 255);
         text->translate(x + 20, y);
-        canvas->push(text);
+        root->push(text);
 
         //solid
         {
             auto bottom = tvg::Shape::gen();
             bottom->appendRect(20.0f + x, 25.0f + y, 100.0f, 100.0f, 10.0f, 10.0f);
             bottom->fill(255, 255, 0);
-            canvas->push(bottom);
+            root->push(bottom);
 
             auto top = tvg::Shape::gen();
             top->appendRect(45.0f + x, 50.0f + y, 100.0f, 100.0f, 10.0f, 10.0f);
             top->fill(0, 255, 255);
             top->blend(method);
-            canvas->push(top);
+            root->push(top);
         }
 
         //solid (half transparent)
@@ -57,13 +57,13 @@ struct UserExample : tvgexam::Example
             auto bottom = tvg::Shape::gen();
             bottom->appendRect(170.0f + x, 25.0f + y, 100.0f, 100.0f, 10.0f, 10.0f);
             bottom->fill(255, 255, 0, 127);
-            canvas->push(bottom);
+            root->push(bottom);
 
             auto top = tvg::Shape::gen();
             top->appendRect(195.0f + x, 50.0f + y, 100.0f, 100.0f, 10.0f, 10.0f);
             top->fill(0, 255, 255, 127);
             top->blend(method);
-            canvas->push(top);
+            root->push(top);
         }
 
         //gradient blending
@@ -79,7 +79,7 @@ struct UserExample : tvgexam::Example
             auto bottom = tvg::Shape::gen();
             bottom->appendRect(325.0f + x, 25.0f + y, 100.0f, 100.0f, 10.0f, 10.0f);
             bottom->fill(fill);
-            canvas->push(bottom);
+            root->push(bottom);
 
             auto fill2 = tvg::LinearGradient::gen();
             fill2->linear(350.0f + x, 50.0f + y, 450.0f + x, 150.0f + y);
@@ -89,7 +89,7 @@ struct UserExample : tvgexam::Example
             top->appendRect(350.0f + x, 50.0f + y, 100.0f, 100.0f, 10.0f, 10.0f);
             top->fill(fill2);
             top->blend(method);
-            canvas->push(top);
+            root->push(top);
         }
 
         //image
@@ -98,13 +98,13 @@ struct UserExample : tvgexam::Example
             bottom->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true);
             bottom->translate(475 + x, 25.0f + y);
             bottom->scale(0.35f);
-            canvas->push(bottom);
+            root->push(bottom);
 
             auto top = bottom->duplicate();
             top->translate(500.0f + x, 50.0f + y);
             top->rotate(-10.0f);
             top->blend(method);
-            canvas->push(top);
+            root->push(top);
         }
 
         //scene
@@ -113,12 +113,12 @@ struct UserExample : tvgexam::Example
             bottom->load(EXAMPLE_DIR"/svg/tiger.svg");
             bottom->translate(600.0f + x, 25.0f + y);
             bottom->scale(0.11f);
-            canvas->push(bottom);
+            root->push(bottom);
 
             auto top = bottom->duplicate();
             top->translate(625.0f + x, 50.0f + y);
             top->blend(method);
-            canvas->push(top);
+            root->push(top);
         }
 
         //scene (half transparent)
@@ -128,17 +128,17 @@ struct UserExample : tvgexam::Example
             bottom->translate(750.0f + x, 25.0f + y);
             bottom->scale(0.11f);
             bottom->opacity(127);
-            canvas->push(bottom);
+            root->push(bottom);
 
             auto top = bottom->duplicate();
             top->translate(775.0f + x, 50.0f + y);
             top->blend(method);
-            canvas->push(top);
+            root->push(top);
         }
     }
 
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         if (!tvgexam::verify(tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf"))) return false;
 
@@ -150,24 +150,24 @@ struct UserExample : tvgexam::Example
         file.read(reinterpret_cast<char *>(data), sizeof (uint32_t) * 200 * 300);
         file.close();
 
-        blender(canvas, "Normal", tvg::BlendMethod::Normal, 0.0f, 0.0f, data);
-        blender(canvas, "Multiply", tvg::BlendMethod::Multiply, 0.0f, 150.0f, data);
-        blender(canvas, "Screen", tvg::BlendMethod::Screen, 0.0f, 300.0f, data);
-        blender(canvas, "Overlay", tvg::BlendMethod::Overlay, 0.0f, 450.0f, data);
-        blender(canvas, "Darken", tvg::BlendMethod::Darken, 0.f, 600.0f, data);
-        blender(canvas, "Lighten", tvg::BlendMethod::Lighten, 0.0f, 750.0f, data);
-        blender(canvas, "ColorDodge", tvg::BlendMethod::ColorDodge, 0.0f, 900.0f, data);
-        blender(canvas, "ColorBurn", tvg::BlendMethod::ColorBurn, 0.0f, 1050.0f, data);
-        blender(canvas, "HardLight", tvg::BlendMethod::HardLight, 0.0f, 1200.0f, data);
+        blender(root, "Normal", tvg::BlendMethod::Normal, 0.0f, 0.0f, data);
+        blender(root, "Multiply", tvg::BlendMethod::Multiply, 0.0f, 150.0f, data);
+        blender(root, "Screen", tvg::BlendMethod::Screen, 0.0f, 300.0f, data);
+        blender(root, "Overlay", tvg::BlendMethod::Overlay, 0.0f, 450.0f, data);
+        blender(root, "Darken", tvg::BlendMethod::Darken, 0.f, 600.0f, data);
+        blender(root, "Lighten", tvg::BlendMethod::Lighten, 0.0f, 750.0f, data);
+        blender(root, "ColorDodge", tvg::BlendMethod::ColorDodge, 0.0f, 900.0f, data);
+        blender(root, "ColorBurn", tvg::BlendMethod::ColorBurn, 0.0f, 1050.0f, data);
+        blender(root, "HardLight", tvg::BlendMethod::HardLight, 0.0f, 1200.0f, data);
 
-        blender(canvas, "SoftLight", tvg::BlendMethod::SoftLight, 900.0f, 0.0f, data);
-        blender(canvas, "Difference", tvg::BlendMethod::Difference, 900.0f, 150.0f, data);
-        blender(canvas, "Exclusion", tvg::BlendMethod::Exclusion, 900.0f, 300.0f, data);
-        blender(canvas, "Hue", tvg::BlendMethod::Hue, 900.0f, 450.0f, data);
-        blender(canvas, "Saturation", tvg::BlendMethod::Saturation, 900.0f, 600.0f, data);
-        blender(canvas, "Color", tvg::BlendMethod::Color, 900.0f, 750.0f, data);
-        blender(canvas, "Luminosity", tvg::BlendMethod::Luminosity, 900.0f, 900.0f, data);
-        blender(canvas, "Add", tvg::BlendMethod::Add, 900.0f, 1050.0f, data);
+        blender(root, "SoftLight", tvg::BlendMethod::SoftLight, 900.0f, 0.0f, data);
+        blender(root, "Difference", tvg::BlendMethod::Difference, 900.0f, 150.0f, data);
+        blender(root, "Exclusion", tvg::BlendMethod::Exclusion, 900.0f, 300.0f, data);
+        blender(root, "Hue", tvg::BlendMethod::Hue, 900.0f, 450.0f, data);
+        blender(root, "Saturation", tvg::BlendMethod::Saturation, 900.0f, 600.0f, data);
+        blender(root, "Color", tvg::BlendMethod::Color, 900.0f, 750.0f, data);
+        blender(root, "Luminosity", tvg::BlendMethod::Luminosity, 900.0f, 900.0f, data);
+        blender(root, "Add", tvg::BlendMethod::Add, 900.0f, 1050.0f, data);
 
         free(data);
 

--- a/examples/BoundingBox.cpp
+++ b/examples/BoundingBox.cpp
@@ -28,15 +28,8 @@
 
 struct UserExample : tvgexam::Example
 {
-    void bbox(tvg::Canvas* canvas, tvg::Paint* paint)
+    void bbox(tvg::Scene* root, tvg::Paint* paint)
     {
-        // Ensure the paint is updated.
-        // In this example, we call update() on the paint directly,
-        // but instead of calling update multiple times,
-        // you can call Canvas::update() once and then retrieve the bounding boxes
-        // for all required paints.
-        canvas->update();
-
         //aabb
         float x, y, w, h;
         if (tvgexam::verify(paint->bounds(&x, &y, &w, &h))) {
@@ -49,7 +42,7 @@ struct UserExample : tvgexam::Example
             bound->strokeWidth(2.0f);
             bound->strokeFill(255, 0, 0, 255);
 
-            canvas->push(bound);
+            root->push(bound);
         }
 
         //obb
@@ -66,18 +59,18 @@ struct UserExample : tvgexam::Example
             bound->strokeDash(dash, 2);
             bound->strokeFill(255, 255, 255, 255);
 
-            canvas->push(bound);
+            root->push(bound);
         }
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         {
             auto shape = tvg::Shape::gen();
             shape->appendCircle(50, 100, 40, 100);
             shape->fill(0, 30, 255);
-            canvas->push(shape);
-            bbox(canvas, shape);
+            root->push(shape);
+            bbox(root, shape);
         }
 
         {
@@ -89,8 +82,8 @@ struct UserExample : tvgexam::Example
             text->fill(255, 255, 0);
             text->translate(100, 20);
             text->rotate(16.0f);
-            canvas->push(text);
-            bbox(canvas, text);
+            root->push(text);
+            bbox(root, text);
         }
 
         {
@@ -98,8 +91,8 @@ struct UserExample : tvgexam::Example
             shape->appendRect(200, 30, 100, 20);
             shape->fill(200, 150, 55);
             shape->rotate(30);
-            canvas->push(shape);
-            bbox(canvas, shape);
+            root->push(shape);
+            bbox(root, shape);
         }
 
         {
@@ -113,8 +106,8 @@ struct UserExample : tvgexam::Example
             tvg::Matrix m = {1.732f, -1.0f, 30.0f, 1.0f, 1.732f, -70.0f, 0.0f, 0.0f, 1.0f};
             shape->transform(m);
 
-            canvas->push(shape);
-            bbox(canvas, shape);
+            root->push(shape);
+            bbox(root, shape);
         }
 
         {
@@ -122,8 +115,8 @@ struct UserExample : tvgexam::Example
             svg->load(EXAMPLE_DIR"/svg/tiger.svg");
             svg->scale(0.3f);
             svg->translate(620, 50);
-            canvas->push(svg);
-            bbox(canvas, svg);
+            root->push(svg);
+            bbox(root, svg);
         }
 
         {
@@ -132,8 +125,8 @@ struct UserExample : tvgexam::Example
             svg->scale(0.2f);
             svg->translate(140, 215);
             svg->rotate(45);
-            canvas->push(svg);
-            bbox(canvas, svg);
+            root->push(svg);
+            bbox(root, svg);
 
         }
 
@@ -146,8 +139,8 @@ struct UserExample : tvgexam::Example
             img->load(EXAMPLE_DIR"/image/test.png");
             scene->push(img);
 
-            canvas->push(scene);
-            bbox(canvas, scene);
+            root->push(scene);
+            bbox(root, scene);
         }
 
         {
@@ -160,8 +153,8 @@ struct UserExample : tvgexam::Example
             img->load(EXAMPLE_DIR"/image/test.jpg");
             scene->push(img);
 
-            canvas->push(scene);
-            bbox(canvas, scene);
+            root->push(scene);
+            bbox(root, scene);
         }
 
         {
@@ -170,8 +163,8 @@ struct UserExample : tvgexam::Example
             line->lineTo(770, 350);
             line->strokeWidth(20);
             line->strokeFill(55, 55, 0);
-            canvas->push(line);
-            bbox(canvas, line);
+            root->push(line);
+            bbox(root, line);
         }
 
         {
@@ -181,8 +174,8 @@ struct UserExample : tvgexam::Example
             curve->translate(50, 770);
             curve->strokeWidth(2.0f);
             curve->strokeFill(255, 255, 255);
-            canvas->push(curve);
-            bbox(canvas, curve);
+            root->push(curve);
+            bbox(root, curve);
         }
 
         {
@@ -193,8 +186,8 @@ struct UserExample : tvgexam::Example
             curve->rotate(20.0f);
             curve->strokeWidth(2.0f);
             curve->strokeFill(255, 0, 255);
-            canvas->push(curve);
-            bbox(canvas, curve);
+            root->push(curve);
+            bbox(root, curve);
         }
 
         {
@@ -211,8 +204,8 @@ struct UserExample : tvgexam::Example
             shape->rotate(20);
             scene->push(shape);
 
-            canvas->push(scene);
-            bbox(canvas, scene);
+            root->push(scene);
+            bbox(root, scene);
         }
 
         {
@@ -233,8 +226,8 @@ struct UserExample : tvgexam::Example
 
             scene->push(shape);
 
-            canvas->push(scene);
-            bbox(canvas, scene);
+            root->push(scene);
+            bbox(root, scene);
         }
 
         {
@@ -255,8 +248,8 @@ struct UserExample : tvgexam::Example
 
             scene->push(shape);
 
-            canvas->push(scene);
-            bbox(canvas, scene);
+            root->push(scene);
+            bbox(root, scene);
         }
 
         {
@@ -280,8 +273,8 @@ struct UserExample : tvgexam::Example
 
             scene->push(shape);
 
-            canvas->push(scene);
-            bbox(canvas, scene);
+            root->push(scene);
+            bbox(root, scene);
         }
 
         {
@@ -298,8 +291,8 @@ struct UserExample : tvgexam::Example
             text->rotate(16.0f);
             scene->push(text);
 
-            canvas->push(scene);
-            bbox(canvas, scene);
+            root->push(scene);
+            bbox(root, scene);
         }
 
         return true;

--- a/examples/Clipping.cpp
+++ b/examples/Clipping.cpp
@@ -43,13 +43,13 @@ struct UserExample : tvgexam::Example
         star->close();
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Background
         auto shape = tvg::Shape::gen();
         shape->appendRect(0, 0, w, h);
         shape->fill(255, 255, 255);
-        canvas->push(shape);
+        root->push(shape);
 
         {
             auto scene = tvg::Scene::gen();
@@ -91,7 +91,7 @@ struct UserExample : tvgexam::Example
             //Clipping scene to shape
             scene->clip(clip);
 
-            canvas->push(scene);
+            root->push(scene);
         }
 
         {
@@ -119,7 +119,7 @@ struct UserExample : tvgexam::Example
             //Clipping scene to rect(shape)
             star3->clip(clipRect);
 
-            canvas->push(star3);
+            root->push(star3);
         }
 
         {
@@ -138,7 +138,7 @@ struct UserExample : tvgexam::Example
             //Clipping picture to path
             picture->clip(clipPath);
 
-            canvas->push(picture);
+            root->push(picture);
         }
 
         {
@@ -154,7 +154,7 @@ struct UserExample : tvgexam::Example
             //Clipping shape1 to clipShape
             shape1->clip(clipShape);
 
-            canvas->push(shape1);
+            root->push(shape1);
         }
 
         return true;

--- a/examples/CustomTransform.cpp
+++ b/examples/CustomTransform.cpp
@@ -28,14 +28,14 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, root, 0);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
-        if (!tvgexam::verify(canvas->remove())) return false;
+        root->remove();
 
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 
@@ -93,7 +93,7 @@ struct UserExample : tvgexam::Example
 
         shape->transform(m);
 
-        canvas->push(shape);
+        root->push(shape);
 
         return true;
     }

--- a/examples/DataLoad.cpp
+++ b/examples/DataLoad.cpp
@@ -30,21 +30,21 @@ struct UserExample : tvgexam::Example
 {
     const char* svg = "<svg height=\"1000\" viewBox=\"0 0 1000 1000\" width=\"1000\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M.10681413.09784845 1000.0527.01592069V1000.0851L.06005738 999.9983Z\" fill=\"#ffffff\" stroke-width=\"3.910218\"/><g fill=\"#252f35\"><g stroke-width=\"3.864492\"><path d=\"M256.61221 100.51736H752.8963V386.99554H256.61221Z\"/><path d=\"M201.875 100.51736H238.366478V386.99554H201.875Z\"/><path d=\"M771.14203 100.51736H807.633508V386.99554H771.14203Z\"/></g><path d=\"M420.82388 380H588.68467V422.805317H420.82388Z\" stroke-width=\"3.227\"/><path d=\"m420.82403 440.7101v63.94623l167.86079 25.5782V440.7101Z\"/><path d=\"M420.82403 523.07258V673.47362L588.68482 612.59701V548.13942Z\"/></g><g fill=\"#222f35\"><path d=\"M420.82403 691.37851 588.68482 630.5019 589 834H421Z\"/><path d=\"m420.82403 852.52249h167.86079v28.64782H420.82403v-28.64782 0 0\"/><path d=\"m439.06977 879.17031c0 0-14.90282 8.49429-18.24574 15.8161-4.3792 9.59153 0 31.63185 0 31.63185h167.86079c0 0 4.3792-22.04032 0-31.63185-3.34292-7.32181-18.24574-15.8161-18.24574-15.8161z\"/></g><g fill=\"#ffffff\"><path d=\"m280 140h15v55l8 10 8-10v-55h15v60l-23 25-23-25z\"/><path d=\"m335 140v80h45v-50h-25v10h10v30h-15v-57h18v-13z\"/></g></svg>";
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Background
         auto shape = tvg::Shape::gen();
         shape->appendRect(0, 0, w, h);          //x, y, w, h
         shape->fill(255, 255, 255);             //r, g, b
 
-        canvas->push(shape);
+        root->push(shape);
 
         auto picture = tvg::Picture::gen();
         if (!tvgexam::verify(picture->load(svg, strlen(svg), "svg"))) return false;
 
         picture->size(w, h);
 
-        canvas->push(picture);
+        root->push(picture);
 
         return true;
     }

--- a/examples/DirectUpdate.cpp
+++ b/examples/DirectUpdate.cpp
@@ -33,13 +33,13 @@ struct UserExample : tvgexam::Example
 
     uint32_t w, h;
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Shape (for BG)
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);
         bg->fill(255, 255, 255);
-        canvas->push(bg);
+        root->push(bg);
 
         //Solid Shape
         {
@@ -51,7 +51,7 @@ struct UserExample : tvgexam::Example
             solid->strokeFill(0, 0, 255);
             solid->strokeWidth(1);
 
-            canvas->push(solid);
+            root->push(solid);
         }
 
         //Gradient Shape
@@ -72,7 +72,7 @@ struct UserExample : tvgexam::Example
             fill->colorStops(colorStops, 3);
             gradient->fill(fill);
 
-            canvas->push(gradient);
+            root->push(gradient);
         }
 
         this->w = w;
@@ -81,7 +81,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 

--- a/examples/Duplicate.cpp
+++ b/examples/Duplicate.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         if (!canvas) return false;
 
@@ -64,9 +64,9 @@ struct UserExample : tvgexam::Example
             auto shape3 = shape2->duplicate();
             shape3->translate(0, 440);
 
-            canvas->push(shape1);
-            canvas->push(shape2);
-            canvas->push(shape3);
+            root->push(shape1);
+            root->push(shape2);
+            root->push(shape3);
         }
 
         //Duplicate Scene
@@ -96,8 +96,8 @@ struct UserExample : tvgexam::Example
             auto scene2 = scene1->duplicate();
             scene2->translate(600, 0);
 
-            canvas->push(scene1);
-            canvas->push(scene2);
+            root->push(scene1);
+            root->push(scene2);
         }
 
         //Duplicate Picture - svg
@@ -110,8 +110,8 @@ struct UserExample : tvgexam::Example
             auto picture2 = picture1->duplicate();
             picture2->translate(550, 250);
 
-            canvas->push(picture1);
-            canvas->push(picture2);
+            root->push(picture1);
+            root->push(picture2);
         }
 
         //Duplicate Picture - raw
@@ -133,8 +133,8 @@ struct UserExample : tvgexam::Example
             picture2->scale(0.7);
             picture2->rotate(8);
 
-            canvas->push(picture1);
-            canvas->push(picture2);
+            root->push(picture1);
+            root->push(picture2);
 
             free(data);
         }
@@ -152,8 +152,8 @@ struct UserExample : tvgexam::Example
             auto text2 = text->duplicate();
             text2->translate(0, 700);
 
-            canvas->push(text);
-            canvas->push(text2);
+            root->push(text);
+            root->push(text2);
         }
 
         return true;

--- a/examples/EffectDropShadow.cpp
+++ b/examples/EffectDropShadow.cpp
@@ -32,13 +32,13 @@ struct UserExample : tvgexam::Example
     tvg::Scene* scene2 = nullptr;
     tvg::Scene* scene3 = nullptr;
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //background
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);
         bg->fill(255, 255, 255);
-        canvas->push(bg);
+        root->push(bg);
 
         float pw, ph;
 
@@ -54,7 +54,7 @@ struct UserExample : tvgexam::Example
             picture->translate(pw * 0.175f, 0.0f);
 
             scene1->push(picture);
-            canvas->push(scene1);
+            root->push(scene1);
         }
 
         //Prepare a scene for post effects
@@ -69,7 +69,7 @@ struct UserExample : tvgexam::Example
             picture->size(pw * 0.75f, ph * 0.75f);
 
             scene2->push(picture);
-            canvas->push(scene2);
+            root->push(scene2);
         }
 
         //Prepare a scene for post effects
@@ -84,13 +84,13 @@ struct UserExample : tvgexam::Example
             picture->size(pw * 0.75f, ph * 0.75f);
 
             scene3->push(picture);
-            canvas->push(scene3);
+            root->push(scene3);
         }
 
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         auto progress = tvgexam::progress(elapsed, 2.5f, true);   //2.5 seconds
 

--- a/examples/FillRule.cpp
+++ b/examples/FillRule.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Star
         auto shape1 = tvg::Shape::gen();
@@ -42,7 +42,7 @@ struct UserExample : tvgexam::Example
         // Use the NonZero fill rule: fills all areas enclosed by paths with non-zero winding numbers
         shape1->fillRule(tvg::FillRule::NonZero);
 
-        canvas->push(shape1);
+        root->push(shape1);
 
         //Star 2
         auto shape2 = tvg::Shape::gen();
@@ -56,7 +56,7 @@ struct UserExample : tvgexam::Example
         // Use the EvenOdd fill rule: fills areas where path overlaps an odd number of times
         shape2->fillRule(tvg::FillRule::EvenOdd);
 
-        canvas->push(shape2);
+        root->push(shape2);
 
         return true;
     }

--- a/examples/FillSpread.cpp
+++ b/examples/FillSpread.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         const int colorCnt = 4;
         tvg::Fill::ColorStop colorStops[colorCnt];
@@ -52,7 +52,7 @@ struct UserExample : tvgexam::Example
             fill1->spread(tvg::FillSpread::Pad);
             shape1->fill(fill1);
 
-            canvas->push(shape1);
+            root->push(shape1);
 
             //Reflect
             x1 = 280.0f;
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
             fill2->spread(tvg::FillSpread::Reflect);
             shape2->fill(fill2);
 
-            canvas->push(shape2);
+            root->push(shape2);
 
             //Repeat
             x1 = 540.0f;
@@ -78,7 +78,7 @@ struct UserExample : tvgexam::Example
             fill3->spread(tvg::FillSpread::Repeat);
             shape3->fill(fill3);
 
-            canvas->push(shape3);
+            root->push(shape3);
         }
 
         //Linear grad
@@ -96,7 +96,7 @@ struct UserExample : tvgexam::Example
             fill1->spread(tvg::FillSpread::Pad);
             shape1->fill(fill1);
 
-            canvas->push(shape1);
+            root->push(shape1);
 
             //Reflect
             x1 = 280.0f;
@@ -109,7 +109,7 @@ struct UserExample : tvgexam::Example
             fill2->spread(tvg::FillSpread::Reflect);
             shape2->fill(fill2);
 
-            canvas->push(shape2);
+            root->push(shape2);
 
             //Repeat
             x1 = 540.0f;
@@ -122,7 +122,7 @@ struct UserExample : tvgexam::Example
             fill3->spread(tvg::FillSpread::Repeat);
             shape3->fill(fill3);
 
-            canvas->push(shape3);
+            root->push(shape3);
 
             return true;
         }

--- a/examples/GradientMasking.cpp
+++ b/examples/GradientMasking.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Solid Rectangle
         {
@@ -49,7 +49,7 @@ struct UserExample : tvgexam::Example
             shape->fill(fill);
 
             shape->mask(mask, tvg::MaskMethod::Alpha);
-            canvas->push(shape);
+            root->push(shape);
         }
 
         //Star
@@ -81,7 +81,7 @@ struct UserExample : tvgexam::Example
             shape1->fill(fill1);
 
             shape1->mask(mask1, tvg::MaskMethod::Alpha);
-            canvas->push(shape1);
+            root->push(shape1);
         }
 
         //Solid Rectangle
@@ -103,7 +103,7 @@ struct UserExample : tvgexam::Example
             shape2->fill(fill2);
 
             shape2->mask(mask2, tvg::MaskMethod::InvAlpha);
-            canvas->push(shape2);
+            root->push(shape2);
         }
 
         // Star
@@ -135,7 +135,7 @@ struct UserExample : tvgexam::Example
             shape3->fill(fill3);
 
             shape3->mask(mask3, tvg::MaskMethod::InvAlpha);
-            canvas->push(shape3);
+            root->push(shape3);
         }
 
         return true;

--- a/examples/GradientStroke.cpp
+++ b/examples/GradientStroke.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         tvg::Fill::ColorStop colorStops1[3];
         colorStops1[0] = {0, 255, 0, 0, 150};
@@ -75,7 +75,7 @@ struct UserExample : tvgexam::Example
         fill1->colorStops(colorStops1, 3);
         shape1->fill(fill1);
 
-        canvas->push(shape1);
+        root->push(shape1);
 
         // radial gradient stroke + duplicate
         auto shape2 = tvg::Shape::gen();
@@ -98,9 +98,9 @@ struct UserExample : tvgexam::Example
         auto shape4 = static_cast<tvg::Shape*>(shape2->duplicate());
         shape4->translate(0, 400);
 
-        canvas->push(shape2);
-        canvas->push(shape3);
-        canvas->push(shape4);
+        root->push(shape2);
+        root->push(shape3);
+        root->push(shape4);
 
         // dashed gradient stroke
         auto shape5 = tvg::Shape::gen();
@@ -120,7 +120,7 @@ struct UserExample : tvgexam::Example
         shape5->fill(fill5);
         shape5->scale(0.8);
 
-        canvas->push(shape5);
+        root->push(shape5);
 
         return true;
     }

--- a/examples/GradientTransform.cpp
+++ b/examples/GradientTransform.cpp
@@ -28,14 +28,14 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, root, 0);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
-        tvgexam::verify(canvas->remove());
+        root->remove();
 
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 
@@ -64,7 +64,7 @@ struct UserExample : tvgexam::Example
         shape->scale(1.0f - 0.75f * progress);
         shape->rotate(360.0f * progress);
 
-        canvas->push(shape);
+        root->push(shape);
 
         //Shape2
         auto shape2 = tvg::Shape::gen();
@@ -86,7 +86,7 @@ struct UserExample : tvgexam::Example
         shape2->rotate(360 * progress);
         shape2->translate(480 + progress * 300, 480);
 
-        canvas->push(shape2);
+        root->push(shape2);
 
         //Shape3
         auto shape3 = tvg::Shape::gen();
@@ -114,7 +114,7 @@ struct UserExample : tvgexam::Example
         shape3->rotate(-360.0f * progress);
         shape3->scale(0.5f + progress);
 
-        canvas->push(shape3);
+        root->push(shape3);
 
         return true;
     }

--- a/examples/ImageRotation.cpp
+++ b/examples/ImageRotation.cpp
@@ -37,7 +37,7 @@ struct UserExample : tvgexam::Example
         return degree * (float(M_PI) / 180.0f);
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         picture = tvg::Picture::gen();
         picture->origin(0.5f, 0.5f);  //center origin
@@ -45,12 +45,12 @@ struct UserExample : tvgexam::Example
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/image/scale.jpg"))) return false;
 
-        canvas->push(picture);
+        root->push(picture);
 
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         picture->scale(0.8f);
         picture->rotate(tvgexam::progress(elapsed, 4.0f) * 360.0f);

--- a/examples/ImageScaling.cpp
+++ b/examples/ImageScaling.cpp
@@ -30,7 +30,7 @@ struct UserExample : tvgexam::Example
 {
     tvg::Picture* picture = nullptr;
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Original
         picture = tvg::Picture::gen();
@@ -41,12 +41,12 @@ struct UserExample : tvgexam::Example
         picture->translate(w/2, h/2);
         picture->scale(1.5f);
 
-        canvas->push(picture);
+        root->push(picture);
 
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         auto progress = tvgexam::progress(elapsed, 3.0f, true);  //play time 3 secs.
 

--- a/examples/Intersects.cpp
+++ b/examples/Intersects.cpp
@@ -37,7 +37,7 @@ struct UserExample : tvgexam::Example
     tvg::Shape* marquee;
     int mx = 0, my = 0, mw = 20, mh = 20;
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //dash stroke filled shape
         {
@@ -59,7 +59,7 @@ struct UserExample : tvgexam::Example
 
             shape->scale(1.25f);
 
-            canvas->push(shape);
+            root->push(shape);
         }
 
         //clipped, rotated image
@@ -74,7 +74,7 @@ struct UserExample : tvgexam::Example
             clip->appendCircle(900, 350, 200, 200);
             picture->clip(clip);
 
-            canvas->push(picture);
+            root->push(picture);
         }
 
         //normal text
@@ -87,7 +87,7 @@ struct UserExample : tvgexam::Example
             text->translate(25, 800);
             text->fill(255, 255, 255);
 
-            canvas->push(text);
+            root->push(text);
         }
 
         //vector scene
@@ -97,7 +97,7 @@ struct UserExample : tvgexam::Example
             tiger->translate(700, 640);
             tiger->scale(0.5f);
 
-            canvas->push(tiger);
+            root->push(tiger);
         }
 
         //marquee
@@ -107,7 +107,7 @@ struct UserExample : tvgexam::Example
             marquee->strokeWidth(2);
             marquee->strokeFill(255, 255, 0);
             marquee->fill(255, 255, 0, 50);
-            canvas->push(marquee);
+            root->push(marquee);
         }
 
         return true;
@@ -122,7 +122,7 @@ struct UserExample : tvgexam::Example
         return false;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         marquee->translate(mx, my);
 

--- a/examples/LinearGradient.cpp
+++ b/examples/LinearGradient.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Prepare Round Rectangle
         auto shape1 = tvg::Shape::gen();
@@ -46,7 +46,7 @@ struct UserExample : tvgexam::Example
         fill->colorStops(colorStops, 2);
 
         shape1->fill(fill);
-        canvas->push(shape1);
+        root->push(shape1);
 
         //Prepare Circle
         auto shape2 = tvg::Shape::gen();
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         fill2->colorStops(colorStops2, 3);
 
         shape2->fill(fill2);
-        canvas->push(shape2);
+        root->push(shape2);
 
         //Prepare Ellipse
         auto shape3 = tvg::Shape::gen();
@@ -85,7 +85,7 @@ struct UserExample : tvgexam::Example
         fill3->colorStops(colorStops3, 4);
 
         shape3->fill(fill3);
-        canvas->push(shape3);
+        root->push(shape3);
 
         return true;
     }

--- a/examples/Lottie.cpp
+++ b/examples/Lottie.cpp
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         counter++;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         for (auto& animation : animations) {
             auto progress = tvgexam::progress(elapsed, animation->duration());
@@ -77,7 +77,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //The default font for fallback in case
         tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf");
@@ -86,7 +86,7 @@ struct UserExample : tvgexam::Example
         auto shape = tvg::Shape::gen();
         shape->appendRect(0, 0, w, h);
         shape->fill(75, 75, 75);
-        canvas->push(shape);
+        root->push(shape);
 
         this->w = w;
         this->h = h;
@@ -96,7 +96,7 @@ struct UserExample : tvgexam::Example
 
         //Run animation loop
         for (auto& animation : animations) {
-            canvas->push(animation->picture());
+            root->push(animation->picture());
         }
 
         return true;

--- a/examples/LottieExpressions.cpp
+++ b/examples/LottieExpressions.cpp
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         counter++;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         for (auto& animation : animations) {
             auto progress = tvgexam::progress(elapsed, animation->duration());
@@ -77,7 +77,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //The default font for fallback in case
         tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf");
@@ -87,7 +87,7 @@ struct UserExample : tvgexam::Example
         shape->appendRect(0, 0, w, h);
         shape->fill(75, 75, 75);
 
-        canvas->push(shape);
+        root->push(shape);
 
         this->w = w;
         this->h = h;
@@ -97,7 +97,7 @@ struct UserExample : tvgexam::Example
 
         //Run animation loop
         for (auto& animation : animations) {
-            canvas->push(animation->picture());
+            root->push(animation->picture());
         }
 
         return true;

--- a/examples/LottieExtension.cpp
+++ b/examples/LottieExtension.cpp
@@ -46,7 +46,7 @@ struct UserExample : tvgexam::Example
         picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + size / 2);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         //slots
         for (auto& slot : slots) {
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //The default font for fallback in case
         tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf");
@@ -74,7 +74,7 @@ struct UserExample : tvgexam::Example
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);
         bg->fill(75, 75, 75);
-        canvas->push(bg);
+        root->push(bg);
 
         this->w = w;
         this->h = h;
@@ -87,7 +87,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/slot0.json"))) return false;
 
             sizing(picture, 0);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -102,7 +102,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(slot->apply(slotId))) return false;
 
             sizing(picture, 1);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -117,7 +117,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(slot->apply(slotId))) return false;
 
             sizing(picture, 2);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -132,7 +132,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(slot->apply(slotId))) return false;
 
             sizing(picture, 3);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -147,7 +147,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(slot->apply(slotId))) return false;
 
             sizing(picture, 4);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -158,7 +158,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/slot5.json"))) return false;
 
             sizing(picture, 5);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -173,7 +173,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(slot->apply(slotId))) return false;
 
             sizing(picture, 6);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -188,7 +188,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(slot->apply(slotId))) return false;
 
             sizing(picture, 7);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -203,7 +203,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(slot->apply(slotId))) return false;
 
             sizing(picture, 8);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -219,7 +219,7 @@ struct UserExample : tvgexam::Example
 
             sizing(picture, 9);
 
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -234,7 +234,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(slot->apply(slotId))) return false;
 
             sizing(picture, 10);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -249,7 +249,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(slot->apply(slotId))) return false;
 
             sizing(picture, 11);
-            canvas->push(picture);
+            root->push(picture);
             slots.push_back(std::move(slot));
         }
 
@@ -261,7 +261,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(marker->segment("sectionC"))) return false;
 
             sizing(picture, 12);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         //asset resolver (image)
@@ -282,7 +282,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/resolver1.json"))) return false;
 
             sizing(picture, 13);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         //asset resolver (font)
@@ -303,7 +303,7 @@ struct UserExample : tvgexam::Example
             if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/resolver2.json"))) return false;
 
             sizing(picture, 14);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         return true;

--- a/examples/LottieInteraction.cpp
+++ b/examples/LottieInteraction.cpp
@@ -109,7 +109,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //LottieAnimation Controller
         lottie = unique_ptr<tvg::LottieAnimation>(tvg::LottieAnimation::gen());
@@ -121,7 +121,7 @@ struct UserExample : tvgexam::Example
             auto shape = tvg::Shape::gen();
             shape->appendRect(100, 100, w - 200, h - 200);
             shape->fill(50, 50, 50);
-            canvas->push(std::move(shape));
+            root->push(std::move(shape));
         }
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/extensions/spin.json"))) return false;
@@ -133,7 +133,7 @@ struct UserExample : tvgexam::Example
         picture->scale(scale);
         picture->translate(float(w) * 0.5f, float(h) * 0.5f);
 
-        canvas->push(picture);
+        root->push(picture);
 
         origin.x = float(w / 2);
         origin.y = float(h / 2);
@@ -141,7 +141,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         //spinning effect
         if (effect.on) {

--- a/examples/LottieTweening.cpp
+++ b/examples/LottieTweening.cpp
@@ -111,7 +111,7 @@ struct UserExample : tvgexam::Example
         return false;
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Animation Controller
         lottie = tvg::LottieAnimation::gen();
@@ -123,7 +123,7 @@ struct UserExample : tvgexam::Example
         shape->appendRect(0, 0, w, h);
         shape->fill(50, 50, 50);
 
-        canvas->push(shape);
+        root->push(shape);
 
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/lottie/emoji.json"))) return false;
 
@@ -135,7 +135,7 @@ struct UserExample : tvgexam::Example
         picture->translate(float(w) * 0.5f, float(h) * 0.5f);
 
 
-        canvas->push(picture);
+        root->push(picture);
 
         init();
 
@@ -171,7 +171,7 @@ struct UserExample : tvgexam::Example
         return false;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         //on state tweening
         if (tween.active) return tweening(canvas);

--- a/examples/LumaMasking.cpp
+++ b/examples/LumaMasking.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Image
         ifstream file(EXAMPLE_DIR"/image/rawimage_200x300.raw", ios::binary);
@@ -56,7 +56,7 @@ struct UserExample : tvgexam::Example
 
             mask->mask(nMask, tvg::MaskMethod::Luma);
             shape->mask(mask, tvg::MaskMethod::Luma);
-            canvas->push(shape);
+            root->push(shape);
 
             //SVG
             auto svg = tvg::Picture::gen();
@@ -71,7 +71,7 @@ struct UserExample : tvgexam::Example
             mask2->appendRect(150, 500, 200, 200, 30, 30);
             mask2->fill(255, 255, 255);
             svg->mask(mask2, tvg::MaskMethod::Luma);
-            canvas->push(svg);
+            root->push(svg);
 
             //Star
             auto star = tvg::Shape::gen();
@@ -95,7 +95,7 @@ struct UserExample : tvgexam::Example
             mask3->appendCircle(600, 200, 125, 125);
             mask3->fill(0, 255, 255);
             star->mask(mask3, tvg::MaskMethod::Luma);
-            canvas->push(star);
+            root->push(star);
 
             auto image = tvg::Picture::gen();
             if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
@@ -112,7 +112,7 @@ struct UserExample : tvgexam::Example
             mask4->push(mask4_rect);
             mask4->push(mask4_circle);
             image->mask(mask4, tvg::MaskMethod::Luma);
-            canvas->push(image);
+            root->push(image);
         }
 
         //Inverse Luma Masking
@@ -134,7 +134,7 @@ struct UserExample : tvgexam::Example
 
             mask->mask(nMask, tvg::MaskMethod::InvLuma);
             shape->mask(mask, tvg::MaskMethod::InvLuma);
-            canvas->push(shape);
+            root->push(shape);
 
             //SVG
             auto svg = tvg::Picture::gen();
@@ -149,7 +149,7 @@ struct UserExample : tvgexam::Example
             mask2->appendRect(950, 500, 200, 200, 30, 30);
             mask2->fill(255, 255, 255);
             svg->mask(mask2, tvg::MaskMethod::InvLuma);
-            canvas->push(svg);
+            root->push(svg);
 
             //Star
             auto star = tvg::Shape::gen();
@@ -173,7 +173,7 @@ struct UserExample : tvgexam::Example
             mask3->appendCircle(1400, 200, 125, 125);
             mask3->fill(0, 255, 255);
             star->mask(mask3, tvg::MaskMethod::InvLuma);
-            canvas->push(star);
+            root->push(star);
 
             auto image = tvg::Picture::gen();
             if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
@@ -190,7 +190,7 @@ struct UserExample : tvgexam::Example
             mask4->push(mask4_rect);
             mask4->push(mask4_circle);
             image->mask(mask4, tvg::MaskMethod::InvLuma);
-            canvas->push(image);
+            root->push(image);
         }
 
         free(data);

--- a/examples/Masking.cpp
+++ b/examples/Masking.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Image
         ifstream file(EXAMPLE_DIR"/image/rawimage_200x300.raw", ios::binary);
@@ -56,7 +56,7 @@ struct UserExample : tvgexam::Example
 
             mask->mask(nMask, tvg::MaskMethod::Alpha);
             shape->mask(mask, tvg::MaskMethod::Alpha);
-            canvas->push(shape);
+            root->push(shape);
 
             //SVG
             auto svg = tvg::Picture::gen();
@@ -71,7 +71,7 @@ struct UserExample : tvgexam::Example
             mask2->appendRect(150, 500, 200, 200, 30, 30);
             mask2->fill(255, 255, 255);       //AlphaMask RGB channels are unused.
             svg->mask(mask2, tvg::MaskMethod::Alpha);
-            canvas->push(svg);
+            root->push(svg);
 
             //Star
             auto star = tvg::Shape::gen();
@@ -97,7 +97,7 @@ struct UserExample : tvgexam::Example
             mask3->fill(255, 255, 255);       //AlphaMask RGB channels are unused.
             mask3->opacity(200);
             star->mask(mask3, tvg::MaskMethod::Alpha);
-            canvas->push(star);
+            root->push(star);
 
             auto image = tvg::Picture::gen();
             if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
@@ -119,7 +119,7 @@ struct UserExample : tvgexam::Example
             mask4->fill(255, 255, 255);        //AlphaMask RGB channels are unused.
             mask4->opacity(70);
             image->mask(mask4, tvg::MaskMethod::Alpha);
-            canvas->push(image);
+            root->push(image);
         }
 
         //Inverse Masking
@@ -141,7 +141,7 @@ struct UserExample : tvgexam::Example
 
             mask->mask(nMask, tvg::MaskMethod::InvAlpha);
             shape->mask(mask, tvg::MaskMethod::InvAlpha);
-            canvas->push(shape);
+            root->push(shape);
 
             //SVG
             auto svg = tvg::Picture::gen();
@@ -156,7 +156,7 @@ struct UserExample : tvgexam::Example
             mask2->appendRect(950, 500, 200, 200, 30, 30);
             mask2->fill(255, 255, 255);   //InvAlphaMask RGB channels are unused.
             svg->mask(mask2, tvg::MaskMethod::InvAlpha);
-            canvas->push(svg);
+            root->push(svg);
 
             //Star
             auto star = tvg::Shape::gen();
@@ -180,7 +180,7 @@ struct UserExample : tvgexam::Example
             mask3->appendCircle(1400, 200, 125, 125);
             mask3->fill(255, 255, 255);        //InvAlphaMask RGB channels are unused.
             star->mask(mask3, tvg::MaskMethod::InvAlpha);
-            canvas->push(star);
+            root->push(star);
 
             auto image = tvg::Picture::gen();
             if (!tvgexam::verify(image->load(data, 200, 300, tvg::ColorSpace::ABGR8888, true))) return false;
@@ -202,7 +202,7 @@ struct UserExample : tvgexam::Example
             mask4->fill(255, 255, 255);      //InvAlphaMask RGB channels are unused.
             mask4->opacity(70);
             image->mask(mask4, tvg::MaskMethod::InvAlpha);
-            canvas->push(image);
+            root->push(image);
         }
 
         free(data);

--- a/examples/MaskingMethods.cpp
+++ b/examples/MaskingMethods.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Image source
         ifstream file(EXAMPLE_DIR"/image/rawimage_200x300.raw", ios::binary);
@@ -41,7 +41,7 @@ struct UserExample : tvgexam::Example
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, 625, h);
         bg->fill(50, 50, 50);
-        canvas->push(bg);
+        root->push(bg);
 
         {
             //Shape + Shape Mask Add
@@ -58,7 +58,7 @@ struct UserExample : tvgexam::Example
             add->fill(255, 255, 255);
             mask->mask(add, tvg::MaskMethod::Add);
             shape->mask(mask, tvg::MaskMethod::Alpha);
-            canvas->push(shape);
+            root->push(shape);
 
             //Shape + Shape Mask Subtract
             auto shape2 = tvg::Shape::gen();
@@ -74,7 +74,7 @@ struct UserExample : tvgexam::Example
             sub->fill(255, 255, 255);
             mask2->mask(sub, tvg::MaskMethod::Subtract);
             shape2->mask(mask2, tvg::MaskMethod::Alpha);
-            canvas->push(shape2);
+            root->push(shape2);
 
             //Shape + Shape Mask Intersect
             auto shape3 = tvg::Shape::gen();
@@ -90,7 +90,7 @@ struct UserExample : tvgexam::Example
             inter->fill(255, 255, 255);
             mask3->mask(inter, tvg::MaskMethod::Intersect);
             shape3->mask(mask3, tvg::MaskMethod::Alpha);
-            canvas->push(shape3);
+            root->push(shape3);
 
             //Shape + Shape Mask Difference
             auto shape4 = tvg::Shape::gen();
@@ -106,7 +106,7 @@ struct UserExample : tvgexam::Example
             diff->fill(255, 255, 255);
             mask4->mask(diff, tvg::MaskMethod::Difference);
             shape4->mask(mask4, tvg::MaskMethod::Alpha);
-            canvas->push(shape4);
+            root->push(shape4);
 
             //Shape + Shape Mask Lighten
             auto shape5 = tvg::Shape::gen();
@@ -122,7 +122,7 @@ struct UserExample : tvgexam::Example
             light->fill(255, 255, 255);
             mask5->mask(light, tvg::MaskMethod::Lighten);
             shape5->mask(mask5, tvg::MaskMethod::Alpha);
-            canvas->push(shape5);
+            root->push(shape5);
 
             //Shape + Shape Mask Darken
             auto shape6 = tvg::Shape::gen();
@@ -138,7 +138,7 @@ struct UserExample : tvgexam::Example
             dark->fill(255, 255, 255);
             mask6->mask(dark, tvg::MaskMethod::Darken);
             shape6->mask(mask6, tvg::MaskMethod::Alpha);
-            canvas->push(shape6);
+            root->push(shape6);
         }
         {
             //Shape + Shape Mask Add
@@ -155,7 +155,7 @@ struct UserExample : tvgexam::Example
             add->fill(255, 255, 255);
             mask->mask(add, tvg::MaskMethod::Add);
             shape->mask(mask, tvg::MaskMethod::InvAlpha);
-            canvas->push(shape);
+            root->push(shape);
 
             //Shape + Shape Mask Subtract
             auto shape2 = tvg::Shape::gen();
@@ -171,7 +171,7 @@ struct UserExample : tvgexam::Example
             sub->fill(255, 255, 255);
             mask2->mask(sub, tvg::MaskMethod::Subtract);
             shape2->mask(mask2, tvg::MaskMethod::InvAlpha);
-            canvas->push(shape2);
+            root->push(shape2);
 
             //Shape + Shape Mask Intersect
             auto shape3 = tvg::Shape::gen();
@@ -187,7 +187,7 @@ struct UserExample : tvgexam::Example
             inter->fill(255, 255, 255);
             mask3->mask(inter, tvg::MaskMethod::Intersect);
             shape3->mask(mask3, tvg::MaskMethod::InvAlpha);
-            canvas->push(shape3);
+            root->push(shape3);
 
             //Shape + Shape Mask Difference
             auto shape4 = tvg::Shape::gen();
@@ -203,7 +203,7 @@ struct UserExample : tvgexam::Example
             diff->fill(255, 255, 255);
             mask4->mask(diff, tvg::MaskMethod::Difference);
             shape4->mask(mask4, tvg::MaskMethod::InvAlpha);
-            canvas->push(shape4);
+            root->push(shape4);
 
             //Shape + Shape Mask Lighten
             auto shape5 = tvg::Shape::gen();
@@ -219,7 +219,7 @@ struct UserExample : tvgexam::Example
             light->fill(255, 255, 255);
             mask5->mask(light, tvg::MaskMethod::Lighten);
             shape5->mask(mask5, tvg::MaskMethod::InvAlpha);
-            canvas->push(shape5);
+            root->push(shape5);
 
             //Shape + Shape Mask Darken
             auto shape6 = tvg::Shape::gen();
@@ -235,7 +235,7 @@ struct UserExample : tvgexam::Example
             dark->fill(255, 255, 255);
             mask6->mask(dark, tvg::MaskMethod::Darken);
             shape6->mask(mask6, tvg::MaskMethod::InvAlpha);
-            canvas->push(shape6);
+            root->push(shape6);
         }
         {
             //Rect + Rect Mask Add
@@ -252,7 +252,7 @@ struct UserExample : tvgexam::Example
             add->fill(255, 255, 255);
             mask->mask(add, tvg::MaskMethod::Add);
             shape->mask(mask, tvg::MaskMethod::Alpha);
-            canvas->push(shape);
+            root->push(shape);
 
             //Rect + Rect Mask Subtract
             auto shape2 = tvg::Shape::gen();
@@ -268,7 +268,7 @@ struct UserExample : tvgexam::Example
             sub->fill(255, 255, 255);
             mask2->mask(sub, tvg::MaskMethod::Subtract);
             shape2->mask(mask2, tvg::MaskMethod::Alpha);
-            canvas->push(shape2);
+            root->push(shape2);
 
             //Rect + Rect Mask Intersect
             auto shape3 = tvg::Shape::gen();
@@ -284,7 +284,7 @@ struct UserExample : tvgexam::Example
             inter->fill(255, 255, 255);
             mask3->mask(inter, tvg::MaskMethod::Intersect);
             shape3->mask(mask3, tvg::MaskMethod::Alpha);
-            canvas->push(shape3);
+            root->push(shape3);
 
             //Rect + Rect Mask Difference
             auto shape4 = tvg::Shape::gen();
@@ -300,7 +300,7 @@ struct UserExample : tvgexam::Example
             diff->fill(255, 255, 255);
             mask4->mask(diff, tvg::MaskMethod::Difference);
             shape4->mask(mask4, tvg::MaskMethod::Alpha);
-            canvas->push(shape4);
+            root->push(shape4);
 
             //Rect + Rect Mask Lighten
             auto shape5 = tvg::Shape::gen();
@@ -316,7 +316,7 @@ struct UserExample : tvgexam::Example
             light->fill(255, 255, 255);
             mask5->mask(light, tvg::MaskMethod::Lighten);
             shape5->mask(mask5, tvg::MaskMethod::Alpha);
-            canvas->push(shape5);
+            root->push(shape5);
 
             //Rect + Rect Mask Darken
             auto shape6 = tvg::Shape::gen();
@@ -332,7 +332,7 @@ struct UserExample : tvgexam::Example
             dark->fill(255, 255, 255);
             mask6->mask(dark, tvg::MaskMethod::Darken);
             shape6->mask(mask6, tvg::MaskMethod::Alpha);
-            canvas->push(shape6);
+            root->push(shape6);
         }
         {
             //Transformed Image + Shape Mask Add
@@ -351,7 +351,7 @@ struct UserExample : tvgexam::Example
             add->fill(255, 255, 255);
             mask->mask(add, tvg::MaskMethod::Add);
             image->mask(mask, tvg::MaskMethod::Alpha);
-            canvas->push(image);
+            root->push(image);
 
             //Transformed Image + Shape Mask Subtract
             auto image2 = tvg::Picture::gen();
@@ -369,7 +369,7 @@ struct UserExample : tvgexam::Example
             sub->fill(255, 255, 255);
             mask2->mask(sub, tvg::MaskMethod::Subtract);
             image2->mask(mask2, tvg::MaskMethod::Alpha);
-            canvas->push(image2);
+            root->push(image2);
 
             //Transformed Image + Shape Mask Intersect
             auto image3 = tvg::Picture::gen();
@@ -387,7 +387,7 @@ struct UserExample : tvgexam::Example
             inter->fill(255, 255, 255, 127);
             mask3->mask(inter, tvg::MaskMethod::Intersect);
             image3->mask(mask3, tvg::MaskMethod::Alpha);
-            canvas->push(image3);
+            root->push(image3);
 
             //Transformed Image + Shape Mask Difference
             auto image4 = tvg::Picture::gen();
@@ -405,7 +405,7 @@ struct UserExample : tvgexam::Example
             diff->fill(255, 255, 255);
             mask4->mask(diff, tvg::MaskMethod::Difference);
             image4->mask(mask4, tvg::MaskMethod::Alpha);
-            canvas->push(image4);
+            root->push(image4);
 
             //Transformed Image + Shape Mask Lighten
             auto image5 = tvg::Picture::gen();
@@ -423,7 +423,7 @@ struct UserExample : tvgexam::Example
             light->fill(255, 255, 255);
             mask5->mask(light, tvg::MaskMethod::Lighten);
             image5->mask(mask5, tvg::MaskMethod::Alpha);
-            canvas->push(image5);
+            root->push(image5);
 
             //Transformed Image + Shape Mask Darken
             auto image6 = tvg::Picture::gen();
@@ -441,7 +441,7 @@ struct UserExample : tvgexam::Example
             dark->fill(255, 255, 255);
             mask6->mask(dark, tvg::MaskMethod::Darken);
             image6->mask(mask6, tvg::MaskMethod::Alpha);
-            canvas->push(image6);
+            root->push(image6);
         }
         {
             //Transformed Image + Shape Mask Add
@@ -460,7 +460,7 @@ struct UserExample : tvgexam::Example
             add->fill(255, 255, 255);
             mask->mask(add, tvg::MaskMethod::Add);
             image->mask(mask, tvg::MaskMethod::InvAlpha);
-            canvas->push(image);
+            root->push(image);
 
             //Transformed Image + Shape Mask Subtract
             auto image2 = tvg::Picture::gen();
@@ -478,7 +478,7 @@ struct UserExample : tvgexam::Example
             sub->fill(255, 255, 255);
             mask2->mask(sub, tvg::MaskMethod::Subtract);
             image2->mask(mask2, tvg::MaskMethod::InvAlpha);
-            canvas->push(image2);
+            root->push(image2);
 
             //Transformed Image + Shape Mask Intersect
             auto image3 = tvg::Picture::gen();
@@ -496,7 +496,7 @@ struct UserExample : tvgexam::Example
             inter->fill(255, 255, 255, 127);
             mask3->mask(inter, tvg::MaskMethod::Intersect);
             image3->mask(mask3, tvg::MaskMethod::InvAlpha);
-            canvas->push(image3);
+            root->push(image3);
 
             //Transformed Image + Shape Mask Difference
             auto image4 = tvg::Picture::gen();
@@ -514,7 +514,7 @@ struct UserExample : tvgexam::Example
             diff->fill(255, 255, 255);
             mask4->mask(diff, tvg::MaskMethod::Difference);
             image4->mask(mask4, tvg::MaskMethod::InvAlpha);
-            canvas->push(image4);
+            root->push(image4);
 
             //Transformed Image + Shape Mask Lighten
             auto image5 = tvg::Picture::gen();
@@ -532,7 +532,7 @@ struct UserExample : tvgexam::Example
             light->fill(255, 255, 255);
             mask5->mask(light, tvg::MaskMethod::Lighten);
             image5->mask(mask5, tvg::MaskMethod::InvAlpha);
-            canvas->push(image5);
+            root->push(image5);
 
             //Transformed Image + Shape Mask Darken
             auto image6 = tvg::Picture::gen();
@@ -550,7 +550,7 @@ struct UserExample : tvgexam::Example
             dark->fill(255, 255, 255);
             mask6->mask(dark, tvg::MaskMethod::Darken);
             image6->mask(mask6, tvg::MaskMethod::InvAlpha);
-            canvas->push(image6);
+            root->push(image6);
         }
         free(data);
         return true;

--- a/examples/Opacity.cpp
+++ b/examples/Opacity.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Create a Scene
         auto scene = tvg::Scene::gen();
@@ -49,7 +49,7 @@ struct UserExample : tvgexam::Example
         scene->push(shape2);
 
         //Draw the Scene onto the Canvas
-        canvas->push(scene);
+        root->push(scene);
 
         //Create a Scene 2
         auto scene2 = tvg::Scene::gen();
@@ -101,7 +101,7 @@ struct UserExample : tvgexam::Example
         scene2->push(shape4);
 
         //Draw the Scene onto the Canvas
-        canvas->push(scene2);
+        root->push(scene2);
 
         return true;
     }

--- a/examples/Particles.cpp
+++ b/examples/Particles.cpp
@@ -41,18 +41,18 @@ struct UserExample : tvgexam::Example
 
     uint32_t w, h;
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         srand(100);
 
         auto city = tvg::Picture::gen();
         city->load(EXAMPLE_DIR"/image/particle.jpg");
-        canvas->push(city);
+        root->push(city);
 
         auto cloud1 = tvg::Picture::gen();
         cloud1->load(EXAMPLE_DIR"/image/clouds.png");
         cloud1->opacity(60);
-        canvas->push(cloud1);
+        root->push(cloud1);
 
         float size;
         cloud1->size(&size, nullptr);
@@ -61,21 +61,21 @@ struct UserExample : tvgexam::Example
         auto cloud2 = cloud1->duplicate();
         cloud2->opacity(30);
         cloud2->translate(400, 100);
-        canvas->push(cloud2);
+        root->push(cloud2);
 
         clouds.push_back({cloud2, 400, 100, 0.125f, size});
 
         auto cloud3 = cloud1->duplicate();
         cloud3->opacity(20);
         cloud3->translate(1200, 200);
-        canvas->push(cloud3);
+        root->push(cloud3);
 
         clouds.push_back({cloud3, 1200, 200, 0.075f, size});
 
         auto darkness = tvg::Shape::gen();
         darkness->appendRect(0, 0, w, h);
         darkness->fill(0, 0, 0, 150);
-        canvas->push(darkness);
+        root->push(darkness);
 
         //rain drops
         size = w / COUNT;
@@ -87,7 +87,7 @@ struct UserExample : tvgexam::Example
             raindrops.push_back({shape, x, float(rand()%h), 10 + float(rand() % 100) * 0.1f, 0 /* unused */});
             shape->appendRect(0, 0, 1, rand() % 15 + size);
             shape->fill(255, 255, 255, 55 + rand() % 100);
-            canvas->push(shape);
+            root->push(shape);
         }
 
         this->w = w;
@@ -96,7 +96,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         for (auto& p : raindrops) {
             p.y += p.speed;

--- a/examples/Path.cpp
+++ b/examples/Path.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Command Calls
         {
@@ -48,7 +48,7 @@ struct UserExample : tvgexam::Example
             shape1->lineTo(146, 143);
             shape1->close();
             shape1->fill(0, 0, 255);
-            canvas->push(shape1);
+            root->push(shape1);
 
             //Circle
             auto shape2 = tvg::Shape::gen();
@@ -66,7 +66,7 @@ struct UserExample : tvgexam::Example
             shape2->cubicTo(cx - radius, cy - halfRadius, cx - halfRadius, cy - radius, cx, cy - radius);
             shape2->close();
             shape2->fill(255, 0, 0);
-            canvas->push(shape2);
+            root->push(shape2);
         }
 
         //Commands Copy
@@ -104,7 +104,7 @@ struct UserExample : tvgexam::Example
             shape1->appendPath(cmds, 11, pts, 10);     //copy path data
             shape1->fill(0, 255, 0);
             shape1->translate(400, 0);
-            canvas->push(shape1);
+            root->push(shape1);
 
             /* Circle */
             auto cx = 550.0f;
@@ -145,7 +145,7 @@ struct UserExample : tvgexam::Example
             shape2->appendPath(cmds2, 6, pts2, 13);     //copy path data
             shape2->fill(255, 255, 0);
             shape2->translate(-300, 0);
-            canvas->push(shape2);
+            root->push(shape2);
         }
 
         return true;

--- a/examples/PictureJpg.cpp
+++ b/examples/PictureJpg.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         auto opacity = 36;
 
@@ -40,7 +40,7 @@ struct UserExample : tvgexam::Example
             picture->rotate(30 * i);
             picture->size(200, 200);
             picture->opacity(opacity + opacity * i);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         //Open file manually
@@ -60,7 +60,7 @@ struct UserExample : tvgexam::Example
         free(data);
         picture->translate(400, 0);
         picture->scale(0.8);
-        canvas->push(picture);
+        root->push(picture);
 
         return true;
     }

--- a/examples/PicturePng.cpp
+++ b/examples/PicturePng.cpp
@@ -28,13 +28,13 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Background
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);    //x, y, w, h
         bg->fill(255, 255, 255);       //r, g, b
-        canvas->push(bg);
+        root->push(bg);
 
         //Load png file from path
         auto opacity = 31;
@@ -46,7 +46,7 @@ struct UserExample : tvgexam::Example
             picture->rotate(30 * i);
             picture->size(200, 200);
             picture->opacity(opacity + opacity * i);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         //Open file manually
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         free(data);
         picture->translate(380, 0);
         picture->scale(0.8);
-        canvas->push(picture);
+        root->push(picture);
 
         return true;
     }

--- a/examples/PictureRaw.cpp
+++ b/examples/PictureRaw.cpp
@@ -28,13 +28,13 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Background
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);
         bg->fill(255, 255, 255);
-        canvas->push(bg);
+        root->push(bg);
 
         string path(EXAMPLE_DIR"/image/rawimage_200x300.raw");
         ifstream file(path, ios::binary);
@@ -46,7 +46,7 @@ struct UserExample : tvgexam::Example
         auto picture = tvg::Picture::gen();
         if (!tvgexam::verify(picture->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
         picture->translate(400, 250);
-        canvas->push(picture);
+        root->push(picture);
 
         auto picture2 = tvg::Picture::gen();
         if (!tvgexam::verify(picture2->load(data, 200, 300, tvg::ColorSpace::ARGB8888, true))) return false;
@@ -61,7 +61,7 @@ struct UserExample : tvgexam::Example
 
         picture2->clip(circle);
 
-        canvas->push(picture2);
+        root->push(picture2);
 
         free(data);
 

--- a/examples/PictureSvg.cpp
+++ b/examples/PictureSvg.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //The default font for fallback in case
         tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf");
@@ -43,7 +43,7 @@ struct UserExample : tvgexam::Example
             picture->rotate(30 * i);
             picture->size(200, 200);
             picture->opacity(opacity + opacity * i);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         //Open file manually
@@ -63,7 +63,7 @@ struct UserExample : tvgexam::Example
         free(data);
         picture->translate(400, 0);
         picture->scale(0.4);
-        canvas->push(picture);
+        root->push(picture);
 
         return true;
     }

--- a/examples/PictureWebp.cpp
+++ b/examples/PictureWebp.cpp
@@ -28,13 +28,13 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Background
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);             //x, y, w, h
         bg->fill(255, 255, 255);                //r, g, b
-        canvas->push(bg);
+        root->push(bg);
 
         //Load webp file from path
         auto opacity = 31;
@@ -46,7 +46,7 @@ struct UserExample : tvgexam::Example
             picture->rotate(30 * i);
             picture->size(200, 200);
             picture->opacity(opacity + opacity * i);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         //Open file manually
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         free(data);
         picture->translate(400, 0);
         picture->scale(0.8);
-        canvas->push(picture);
+        root->push(picture);
 
         return true;
     }

--- a/examples/RadialGradient.cpp
+++ b/examples/RadialGradient.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Prepare Round Rectangle
         auto shape1 = tvg::Shape::gen();
@@ -46,7 +46,7 @@ struct UserExample : tvgexam::Example
         fill->colorStops(colorStops, 2);
 
         shape1->fill(fill);
-        canvas->push(shape1);
+        root->push(shape1);
 
         //Prepare Circle
         auto shape2 = tvg::Shape::gen();
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         fill2->colorStops(colorStops2, 3);
 
         shape2->fill(fill2);
-        canvas->push(shape2);
+        root->push(shape2);
 
         //Prepare Ellipse
         auto shape3 = tvg::Shape::gen();
@@ -85,7 +85,7 @@ struct UserExample : tvgexam::Example
         fill3->colorStops(colorStops3, 4);
 
         shape3->fill(fill3);
-        canvas->push(shape3);
+        root->push(shape3);
 
         return true;
     }

--- a/examples/Scene.cpp
+++ b/examples/Scene.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Create a Scene
         auto scene = tvg::Scene::gen();
@@ -93,7 +93,7 @@ struct UserExample : tvgexam::Example
         scene->push(scene2);
 
         //Draw the Scene onto the Canvas
-        canvas->push(scene);
+        root->push(scene);
 
         return true;
     }

--- a/examples/SceneBlending.cpp
+++ b/examples/SceneBlending.cpp
@@ -28,13 +28,13 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //BG
         auto bg = tvg::Shape::gen();
         bg->appendRect(0, 0, w, h);
         bg->fill(100, 100, 100);
-        canvas->push(bg);
+        root->push(bg);
 
         //Create a Scene
         auto scene = tvg::Scene::gen();
@@ -55,7 +55,7 @@ struct UserExample : tvgexam::Example
         scene->push(shape2);
 
         //Draw the Scene onto the Canvas
-        canvas->push(scene);
+        root->push(scene);
 
         //Create a Scene 2
         auto scene2 = tvg::Scene::gen();
@@ -108,7 +108,7 @@ struct UserExample : tvgexam::Example
         scene2->push(shape4);
 
         //Draw the Scene onto the Canvas
-        canvas->push(scene2);
+        root->push(scene2);
 
         return true;
     }

--- a/examples/SceneEffects.cpp
+++ b/examples/SceneEffects.cpp
@@ -35,7 +35,7 @@ struct UserExample : tvgexam::Example
     tvg::Scene* tint = nullptr;
     tvg::Scene* trintone = nullptr;
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //blur scene
         for (int i = 0; i < 3; ++i) {
@@ -47,7 +47,7 @@ struct UserExample : tvgexam::Example
             picture->translate(SIZE * i, 0);
 
             blur[i]->push(picture);
-            canvas->push(blur[i]);
+            root->push(blur[i]);
         }
 
         //fill scene
@@ -60,7 +60,7 @@ struct UserExample : tvgexam::Example
             picture->translate(0, SIZE);
 
             fill->push(picture);
-            canvas->push(fill);
+            root->push(fill);
         }
 
         //tint scene
@@ -73,7 +73,7 @@ struct UserExample : tvgexam::Example
             picture->translate(SIZE, SIZE);
 
             tint->push(picture);
-            canvas->push(tint);
+            root->push(tint);
         }
 
         //trinton scene
@@ -86,14 +86,14 @@ struct UserExample : tvgexam::Example
             picture->translate(SIZE * 2, SIZE);
 
             trintone->push(picture);
-            canvas->push(trintone);
+            root->push(trintone);
         }
 
 
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         auto progress = tvgexam::progress(elapsed, 2.5f, true);   //2.5 seconds
 

--- a/examples/SceneTransform.cpp
+++ b/examples/SceneTransform.cpp
@@ -28,14 +28,14 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, root, 0);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
-        if (!tvgexam::verify(canvas->remove())) return false;
+        root->remove();
 
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 
@@ -114,7 +114,7 @@ struct UserExample : tvgexam::Example
         scene->push(scene2);
 
         //Draw the Scene onto the Canvas
-        canvas->push(scene);
+        root->push(scene);
 
         return true;
     }

--- a/examples/Shapes.cpp
+++ b/examples/Shapes.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Prepare a Composite Shape (Rectangle + Rectangle + Circle + Circle)
         auto shape4 = tvg::Shape::gen();
@@ -36,25 +36,25 @@ struct UserExample : tvgexam::Example
         shape4->appendCircle(400, 150, 150, 150);       //cx, cy, radiusW, radiusH
         shape4->appendCircle(600, 150, 150, 100);       //cx, cy, radiusW, radiusH
         shape4->fill(255, 255, 0);                      //r, g, b
-        canvas->push(shape4);
+        root->push(shape4);
 
         //Prepare Round Rectangle
         auto shape1 = tvg::Shape::gen();
         shape1->appendRect(0, 450, 300, 300, 50, 50);  //x, y, w, h, rx, ry
         shape1->fill(0, 255, 0);                       //r, g, b
-        canvas->push(shape1);
+        root->push(shape1);
 
         //Prepare Circle
         auto shape2 = tvg::Shape::gen();
         shape2->appendCircle(400, 600, 150, 150);    //cx, cy, radiusW, radiusH
         shape2->fill(255, 255, 0);                   //r, g, b
-        canvas->push(shape2);
+        root->push(shape2);
 
         //Prepare Ellipse
         auto shape3 = tvg::Shape::gen();
         shape3->appendCircle(600, 600, 150, 100);    //cx, cy, radiusW, radiusH
         shape3->fill(0, 255, 255);                   //r, g, b
-        canvas->push(shape3);
+        root->push(shape3);
 
         return true;
     }

--- a/examples/Stroke.cpp
+++ b/examples/Stroke.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Shape 1
         auto shape1 = tvg::Shape::gen();
@@ -38,7 +38,7 @@ struct UserExample : tvgexam::Example
         shape1->strokeJoin(tvg::StrokeJoin::Bevel);   //default is Bevel
         shape1->strokeWidth(10);                       //width: 10px
 
-        canvas->push(shape1);
+        root->push(shape1);
 
         //Shape 2
         auto shape2 = tvg::Shape::gen();
@@ -48,7 +48,7 @@ struct UserExample : tvgexam::Example
         shape2->strokeJoin(tvg::StrokeJoin::Round);
         shape2->strokeWidth(10);
 
-        canvas->push(shape2);
+        root->push(shape2);
 
         //Shape 3
         auto shape3 = tvg::Shape::gen();
@@ -58,7 +58,7 @@ struct UserExample : tvgexam::Example
         shape3->strokeJoin(tvg::StrokeJoin::Miter);
         shape3->strokeWidth(10);
 
-        canvas->push(shape3);
+        root->push(shape3);
 
         //Shape 4
         auto shape4 = tvg::Shape::gen();
@@ -67,7 +67,7 @@ struct UserExample : tvgexam::Example
         shape4->strokeFill(255, 255, 255);
         shape4->strokeWidth(1);
 
-        canvas->push(shape4);
+        root->push(shape4);
 
         //Shape 5
         auto shape5 = tvg::Shape::gen();
@@ -76,7 +76,7 @@ struct UserExample : tvgexam::Example
         shape5->strokeFill(255, 255, 255);
         shape5->strokeWidth(2);
 
-        canvas->push(shape5);
+        root->push(shape5);
 
         //Shape 6
         auto shape6 = tvg::Shape::gen();
@@ -85,7 +85,7 @@ struct UserExample : tvgexam::Example
         shape6->strokeFill(255, 255, 255);
         shape6->strokeWidth(4);
 
-        canvas->push(shape6);
+        root->push(shape6);
 
         //Stroke width test
         for (int i = 0; i < 10; ++i) {
@@ -95,7 +95,7 @@ struct UserExample : tvgexam::Example
             hline->strokeFill(255, 255, 255);            //color: r, g, b
             hline->strokeWidth(i + 1);                   //stroke width
             hline->strokeCap(tvg::StrokeCap::Round);     //default is Square
-            canvas->push(hline);
+            root->push(hline);
 
             auto vline = tvg::Shape::gen();
             vline->moveTo(500 + (25 * i), 550);
@@ -103,7 +103,7 @@ struct UserExample : tvgexam::Example
             vline->strokeFill(255, 255, 255);            //color: r, g, b
             vline->strokeWidth(i + 1);                   //stroke width
             vline->strokeCap(tvg::StrokeCap::Round);     //default is Square
-            canvas->push(vline);
+            root->push(vline);
         }
 
         //Stroke cap test
@@ -116,15 +116,15 @@ struct UserExample : tvgexam::Example
 
         auto line2 = static_cast<tvg::Shape*>(line1->duplicate());
         auto line3 = static_cast<tvg::Shape*>(line1->duplicate());
-        canvas->push(line1);
+        root->push(line1);
 
         line2->strokeCap(tvg::StrokeCap::Square);
         line2->translate(0, 50);
-        canvas->push(line2);
+        root->push(line2);
 
         line3->strokeCap(tvg::StrokeCap::Butt);
         line3->translate(0, 100);
-        canvas->push(line3);
+        root->push(line3);
 
         return true;
     }

--- a/examples/StrokeLine.cpp
+++ b/examples/StrokeLine.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //StrokeJoin & StrokeCap
         auto shape1 = tvg::Shape::gen();
@@ -41,7 +41,7 @@ struct UserExample : tvgexam::Example
         shape1->strokeWidth(10);
         shape1->strokeJoin(tvg::StrokeJoin::Round);
         shape1->strokeCap(tvg::StrokeCap::Round);
-        canvas->push(shape1);
+        root->push(shape1);
 
         auto shape2 = tvg::Shape::gen();
         shape2->moveTo(270, 50);
@@ -53,7 +53,7 @@ struct UserExample : tvgexam::Example
         shape2->strokeWidth(10);
         shape2->strokeJoin(tvg::StrokeJoin::Bevel);
         shape2->strokeCap(tvg::StrokeCap::Square);
-        canvas->push(shape2);
+        root->push(shape2);
 
         auto shape3 = tvg::Shape::gen();
         shape3->moveTo(520, 50);
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         shape3->strokeWidth(10);
         shape3->strokeJoin(tvg::StrokeJoin::Miter);
         shape3->strokeCap(tvg::StrokeCap::Butt);
-        canvas->push(shape3);
+        root->push(shape3);
 
         //Stroke Dash
         auto shape4 = tvg::Shape::gen();
@@ -81,7 +81,7 @@ struct UserExample : tvgexam::Example
 
         float dashPattern1[2] = {20, 10};
         shape4->strokeDash(dashPattern1, 2);
-        canvas->push(shape4);
+        root->push(shape4);
 
         auto shape5 = tvg::Shape::gen();
         shape5->moveTo(270, 230);
@@ -96,7 +96,7 @@ struct UserExample : tvgexam::Example
 
         float dashPattern2[2] = {10, 10};
         shape5->strokeDash(dashPattern2, 2);
-        canvas->push(shape5);
+        root->push(shape5);
 
         auto shape6 = tvg::Shape::gen();
         shape6->moveTo(520, 230);
@@ -111,7 +111,7 @@ struct UserExample : tvgexam::Example
 
         float dashPattern3[6] = {10, 10, 1, 8, 1, 10};
         shape6->strokeDash(dashPattern3, 6);
-        canvas->push(shape6);
+        root->push(shape6);
 
         //Closed Shape Stroke
         auto shape7 = tvg::Shape::gen();
@@ -123,7 +123,7 @@ struct UserExample : tvgexam::Example
         shape7->strokeWidth(15);
         shape7->strokeJoin(tvg::StrokeJoin::Round);
         shape7->strokeCap(tvg::StrokeCap::Round);
-        canvas->push(shape7);
+        root->push(shape7);
 
         auto shape8 = tvg::Shape::gen();
         shape8->moveTo(320, 440);
@@ -134,7 +134,7 @@ struct UserExample : tvgexam::Example
         shape8->strokeWidth(15);
         shape8->strokeJoin(tvg::StrokeJoin::Bevel);
         shape8->strokeCap(tvg::StrokeCap::Square);
-        canvas->push(shape8);
+        root->push(shape8);
 
         auto shape9 = tvg::Shape::gen();
         shape9->moveTo(570, 440);
@@ -145,7 +145,7 @@ struct UserExample : tvgexam::Example
         shape9->strokeWidth(15);
         shape9->strokeJoin(tvg::StrokeJoin::Miter);
         shape9->strokeCap(tvg::StrokeCap::Butt);
-        canvas->push(shape9);
+        root->push(shape9);
 
         //Stroke Dash for Circle and Rect
         auto shape10 = tvg::Shape::gen();
@@ -156,7 +156,7 @@ struct UserExample : tvgexam::Example
         shape10->strokeJoin(tvg::StrokeJoin::Round);
         shape10->strokeCap(tvg::StrokeCap::Round);
         shape10->strokeDash(dashPattern1, 2);
-        canvas->push(shape10);
+        root->push(shape10);
 
         auto shape11 = tvg::Shape::gen();
         shape11->appendCircle(320, 700, 20, 60);
@@ -166,7 +166,7 @@ struct UserExample : tvgexam::Example
         shape11->strokeJoin(tvg::StrokeJoin::Bevel);
         shape11->strokeCap(tvg::StrokeCap::Square);
         shape11->strokeDash(dashPattern2, 2);
-        canvas->push(shape11);
+        root->push(shape11);
 
         auto shape12 = tvg::Shape::gen();
         shape12->appendCircle(570, 700, 20, 60);
@@ -176,7 +176,7 @@ struct UserExample : tvgexam::Example
         shape12->strokeJoin(tvg::StrokeJoin::Miter);
         shape12->strokeCap(tvg::StrokeCap::Butt);
         shape12->strokeDash(dashPattern3, 6);
-        canvas->push(shape12);
+        root->push(shape12);
 
         //Zero length Dashes
         float dashPattern[] = {0, 20};
@@ -189,7 +189,7 @@ struct UserExample : tvgexam::Example
         shape13->strokeDash(dashPattern, 2);
         shape13->strokeJoin(tvg::StrokeJoin::Round);
         shape13->strokeCap(tvg::StrokeCap::Round);
-        canvas->push(shape13);
+        root->push(shape13);
 
         auto shape14 = tvg::Shape::gen();
         shape14->appendCircle(320, 850, 20, 60);
@@ -199,7 +199,7 @@ struct UserExample : tvgexam::Example
         shape14->strokeDash(dashPattern, 2);
         shape14->strokeJoin(tvg::StrokeJoin::Bevel);
         shape14->strokeCap(tvg::StrokeCap::Square);
-        canvas->push(shape14);
+        root->push(shape14);
 
         auto shape15 = tvg::Shape::gen();
         shape15->appendCircle(570, 850, 20, 60);
@@ -209,7 +209,7 @@ struct UserExample : tvgexam::Example
         shape15->strokeDash(dashPattern, 2);
         shape15->strokeJoin(tvg::StrokeJoin::Miter);
         shape15->strokeCap(tvg::StrokeCap::Butt);  //butt has no cap expansions, so no visible
-        canvas->push(shape15);
+        root->push(shape15);
 
         return true;
     }

--- a/examples/StrokeMiterlimit.cpp
+++ b/examples/StrokeMiterlimit.cpp
@@ -28,14 +28,14 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //background
         {
             auto bg = tvg::Shape::gen();
             bg->appendRect(0, 0, w, h);    //x, y, w, h
             bg->fill(200, 200, 255);       //r, g, b
-            canvas->push(bg);
+            root->push(bg);
         }
 
         //wild
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
             static float ml = path->strokeMiterlimit();
             cout << "stroke miterlimit = " << ml << endl;
 
-            canvas->push(path);
+            root->push(path);
         }
 
         //blueprint
@@ -78,7 +78,7 @@ struct UserExample : tvgexam::Example
 
             picture->opacity(42);
             picture->translate(24, 0);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         //svg
@@ -138,7 +138,7 @@ struct UserExample : tvgexam::Example
             auto picture = tvg::Picture::gen();
             if (!tvgexam::verify(picture->load(svgText.data(), svgText.size(), "svg", "", true))) return false;
             picture->scale(20);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         return true;

--- a/examples/Svg.cpp
+++ b/examples/Svg.cpp
@@ -63,7 +63,7 @@ struct UserExample : tvgexam::Example
         counter++;
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //The default font for fallback in case
         tvg::Text::load(EXAMPLE_DIR"/font/Arial.ttf");
@@ -73,7 +73,7 @@ struct UserExample : tvgexam::Example
         shape->appendRect(0, 0, w, h);
         shape->fill(255, 255, 255);
 
-        canvas->push(shape);
+        root->push(shape);
 
         this->w = w;
         this->h = h;
@@ -86,7 +86,7 @@ struct UserExample : tvgexam::Example
            This allows time for the tvg resources to finish loading;
            otherwise, you can push pictures immediately. */
         for (auto& paint : pictures) {
-            canvas->push(paint);
+            root->push(paint);
         }
 
         pictures.clear();

--- a/examples/Text.cpp
+++ b/examples/Text.cpp
@@ -28,13 +28,13 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Background
         auto shape = tvg::Shape::gen();
         shape->appendRect(0, 0, w, h);
         shape->fill(75, 75, 75);
-        canvas->push(shape);
+        root->push(shape);
 
         //Load a necessary font data.
         //The loaded font will be released when the Initializer::term() is called.
@@ -62,7 +62,7 @@ struct UserExample : tvgexam::Example
         text->size(80);
         text->text("THORVG Text");
         text->fill(255, 255, 255);
-        canvas->push(text);
+        root->push(text);
 
         auto text2 = tvg::Text::gen();
         text2->font("Arial");
@@ -71,7 +71,7 @@ struct UserExample : tvgexam::Example
         text2->text("Font = \"Arial\", Size = 40, Style = Italic");
         text2->translate(0, 150);
         text2->fill(255, 255, 255);
-        canvas->push(text2);
+        root->push(text2);
 
         auto text3 = tvg::Text::gen();
         text3->font(nullptr);  //Use any font
@@ -79,7 +79,7 @@ struct UserExample : tvgexam::Example
         text3->text("Kerning Test: VA, AV, TJ, JT");
         text3->fill(255, 255, 255);
         text3->translate(0, 225);
-        canvas->push(text3);
+        root->push(text3);
 
         auto text4 = tvg::Text::gen();
         text4->font("Arial");
@@ -87,7 +87,7 @@ struct UserExample : tvgexam::Example
         text4->text("Purple Text");
         text4->fill(255, 0, 255);
         text4->translate(0, 310);
-        canvas->push(text4);
+        root->push(text4);
 
         auto text5 = tvg::Text::gen();
         text5->font("Arial");
@@ -95,7 +95,7 @@ struct UserExample : tvgexam::Example
         text5->text("Gray Text");
         text5->fill(150, 150, 150);
         text5->translate(220, 310);
-        canvas->push(text5);
+        root->push(text5);
 
         auto text6 = tvg::Text::gen();
         text6->font("Arial");
@@ -103,7 +103,7 @@ struct UserExample : tvgexam::Example
         text6->text("Yellow Text");
         text6->fill(255, 255, 0);
         text6->translate(400, 310);
-        canvas->push(text6);
+        root->push(text6);
 
         auto text7 = tvg::Text::gen();
         text7->font("NOTO-SANS-KR");
@@ -112,7 +112,7 @@ struct UserExample : tvgexam::Example
         text7->fill(0, 0, 0);
         text7->translate(600, 400);
         text7->rotate(30);
-        canvas->push(text7);
+        root->push(text7);
 
         auto text8 = tvg::Text::gen();
         text8->font("NOTO-SANS-KR");
@@ -121,7 +121,7 @@ struct UserExample : tvgexam::Example
         text8->text("Transformed Text - 90'");
         text8->translate(600, 400);
         text8->rotate(90);
-        canvas->push(text8);
+        root->push(text8);
 
         auto text9 = tvg::Text::gen();
         text9->font("NOTO-SANS-KR");
@@ -130,7 +130,7 @@ struct UserExample : tvgexam::Example
         text9->text("Transformed Text - 180'");
         text9->translate(800, 400);
         text9->rotate(180);
-        canvas->push(text9);
+        root->push(text9);
 
         //gradient texts
         float x, y, w2, h2;
@@ -155,7 +155,7 @@ struct UserExample : tvgexam::Example
 
         text10->translate(0, 350);
 
-        canvas->push(text10);
+        root->push(text10);
 
         auto text11 = tvg::Text::gen();
         text11->font("NanumGothicCoding");
@@ -179,7 +179,7 @@ struct UserExample : tvgexam::Example
 
         text11->translate(0, 450);
 
-        canvas->push(text11);
+        root->push(text11);
 
         auto text12 = tvg::Text::gen();
         text12->font("SentyCloud");
@@ -188,7 +188,7 @@ struct UserExample : tvgexam::Example
         text12->outline(3, 255, 200, 200);
         text12->text("\xe4\xb8\x8d\xe5\x88\xb0\xe9\x95\xbf\xe5\x9f\x8e\xe9\x9d\x9e\xe5\xa5\xbd\xe6\xb1\x89\xef\xbc\x81");
         text12->translate(0, 525);
-        canvas->push(text12);
+        root->push(text12);
 
         auto text13 = tvg::Text::gen();
         text13->font("Arial");
@@ -196,7 +196,7 @@ struct UserExample : tvgexam::Example
         text13->fill(255, 255, 255);
         text13->text("LINE-FEED TEST. THIS IS THE FIRST LINE - \nTHIS IS THE SECOND LINE.");
         text13->translate(0, 625);
-        canvas->push(text13);
+        root->push(text13);
 
         auto text14 = tvg::Text::gen();
         text14->font("Arial");
@@ -205,7 +205,7 @@ struct UserExample : tvgexam::Example
         text14->spacing(1.5f, 1.5f);
         text14->text("1.5x SPACING TEST. THIS IS THE FIRST LINE - \nTHIS IS THE SECOND LINE.");
         text14->translate(0, 700);
-        canvas->push(text14);
+        root->push(text14);
 
         return true;
     }

--- a/examples/TextLayout.cpp
+++ b/examples/TextLayout.cpp
@@ -32,7 +32,7 @@ struct UserExample : tvgexam::Example
     static constexpr int HEIGHT = 800;
 
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         if (!tvgexam::verify(tvg::Text::load(EXAMPLE_DIR"/font/NOTO-SANS-KR.ttf"))) return false;
 
@@ -58,7 +58,7 @@ struct UserExample : tvgexam::Example
         lines->close();
         lines->moveTo(900, 0);
         lines->lineTo(900, h);
-        canvas->push(lines);
+        root->push(lines);
 
         auto fontSize = 15.0f;
         w -= border * 2.0f;
@@ -74,7 +74,7 @@ struct UserExample : tvgexam::Example
             text->layout(w, h);
             text->text("Top-Left");
             text->fill(255, 255, 255);
-            canvas->push(text);
+            root->push(text);
         }
 
         //top center
@@ -87,7 +87,7 @@ struct UserExample : tvgexam::Example
             text->layout(w, h);
             text->text("Top-Center");
             text->fill(255, 255, 255);
-            canvas->push(text);
+            root->push(text);
         }
 
         //top right
@@ -100,7 +100,7 @@ struct UserExample : tvgexam::Example
             text->layout(w, h);
             text->text("Top-End");
             text->fill(255, 255, 255);
-            canvas->push(text);
+            root->push(text);
         }
 
         //middle left
@@ -113,7 +113,7 @@ struct UserExample : tvgexam::Example
             text->layout(w, h);
             text->text("Middle-Left");
             text->fill(255, 255, 255);
-            canvas->push(text);
+            root->push(text);
         }
 
         //middle center
@@ -126,7 +126,7 @@ struct UserExample : tvgexam::Example
             text->layout(w, h);
             text->text("Middle-Center");
             text->fill(255, 255, 255);
-            canvas->push(text);
+            root->push(text);
         }
 
         //middle right
@@ -139,7 +139,7 @@ struct UserExample : tvgexam::Example
             text->layout(w, h);
             text->text("Middle-End");
             text->fill(255, 255, 255);
-            canvas->push(text);
+            root->push(text);
         }
 
         //bottom left
@@ -152,7 +152,7 @@ struct UserExample : tvgexam::Example
             text->layout(w, h);
             text->text("Bottom-Left");
             text->fill(255, 255, 255);
-            canvas->push(text);
+            root->push(text);
         }
 
         //bottom center
@@ -165,7 +165,7 @@ struct UserExample : tvgexam::Example
             text->layout(w, h);
             text->text("Bottom-Center");
             text->fill(255, 255, 255);
-            canvas->push(text);
+            root->push(text);
         }
 
         //bottom right
@@ -178,7 +178,7 @@ struct UserExample : tvgexam::Example
             text->layout(w, h);
             text->text("Bottom-End");
             text->fill(255, 255, 255);
-            canvas->push(text);
+            root->push(text);
         }
 
         //origin
@@ -193,7 +193,7 @@ struct UserExample : tvgexam::Example
             text->fill(255, 255, 255);
             text->translate(900, 200 + i * 100);
             text->align(alignments[i].x, alignments[i].y);
-            canvas->push(text);
+            root->push(text);
         }
 
         return true;

--- a/examples/TextLineWrap.cpp
+++ b/examples/TextLineWrap.cpp
@@ -30,7 +30,7 @@ struct UserExample : tvgexam::Example
 {
     tvg::Point size = {230.0f, 120.0f};
 
-    void guide(tvg::Canvas* canvas, const char* title, float x, float y)
+    void guide(tvg::Scene* root, const char* title, float x, float y)
     {
         auto txt = tvg::Text::gen();
         txt->font("NOTO-SANS-KR");
@@ -38,16 +38,16 @@ struct UserExample : tvgexam::Example
         txt->size(12);
         txt->text(title);
         txt->fill(200, 200, 200);
-        canvas->push(txt);
+        root->push(txt);
 
         auto lines = tvg::Shape::gen();
         lines->strokeFill(100, 100, 100);
         lines->strokeWidth(1);
         lines->appendRect(x, y + 30.0f, size.x, size.y);
-        canvas->push(lines);
+        root->push(lines);
     }
 
-    void text(tvg::Canvas* canvas, const char* content, const tvg::Point& pos, const tvg::Point& align, tvg::TextWrap wrapMode)
+    void text(tvg::Scene* root, const char* content, const tvg::Point& pos, const tvg::Point& align, tvg::TextWrap wrapMode)
     {
         auto txt = tvg::Text::gen();
         txt->font("NOTO-SANS-KR");
@@ -58,52 +58,52 @@ struct UserExample : tvgexam::Example
         txt->align(align.x, align.y);
         txt->wrap(wrapMode);
         txt->fill(255, 255, 255);
-        canvas->push(txt);
+        root->push(txt);
     }
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         if (!tvgexam::verify(tvg::Text::load(EXAMPLE_DIR"/font/NOTO-SANS-KR.ttf"))) return false;
 
         auto character = "TextWrap::Character";
-        guide(canvas, character, 25.0f, 25.0f);
-        text(canvas, "This is a lengthy text used to test line wrapping with top-left.", {25.0f, 25.0f}, {0.0f, 0.0f}, tvg::TextWrap::Character);
+        guide(root, character, 25.0f, 25.0f);
+        text(root, "This is a lengthy text used to test line wrapping with top-left.", {25.0f, 25.0f}, {0.0f, 0.0f}, tvg::TextWrap::Character);
 
-        guide(canvas, character, 290.0f, 25.0f);
-        text(canvas, "This is a lengthy text used to test line wrapping with middle-center.", {290.0f, 25.0f}, {0.5f, 0.5f}, tvg::TextWrap::Character);
+        guide(root, character, 290.0f, 25.0f);
+        text(root, "This is a lengthy text used to test line wrapping with middle-center.", {290.0f, 25.0f}, {0.5f, 0.5f}, tvg::TextWrap::Character);
 
-        guide(canvas, character, 550.0f, 25.0f);
-        text(canvas, "This is a lengthy text used to test line wrapping with bottom-right.", {550.0f, 25.0f}, {1.0f, 1.0f}, tvg::TextWrap::Character);
+        guide(root, character, 550.0f, 25.0f);
+        text(root, "This is a lengthy text used to test line wrapping with bottom-right.", {550.0f, 25.0f}, {1.0f, 1.0f}, tvg::TextWrap::Character);
 
         auto word = "TextWrap::Word";
-        guide(canvas, word, 25.0f, 195.0f);
-        text(canvas, "An extreame-long-length-word to test with top-left.", {25.0f, 195.0f}, {0.0f, 0.0f}, tvg::TextWrap::Word);
+        guide(root, word, 25.0f, 195.0f);
+        text(root, "An extreame-long-length-word to test with top-left.", {25.0f, 195.0f}, {0.0f, 0.0f}, tvg::TextWrap::Word);
 
-        guide(canvas, word, 290.0f, 195.0f);
-        text(canvas, "An extreame-long-length-word to test with middle-center.", {290.0f, 195.0f}, {0.5f, 0.5f}, tvg::TextWrap::Word);
+        guide(root, word, 290.0f, 195.0f);
+        text(root, "An extreame-long-length-word to test with middle-center.", {290.0f, 195.0f}, {0.5f, 0.5f}, tvg::TextWrap::Word);
 
-        guide(canvas, word, 550.0f, 195.0f);
-        text(canvas, "An extreame-long-length-word to test with bottom-right.", {550.0f, 195.0f}, {1.0f, 1.0f}, tvg::TextWrap::Word);
+        guide(root, word, 550.0f, 195.0f);
+        text(root, "An extreame-long-length-word to test with bottom-right.", {550.0f, 195.0f}, {1.0f, 1.0f}, tvg::TextWrap::Word);
 
         auto smart = "TextWrap::Smart";
-        guide(canvas, smart, 25.0f, 365.0f);
-        text(canvas, "An extreame-long-length-word to test with top-left.", {25.0f, 365.0f}, {0.0f, 0.0f}, tvg::TextWrap::Smart);
+        guide(root, smart, 25.0f, 365.0f);
+        text(root, "An extreame-long-length-word to test with top-left.", {25.0f, 365.0f}, {0.0f, 0.0f}, tvg::TextWrap::Smart);
 
-        guide(canvas, smart, 290.0f, 365.0f);
-        text(canvas, "An extreame-long-length-word to test with middle-center.", {290.0f, 365.0f}, {0.5f, 0.5f}, tvg::TextWrap::Smart);
+        guide(root, smart, 290.0f, 365.0f);
+        text(root, "An extreame-long-length-word to test with middle-center.", {290.0f, 365.0f}, {0.5f, 0.5f}, tvg::TextWrap::Smart);
 
-        guide(canvas, smart, 550.0f, 365.0f);
-        text(canvas, "An extreame-long-length-word to test with bottom-right.", {550.0f, 365.0f}, {1.0f, 1.0f}, tvg::TextWrap::Smart);
+        guide(root, smart, 550.0f, 365.0f);
+        text(root, "An extreame-long-length-word to test with bottom-right.", {550.0f, 365.0f}, {1.0f, 1.0f}, tvg::TextWrap::Smart);
 
         auto ellipsis = "TextWrap::Ellipsis";
-        guide(canvas, ellipsis, 25.0f, 535.0f);
-        text(canvas, "This is a lengthy text used to test line wrapping with top-left.", {25.0f, 535.0f}, {0.0f, 0.0f}, tvg::TextWrap::Ellipsis);
+        guide(root, ellipsis, 25.0f, 535.0f);
+        text(root, "This is a lengthy text used to test line wrapping with top-left.", {25.0f, 535.0f}, {0.0f, 0.0f}, tvg::TextWrap::Ellipsis);
 
-        guide(canvas, ellipsis, 290.0f, 535.0f);
-        text(canvas, "This is a lengthy text used to test line wrapping with middle-center.", {290.0f, 535.0f}, {0.5f, 0.5f}, tvg::TextWrap::Ellipsis);
+        guide(root, ellipsis, 290.0f, 535.0f);
+        text(root, "This is a lengthy text used to test line wrapping with middle-center.", {290.0f, 535.0f}, {0.5f, 0.5f}, tvg::TextWrap::Ellipsis);
 
-        guide(canvas, ellipsis, 550.0f, 535.0f);
-        text(canvas, "This is a lengthy text used to test line wrapping with bottom-right.", {550.0f, 535.0f}, {1.0f, 1.0f}, tvg::TextWrap::Ellipsis);
+        guide(root, ellipsis, 550.0f, 535.0f);
+        text(root, "This is a lengthy text used to test line wrapping with bottom-right.", {550.0f, 535.0f}, {1.0f, 1.0f}, tvg::TextWrap::Ellipsis);
 
         return true;
     }

--- a/examples/Transform.cpp
+++ b/examples/Transform.cpp
@@ -28,14 +28,14 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, root, 0);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
-        if (!tvgexam::verify(canvas->remove())) return false;
+        root->remove();
 
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 
@@ -50,7 +50,7 @@ struct UserExample : tvgexam::Example
         shape->scale(1.0f - 0.75f * progress);
         shape->rotate(360 * progress);
 
-        canvas->push(shape);
+        root->push(shape);
 
         //Shape2
         auto shape2 = tvg::Shape::gen();
@@ -59,7 +59,7 @@ struct UserExample : tvgexam::Example
         shape2->translate(480, 480);
         shape2->rotate(360 * progress);
         shape2->translate(400 + progress * 300, 400);
-        canvas->push(shape2);
+        root->push(shape2);
 
         //Shape3
         auto shape3 = tvg::Shape::gen();
@@ -71,7 +71,7 @@ struct UserExample : tvgexam::Example
         shape3->translate(560, 560);
         shape3->rotate(-360.0f * progress);
         shape3->scale(0.5f + progress);
-        canvas->push(shape3);
+        root->push(shape3);
 
         return true;
     }

--- a/examples/TrimPath.cpp
+++ b/examples/TrimPath.cpp
@@ -28,7 +28,7 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Shape 1
         auto shape1 = tvg::Shape::gen();
@@ -52,8 +52,8 @@ struct UserExample : tvgexam::Example
         shape2->strokeDash(dashPatterns, 2, 10);
         shape2->trimpath(0.25f, 0.75f, true);
 
-        canvas->push(shape1);
-        canvas->push(shape2);
+        root->push(shape1);
+        root->push(shape2);
 
         return true;
     }

--- a/examples/Update.cpp
+++ b/examples/Update.cpp
@@ -28,20 +28,19 @@
 
 struct UserExample : tvgexam::Example
 {
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //Shape
         auto shape = tvg::Shape::gen();
         shape->appendRect(-100, -100, 200, 200);
-        shape->fill(255, 255, 255);
-        canvas->push(shape);
+        root->push(shape);
 
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
-        if (!tvgexam::verify(canvas->remove())) return false;
+        root->remove();
 
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 
@@ -53,7 +52,7 @@ struct UserExample : tvgexam::Example
         shape->scale(1.0f - 0.75f * progress);
         shape->rotate(360.0f * progress);
 
-        canvas->push(shape);
+        root->push(shape);
 
         return true;
     }

--- a/examples/Viewport.cpp
+++ b/examples/Viewport.cpp
@@ -32,7 +32,7 @@ struct UserExample : tvgexam::Example
     uint32_t w, h;
     tvg::Picture* picture = nullptr;
 
-    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
+    bool content(tvg::Canvas* canvas, tvg::Scene* root, uint32_t w, uint32_t h) override
     {
         //set viewport before canvas become dirty.
         if (!tvgexam::verify(canvas->viewport(0, 0, VPORT_SIZE, VPORT_SIZE))) return false;
@@ -47,7 +47,7 @@ struct UserExample : tvgexam::Example
         if (!tvgexam::verify(picture->load(EXAMPLE_DIR"/svg/tiger.svg"))) return false;
         picture->size(w, h);
         picture->mask(mask, tvg::MaskMethod::Alpha);
-        canvas->push(picture);
+        root->push(picture);
 
         this->w = w;
         this->h = h;
@@ -55,7 +55,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, tvg::Scene* root, uint32_t elapsed) override
     {
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 


### PR DESCRIPTION
The existing example fixed the canvas to the size specified in the window. 
So, even when the window size changed, the example did not resized, and noise appeared in the background.

Add a root scene(and background) at the top of paint tree added to the canvas. When the window size changes, adjust it to fit the new window size. Output it by fixing the aspect ratio based on the initial size.

+) Tested on sw, gl, not tested on wg.