### PR TITLE
api: revise the canvas apis

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -2212,13 +2212,22 @@ struct TVG_API GlCanvas final : Canvas
     Result target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs) noexcept;
 
     /**
-     * @brief Creates a new GlCanvas object.
+     * @brief Creates a new OpenGL/ES Canvas object with optional rendering engine settings.
+     *
+     * This method generates a OpenGL canvas instance that can be used for drawing vector graphics.
+     * It accepts an optional parameter @p op to choose between different rendering engine behaviors.
+     *
+     * @param[in] op The rendering engine option. Default is @c EngineOption::Default.
      *
      * @return A new GlCanvas object.
      *
-     * @since 0.14
+     * @note Currently, it does not support @c EngineOption::SmartRender. The request will be ignored.
+     *
+     * @see enum EngineOption
+     *
+     * @since 1.0
      */
-    static GlCanvas* gen() noexcept;
+    static GlCanvas* gen(EngineOption op = EngineOption::Default) noexcept;
 
     _TVG_DECLARE_PRIVATE(GlCanvas);
 };
@@ -2259,13 +2268,22 @@ struct TVG_API WgCanvas final : Canvas
     Result target(void* device, void* instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0) noexcept;
 
     /**
-     * @brief Creates a new WgCanvas object.
+     * @brief Creates a new WebGPU Canvas object with optional rendering engine settings.
+     *
+     * This method generates a WebGPU canvas instance that can be used for drawing vector graphics.
+     * It accepts an optional parameter @p op to choose between different rendering engine behaviors.
+     *
+     * @param[in] op The rendering engine option. Default is @c EngineOption::Default.
      *
      * @return A new WgCanvas object.
      *
-     * @since 0.15
+     * @note Currently, it does not support @c EngineOption::SmartRender. The request will be ignored.
+     *
+     * @see enum EngineOption
+     *
+     * @since 1.0
      */
-    static WgCanvas* gen() noexcept;
+    static WgCanvas* gen(EngineOption op = EngineOption::Default) noexcept;
 
     _TVG_DECLARE_PRIVATE(WgCanvas);
 };

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -437,7 +437,7 @@ TVG_API Tvg_Result tvg_engine_version(uint32_t* major, uint32_t* minor, uint32_t
 /************************************************************************/
 
 /**
- * @brief Creates a new SwCanvas object with optional rendering engine settings.
+ * @brief Creates a new Software Canvas object with optional rendering engine settings.
  *
  * This method generates a software canvas instance that can be used for drawing vector graphics.
  * It accepts an optional parameter @p op to choose between different rendering engine behaviors.
@@ -492,13 +492,22 @@ TVG_API Tvg_Result tvg_swcanvas_set_target(Tvg_Canvas canvas, uint32_t* buffer, 
 /************************************************************************/
 
 /**
- * @brief Creates a OpenGL rasterizer Canvas object.
+ * @brief Creates a new OpenGL/ES Canvas object with optional rendering engine settings.
+ *
+ * This method generates a OpenGL/ES canvas instance that can be used for drawing vector graphics.
+ * It accepts an optional parameter @p op to choose between different rendering engine behaviors.
+ *
+ * @param[in] op The rendering engine option.
  *
  * @return A new Tvg_Canvas object.
  *
- * @since 1.0.0
+ * @note Currently, it does not support @c TVG_ENGINE_OPTION_SMART_RENDER. The request will be ignored.
+ *
+ * @see enum Tvg_Engine_Option
+ *
+ * @since 1.0
  */
-TVG_API Tvg_Canvas tvg_glcanvas_create(void);
+TVG_API Tvg_Canvas tvg_glcanvas_create(Tvg_Engine_Option op);
 
 
 /**
@@ -545,13 +554,22 @@ TVG_API Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas canvas, void* display, voi
 /************************************************************************/
 
 /**
- * @brief Creates a WebGPU rasterizer Canvas object.
+ * @brief Creates a new WebGPU Canvas object with optional rendering engine settings.
+ *
+ * This method generates a WebGPU canvas instance that can be used for drawing vector graphics.
+ * It accepts an optional parameter @p op to choose between different rendering engine behaviors.
+ *
+ * @param[in] op The rendering engine option.
  *
  * @return A new Tvg_Canvas object.
  *
- * @since 1.0.0
+ * @note Currently, it does not support @c TVG_ENGINE_OPTION_SMART_RENDER. The request will be ignored.
+ *
+ * @see enum Tvg_Engine_Option
+ *
+ * @since 1.0
  */
-TVG_API Tvg_Canvas tvg_wgcanvas_create(void);
+TVG_API Tvg_Canvas tvg_wgcanvas_create(Tvg_Engine_Option op);
 
 /**
  * @brief Sets the drawing target for the rasterization.
@@ -582,7 +600,6 @@ TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas canvas, void* device, void
  *
  * @param[in] canvas The Tvg_Canvas object to be destroyed.
  *
- * @retval TVG_RESULT_INVALID_ARGUMENT An invalid pointer to the Tvg_Canvas object is passed.
  */
 TVG_API Tvg_Result tvg_canvas_destroy(Tvg_Canvas canvas);
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -68,15 +68,15 @@ TVG_API Tvg_Canvas tvg_swcanvas_create(Tvg_Engine_Option op)
 }
 
 
