### PR TITLE
gl_engine: add cross-platform GL context management

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -2165,21 +2165,26 @@ struct TVG_API GlCanvas final : Canvas
      * This function specifies the drawing target where the rasterization will occur. It can target
      * a specific framebuffer object (FBO) or the main surface.
      *
-     * @param[in] context The GL context assigning to the current canvas rendering.
+     * @param[in] display The platform-specific display handle (EGLDisplay for EGL). Set @c nullptr for other systems.
+     * @param[in] surface The platform-specific surface handle (EGLSurface for EGL, HDC for WGL). Set @c nullptr for other systems.
+     * @param[in] context The OpenGL context to be used for rendering on this canvas.
      * @param[in] id The GL target ID, usually indicating the FBO ID. A value of @c 0 specifies the main surface.
      * @param[in] w The width (in pixels) of the raster image.
      * @param[in] h The height (in pixels) of the raster image.
      * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it only allows @c ColorSpace::ABGR8888S as @c GL_RGBA8.
      *
-     * @retval Result::InsufficientCondition if the canvas is performing rendering. Please ensure the canvas is synced.
+     * @retval Result::InsufficientCondition If the canvas is currently rendering.
+     *         Ensure that @ref Canvas::sync() has been called before setting a new target.
      * @retval Result::NonSupport In case the gl engine is not supported.
      *
-     * @see Canvas::viewport()
+     * @note If @p display and @p surface are not provided, the ThorVG GL engine assumes that
+     *       the appropriate OpenGL context is already current and will not attempt to bind a new one.
+     *
      * @see Canvas::sync()
      *
      * @since 1.0
     */
-    Result target(void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs) noexcept;
+    Result target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs) noexcept;
 
     /**
      * @brief Creates a new GlCanvas object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -503,18 +503,26 @@ TVG_API Tvg_Canvas tvg_glcanvas_create(void);
  * This function specifies the drawing target where the rasterization will occur. It can target
  * a specific framebuffer object (FBO) or the main surface.
  *
- * @param[in] context The GL context assigning to the current canvas rendering.
+ * @param[in] display The platform-specific display handle (EGLDisplay for EGL). Set @c nullptr for other systems.
+ * @param[in] surface The platform-specific surface handle (EGLSurface for EGL, HDC for WGL). Set @c nullptr for other systems.
+ * @param[in] context The OpenGL context to be used for rendering on this canvas.
  * @param[in] id The GL target ID, usually indicating the FBO ID. A value of @c 0 specifies the main surface.
  * @param[in] w The width (in pixels) of the raster image.
  * @param[in] h The height (in pixels) of the raster image.
  * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it only allows @c TVG_COLORSPACE_ABGR8888S as @c GL_RGBA8.
  *
- * @retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
+ * @note If @p display and @p surface are not provided, the ThorVG GL engine assumes that
+ *       the appropriate OpenGL context is already current and will not attempt to bind a new one.
+ *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the canvas is currently rendering.
+ *         Ensure that @ref tvg_canvas_sync() has been called before setting a new target.
  * @retval TVG_RESULT_NOT_SUPPORTED In case the gl engine is not supported.
+ *
+ * @see tvg_canvas_sync()
  *
  * @since 1.0
  */
-TVG_API Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas canvas, void* context, int32_t id, uint32_t w, uint32_t h, Tvg_Colorspace cs);
+TVG_API Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas canvas, void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, Tvg_Colorspace cs);
 
 /** \} */   // end defgroup ThorVGCapi_GlCanvas
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -97,9 +97,9 @@ TVG_API Tvg_Result tvg_swcanvas_set_target(Tvg_Canvas canvas, uint32_t* buffer, 
 }
 
 
