### PR TITLE
examples: Enhance update() of examples

### DIFF
--- a/examples/Animation.cpp
+++ b/examples/Animation.cpp
@@ -61,7 +61,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         auto progress = tvgexam::progress(elapsed, animation->duration());
 

--- a/examples/CustomTransform.cpp
+++ b/examples/CustomTransform.cpp
@@ -30,10 +30,10 @@ struct UserExample : tvgexam::Example
 {
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, 0, w, h);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         if (!tvgexam::verify(canvas->remove())) return false;
 

--- a/examples/DirectUpdate.cpp
+++ b/examples/DirectUpdate.cpp
@@ -31,7 +31,7 @@ struct UserExample : tvgexam::Example
     tvg::Shape* solid = nullptr;
     tvg::Shape* gradient = nullptr;
 
-    uint32_t w, h;
+    uint32_t initWidth, initHeight;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
@@ -75,24 +75,24 @@ struct UserExample : tvgexam::Example
             canvas->push(gradient);
         }
 
-        this->w = w;
-        this->h = h;
+        this->initWidth = w;
+        this->initHeight = h;
 
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 
         //Reset Shape
         if (tvgexam::verify(solid->reset())) {
             //Solid Shape
-            solid->appendRect(-100 + (w * progress), -100 + (h * progress), 200, 200, (100 * progress), (100 * progress));
+            solid->appendRect(-100 + (initWidth * progress), -100 + (initHeight * progress), 200, 200, (100 * progress), (100 * progress));
             solid->strokeWidth(30 * progress);
 
             //Gradient Shape
-            gradient->translate(-(w * progress), (h * progress));
+            gradient->translate(-(initWidth * progress), (initHeight * progress));
 
             canvas->update();
 

--- a/examples/EffectDropShadow.cpp
+++ b/examples/EffectDropShadow.cpp
@@ -90,7 +90,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         auto progress = tvgexam::progress(elapsed, 2.5f, true);   //2.5 seconds
 

--- a/examples/Example.h
+++ b/examples/Example.h
@@ -68,7 +68,7 @@ struct Example
     uint32_t elapsed = 0;
 
     virtual bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) = 0;
-    virtual bool update(tvg::Canvas* canvas, uint32_t elapsed) { return false; }
+    virtual bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) { return false; }
     virtual bool clickdown(tvg::Canvas* canvas, int32_t x, int32_t y) { return false; }
     virtual bool clickup(tvg::Canvas* canvas, int32_t x, int32_t y) { return false; }
     virtual bool motion(tvg::Canvas* canvas, int32_t x, int32_t y) { return false; }
@@ -291,7 +291,7 @@ struct Window
             }
 
             if (tickCnt > 0) {
-                needDraw |= example->update(canvas, example->elapsed);
+                needDraw |= example->update(canvas, example->elapsed, width, height);
             }
 
             if (needDraw) {

--- a/examples/GradientTransform.cpp
+++ b/examples/GradientTransform.cpp
@@ -30,10 +30,10 @@ struct UserExample : tvgexam::Example
 {
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, 0, w, h);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         tvgexam::verify(canvas->remove());
 

--- a/examples/ImageRotation.cpp
+++ b/examples/ImageRotation.cpp
@@ -50,7 +50,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         picture->scale(0.8f);
         picture->rotate(tvgexam::progress(elapsed, 4.0f) * 360.0f);

--- a/examples/ImageScaling.cpp
+++ b/examples/ImageScaling.cpp
@@ -46,7 +46,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         auto progress = tvgexam::progress(elapsed, 3.0f, true);  //play time 3 secs.
 

--- a/examples/Intersects.cpp
+++ b/examples/Intersects.cpp
@@ -122,7 +122,7 @@ struct UserExample : tvgexam::Example
         return false;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         marquee->translate(mx, my);
 

--- a/examples/Lottie.cpp
+++ b/examples/Lottie.cpp
@@ -32,7 +32,7 @@
 struct UserExample : tvgexam::Example
 {
     std::vector<unique_ptr<tvg::Animation>> animations;
-    uint32_t w, h;
+    uint32_t initWidth, initHeight;
     uint32_t size;
 
     int counter = 0;
@@ -56,7 +56,7 @@ struct UserExample : tvgexam::Example
         float w, h;
         picture->size(&w, &h);
         picture->scale((w > h) ? size / w : size / h);
-        picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + size / 2);
+        picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->initHeight / NUM_PER_COL) + size / 2);
 
         animations.push_back(unique_ptr<tvg::Animation>(animation));
 
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         counter++;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         for (auto& animation : animations) {
             auto progress = tvgexam::progress(elapsed, animation->duration());
@@ -88,8 +88,8 @@ struct UserExample : tvgexam::Example
         shape->fill(75, 75, 75);
         canvas->push(shape);
 
-        this->w = w;
-        this->h = h;
+        this->initWidth = w;
+        this->initHeight = h;
         this->size = w / NUM_PER_ROW;
 
         this->scandir(EXAMPLE_DIR"/lottie");

--- a/examples/LottieExpressions.cpp
+++ b/examples/LottieExpressions.cpp
@@ -32,7 +32,7 @@
 struct UserExample : tvgexam::Example
 {
     std::vector<unique_ptr<tvg::Animation>> animations;
-    uint32_t w, h;
+    uint32_t initWidth, initHeight;
     uint32_t size;
 
     int counter = 0;
@@ -56,7 +56,7 @@ struct UserExample : tvgexam::Example
         float w, h;
         picture->size(&w, &h);
         picture->scale((w > h) ? size / w : size / h);
-        picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + size / 2);
+        picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->initHeight / NUM_PER_COL) + size / 2);
 
         animations.push_back(unique_ptr<tvg::Animation>(animation));
 
