### PR TITLE
lottie/slot: Support Skew/Skew Axis(Transform) slot overriding

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -761,6 +761,14 @@ struct LottieTransform : LottieObject
             if (release) opacity.release();
             else backup = new LottieOpacity(opacity);
             opacity.copy(*static_cast<LottieOpacity*>(prop), false);
+        } else if (skewAngle.sid == prop->sid) {
+            if (release) skewAngle.release();
+            else backup = new LottieFloat(skewAngle);
+            skewAngle.copy(*static_cast<LottieFloat*>(prop), false);
+        } else if (skewAxis.sid == prop->sid) {
+            if (release) skewAxis.release();
+            else backup = new LottieFloat(skewAxis);
+            skewAxis.copy(*static_cast<LottieFloat*>(prop), false);
         }
         return backup;
     }

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -603,8 +603,8 @@ LottieTransform* LottieParser::parseTransform(bool ddd)
         else if (transform->rotationEx && KEY_AS("rx")) parseProperty(transform->rotationEx->x);
         else if (transform->rotationEx && KEY_AS("ry")) parseProperty(transform->rotationEx->y);
         else if (transform->rotationEx && KEY_AS("rz")) parseProperty(transform->rotation);
-        else if (KEY_AS("sk")) parseProperty(transform->skewAngle);
-        else if (KEY_AS("sa")) parseProperty(transform->skewAxis);
+        else if (KEY_AS("sk")) parseProperty(transform->skewAngle, transform);
+        else if (KEY_AS("sa")) parseProperty(transform->skewAxis, transform);
         else skip();
     }
     return transform;


### PR DESCRIPTION
Test file : [skew_default_slot.json](https://github.com/user-attachments/files/25069967/skew_default_slot.json)


**[Before]** Crashed

**[After]**

<img width="2492" height="2342" alt="CleanShot 2026-02-04 at 19 59 34@2x" src="https://github.com/user-attachments/assets/a2d92dd7-593c-4653-851a-cc28d80e4847" />

**[Expectation]**
<img width="1046" height="1112" alt="CleanShot 2026-02-04 at 20 03 43@2x" src="https://github.com/user-attachments/assets/e95dc708-26d0-4c32-a9c7-66e3602f23e1" />