-TVG_API Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas canvas, void* context, int32_t id, uint32_t w, uint32_t h, Tvg_Colorspace cs)
+TVG_API Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas canvas, void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, Tvg_Colorspace cs)
 {
-    if (canvas) return (Tvg_Result) reinterpret_cast<GlCanvas*>(canvas)->target(context, id, w, h, static_cast<ColorSpace>(cs));
+    if (canvas) return (Tvg_Result) reinterpret_cast<GlCanvas*>(canvas)->target(display, surface, context, id, w, h, static_cast<ColorSpace>(cs));
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 

--- a/src/renderer/gl_engine/tvgGl.cpp
+++ b/src/renderer/gl_engine/tvgGl.cpp
@@ -38,7 +38,7 @@ bool glTerm()
 
 #else //__EMSCRIPTEN__
 
-#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 
 #ifdef THORVG_GL_TARGET_GL
     typedef PROC(WINAPI *PFNGLGETPROCADDRESSPROC)(LPCSTR);
@@ -46,6 +46,9 @@ bool glTerm()
 #endif
 
 static HMODULE _libGL = NULL;
+#ifdef THORVG_GL_TARGET_GLES
+    static HMODULE _libEGL = NULL;
+#endif
 
 static bool _glLoad()
 {
@@ -89,6 +92,9 @@ static PROC _getProcAddress(const char* procName)
 #endif
 
 static void* _libGL = nullptr;
+#ifdef THORVG_GL_TARGET_GLES
+    static void* _libEGL = nullptr;
+#endif
 
 static bool _glLoad()
 {
@@ -130,6 +136,9 @@ static void* _getProcAddress(const char* procName)
 #include <dlfcn.h>
 
 static void* _libGL = nullptr;
+#ifdef THORVG_GL_TARGET_GLES
+    static void* _libEGL = nullptr;
+#endif
 
 static bool _glLoad()
 {
@@ -479,6 +488,16 @@ PFNGLUNIFORMBLOCKBINDINGPROC       glUniformBlockBinding;
 //PFNGLGETACTIVEUNIFORMBLOCKIVPROC   glGetActiveUniformBlockiv;
 //PFNGLGETACTIVEUNIFORMBLOCKNAMEPROC glGetActiveUniformBlockName;
 
+#if defined(_WIN32) && !defined(__CYGWIN__) && defined(THORVG_GL_TARGET_GL)
+    PFNWGLGETCURRENTCONTEXTPROC  tvgWglGetCurrentContext;
+    PFNWGLMAKECURRENTPROC        tvgWglMakeCurrent;
+#endif
+
+#if defined(THORVG_GL_TARGET_GLES)
+    PFNEGLGETCURRENTCONTEXTPROC  tvgEglGetCurrentContext;
+    PFNEGLMAKECURRENTPROC        tvgEglMakeCurrent;
+#endif
+
 bool glInit()
 {
     if (!_glLoad()) return false;
@@ -812,6 +831,41 @@ bool glInit()
     // GL_FUNCTION_FETCH(glGetActiveUniformBlockName, PFNGLGETACTIVEUNIFORMBLOCKNAMEPROC);
     GL_FUNCTION_FETCH(glUniformBlockBinding, PFNGLUNIFORMBLOCKBINDINGPROC);
 
+#if defined(_WIN32) && !defined(__CYGWIN__) && defined(THORVG_GL_TARGET_GL)
+    tvgWglGetCurrentContext = (PFNWGLGETCURRENTCONTEXTPROC)GetProcAddress(_libGL, "wglGetCurrentContext");
+    tvgWglMakeCurrent = (PFNWGLMAKECURRENTPROC)GetProcAddress(_libGL, "wglMakeCurrent");
+    if (!tvgWglGetCurrentContext || !tvgWglMakeCurrent) {
+        TVGERR("GL_ENGINE", "Failed to load WGL context management functions.");
+        return false;
+    }
+#endif
+
+#if defined(THORVG_GL_TARGET_GLES)
+    #if defined(_WIN32) && !defined(__CYGWIN__)
+        if (!_libEGL) _libEGL = LoadLibraryW(L"libEGL.dll");
+        if (!_libEGL) _libEGL = LoadLibraryW(L"EGL.dll");
+        if (!_libEGL) {
+            TVGERR("GL_ENGINE", "Cannot find EGL library.");
+            return false;
+        }
+        tvgEglGetCurrentContext = (PFNEGLGETCURRENTCONTEXTPROC)GetProcAddress(_libEGL, "eglGetCurrentContext");
+        tvgEglMakeCurrent = (PFNEGLMAKECURRENTPROC)GetProcAddress(_libEGL, "eglMakeCurrent");
+    #else
+        if (!_libEGL) _libEGL = dlopen("libEGL.so.1", RTLD_LAZY);
+        if (!_libEGL) _libEGL = dlopen("libEGL.so", RTLD_LAZY);
+        if (!_libEGL) {
+            TVGERR("GL_ENGINE", "Cannot find EGL library.");
+            return false;
+        }
+        tvgEglGetCurrentContext = (PFNEGLGETCURRENTCONTEXTPROC)dlsym(_libEGL, "eglGetCurrentContext");
+        tvgEglMakeCurrent = (PFNEGLMAKECURRENTPROC)dlsym(_libEGL, "eglMakeCurrent");
+    #endif
+    if (!tvgEglGetCurrentContext || !tvgEglMakeCurrent) {
+        TVGERR("GL_ENGINE", "Failed to load EGL context management functions.");
+        return false;
+    }
+#endif
+
     //Confirm the version
     GLint vMajor, vMinor;
     glGetIntegerv(GL_MAJOR_VERSION, &vMajor);
@@ -829,10 +883,16 @@ bool glInit()
 
 bool glTerm()
 {
-#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     if (_libGL) FreeLibrary(_libGL);
+    #if defined(THORVG_GL_TARGET_GLES)
+        if (_libEGL) FreeLibrary(_libEGL);
+    #endif
 #else
     if (_libGL) dlclose(_libGL);
+    #if defined(THORVG_GL_TARGET_GLES)
+        if (_libEGL) dlclose(_libEGL);
+    #endif
 #endif
 
     return true;

--- a/src/renderer/gl_engine/tvgGl.h
+++ b/src/renderer/gl_engine/tvgGl.h
@@ -36,6 +36,8 @@
         #define TVG_REQUIRE_GL_MINOR_VER 3
     #endif
 
+    #include "tvgCommon.h"
+
     #ifdef _DEBUG
         #define GL_CHECK(stmt) stmt; assert(glGetError() == GL_NO_ERROR);
     #else
@@ -1163,6 +1165,19 @@
         //typedef void (*PFNGLGETACTIVEUNIFORMBLOCKNAMEPROC)(GLuint program, GLuint uniformBlockIndex, GLsizei bufSize, GLsizei *length, GLchar *uniformBlockName);
     #endif /* GL_VERSION_3_1 */
 
+    #if defined(_WIN32) && !defined(__CYGWIN__) && defined(THORVG_GL_TARGET_GL)
+        typedef HGLRC (WINAPI *PFNWGLGETCURRENTCONTEXTPROC)(void);
+        typedef BOOL (WINAPI *PFNWGLMAKECURRENTPROC)(HDC, HGLRC);
+    #endif
+
+    #if defined(THORVG_GL_TARGET_GLES)
+        typedef void* EGLDisplay;
+        typedef void* EGLSurface;
+        typedef void* EGLContext;
+        typedef EGLContext (*PFNEGLGETCURRENTCONTEXTPROC)(void);
+        typedef unsigned int (*PFNEGLMAKECURRENTPROC)(EGLDisplay dpy, EGLSurface draw, EGLSurface read, EGLContext ctx);
+    #endif
+
     //GL_VERSION_1_0
     extern PFNGLCULLFACEPROC               glCullFace;
     extern PFNGLFRONTFACEPROC              glFrontFace;
@@ -1483,6 +1498,17 @@
     //extern PFNGLGETACTIVEUNIFORMNAMEPROC      glGetActiveUniformName;
     //extern PFNGLGETACTIVEUNIFORMBLOCKIVPROC   glGetActiveUniformBlockiv;
     //extern PFNGLGETACTIVEUNIFORMBLOCKNAMEPROC glGetActiveUniformBlockName;
+
+    #if defined(_WIN32) && !defined(__CYGWIN__) && defined(THORVG_GL_TARGET_GL)
+        extern PFNWGLGETCURRENTCONTEXTPROC  tvgWglGetCurrentContext;
+        extern PFNWGLMAKECURRENTPROC        tvgWglMakeCurrent;
+    #endif
+
+    #if defined(THORVG_GL_TARGET_GLES)
+        extern PFNEGLGETCURRENTCONTEXTPROC  tvgEglGetCurrentContext;
+        extern PFNEGLMAKECURRENTPROC        tvgEglMakeCurrent;
+    #endif
+
 #endif // __EMSCRIPTEN__
 
 bool glInit();

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -162,7 +162,7 @@ struct GlRenderer : RenderMethod
     bool clear() override;
     bool intersectsShape(RenderData data, const RenderRegion& region) override;
     bool intersectsImage(RenderData data, const RenderRegion& region) override;
-    bool target(void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs);
+    bool target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs);
 
     //composition
     RenderCompositor* target(const RenderRegion& region, ColorSpace cs, CompositionFlag flags) override;
@@ -205,9 +205,12 @@ private:
 
     void flush();
     void clearDisposes();
-    void currentContext();
+    bool currentContext();
 
+    void* mDisplay = nullptr;   // EGLDisplay for EGL; unused for other app-managed contexts.
+    void* mSurface = nullptr;   // EGLSurface for EGL, HDC for WGL; unused for other app-managed contexts.
     void* mContext = nullptr;
+
     RenderSurface surface;
     GLint mTargetFboId = 0;
     GlStageBuffer mGpuBuffer;

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -176,7 +176,7 @@ GlCanvas::~GlCanvas()
 }
 
 
-Result GlCanvas::target(void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs) noexcept
+Result GlCanvas::target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs) noexcept
 {
 #ifdef THORVG_GL_RASTER_SUPPORT
     if (cs != ColorSpace::ABGR8888S) return Result::NonSupport;
@@ -189,7 +189,7 @@ Result GlCanvas::target(void* context, int32_t id, uint32_t w, uint32_t h, Color
     auto renderer = static_cast<GlRenderer*>(pImpl->renderer);
     if (!renderer) return Result::MemoryCorruption;
 
-    if (!renderer->target(context, id, w, h, cs)) return Result::Unknown;
+    if (!renderer->target(display, surface, context, id, w, h, cs)) return Result::Unknown;
     pImpl->vport = {{0, 0}, {(int32_t)w, (int32_t)h}};
     renderer->viewport(pImpl->vport);
 


### PR DESCRIPTION
Implement platform-specific OpenGL context switching support for the GL renderer. This enables proper context management when ThorVG needs to ensure the correct GL context is current before rendering.

Supported platforms:
- Windows (WGL) - for desktop OpenGL
- EGL - for OpenGL ES on all platforms

