### PR TITLE
Use major version instead of hardcoded '1'

### DIFF
--- a/inc/meson.build
+++ b/inc/meson.build
@@ -2,4 +2,4 @@ header_files = ['thorvg.h']
 
 thorvg_inc = include_directories('.')
 
-install_headers(header_files, subdir: 'thorvg-1')
+install_headers(header_files, subdir: 'thorvg-' + vmaj)

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,9 @@ project('thorvg',
         version : '1.0.0',
         license : 'MIT')
 
+v_array = meson.project_version().split('.')
+vmaj = v_array[0]
+
 config_h = configuration_data()
 
 src_dir = '/'.join(meson.current_source_dir().split('\\'))

--- a/pc/thorvg-1.pc.in
+++ b/pc/thorvg-1.pc.in
@@ -1,10 +1,10 @@
 prefix=@PREFIX@
 libdir=@LIBDIR@
-includedir=@INCDIR@/thorvg-1
+includedir=@INCDIR@/thorvg-@VMAJ@
 
 Name: Thor Vector Graphics
 Description: Thor Vector Graphics Library
 Version: @VERSION@
 Requires:
-Libs: -L${libdir} -lthorvg-1
+Libs: -L${libdir} -lthorvg-@VMAJ@
 Cflags: -I${includedir}

--- a/src/bindings/capi/meson.build
+++ b/src/bindings/capi/meson.build
@@ -7,5 +7,5 @@ thorvg_lib_dep += [declare_dependency(
     sources : source_file
 )]
 
-install_headers('thorvg_capi.h', subdir: 'thorvg-1')
+install_headers('thorvg_capi.h', subdir: 'thorvg-' + vmaj)
 headers += include_directories('.')

--- a/src/loaders/lottie/meson.build
+++ b/src/loaders/lottie/meson.build
@@ -30,5 +30,5 @@ subloader_dep += [declare_dependency(
     sources : source_file
 )]
 
-install_headers('thorvg_lottie.h', subdir: 'thorvg-1')
+install_headers('thorvg_lottie.h', subdir: 'thorvg-' + vmaj)
 headers += include_directories('.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -65,7 +65,7 @@ endif
 subdir('bindings')
 
 thorvg_lib = library(
-    'thorvg-1',
+    'thorvg-' + vmaj,
     include_directories    : headers,
     version                : meson.project_version(),
     dependencies           : thorvg_lib_dep,
@@ -80,7 +80,7 @@ thorvg_dep = declare_dependency(
   include_directories: thorvg_inc,
   link_with: thorvg_lib,
 )
-meson.override_dependency('thorvg-1', thorvg_dep)
+meson.override_dependency('thorvg-' + vmaj, thorvg_dep)
 
 pkg_mod = import('pkgconfig')
 
@@ -88,6 +88,7 @@ pkg_mod.generate(
     libraries    : thorvg_lib,
     version      : meson.project_version(),
     name         : 'libthorvg',
-    filebase     : 'thorvg-1',
+    filebase     : 'thorvg-' + vmaj,
+    subdirs      : 'thorvg-' + vmaj,
     description  : 'A Thor library for rendering vector graphics'
 )


### PR DESCRIPTION
This patch fixes also an incorrect value of Cflags in generated .pc file