### PR TITLE
sw_engine: revise the anti-aliasing mechanism

### DIFF
--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -334,4 +334,31 @@ TEST_CASE("Filling Draw", "[tvgSwEngine]")
     }
     REQUIRE(Initializer::term() == Result::Success);
 }
+
+TEST_CASE("Image Rotation", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+        REQUIRE(canvas);
+
+        const uint32_t cw = 960;
+        const uint32_t ch = 960;
+        vector<uint32_t> buffer(static_cast<size_t>(cw) * ch);
+        REQUIRE(canvas->target(buffer.data(), cw, ch, cw, ColorSpace::ARGB8888) == Result::Success);
+
+        auto picture = Picture::gen();
+        REQUIRE(picture);
+
+        REQUIRE(picture->load(TEST_DIR "/test.png") == Result::Success);
+        REQUIRE(picture->size(240, 240) == Result::Success);
+        REQUIRE(picture->transform({0.572866f, -4.431353f, 336.605835f, 5.198910f, -0.386219f, 30.710693f, 0.0f, 0.0f, 1.0f}) == Result::Success);
+        REQUIRE(canvas->push(picture) == Result::Success);
+
+        REQUIRE(canvas->draw(true) == Result::Success);
+        REQUIRE(canvas->sync() == Result::Success);
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
 #endif


### PR DESCRIPTION
removed Hermet's analitical anti-aliasing,
applied the bilinear interpolation approach
with a existing texture mapping.

This resolves poor aa quality at a edge case.

size: -1.8kb

issue: https://github.com/thorvg/thorvg/issues/1729

before vs after:

<img width="653" height="298" alt="image" src="https://github.com/user-attachments/assets/d45389b3-fb5a-4021-88fa-54528a0d9759" />