### PR TITLE
wg_engine: convex shapes rendering optimization

### DIFF
--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -328,6 +328,27 @@ void WgPipelines::initialize(WgContext& context)
         layout_gradient, vertexBufferLayoutsShape, 1,
         WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
         depthStencilStateShape, multisampleState);
+    // render pipeline solid (no stencil)
+    solid_conv = createRenderPipeline(
+        context.device, "The render pipeline solid",
+        shader_solid, "vs_main", "fs_main",
+        layout_solid, vertexBufferLayoutsShape, 1,
+        WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
+        depthStencilStateScene, multisampleState);
+    // render pipeline radial (no stencil)
+    radial_conv = createRenderPipeline(
+        context.device, "The render pipeline radial",
+        shader_radial, "vs_main", "fs_main",
+        layout_gradient, vertexBufferLayoutsShape, 1,
+        WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
+        depthStencilStateScene, multisampleState);
+    // render pipeline linear (no stencil)
+    linear_conv = createRenderPipeline(
+        context.device, "The render pipeline linear",
+        shader_linear, "vs_main", "fs_main",
+        layout_gradient, vertexBufferLayoutsShape, 1,
+        WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
+        depthStencilStateScene, multisampleState);
     // render pipeline image
     image = createRenderPipeline(
         context.device, "The render pipeline image",
@@ -522,6 +543,9 @@ void WgPipelines::releaseGraphicHandles(WgContext& context)
     // pipelines normal blend
     releaseRenderPipeline(scene);
     releaseRenderPipeline(image);
+    releaseRenderPipeline(linear_conv);
+    releaseRenderPipeline(radial_conv);
+    releaseRenderPipeline(solid_conv);
     releaseRenderPipeline(linear);
     releaseRenderPipeline(radial);
     releaseRenderPipeline(solid);

--- a/src/renderer/wg_engine/tvgWgPipelines.h
+++ b/src/renderer/wg_engine/tvgWgPipelines.h
@@ -85,6 +85,9 @@ public:
     WGPURenderPipeline solid{};
     WGPURenderPipeline radial{};
     WGPURenderPipeline linear{};
+    WGPURenderPipeline solid_conv{};  // convex geometry (no stencil)
+    WGPURenderPipeline radial_conv{}; // convex geometry (no stencil)
+    WGPURenderPipeline linear_conv{}; // convex geometry (no stencil)
     WGPURenderPipeline image{};
     WGPURenderPipeline scene{};
     // pipelines custom blend

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -167,6 +167,7 @@ void WgRenderDataShape::updateVisibility(const RenderShape& rshape, uint8_t opac
 void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag flag, const Matrix& matrix)
 {
     releaseMeshes();
+    convex = false;
     strokeFirst = rshape.strokeFirst();
     renderSettingsShape.opacityMultiplier = 1.0f;
     renderSettingsStroke.opacityMultiplier = 1.0f;
@@ -196,6 +197,7 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
         } else {
             WgBWTessellator bwTess{&meshShape};
             bwTess.tessellate(optPath, matrix);
+            convex = bwTess.convex;
             bbox = bwTess.getBBox();
         }
 

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -81,6 +81,7 @@ struct WgRenderDataShape: public WgRenderDataPaint
     WgMeshData meshStrokesBBox{};
     bool strokeFirst{};
     FillRule fillRule{};
+    bool convex{};
     BBox bbox;
 
     void updateBBox(BBox bb);

--- a/src/renderer/wg_engine/tvgWgTessellator.h
+++ b/src/renderer/wg_engine/tvgWgTessellator.h
@@ -82,12 +82,17 @@ public:
     void tessellate(const RenderPath& path, const Matrix& matrix);
     RenderRegion bounds() const;
     BBox getBBox() const;
+    bool convex = true;
 private:
     uint32_t pushVertex(float x, float y);
     void pushTriangle(uint32_t a, uint32_t b, uint32_t c);
 
     WgMeshData* mBuffer;
     BBox bbox = {};
+    Point firstPt = {};
+    Point prevPt = {};
+    Point prevEdge = {};
+    int8_t winding = -1;   //0: unknown, 1: CW, -1: CCW
 };
 
 #endif /* _TVG_WG_TESSELLATOR_H_ */


### PR DESCRIPTION
do not use stencil buffer pass for rendering of convex shapes

https://github.com/thorvg/thorvg/pull/4044

Speedup of 10% FPS in one specific case:
<img width="769" height="788" alt="image" src="https://github.com/user-attachments/assets/b1775e33-634b-4de7-848a-4fe8d94bf4e3" />
main vs pr:
<img width="501" height="222" alt="image" src="https://github.com/user-attachments/assets/de777890-912c-46f2-97f8-02fb162a9172" />

