### PR TITLE
gl_engine: fix partial blit fail on GLES MSAA buffer

### DIFF
--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -682,6 +682,10 @@ vec4 postProcess(vec4 R) { return mix(vec4(d.Dc, d.Da), R, d.Sa * d.So); }
 )";
 
 const char* BLEND_IMAGE_FRAG_HEADER = R"(
+layout(std140) uniform BlendRegion {
+    vec4 region;
+} uBlendRegion;
+
 uniform sampler2D uSrcTexture;
 uniform sampler2D uDstTexture;
 
@@ -695,7 +699,8 @@ FragData d;
 void getFragData() {
     // get source data
     vec4 colorSrc = texture(uSrcTexture, vUV);
-    vec4 colorDst = texture(uDstTexture, vUV);
+    vec2 uvDst = (gl_FragCoord.xy - uBlendRegion.region.xy) / uBlendRegion.region.zw;
+    vec4 colorDst = texture(uDstTexture, uvDst);
     // fill fragment data
     d.Sc = colorSrc.rgb;
     d.Sa = colorSrc.a;
@@ -715,6 +720,11 @@ layout(std140) uniform ColorInfo {
     int opacity;
     int dummy;
 } uColorInfo;
+
+layout(std140) uniform BlendRegion {
+    vec4 region;
+} uBlendRegion;
+
 uniform sampler2D uSrcTexture;
 uniform sampler2D uDstTexture;
 
@@ -728,7 +738,8 @@ FragData d;
 void getFragData() {
     // get source data
     vec4 colorSrc = texture(uSrcTexture, vUV);
-    vec4 colorDst = texture(uDstTexture, vUV);
+    vec2 uvDst = (gl_FragCoord.xy - uBlendRegion.region.xy) / uBlendRegion.region.zw;
+    vec4 colorDst = texture(uDstTexture, uvDst);
     // fill fragment data
     d.Sc = colorSrc.rgb;
     d.Sa = colorSrc.a;


### PR DESCRIPTION
## Description
This PR addresses Issue #4112 where OpenGL ES and WebGL rendering contexts fail to blit or resolve multisampled framebuffers when specifying partial regions.

## Key Changes
- **Renderer**: Modified [tvgGlRenderer.cpp](cci:7://file:///c:/Users/warch/OneDrive/repo/workspace/thorvg/src/renderer/gl_engine/tvgGlRenderer.cpp:0:0-0:0) to enforce full buffer blits (resolves) when compiling for non-Desktop GL targets (GLES/WebGL).[^note]
- **Coordinate Correction**: Introduced a `BlendRegion` uniform block in shaders (`BlendRegion`) to correctly map fragment coordinates to destination texture UVs. This is necessary because the full buffer blit changes the relationship between the viewport and the underlying texture coordinates compared to a partial blit.
- The blit burden remains unchanged. The attached picture shows that we only copy the partial region.
<img width="2048" height="1151" alt="Screenshot 2026-01-19 210616" src="https://github.com/user-attachments/assets/22008924-3962-43e4-ab79-4f7d8d640b52" />

## Motivation
To ensure correct rendering and resolve crashes or artifacts on mobile (GLES) and web (WebGL) platforms caused by invalid partial MSAA blits.

[^note]: I intentionally don’t blit into a smaller FBO because it adds an extra full copy pass (read + write) that we can avoid. In the next pass, sampling from a full-size resolved texture is not inherently more expensive: the GPU only fetches the texels needed for the fragments we actually draw, not the whole texture. Since the blend is typically a single pass and the affected area isn’t known reliably ahead of time, a “small” FBO often ends up near full size anyway, making the extra blit pure overhead (and can introduce extra bandwidth/stalls on mobile). 