### PR TITLE
wg_engine: alpha premultiplied bug fix

### DIFF
--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -39,10 +39,12 @@ void WgContext::initialize(WGPUInstance instance, WGPUDevice device)
     assert(queue);
 
     // create shared webgpu assets
-    samplerNearestRepeat = createSampler(WGPUFilterMode_Nearest, WGPUMipmapFilterMode_Nearest, WGPUAddressMode_Repeat);
-    samplerLinearRepeat = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_Repeat, 4);
-    samplerLinearMirror = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_MirrorRepeat, 4);
-    samplerLinearClamp = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_ClampToEdge, 4);
+    samplerImages = createSampler(WGPUFilterMode_Nearest, WGPUFilterMode_Linear, WGPUMipmapFilterMode_Nearest, WGPUAddressMode_ClampToEdge);
+    samplerNearestRepeat = createSampler(WGPUFilterMode_Nearest, WGPUFilterMode_Nearest, WGPUMipmapFilterMode_Nearest, WGPUAddressMode_Repeat);
+    samplerLinearRepeat = createSampler(WGPUFilterMode_Linear, WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_Repeat, 4);
+    samplerLinearMirror = createSampler(WGPUFilterMode_Linear, WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_MirrorRepeat, 4);
+    samplerLinearClamp = createSampler(WGPUFilterMode_Linear, WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_ClampToEdge, 4);
+    assert(samplerImages);
     assert(samplerNearestRepeat);
     assert(samplerLinearRepeat);
     assert(samplerLinearMirror);
@@ -60,15 +62,16 @@ void WgContext::release()
     releaseSampler(samplerLinearMirror);
     releaseSampler(samplerLinearRepeat);
     releaseSampler(samplerNearestRepeat);
+    releaseSampler(samplerImages);
     releaseQueue(queue);
 }
 
 
-WGPUSampler WgContext::createSampler(WGPUFilterMode filter, WGPUMipmapFilterMode mipmapFilter, WGPUAddressMode addrMode, uint16_t anisotropy)
+WGPUSampler WgContext::createSampler(WGPUFilterMode minFilter, WGPUFilterMode magFilter, WGPUMipmapFilterMode mipmapFilter, WGPUAddressMode addrMode, uint16_t anisotropy)
 {
     const WGPUSamplerDescriptor samplerDesc {
         .addressModeU = addrMode, .addressModeV = addrMode, .addressModeW = addrMode,
-        .magFilter = filter, .minFilter = filter, .mipmapFilter = mipmapFilter,
+        .magFilter = magFilter, .minFilter = minFilter, .mipmapFilter = mipmapFilter,
         .lodMinClamp = 0.0f, .lodMaxClamp = 32.0f, .maxAnisotropy = anisotropy
     };
     return wgpuDeviceCreateSampler(device, &samplerDesc);

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -34,6 +34,7 @@ struct WgContext {
     WGPUQueue queue{};
     WGPUTextureFormat preferredFormat{};
     // shared webgpu assets
+    WGPUSampler samplerImages{};
     WGPUSampler samplerNearestRepeat{};
     WGPUSampler samplerLinearRepeat{};
     WGPUSampler samplerLinearMirror{};
@@ -45,7 +46,7 @@ struct WgContext {
     void release();
     
     // create common objects
-    WGPUSampler createSampler(WGPUFilterMode filter, WGPUMipmapFilterMode mipmapFilter, WGPUAddressMode addrMode, uint16_t anisotropy = 1);
+    WGPUSampler createSampler(WGPUFilterMode minFilter, WGPUFilterMode magFilter, WGPUMipmapFilterMode mipmapFilter, WGPUAddressMode addrMode, uint16_t anisotropy = 1);
     WGPUTexture createTexture(uint32_t width, uint32_t height, WGPUTextureFormat format);
     WGPUTexture createTexStorage(uint32_t width, uint32_t height, WGPUTextureFormat format);
     WGPUTexture createTexAttachement(uint32_t width, uint32_t height, WGPUTextureFormat format, uint32_t sc);

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -46,7 +46,7 @@ void WgImageData::update(WgContext& context, const RenderSurface* surface)
         textureView = context.createTextureView(texture);
         // update bind group
         context.layouts.releaseBindGroup(bindGroup);
-        bindGroup = context.layouts.createBindGroupTexSampled(context.samplerLinearClamp, textureView);
+        bindGroup = context.layouts.createBindGroupTexSampled(context.samplerImages, textureView);
     }
 };
 


### PR DESCRIPTION
Fix sampler setings for un-premultiplied images by updating sampler for images

<img width="1613" height="928" alt="image" src="https://github.com/user-attachments/assets/4212fe18-2258-4630-987c-68b348cc0327" />

https://github.com/thorvg/thorvg/issues/4041