### PR TITLE
lottie/slot: Support Text Style slot overriding

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -203,57 +203,11 @@ void LottieSlot::reset()
 
 void LottieSlot::apply(LottieProperty* prop, bool byDefault)
 {
-    auto copy = !overridden && !byDefault;
+    auto release = overridden || byDefault;
 
     //apply slot object to all targets
     ARRAY_FOREACH(pair, pairs) {
-        //backup the original properties before overwriting
-        switch (type) {
-            case LottieProperty::Type::Float: {
-                if (copy) pair->prop = new LottieFloat(static_cast<LottieTransform*>(pair->obj)->rotation);
-                pair->obj->override(prop, !copy);
-                break;
-            }
-            case LottieProperty::Type::Scalar: {
-                if (copy) pair->prop = new LottieScalar(static_cast<LottieTransform*>(pair->obj)->scale);
-                pair->obj->override(prop, !copy);
-                break;
-            }
-            case LottieProperty::Type::Vector: {
-                if (copy) pair->prop = new LottieVector(static_cast<LottieTransform*>(pair->obj)->position);
-                pair->obj->override(prop, !copy);
-                break;
-            }
-            case LottieProperty::Type::Color: {
-                if (copy) pair->prop = new LottieColor(static_cast<LottieSolid*>(pair->obj)->color);
-                pair->obj->override(prop, !copy);
-                break;
-            }
-            case LottieProperty::Type::Opacity: {
-                if (copy) {
-                    if (pair->obj->type == LottieObject::Type::Transform) pair->prop = new LottieOpacity(static_cast<LottieTransform*>(pair->obj)->opacity);
-                    else pair->prop = new LottieOpacity(static_cast<LottieSolid*>(pair->obj)->opacity);
-                }
-                pair->obj->override(prop, !copy);
-                break;
-            }
-            case LottieProperty::Type::ColorStop: {
-                if (copy) pair->prop = new LottieColorStop(static_cast<LottieGradient*>(pair->obj)->colorStops);
-                pair->obj->override(prop, !copy);
-                break;
-            }
-            case LottieProperty::Type::TextDoc: {
-                if (copy) pair->prop = new LottieTextDoc(static_cast<LottieText*>(pair->obj)->doc);
-                pair->obj->override(prop, !copy);
-                break;
-            }
-            case LottieProperty::Type::Image: {
-                if (copy) pair->prop = new LottieBitmap(static_cast<LottieImage*>(pair->obj)->bitmap);
-                pair->obj->override(prop, !copy);
-                break;
-            }
-            default: break;
-        }
+        pair->prop = pair->obj->override(prop, release);
     }
 
     if (!byDefault) overridden = true;

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -130,7 +130,7 @@ private:
 
     char* captureType();
     void captureSlots(const char* key);
-    void registerSlot(LottieObject* obj, const char* sid, LottieProperty::Type type);
+    void registerSlot(LottieObject* obj, const char* sid, LottieProperty& prop);
 
     //Current parsing context
     struct Context {

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -184,6 +184,7 @@ struct LottieProperty
     LottieExpression* exp = nullptr;
     Type type;
     uint8_t ix;  //property index
+    unsigned long sid; //property sid for slot
 
     LottieProperty(Type type = Type::Invalid) : type(type) {}
     virtual ~LottieProperty() {}
@@ -197,6 +198,7 @@ struct LottieProperty
     {
         type = rhs->type;
         ix = rhs->ix;
+        sid = rhs->sid;
 
         if (!rhs->exp) return false;
         if (shallow) {


### PR DESCRIPTION
# Overview
Added support for Lottie Slot Overriding for [Text Style](https://lottiefiles.github.io/lottie-docs/text/#text-style) of Text Range, including textColor, strokeColor, strokeWidth and transform related properties(position, scale, rotation, opacity)

related issue : #4125, #4138

# Preview

## Default Slot (color, scale, strokeColor, strokeWidth)

file: [example.json](https://github.com/user-attachments/files/25042845/example.json)

| Original | Overriden |
|---------|-----------|
| ![Original](https://github.com/user-attachments/assets/995f4308-db29-483d-ac9f-f63641b30550) | ![Overriden](https://github.com/user-attachments/assets/53b18f23-d241-4c2c-9df3-25cc1cdb9e85) |

## Via API

original file : [original.json](https://github.com/user-attachments/files/25044200/original.json)


![CleanShot 2026-02-03 at 21 40 09](https://github.com/user-attachments/assets/cbf95c66-280b-4d6e-a992-fab7a6c156f0)




### Text Color

```cpp
//slot (textColor override - red)
const char* slotJson = R"({"textColor":{"p":{"a":0,"k":[1,0,0,1]}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Stroke Color

```cpp
//slot (strokeColor override - green)
const char* slotJson = R"({"strokeColor":{"p":{"a":0,"k":[0,1,0,1]}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Stroke Width

```cpp
//slot (strokeWidth override - thicker)
const char* slotJson = R"({"strokeWidth":{"p":{"a":0,"k":8}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Text Scale

```cpp
//slot (textScale override - scaled up)
const char* slotJson = R"({"textScale":{"a":0,"k":[150,150,100]}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Text Position

```cpp
//slot (position override)
const char* slotJson = R"({"textPosition":{"p":{"a":0,"k":[30,30]}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Letter Space

```cpp
//slot (letterSpace override)
const char* slotJson = R"({"letterSpace":{"p":{"a":0,"k":15}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Line Space

```cpp
//slot (lineSpace override)
const char* slotJson = R"({"lineSpace":{"p":{"a":0,"k":10}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Text Rotation

```cpp
//slot (rotation override)
const char* slotJson = R"({"textRotation":{"p":{"a":0,"k":30}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Fill Opacity

```cpp
//slot (fillOpacity override)
const char* slotJson = R"({"fillOpacity":{"p":{"a":0,"k":50}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Stroke Opacity

```cpp
//slot (strokeOpacity override)
const char* slotJson = R"({"strokeOpacity":{"p":{"a":0,"k":30}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```

### Text Opacity

```cpp
//slot (opacity override)
const char* slotJson = R"({"textOpacity":{"p":{"a":0,"k":50}}})";
auto slotId = slot->gen(slotJson);
if (!tvgexam::verify(slot->apply(slotId))) return false;
```


# Lottie Object Model Revision

<img width="2040" height="868" alt="CleanShot 2026-02-04 at 14 47 24@2x" src="https://github.com/user-attachments/assets/419b2613-bf48-43fe-a542-55a924a3b481" />


- `LottieTextRange` inherits `LottieObject` to pair each overriding case per specific Text Range (LottieText could have multiple text range.
- Text Range slot overriding supports TextStyle only for now as needed.
- added `sid` in `LottieProperty` to explicitly target slot property (Since TextStyle has duplicated types, a single branching based on `LottieProperty::Type` is not feasible.)
- refactored another overriding cases, those have `LottieProperty::Type` based condition to make it verify `sid` instead of type check (Transform, LottieSolid)

> We may need to review additional memory usage by `sid` for all properties. (Alternatively, we can use `ix`, but this value isn't always guaranteed)