### PR TITLE
lottie: round polystar point count to nearest integer

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -520,7 +520,7 @@ void LottieBuilder::updateStar(LottiePolyStar* star, float frameNo, Matrix* tran
 {
     static constexpr auto POLYSTAR_MAGIC_NUMBER = 0.47829f / 0.28f;
 
-    auto ptsCnt = star->ptsCnt(frameNo, tween, exps);
+    auto ptsCnt = roundf(star->ptsCnt(frameNo, tween, exps));
     auto innerRadius = star->innerRadius(frameNo, tween, exps);
     auto outerRadius = star->outerRadius(frameNo, tween, exps);
     auto innerRoundness = star->innerRoundness(frameNo, tween, exps) * 0.01f;
@@ -635,7 +635,7 @@ void LottieBuilder::updatePolygon(LottieGroup* parent, LottiePolyStar* star, flo
 {
     static constexpr auto POLYGON_MAGIC_NUMBER = 0.25f;
 
-    auto ptsCnt = size_t(floor(star->ptsCnt(frameNo, tween, exps)));
+    auto ptsCnt = static_cast<size_t>(lroundf(star->ptsCnt(frameNo, tween, exps)));
     auto radius = star->outerRadius(frameNo, tween, exps);
     auto outerRoundness = star->outerRoundness(frameNo, tween, exps) * 0.01f;
 


### PR DESCRIPTION
## Summary

Fixes polystar/polygon point count handling to comply with the Lottie specification.

## Problem

According to the [Lottie spec](https://lottie.github.io/lottie-spec/1.0.1/single-page/#specs-shapes-polystar), the point count (`pt`) property for polystar shapes **MUST be rounded to the nearest integer**.

Previously:
- `updateStar()` used the raw float value without any rounding
- `updatePolygon()` used `floor()` instead of `round()`

This caused uneven/incorrect rendering when point counts were animated with non-integer values.

## Solution

Changed both functions to use `roundf()` for the point count, ensuring spec compliance.

## Before/After

The test case from #3838 (animating point count from 5 to 9) should now render correctly with proper integer point counts at each frame.

Closes #3838
Related to #3732