### PR TITLE
wg_engine: alpha premultiplied bug fix

### DIFF
--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -206,8 +206,10 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {
-    var Sc: vec4f = textureSample(uTextureView, uSampler, in.vTexCoord.xy);
+    let Sc: vec4f = textureSample(uTextureView, uSampler, in.vTexCoord.xy);
     let So: f32 = uPaintSettings.options.a;
+    let Cs: u32 = u32(uPaintSettings.options.x); // color space
+    if ((Cs == 2) || (Cs == 3)) { return vec4f(Sc.rgb * So, Sc.a * So); }
     return vec4f(Sc.rgb * Sc.a * So, Sc.a * So);
 };
 )";


### PR DESCRIPTION
In a case of ABGR8888S or ARGB8888S we should not premultiply color on alpha

<img width="1203" height="1241" alt="image" src="https://github.com/user-attachments/assets/575c6eb1-a4b6-47af-8297-b5c11fa9c038" />

https://github.com/thorvg/thorvg/issues/4041