### PR TITLE
sw_engine: unify shape and stroke outline caches for memory efficiency

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -336,7 +336,6 @@ struct SwCellPool
 struct SwMpool
 {
     SwOutline* outline;
-    SwOutline* strokeOutline;
     SwStrokeBorder* leftBorder;
     SwStrokeBorder* rightBorder;
     SwCellPool* cellPool;
@@ -694,16 +693,11 @@ bool rleClip(SwRle* rle, const RenderRegion* clip);
 bool rleIntersect(const SwRle* rle, const RenderRegion& region);
 
 SwMpool* mpoolInit(uint32_t threads);
-bool mpoolTerm(SwMpool* mpool);
+void mpoolTerm(SwMpool* mpool);
 SwOutline* mpoolReqOutline(SwMpool* mpool, unsigned idx);
-void mpoolRetOutline(SwMpool* mpool, unsigned idx);
-SwOutline* mpoolReqStrokeOutline(SwMpool* mpool, unsigned idx);
-void mpoolRetStrokeOutline(SwMpool* mpool, unsigned idx);
 SwOutline* mpoolReqDashOutline(SwMpool* mpool, unsigned idx);
-void mpoolRetDashOutline(SwMpool* mpool, unsigned idx);
 SwStrokeBorder* mpoolReqStrokeLBorder(SwMpool* mpool, unsigned idx);
 SwStrokeBorder* mpoolReqStrokeRBorder(SwMpool* mpool, unsigned idx);
-void mpoolRetStrokeBorders(SwMpool* mpool, unsigned idx);
 SwCellPool* mpoolReqCellPool(SwMpool* mpool, unsigned idx);
 
 bool rasterCompositor(SwSurface* surface);

--- a/src/renderer/sw_engine/tvgSwImage.cpp
+++ b/src/renderer/sw_engine/tvgSwImage.cpp
@@ -106,7 +106,6 @@ bool imageGenRle(SwImage& image, const RenderRegion& renderBox, SwMpool* mpool, 
 
 void imageDelOutline(SwImage& image, SwMpool* mpool, uint32_t tid)
 {
-    mpoolRetOutline(mpool, tid);
     image.outline = nullptr;
 }
 

--- a/src/renderer/sw_engine/tvgSwMemPool.cpp
+++ b/src/renderer/sw_engine/tvgSwMemPool.cpp
@@ -29,54 +29,28 @@
 
 SwOutline* mpoolReqOutline(SwMpool* mpool, unsigned idx)
 {
-    return &mpool->outline[idx];
-}
-
-
-void mpoolRetOutline(SwMpool* mpool, unsigned idx)
-{
     mpool->outline[idx].pts.clear();
     mpool->outline[idx].cntrs.clear();
     mpool->outline[idx].types.clear();
     mpool->outline[idx].closed.clear();
-}
 
-
-SwOutline* mpoolReqStrokeOutline(SwMpool* mpool, unsigned idx)
-{
-    return &mpool->strokeOutline[idx];
-}
-
-
-void mpoolRetStrokeOutline(SwMpool* mpool, unsigned idx)
-{
-    mpool->strokeOutline[idx].pts.clear();
-    mpool->strokeOutline[idx].cntrs.clear();
-    mpool->strokeOutline[idx].types.clear();
-    mpool->strokeOutline[idx].closed.clear();
-
-    mpoolRetStrokeBorders(mpool, idx);
+    return &mpool->outline[idx];
 }
 
 
 SwStrokeBorder* mpoolReqStrokeLBorder(SwMpool* mpool, unsigned idx)
 {
+    mpool->leftBorder[idx].pts.clear();
+    mpool->leftBorder[idx].start = -1;
     return &mpool->leftBorder[idx];
 }
 
 
 SwStrokeBorder* mpoolReqStrokeRBorder(SwMpool* mpool, unsigned idx)
 {
-    return &mpool->rightBorder[idx];
-}
-
-
-void mpoolRetStrokeBorders(SwMpool* mpool, unsigned idx)
-{
-    mpool->leftBorder[idx].pts.clear();
-    mpool->leftBorder[idx].start = -1;
     mpool->rightBorder[idx].pts.clear();
     mpool->rightBorder[idx].start = -1;
+    return &mpool->rightBorder[idx];
 }
 
 
@@ -92,7 +66,6 @@ SwMpool* mpoolInit(uint32_t threads)
 
     auto mpool = tvg::malloc<SwMpool>(sizeof(SwMpool));
     mpool->outline = new SwOutline[allocSize];
-    mpool->strokeOutline = new SwOutline[allocSize];
     mpool->leftBorder = new SwStrokeBorder[allocSize];
     mpool->rightBorder = new SwStrokeBorder[allocSize];
     mpool->cellPool = new SwCellPool[allocSize];
@@ -103,17 +76,14 @@ SwMpool* mpoolInit(uint32_t threads)
 }
 
 
-bool mpoolTerm(SwMpool* mpool)
+void mpoolTerm(SwMpool* mpool)
 {
-    if (!mpool) return false;
+    if (!mpool) return;
 
     delete[](mpool->outline);
-    delete[](mpool->strokeOutline);
     delete[](mpool->leftBorder);
     delete[](mpool->rightBorder);
     delete[](mpool->cellPool);
 
     tvg::free(mpool);
-
-    return true;
 }

--- a/src/renderer/sw_engine/tvgSwStroke.cpp
+++ b/src/renderer/sw_engine/tvgSwStroke.cpp
@@ -798,7 +798,7 @@ bool strokeParseOutline(SwStroke* stroke, const SwOutline& outline, SwMpool* mpo
 SwOutline* strokeExportOutline(SwStroke* stroke, SwMpool* mpool, unsigned tid)
 {
     auto reserve = stroke->borders[0]->pts.count + stroke->borders[1]->pts.count;
-    auto outline = mpoolReqStrokeOutline(mpool, tid);
+    auto outline = mpoolReqOutline(mpool, tid);
     outline->pts.reserve(reserve);
     outline->types.reserve(reserve);
     outline->fillRule = FillRule::NonZero;


### PR DESCRIPTION
Currently, the sw engine processes shape and stroke outlines sequentially rather than in parallel.

Since these memory caches don't need to be separated, we can reuse the shape outline for stroke outlines to improve memory efficiency.