### PR TITLE
gl: convert straight alpha to premultiplied alpha on texture upload

### DIFF
--- a/src/renderer/gpu_engine/gl/meson.build
+++ b/src/renderer/gpu_engine/gl/meson.build
@@ -42,7 +42,14 @@ else
     compiler_flags += ['-DTHORVG_GL_TARGET_GL=1']
 endif
 
+omp_dep = []
+
+if openmp
+    omp_dep = dependency('openmp', required: false)
+endif
+
 engine_dep += [declare_dependency(
     include_directories : include_directories('.'),
+    dependencies        : omp_dep,
     sources             : source_file,
 )]

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -1261,6 +1261,16 @@ void GlRenderer::dispose(RenderData data)
     delete sdata;
 }
 
+static ColorSpace _textureColorSpace(const RenderSurface* image)
+{
+    if (!image->premultiplied && image->channelSize == sizeof(uint32_t)) {
+        if (image->cs == ColorSpace::ABGR8888S) return ColorSpace::ABGR8888;
+        if (image->cs == ColorSpace::ARGB8888S) return ColorSpace::ARGB8888;
+        TVGERR("GL_ENGINE", "Unsupported Colorspace(%d) is expected for GL engine!", (int) image->cs);
+    }
+    return image->cs;
+}
+
 RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matrix& transform, const Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags)
 {
     if (opacity == 0) return data;
@@ -1288,7 +1298,7 @@ RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matr
         TextureMgr::upload(sdata->texId, image, filter);
     }
 
-    sdata->texColorSpace = image->cs;
+    sdata->texColorSpace = _textureColorSpace(image);
     sdata->texFlipY = 1;
     sdata->opacity = opacity;
     sdata->geometry.setMatrix(transform);

--- a/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
@@ -353,9 +353,9 @@ const char* IMAGE_FRAG_SHADER = TVG_COMPOSE_SHADER(
         } else if (uColorInfo.format == 1) { /* FMT_ARGB8888 */                             \n
             result = color.bgra;                                                            \n
         } else if (uColorInfo.format == 2) { /* FMT_ABGR8888S */                            \n
-            result = vec4(color.rgb * color.a, color.a);                                    \n
+            result = vec4(color.rgb * color.a, color.a); /*Forbidden in GL*/                \n
         } else if (uColorInfo.format == 3) { /* FMT_ARGB8888S */                            \n
-            result = vec4(color.bgr * color.a, color.a);                                    \n
+            result = vec4(color.bgr * color.a, color.a); /*Forbidden in GL*/                \n
         }                                                                                   \n
         FragColor = result * float(uColorInfo.opacity) / 255.0;                             \n
    }                                                                                        \n

--- a/src/renderer/gpu_engine/gl/tvgGlTextureMgr.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlTextureMgr.cpp
@@ -22,6 +22,17 @@
 
 #include "tvgGlTextureMgr.h"
 
+static inline uint32_t _premultiply(uint32_t c)
+{
+    auto a = (c >> 24);
+    return (c & 0xff000000) + ((((c >> 8) & 0xff) * a) & 0xff00) + ((((c & 0x00ff00ff) * a) >> 8) & 0x00ff00ff);
+}
+
+static inline bool _needsPremultiply(const RenderSurface* surface)
+{
+    return !surface->premultiplied && surface->channelSize == sizeof(uint32_t);
+}
+
 TextureMgr::SurfaceEntry* TextureMgr::find(const RenderSurface* surface)
 {
     INLIST_FOREACH(surfaces, entry)
@@ -34,7 +45,24 @@ TextureMgr::SurfaceEntry* TextureMgr::find(const RenderSurface* surface)
 void TextureMgr::upload(GLuint texId, const RenderSurface* surface, FilterMethod filter)
 {
     GL_CHECK(glBindTexture(GL_TEXTURE_2D, texId));
-    GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, surface->w, surface->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, surface->data));
+    if (_needsPremultiply(surface)) {
+        auto buffer = (uint32_t*)malloc(surface->w * surface->h * sizeof(uint32_t));
+        auto h = static_cast<int32_t>(surface->h);
+        #pragma omp parallel for
+        for (int32_t y = 0; y < h; ++y) {
+            auto src = surface->buf32 + surface->stride * y;
+            auto dst = buffer + surface->w * y;
+            for (uint32_t x = 0; x < surface->w; ++x) {
+                auto c = src[x];
+                if ((c >> 24) < 255) dst[x] = _premultiply(c);
+                else dst[x] = c;
+            }
+        }
+        GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, surface->w, surface->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, buffer));
+        free(buffer);
+    } else {
+        GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, surface->w, surface->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, surface->data));
+    }
     GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
     GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));


### PR DESCRIPTION
- Move straight-alpha premultiplication from fragment shader to CPU during texture upload, using a buffered conversion path with OpenMP to keep upload O(n) but off the GPU hot path.
- Set texture color space to premultiplied variants after conversion so downstream pipeline treats uploads consistently.
- Update the GL image shader to indicate there is no long straight color space in the GL image texture.

---

The problematic file in https://github.com/thorvg/thorvg/issues/2863 performs correctly.
<img width="738" height="487" alt="Screenshot 2025-12-05 161721" src="https://github.com/user-attachments/assets/5235cb76-8d6c-4f3f-ab3b-ee70d16f9f7b" />

<img width="1490" height="791" alt="Screenshot 2025-12-05 162111" src="https://github.com/user-attachments/assets/77137c41-49d8-4061-b46f-2b2cda527b26" />

---

- The boot time recorded for the example `PicturePng` shows a difference of less than 1%.
- FPS in Lottie shows a difference of less than 0.05% after 2000 frames.
- Running all examples, particularly `Picture*` and `Image*` is not observed significant regression.


Related issues #4041