-TVG_API Tvg_Canvas tvg_glcanvas_create()
+TVG_API Tvg_Canvas tvg_glcanvas_create(Tvg_Engine_Option op)
 {
-    return (Tvg_Canvas) GlCanvas::gen();
+    return (Tvg_Canvas) GlCanvas::gen(static_cast<EngineOption>(op));
 }
 
 
-TVG_API Tvg_Canvas tvg_wgcanvas_create()
+TVG_API Tvg_Canvas tvg_wgcanvas_create(Tvg_Engine_Option op)
 {
-    return (Tvg_Canvas) WgCanvas::gen();
+    return (Tvg_Canvas) WgCanvas::gen(static_cast<EngineOption>(op));
 }
 
 

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -202,10 +202,11 @@ Result GlCanvas::target(void* display, void* surface, void* context, int32_t id,
 }
 
 
-GlCanvas* GlCanvas::gen() noexcept
+GlCanvas* GlCanvas::gen(EngineOption op) noexcept
 {
 #ifdef THORVG_GL_RASTER_SUPPORT
     if (engineInit > 0) {
+        if (op == EngineOption::SmartRender) TVGLOG("RENDERER", "GlCanvas doesn't support Smart Rendering");
         auto renderer = GlRenderer::gen(TaskScheduler::threads());
         if (!renderer) return nullptr;
         renderer->ref();
@@ -261,10 +262,11 @@ Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, 
 }
 
 
-WgCanvas* WgCanvas::gen() noexcept
+WgCanvas* WgCanvas::gen(EngineOption op) noexcept
 {
 #ifdef THORVG_WG_RASTER_SUPPORT
     if (engineInit > 0) {
+        if (op == EngineOption::SmartRender) TVGLOG("RENDERER", "WgCanvas doesn't support Smart Rendering");
         auto renderer = WgRenderer::gen(TaskScheduler::threads());
         renderer->ref();
         auto ret = new WgCanvas;


### PR DESCRIPTION
add render option for gl, wgpu canvases.

this option is reserved for the future expansion.
```
C++ API:
 * GlCanvas* GlCanvas::gen() -> GlCanvas* GlCanvas::gen(EngineOption op = EngineOption::Default)
 * WgCanvas* WgCanvas::gen() -> WgCanvas* WgCanvas::gen(EngineOption op = EngineOption::Default)

C API:
 * Tvg_Canvas tvg_glcanvas_create() -> Tvg_Canvas tvg_glcanvas_create(Tvg_Engine_Option op)
 * Tvg_Canvas tvg_wgcanvas_create() -> Tvg_Canvas tvg_wgcanvas_create(Tvg_Engine_Option op)
```
issue: https://github.com/thorvg/thorvg/issues/3116