### PR TITLE
wg_engine: artifacts bugs fix

### DIFF
--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -46,7 +46,7 @@ void WgImageData::update(WgContext& context, const RenderSurface* surface)
         textureView = context.createTextureView(texture);
         // update bind group
         context.layouts.releaseBindGroup(bindGroup);
-        bindGroup = context.layouts.createBindGroupTexSampled(context.samplerLinearRepeat, textureView);
+        bindGroup = context.layouts.createBindGroupTexSampled(context.samplerLinearClamp, textureView);
     }
 };
 


### PR DESCRIPTION
Fix borders artifacts by changing sampling clamp method from repeat to clamp

<img width="1539" height="1577" alt="image" src="https://github.com/user-attachments/assets/3506a558-4aec-4069-800e-6e34f7ffa004" />


https://github.com/thorvg/thorvg/issues/3528