### PR TITLE
gl_engine: fix mismatched-tags warning for GlRenderTarget

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTask.h
+++ b/src/renderer/gl_engine/tvgGlRenderTask.h
@@ -114,7 +114,7 @@ private:
     GlStencilMode mStencilMode;
 };
 
-class GlRenderTarget;
+struct GlRenderTarget;
 
 class GlComposeTask : public GlRenderTask 
 {


### PR DESCRIPTION
Change forward declaration from class to struct
to match the actual definition, preventing potential linker errors under Microsoft C++ ABI.

<img width="2982" height="916" alt="CleanShot 2026-01-27 at 18 54 47@2x" src="https://github.com/user-attachments/assets/b21f4f04-8390-48c7-92a0-3060a448690c" />
