### PR TITLE
gl_engine: fix Emscripten context handle cast

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -70,7 +70,7 @@ void GlRenderer::flush()
 bool GlRenderer::currentContext()
 {
 #if defined(__EMSCRIPTEN__)
-    const auto targetContext = static_cast<EMSCRIPTEN_WEBGL_CONTEXT_HANDLE>(mContext);
+    const auto targetContext = reinterpret_cast<EMSCRIPTEN_WEBGL_CONTEXT_HANDLE>(mContext);
     if (emscripten_webgl_get_current_context() == targetContext) return true;
     return emscripten_webgl_make_context_current(targetContext) == 0;
 #elif defined(_WIN32) && !defined(__CYGWIN__) && defined(THORVG_GL_TARGET_GL)


### PR DESCRIPTION
Use reinterpret_cast instead of static_cast when converting void* to EMSCRIPTEN_WEBGL_CONTEXT_HANDLE (unsigned long) as static_cast cannot convert pointer types to integer types.

<img width="2194" height="184" alt="CleanShot 2026-01-19 at 12 59 31@2x" src="https://github.com/user-attachments/assets/34b0fd6d-ba70-457e-b46b-66f23d2e381b" />


