### PR TITLE
api: added thorvg version for compile-time reference

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -6,6 +6,10 @@
 #include <list>
 #include <cstdarg>
 
+#define TVG_VERSION_MAJOR 1  // for compile-time checks
+#define TVG_VERSION_MINOR 0  // for compile-time checks
+#define TVG_VERSION_MICRO 0  // for compile-time checks
+
 #ifdef TVG_API
     #undef TVG_API
 #endif


### PR DESCRIPTION
TVG_VERSION_MAJOR - reference major version value
TVG_VERSION_MINOR - reference minor version value
TVG_VERSION_MICRO - reference minor version value

issue: https://github.com/thorvg/thorvg/issues/4077