@@ -65,7 +65,7 @@ struct UserExample : tvgexam::Example
         counter++;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         for (auto& animation : animations) {
             auto progress = tvgexam::progress(elapsed, animation->duration());
@@ -89,8 +89,8 @@ struct UserExample : tvgexam::Example
 
         canvas->push(shape);
 
-        this->w = w;
-        this->h = h;
+        this->initWidth = w;
+        this->initHeight = h;
         this->size = w / NUM_PER_ROW;
 
         this->scandir(EXAMPLE_DIR"/lottie/expressions");

--- a/examples/LottieExtension.cpp
+++ b/examples/LottieExtension.cpp
@@ -32,7 +32,7 @@ struct UserExample : tvgexam::Example
     vector<unique_ptr<tvg::LottieAnimation>> slots;
     unique_ptr<tvg::LottieAnimation> marker;
     unique_ptr<tvg::LottieAnimation> resolver[2];  //picture, text
-    uint32_t w, h;
+    uint32_t initWidth, initHeight;
     uint32_t size;
 
     void sizing(tvg::Picture* picture, uint32_t counter)
@@ -43,10 +43,10 @@ struct UserExample : tvgexam::Example
         float w, h;
         picture->size(&w, &h);
         picture->scale((w > h) ? size / w : size / h);
-        picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->h / NUM_PER_COL) + size / 2);
+        picture->translate((counter % NUM_PER_ROW) * size + size / 2, (counter / NUM_PER_ROW) * (this->initHeight / NUM_PER_COL) + size / 2);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         //slots
         for (auto& slot : slots) {
@@ -76,8 +76,8 @@ struct UserExample : tvgexam::Example
         bg->fill(75, 75, 75);
         canvas->push(bg);
 
-        this->w = w;
-        this->h = h;
+        this->initWidth = w;
+        this->initHeight = h;
         this->size = w / NUM_PER_ROW;
 
         //slot (default)

--- a/examples/LottieInteraction.cpp
+++ b/examples/LottieInteraction.cpp
@@ -141,7 +141,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         //spinning effect
         if (effect.on) {

--- a/examples/LottieTweening.cpp
+++ b/examples/LottieTweening.cpp
@@ -171,7 +171,7 @@ struct UserExample : tvgexam::Example
         return false;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         //on state tweening
         if (tween.active) return tweening(canvas);

--- a/examples/Particles.cpp
+++ b/examples/Particles.cpp
@@ -39,7 +39,7 @@ struct UserExample : tvgexam::Example
     std::vector<Particle> raindrops;
     std::vector<Particle> clouds;
 
-    uint32_t w, h;
+    uint32_t initWidth, initHeight;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
@@ -90,18 +90,18 @@ struct UserExample : tvgexam::Example
             canvas->push(shape);
         }
 
-        this->w = w;
-        this->h = h;
+        this->initWidth = w;
+        this->initHeight = h;
 
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         for (auto& p : raindrops) {
             p.y += p.speed;
-            if (p.y > h) {
-                p.y -= h;
+            if (p.y > initHeight) {
+                p.y -= initHeight;
             }
             p.obj->translate(p.x, p.y);
         }
@@ -109,7 +109,7 @@ struct UserExample : tvgexam::Example
         for (auto& p : clouds) {
             p.x -= p.speed;
             if (p.x + p.size < 0) {
-                p.x = w;
+                p.x = initWidth;
             }
             p.obj->translate(p.x, p.y);
         }

--- a/examples/PictureSvg.cpp
+++ b/examples/PictureSvg.cpp
@@ -28,6 +28,10 @@
 
 struct UserExample : tvgexam::Example
 {
+    tvg::Scene* root = tvg::Scene::gen();
+    uint32_t initWidth, initHeight;
+    uint32_t beforeWidth = 0, beforeHeight = 0;
+
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
         //The default font for fallback in case
@@ -43,7 +47,7 @@ struct UserExample : tvgexam::Example
             picture->rotate(30 * i);
             picture->size(200, 200);
             picture->opacity(opacity + opacity * i);
-            canvas->push(picture);
+            root->push(picture);
         }
 
         //Open file manually
@@ -63,8 +67,28 @@ struct UserExample : tvgexam::Example
         free(data);
         picture->translate(400, 0);
         picture->scale(0.4);
-        canvas->push(picture);
+        root->push(picture);
 
+        canvas->push(root);
+
+        beforeWidth = initWidth = w;
+        beforeHeight = initHeight = h;
+        return true;
+    }
+
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
+    {
+        if (beforeWidth == width && beforeHeight == height) return false;
+
+        auto scale = 1.0f;
+        if (width > height) scale = (float)height / (float)initHeight;
+        else scale = (float)width / (float)initWidth;
+
+        root->scale(scale);
+        root->translate((width - initWidth * scale) * 0.5f, (height - initHeight * scale) * 0.5f);
+
+        beforeWidth = width;
+        beforeHeight = height;
         return true;
     }
 };

