### PR TITLE
lottie/expressions: fix wiggle calculation

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -875,17 +875,23 @@ static jerry_value_t _wiggle(const jerry_call_info_t* info, const jerry_value_t 
     auto freq = jerry_value_as_number(args[0]);
     auto amp = jerry_value_as_number(args[1]);
     auto octaves = (argsCnt > 2) ? jerry_value_as_int32(args[2]) : 1;
-    auto ampm = (argsCnt > 3) ? jerry_value_as_number(args[3]) : 5.0f;
+    auto ampm = (argsCnt > 3) ? jerry_value_as_number(args[3]) : 0.5f;
     auto time = (argsCnt > 4) ? jerry_value_as_number(args[4]) : data->exp->comp->timeAtFrame(data->frameNo);
 
-    Point result = {100.0f, 100.0f};
+    Point result = {0.0f, 0.0f};
+    auto property = data->exp->property;
+
+    if (property->type == LottieProperty::Type::Vector) {
+        result = (*static_cast<LottieVector*>(property))(data->frameNo);
+    } else if (property->type == LottieProperty::Type::Scalar) {
+        result = (*static_cast<LottieScalar*>(property))(data->frameNo);
+    }
 
     for (int o = 0; o < octaves; ++o) {
-        auto repeat = int(time * freq);
-        auto frac = (time * freq - float(repeat)) * 1.25f;
+        auto repeat = (int)ceil(time * freq);
         for (int i = 0; i < repeat; ++i) {
-            result.x += (_rand() * 2.0f - 1.0f) * amp * frac;
-            result.y += (_rand() * 2.0f - 1.0f) * amp * frac;
+            result.x += (_rand() * 2.0f - 1.0f) * amp;
+            result.y += (_rand() * 2.0f - 1.0f) * amp;
         }
         freq *= 2.0f;
         amp *= ampm;


### PR DESCRIPTION
- Fixed hardcoded {100, 100} initialization to use the property’s current value, preventing shape shifts.
- Changed default amplitude multiplier from 5.0 to 0.5 so octaves decay correctly (fBm standard).
-  Removed incorrect frac from loop iterations and 1.25x compensation

### Test Files
- [wiggle.json](https://github.com/user-attachments/files/24129962/wiggle.json)
- [wiggle X only.json](https://github.com/user-attachments/files/24129961/wiggle.X.only.json)
- [wiggle Y only.json](https://github.com/user-attachments/files/24129963/wiggle.Y.only.json)


### Wiggle X Only

| lottie-web | ThorVG (Before) | ThorVG (Patched) |
|------------|----------------|------------------|
| ![lottie-web](https://github.com/user-attachments/assets/3a29fbbf-09c4-41f0-a7d7-ce4ecf9d1f95) | ![ThorVG Before](https://github.com/user-attachments/assets/671749ea-7581-4fd3-9072-a404781f7b1f) | ![ThorVG Patched](https://github.com/user-attachments/assets/ff11444d-160f-4a2e-895a-2dec9193b5b8) |

### Wiggle Y Only

| lottie-web | ThorVG (Before) | ThorVG (Patched) |
|------------|------------------|------------------|
| ![CleanShot 2025-12-12 at 23 53 00](https://github.com/user-attachments/assets/f7c1a4f6-3c0a-48db-8b35-c25977bbcb64) | ![CleanShot 2025-12-12 at 23 53 42](https://github.com/user-attachments/assets/ecc11a43-8dc8-402b-b155-f9de3cf759d7) | ![CleanShot 2025-12-12 at 23 56 32](https://github.com/user-attachments/assets/a5cb9077-0528-4426-8c77-da6305ad5e3f) |


### Wiggle

| lottie-web | ThorVG (Before) | ThorVG (Patched) |
|------------|------------------|------------------|
| ![CleanShot 2025-12-12 at 23 59 08](https://github.com/user-attachments/assets/e5f9351c-c1bb-417c-907d-1666cf0398d4) | ![CleanShot 2025-12-12 at 23 59 55](https://github.com/user-attachments/assets/07ca21c2-1afd-4ac1-8536-0989b5babf9a) | ![CleanShot 2025-12-13 at 00 05 28](https://github.com/user-attachments/assets/178c2290-3b79-483d-ac19-1e607bb50d52) |