### PR TITLE
svg_loader,renderer : fix incorrect gradient mapping by providing untransformed bounds

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -50,9 +50,18 @@ static inline bool _isGroupType(SvgNodeType type)
 //a stroke width should be ignored for bounding box calculations
 static Box _bounds(Paint* paint)
 {
-    float x, y, w, h;
-    paint->bounds(&x, &y, &w, &h);
-    return {x, y, w, h};
+    Point pt4[4] = {};
+    if (PAINT(paint)->bounds(pt4, nullptr, true)) {
+        BBox box = {{FLT_MAX, FLT_MAX}, {-FLT_MAX, -FLT_MAX}};
+        for (int i = 0; i < 4; ++i) {
+            if (pt4[i].x < box.min.x) box.min.x = pt4[i].x;
+            if (pt4[i].x > box.max.x) box.max.x = pt4[i].x;
+            if (pt4[i].y < box.min.y) box.min.y = pt4[i].y;
+            if (pt4[i].y > box.max.y) box.max.y = pt4[i].y;
+        }
+        return {box.min.x, box.min.y, box.max.x - box.min.x, box.max.y - box.min.y};
+    }
+    return {0, 0, 0, 0};
 }
 
 

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -275,8 +275,9 @@ RenderData Paint::Impl::update(RenderMethod* renderer, const Matrix& pm, Array<R
 
 bool Paint::Impl::bounds(Point* pt4, const Matrix* pm, bool obb)
 {
-    bool ret;
-    PAINT_METHOD(ret, bounds(pt4, pm * transform(), obb));
+    bool ret = false;
+    if (pm) PAINT_METHOD(ret, bounds(pt4, *pm * transform(), obb))
+    else PAINT_METHOD(ret, bounds(pt4, tvg::identity(), obb))
     return ret;
 }
 


### PR DESCRIPTION
This commit fixes a regression(333e65e) in SVG gradient rendering where gradients were being incorrectly mapped when the target element had a transformation. The root cause was that Paint::bounds() was always applying the local transform, even when untransformed bounds were requested (by passing nullptr as the parent matrix).

Changes:
- renderer: modify Paint::Impl::bounds to ignore local transform if pm is nullptr.
- svg_loader: update _bounds() helper to use the fixed bounds() API.

https://github.com/thorvg/thorvg/issues/4082