--- a/examples/Retaining.cpp
+++ b/examples/Retaining.cpp
@@ -72,7 +72,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         //update per every 250ms
         //reorder with a circular list

--- a/examples/SceneEffects.cpp
+++ b/examples/SceneEffects.cpp
@@ -93,7 +93,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         auto progress = tvgexam::progress(elapsed, 2.5f, true);   //2.5 seconds
 

--- a/examples/SceneTransform.cpp
+++ b/examples/SceneTransform.cpp
@@ -30,10 +30,10 @@ struct UserExample : tvgexam::Example
 {
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, 0, w, h);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         if (!tvgexam::verify(canvas->remove())) return false;
 

--- a/examples/Transform.cpp
+++ b/examples/Transform.cpp
@@ -30,10 +30,10 @@ struct UserExample : tvgexam::Example
 {
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        return update(canvas, 0);
+        return update(canvas, 0, w, h);
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         if (!tvgexam::verify(canvas->remove())) return false;
 

--- a/examples/Update.cpp
+++ b/examples/Update.cpp
@@ -39,7 +39,7 @@ struct UserExample : tvgexam::Example
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         if (!tvgexam::verify(canvas->remove())) return false;
 

--- a/examples/Viewport.cpp
+++ b/examples/Viewport.cpp
@@ -29,7 +29,7 @@
 struct UserExample : tvgexam::Example
 {
     static constexpr uint32_t VPORT_SIZE = 300;
-    uint32_t w, h;
+    uint32_t initWidth, initHeight;
     tvg::Picture* picture = nullptr;
 
     bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
@@ -49,17 +49,17 @@ struct UserExample : tvgexam::Example
         picture->mask(mask, tvg::MaskMethod::Alpha);
         canvas->push(picture);
 
-        this->w = w;
-        this->h = h;
+        this->initWidth = w;
+        this->initHeight = h;
 
         return true;
     }
 
-    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
+    bool update(tvg::Canvas* canvas, uint32_t elapsed, uint32_t width, uint32_t height) override
     {
         auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.
 
-        if (!tvgexam::verify(canvas->viewport((w - VPORT_SIZE) * progress, (h - VPORT_SIZE) * progress, VPORT_SIZE, VPORT_SIZE))) return false;
+        if (!tvgexam::verify(canvas->viewport((initWidth - VPORT_SIZE) * progress, (initHeight - VPORT_SIZE) * progress, VPORT_SIZE, VPORT_SIZE))) return false;
 
         canvas->update();
 


### PR DESCRIPTION
Add for the window's width and height to the update(). Each example can receive the actual size of the canvas.
The SVG and PictureSVG examples now include an example that adjusts the scale of the content based on the actual size of the Canvas.