### PR TITLE
gl: Skip stencil usage for convex GL fills

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -93,6 +93,7 @@ struct GlGeometry
     RenderRegion bounds = {};
     FillRule fillRule = FillRule::NonZero;
     RenderPath optPath;  //optimal path
+    bool convex;
 };
 
 

--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -150,6 +150,7 @@ void GlGeometry::prepare(const RenderShape& rshape)
 bool GlGeometry::tesselateShape(const RenderShape& rshape, float* opacityMultiplier)
 {
     fill.clear();
+    convex = false;
 
     // When the CTM scales a filled path so small that its device-space
     // World:  [========]     // normal-sized filled path
@@ -172,6 +173,7 @@ bool GlGeometry::tesselateShape(const RenderShape& rshape, float* opacityMultipl
     bwTess.tessellate(optPath, matrix);
     fillRule = rshape.rule;
     bounds = bwTess.bounds();
+    convex = bwTess.convex;
     if (opacityMultiplier) *opacityMultiplier = 1.0f;
     return true;
 }
@@ -287,6 +289,7 @@ GlStencilMode GlGeometry::getStencilMode(RenderUpdateFlag flag)
     if (flag & RenderUpdateFlag::GradientStroke) return GlStencilMode::Stroke;
     if (flag & RenderUpdateFlag::Image) return GlStencilMode::None;
 
+    if (convex) return GlStencilMode::None;
     if (fillRule == FillRule::NonZero) return GlStencilMode::FillNonZero;
     if (fillRule == FillRule::EvenOdd) return GlStencilMode::FillEvenOdd;
 

--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -444,48 +444,75 @@ void BWTessellator::tessellate(const RenderPath& path, const Matrix& matrix)
     mBuffer->vertex.reserve(ptsCnt * 2);
     mBuffer->index.reserve((ptsCnt - 2) * 3);
 
+    auto updateConvexity = [&](const Point& edge) {
+        if (!convex) return;
+        if (prevEdge.x == 0.0f && prevEdge.y == 0.0f) { prevEdge = edge; return; }
+        auto c = cross(prevEdge, edge);
+        if (zero(c)) { prevEdge = edge; return; }
+        auto sign = (c > 0) ? 1 : -1;
+        if (winding == 0) winding = sign; // The default winding is CCW, but it might be otherwise once we support unordered points.
+        else if (sign != winding) convex = false;
+        prevEdge = edge;
+    };
+
     for (uint32_t i = 0; i < cmdCnt; i++) {
         switch(cmds[i]) {
             case PathCommand::MoveTo: {
                 firstIndex = pushVertex(pts->x, pts->y);
+                firstPt = prevPt = *pts;
+                prevEdge = {};
                 prevIndex = 0;
                 pts++;
             } break;
             case PathCommand::LineTo: {
                 if (prevIndex == 0) {
                     prevIndex = pushVertex(pts->x, pts->y);
-                    pts++;
+                    prevEdge = *pts - prevPt;
+                    prevPt = *pts++;
                 } else {
+                    updateConvexity(*pts - prevPt);
                     auto currIndex = pushVertex(pts->x, pts->y);
                     pushTriangle(firstIndex, prevIndex, currIndex);
                     prevIndex = currIndex;
-                    pts++;
+                    prevPt = *pts++;
                 }
             } break;
             case PathCommand::CubicTo: {
                 Bezier curve{pts[-1], pts[0], pts[1], pts[2]};
+                if (convex) {
+                    auto e1 = curve.ctrl1 - curve.start;
+                    auto e2 = curve.ctrl2 - curve.ctrl1;
+                    auto e3 = curve.end - curve.ctrl2;
+                    if (prevIndex != 0) updateConvexity(e1);
+                    else prevEdge = e1;
+                    updateConvexity(e2);
+                    updateConvexity(e3);
+                }
 
                 auto stepCount = (curve * matrix).segments();
                 if (stepCount <= 1) stepCount = 2;
-
                 float step = 1.f / stepCount;
 
                 for (uint32_t s = 1; s <= static_cast<uint32_t>(stepCount); s++) {
                     auto pt = curve.at(step * s);
                     auto currIndex = pushVertex(pt.x, pt.y);
-
-                    if (prevIndex == 0) {
-                        prevIndex = currIndex;
-                        continue;
-                    }
-
+                    if (prevIndex == 0) { prevIndex = currIndex; continue; }
                     pushTriangle(firstIndex, prevIndex, currIndex);
                     prevIndex = currIndex;
                 }
-
+                prevPt = curve.end;
                 pts += 3;
             } break;
-            case PathCommand::Close:
+            case PathCommand::Close: {
+                if (convex && prevIndex != 0) {
+                    updateConvexity(firstPt - prevPt);
+                    if (convex && winding != 0) {
+                        auto& v = mBuffer->vertex;
+                        auto secondPt = Point{v[firstIndex * 2 + 2], v[firstIndex * 2 + 3]};
+                        updateConvexity(secondPt - firstPt);
+                    }
+                }
+            } break;
             default:
                 break;
         }

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -80,6 +80,7 @@ public:
     BWTessellator(GlGeometryBuffer* buffer);
     void tessellate(const RenderPath& path, const Matrix& matrix);
     RenderRegion bounds() const;
+    bool convex = true;
 
 private:
     uint32_t pushVertex(float x, float y);
@@ -87,6 +88,10 @@ private:
 
     GlGeometryBuffer* mBuffer;
     BBox bbox = {};
+    Point firstPt = {};
+    Point prevPt = {};
+    Point prevEdge = {};
+    int8_t winding = -1;   //0: unknown, 1: CW, -1: CCW
 };
 
 }  // namespace tvg


### PR DESCRIPTION
To skip the stencil for convex GL fills, we track convexity during tessellation and expose this information through `GlGeometry::isConvex()`. Convex shapes can now be rendered with direct fills instead of stencil passes, which reduces overall workload.

Key changes include:

- Tracking winding and convexity in `tvgGlTessellator` while building paths and propagating this data to `GlGeometry`.
- Adding `isConvex()` to `GlGeometry` to allow us to bypass stencil mode for convex fills.
- Keeping non-convex paths unchanged to maintain correct winding behavior.

Performance improvements:

- Speedup of 31% FPS in one specific case:
  <img width="384.5" height="392.25" alt="image" src="https://github.com/user-attachments/assets/061c6708-8462-46f1-a437-d7d6863926f5" />

- Speedup of 6% FPS in the `Lottie` example.

- Reduced Graphic API calls by 32.1% in one specific case:
  <img width="442" height="156" alt="image" src="https://github.com/user-attachments/assets/e39ea788-2dfd-4d93-a0c3-d843706cfbe6" />

No regressions were found in any examples or previously problematic test files.