### PR TITLE
renderer: add image filter method API for rendering quality control

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -195,6 +195,18 @@ enum struct FillRule : uint8_t
 
 
 /**
+ * @brief Defines the image filtering method used during image scaling or transformation.
+ *
+ * @note Experimental API
+ */
+enum struct FilterMethod : uint8_t
+{
+    Bilinear = 0,  ///< Smooth interpolation using surrounding pixels for higher quality.
+    Nearest        ///< Fast filtering using nearest-neighbor sampling.
+};
+
+
+/**
  * @brief Enumeration indicating the method used in the mask of two objects - the target and the source.
  *
  * Notation: S(Source), T(Target), SA(Source Alpha), TA(Target Alpha)
@@ -1714,6 +1726,21 @@ struct TVG_API Picture : Paint
      * @note Experimental API
      */
     Result resolver(std::function<bool(Paint* paint, const char* src, void* data)> func, void* data) noexcept;
+
+    /**
+     * @brief Sets the image filtering method for rendering this picture.
+     *
+     * Specifies how the image data should be filtered when it is scaled or transformed
+     * during rendering. This affects the visual quality and performance of the output.
+     *
+     * @param[in] method The filtering method to apply. Default is @c FilterMethod::Bilinear.
+     *
+     * @return Always returns @c Result::Success.
+     *
+     * @see FilterMethod
+     * @note Experimental API
+     */
+    Result filter(FilterMethod method) noexcept;
 
     /**
      * @brief Retrieve a paint object from the Picture scene by its Unique ID.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -113,7 +113,31 @@ typedef enum {
 
 
 /**
+ * @brief A data structure representing a point in two-dimensional space.
+ */
+typedef struct {
+    float x, y;
+} Tvg_Point;
+
+
+/**
+ * @brief A data structure representing a three-dimensional matrix.
+ *
+ * The elements e11, e12, e21 and e22 represent the rotation matrix, including the scaling factor.
+ * The elements e13 and e23 determine the translation of the object along the x and y-axis, respectively.
+ * The elements e31 and e32 are set to 0, e33 is set to 1.
+ */
+typedef struct {
+    float e11, e12, e13;
+    float e21, e22, e23;
+    float e31, e32, e33;
+} Tvg_Matrix;
+
+
+/**
  * @brief Enumeration specifying the methods of combining the 8-bit color channels into 32-bit color.
+ *
+ * @ingroup ThorVGCapi_Canvas
  */
 typedef enum {
     TVG_COLORSPACE_ABGR8888 = 0,  ///< The channels are joined in the order: alpha, blue, green, red. Colors are alpha-premultiplied.
@@ -135,6 +159,8 @@ typedef enum {
  *       or heavy object movements), the overhead of tracking changes and managing update regions may outweigh the benefits,
  *       resulting in decreased performance compared to the default rendering mode. Thus, it is recommended to benchmark
  *       both modes in your specific use case to determine the optimal setting.
+ *
+ * @ingroup ThorVGCapi_Initializer
  *
  * @since 1.0
  */
@@ -312,26 +338,21 @@ typedef enum {
 
 /** \} */  // end addtogroup ThorVGCapi_Text
 
+
 /**
- * @brief A data structure representing a point in two-dimensional space.
+ * @addtogroup ThorVGCapi_Picture
+ * \{
  */
-typedef struct {
-    float x, y;
-} Tvg_Point;
-
 
 /**
- * @brief A data structure representing a three-dimensional matrix.
+ * @brief Defines the image filtering method used during image scaling or transformation.
  *
- * The elements e11, e12, e21 and e22 represent the rotation matrix, including the scaling factor.
- * The elements e13 and e23 determine the translation of the object along the x and y-axis, respectively.
- * The elements e31 and e32 are set to 0, e33 is set to 1.
+ * @note Experimental API
  */
-typedef struct {
-    float e11, e12, e13;
-    float e21, e22, e23;
-    float e31, e32, e33;
-} Tvg_Matrix;
+typedef enum {
+    TVG_FILTER_METHOD_BILINEAR = 0,  ///< Smooth interpolation using surrounding pixels for higher quality.
+    TVG_FILTER_METHOD_NEAREST        ///< Fast filtering using nearest-neighbor sampling.
+} Tvg_Filter_Method;
 
 
 /**
@@ -394,6 +415,8 @@ typedef struct {
  * @note Experimental API
  */
 typedef bool (*Tvg_Picture_Asset_Resolver)(Tvg_Paint paint, const char* src, void* data);
+
+/** \} */   // end addtogroup ThorVGCapi_Picture
 
 
 /**
@@ -2107,6 +2130,20 @@ TVG_API Tvg_Result tvg_picture_get_origin(const Tvg_Paint picture, float* x, flo
  */
 TVG_API const Tvg_Paint tvg_picture_get_paint(Tvg_Paint picture, uint32_t id);
 
+
+/**
+ * @brief Sets the image filtering method for rendering this picture.
+ *
+ * Specifies how the image data should be filtered when it is scaled or transformed
+ * during rendering. This affects the visual quality and performance of the output.
+ *
+ * @param[in] picture A Tvg_Paint pointer to the picture object.
+ * @param[in] method The filtering method to apply. Default is @c TVG_FILTER_METHOD_BILINEAR.
+ *
+ * @see Tvg_Filter_Method
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_picture_set_filter(Tvg_Paint picture, Tvg_Filter_Method method);
 
 /** \} */   // end defgroup ThorVGCapi_Picture
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -669,6 +669,12 @@ TVG_API Tvg_Result tvg_picture_get_origin(const Tvg_Paint picture, float* x, flo
 }
 
 
+TVG_API Tvg_Result tvg_picture_set_filter(Tvg_Paint picture, Tvg_Filter_Method method)
+{
+    if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->filter(FilterMethod(method));
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
 /************************************************************************/
 /* Gradient API                                                         */
 /************************************************************************/

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -1258,7 +1258,7 @@ void GlRenderer::dispose(RenderData data)
 }
 
 
-RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags)
+RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags)
 {
     //TODO: redefine GlImage.
     auto sdata = static_cast<GlShape*>(data);
@@ -1277,8 +1277,8 @@ RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matr
         GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, image->w, image->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, image->data));
         GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
         GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
         GL_CHECK(glBindTexture(GL_TEXTURE_2D, 0));
 
         sdata->texColorSpace = image->cs;

--- a/src/renderer/gl_engine/tvgGlRenderer.h
+++ b/src/renderer/gl_engine/tvgGlRenderer.h
@@ -146,7 +146,7 @@ struct GlRenderer : RenderMethod
     //main features
     bool preUpdate() override;
     RenderData prepare(const RenderShape& rshape, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags, bool clipper) override;
-    RenderData prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags) override;
+    RenderData prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags) override;
     bool postUpdate() override;
     bool preRender() override;
     bool renderShape(RenderData data) override;

--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -271,8 +271,9 @@ struct SwImage
     int32_t      ox = 0;         //offset x
     int32_t      oy = 0;         //offset y
     float        scale;
-    uint8_t      channelSize;
 
+    uint8_t      channelSize;
+    FilterMethod filter;
     bool         direct = false;  //draw image directly (with offset)
     bool         scaled = false;  //draw scaled image
 };

--- a/src/renderer/sw_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/sw_engine/tvgSwRasterTexmap.h
@@ -123,20 +123,22 @@ static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage
 
                 px = *(sbuf + (vv * image.stride) + uu);
 
-                // horizontal interpolate
-                if (iru < sw) {
-                    int px2 = *(sbuf + (vv * image.stride) + iru);
-                    px = INTERPOLATE(px, px2, ar);
-                }
-                // vertical interpolate
-                if (irv < sh) {
-                    int px2 = *(sbuf + (irv * image.stride) + uu);
+                if (image.filter == FilterMethod::Bilinear) {
                     // horizontal interpolate
                     if (iru < sw) {
-                        int px3 = *(sbuf + (irv * image.stride) + iru);
-                        px2 = INTERPOLATE(px2, px3, ar);
+                        int px2 = *(sbuf + (vv * image.stride) + iru);
+                        px = INTERPOLATE(px, px2, ar);
                     }
-                    px = INTERPOLATE(px, px2, ab);
+                    // vertical interpolate
+                    if (irv < sh) {
+                        int px2 = *(sbuf + (irv * image.stride) + uu);
+                        // horizontal interpolate
+                        if (iru < sw) {
+                            int px3 = *(sbuf + (irv * image.stride) + iru);
+                            px2 = INTERPOLATE(px2, px3, ar);
+                        }
+                        px = INTERPOLATE(px, px2, ab);
+                    }
                 }
 
                 // anti-aliasing
@@ -224,21 +226,24 @@ static void _rasterPolygonImageSegment32(SwSurface* surface, const SwImage& imag
 
                 px = *(sbuf + (vv * image.stride) + uu);
 
-                // horizontal interpolate
-                if (iru < sw) {
-                    int px2 = *(sbuf + (vv * image.stride) + iru);
-                    px = INTERPOLATE(px, px2, ar);
-                }
-                // vertical interpolate
-                if (irv < sh) {
-                    int px2 = *(sbuf + (irv * image.stride) + uu);
+                if (image.filter == FilterMethod::Bilinear) {
                     // horizontal interpolate
                     if (iru < sw) {
-                        int px3 = *(sbuf + (irv * image.stride) + iru);
-                        px2 = INTERPOLATE(px2, px3, ar);
+                        int px2 = *(sbuf + (vv * image.stride) + iru);
+                        px = INTERPOLATE(px, px2, ar);
                     }
-                    px = INTERPOLATE(px, px2, ab);
+                    // vertical interpolate
+                    if (irv < sh) {
+                        int px2 = *(sbuf + (irv * image.stride) + uu);
+                        // horizontal interpolate
+                        if (iru < sw) {
+                            int px3 = *(sbuf + (irv * image.stride) + iru);
+                            px2 = INTERPOLATE(px2, px3, ar);
+                        }
+                        px = INTERPOLATE(px, px2, ab);
+                    }
                 }
+
                 uint32_t src;
                 if (matting) {
                     auto a = alpha(cmp);

--- a/src/renderer/sw_engine/tvgSwRenderer.cpp
+++ b/src/renderer/sw_engine/tvgSwRenderer.cpp
@@ -877,7 +877,7 @@ void* SwRenderer::prepareCommon(SwTask* task, const Matrix& transform, const Arr
 }
 
 
-RenderData SwRenderer::prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags)
+RenderData SwRenderer::prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags)
 {
     auto task = static_cast<SwImageTask*>(data);
     if (task) task->done();
@@ -885,7 +885,7 @@ RenderData SwRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
         task = new SwImageTask;
         task->source = surface;
     }
-
+    task->image.filter = filter;
     return prepareCommon(task, transform, clips, opacity, flags);
 }
 

--- a/src/renderer/sw_engine/tvgSwRenderer.h
+++ b/src/renderer/sw_engine/tvgSwRenderer.h
@@ -38,7 +38,7 @@ struct SwRenderer : RenderMethod
     //main features
     bool preUpdate() override;
     RenderData prepare(const RenderShape& rshape, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags, bool clipper) override;
-    RenderData prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags) override;
+    RenderData prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags) override;
     bool postUpdate() override;
     bool preRender() override;
     bool renderShape(RenderData data) override;

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -121,3 +121,9 @@ const Paint* Picture::paint(uint32_t id) noexcept
 
     return value.ret;
 }
+
+
+Result Picture::filter(FilterMethod method) noexcept
+{
+    return to<PictureImpl>(this)->filterMethod(method);
+}

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -595,7 +595,7 @@ public:
     virtual ~RenderMethod() {}
     virtual bool preUpdate() = 0;
     virtual RenderData prepare(const RenderShape& rshape, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags, bool clipper) = 0;
-    virtual RenderData prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags) = 0;
+    virtual RenderData prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags) = 0;
     virtual bool postUpdate() = 0;
     virtual bool preRender() = 0;
     virtual bool renderShape(RenderData data) = 0;

--- a/src/renderer/wg_engine/tvgWgCommon.cpp
+++ b/src/renderer/wg_engine/tvgWgCommon.cpp
@@ -26,29 +26,17 @@
 
 void WgContext::initialize(WGPUInstance instance, WGPUDevice device)
 {
-    assert(instance);
-    assert(device);
-    
-    // store global instance and surface
     this->instance = instance;
     this->device = device;
-    this->preferredFormat = WGPUTextureFormat_BGRA8Unorm;
 
-    // get current queue
     queue = wgpuDeviceGetQueue(device);
-    assert(queue);
 
-    // create shared webgpu assets
+    samplerNearestClamp = createSampler(WGPUFilterMode_Nearest, WGPUMipmapFilterMode_Nearest, WGPUAddressMode_ClampToEdge, 1);
     samplerNearestRepeat = createSampler(WGPUFilterMode_Nearest, WGPUMipmapFilterMode_Nearest, WGPUAddressMode_Repeat);
     samplerLinearRepeat = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_Repeat, 4);
     samplerLinearMirror = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_MirrorRepeat, 4);
     samplerLinearClamp = createSampler(WGPUFilterMode_Linear, WGPUMipmapFilterMode_Linear, WGPUAddressMode_ClampToEdge, 4);
-    assert(samplerNearestRepeat);
-    assert(samplerLinearRepeat);
-    assert(samplerLinearMirror);
-    assert(samplerLinearClamp);
 
-    // initialize bind group layouts
     layouts.initialize(device);
 }
 
@@ -60,6 +48,7 @@ void WgContext::release()
     releaseSampler(samplerLinearMirror);
     releaseSampler(samplerLinearRepeat);
     releaseSampler(samplerNearestRepeat);
+    releaseSampler(samplerNearestClamp);
     releaseQueue(queue);
 }
 

--- a/src/renderer/wg_engine/tvgWgCommon.h
+++ b/src/renderer/wg_engine/tvgWgCommon.h
@@ -26,19 +26,15 @@
 #include "tvgWgBindGroups.h"
 
 struct WgContext {
-    // external webgpu handles
     WGPUInstance instance{};
-    WGPUAdapter adapter{};
     WGPUDevice device{};
-    // common webgpu handles
     WGPUQueue queue{};
-    WGPUTextureFormat preferredFormat{};
-    // shared webgpu assets
-    WGPUSampler samplerNearestRepeat{};
-    WGPUSampler samplerLinearRepeat{};
-    WGPUSampler samplerLinearMirror{};
-    WGPUSampler samplerLinearClamp{};
-    // bind groups layouts
+    WGPUTextureFormat format = WGPUTextureFormat_BGRA8Unorm;
+    WGPUSampler samplerNearestClamp;
+    WGPUSampler samplerNearestRepeat;
+    WGPUSampler samplerLinearRepeat;
+    WGPUSampler samplerLinearMirror;
+    WGPUSampler samplerLinearClamp;
     WgBindGroupLayouts layouts;
 
     void initialize(WGPUInstance instance, WGPUDevice device);

--- a/src/renderer/wg_engine/tvgWgPipelines.cpp
+++ b/src/renderer/wg_engine/tvgWgPipelines.cpp
@@ -475,7 +475,7 @@ void WgPipelines::initialize(WgContext& context)
         context.device, "The render pipeline blit",
         shader_blit, "vs_main", "fs_main", 
         layout_blit, vertexBufferLayoutsImage, 2,
-        WGPUColorWriteMask_All, context.preferredFormat, blendStateSrc, // must be preferred screen pixel format
+        WGPUColorWriteMask_All, context.format, blendStateSrc, // must be preferred screen pixel format
         depthStencilStateScene, multisampleStateX1);
 
     // effects

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -32,7 +32,7 @@
 // WgImageData
 //***********************************************************************
 
-void WgImageData::update(WgContext& context, const RenderSurface* surface)
+void WgImageData::update(WgContext& context, const RenderSurface* surface, FilterMethod filter)
 {
     // get appropriate texture format from color space
     WGPUTextureFormat texFormat = WGPUTextureFormat_BGRA8Unorm;
@@ -48,7 +48,8 @@ void WgImageData::update(WgContext& context, const RenderSurface* surface)
         textureView = context.createTextureView(texture);
         // update bind group
         context.layouts.releaseBindGroup(bindGroup);
-        bindGroup = context.layouts.createBindGroupTexSampled(context.samplerLinearClamp, textureView);
+        auto sampler = (filter == FilterMethod::Bilinear) ? context.samplerLinearClamp : context.samplerNearestClamp;
+        bindGroup = context.layouts.createBindGroupTexSampled(sampler, textureView);
     }
 };
 
@@ -302,10 +303,10 @@ void WgRenderDataShapePool::release(WgContext& context)
 // WgRenderDataPicture
 //***********************************************************************
 
-void WgRenderDataPicture::updateSurface(WgContext& context, const RenderSurface* surface, const Matrix& transform, bool updateTexture)
+void WgRenderDataPicture::updateSurface(WgContext& context, const RenderSurface* surface, const Matrix& transform, FilterMethod filter, bool updateTexture)
 {
     meshData.imageBox(surface->w, surface->h, transform);
-    if (updateTexture) imageData.update(context, surface);
+    if (updateTexture) imageData.update(context, surface, filter);
 }
 
 

--- a/src/renderer/wg_engine/tvgWgRenderData.h
+++ b/src/renderer/wg_engine/tvgWgRenderData.h
@@ -32,7 +32,7 @@ struct WgImageData {
     WGPUTextureView textureView{};
     WGPUBindGroup bindGroup{};
 
-    void update(WgContext& context, const RenderSurface* surface);
+    void update(WgContext& context, const RenderSurface* surface, FilterMethod filter);
     void update(WgContext& context, const Fill* fill);
     void release(WgContext& context);
 };
@@ -114,7 +114,7 @@ struct WgRenderDataPicture: public WgRenderDataPaint
     WgImageData imageData{};
     WgMeshData meshData{};
 
-    void updateSurface(WgContext& context, const RenderSurface* surface, const Matrix& transform, bool updateTexture);
+    void updateSurface(WgContext& context, const RenderSurface* surface, const Matrix& transform, FilterMethod filter, bool updateTexture);
     void release(WgContext& context) override;
     Type type() override { return Type::Picture; };
 };

--- a/src/renderer/wg_engine/tvgWgRenderer.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderer.cpp
@@ -104,7 +104,7 @@ bool WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint3
     // setup surface configuration
     WGPUSurfaceConfiguration surfaceConfiguration {
         .device = context.device,
-        .format = context.preferredFormat,
+        .format = context.format,
         .usage = WGPUTextureUsage_RenderAttachment,
         .width = width,
         .height = height,
@@ -176,7 +176,7 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
 }
 
 
-RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags)
+RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags)
 {
     auto renderDataPicture = data ? (WgRenderDataPicture*)data : mRenderDataPicturePool.allocate(mContext);
 
@@ -189,8 +189,8 @@ RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
 
     // update image data
     if (!data || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path | RenderUpdateFlag::Image))) {
-        bool updateTexture = !data || ((flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Image)) != RenderUpdateFlag::None);
-        renderDataPicture->updateSurface(mContext, surface, transform, updateTexture);
+        auto updateTexture = !data || ((flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Image)) != RenderUpdateFlag::None);
+        renderDataPicture->updateSurface(mContext, surface, transform, filter, updateTexture);
     }
 
     if (flags & RenderUpdateFlag::Clip) renderDataPicture->updateClips(clips);

--- a/src/renderer/wg_engine/tvgWgRenderer.h
+++ b/src/renderer/wg_engine/tvgWgRenderer.h
@@ -30,7 +30,7 @@ struct WgRenderer : RenderMethod
     //main features
     bool preUpdate() override;
     RenderData prepare(const RenderShape& rshape, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags, bool clipper) override;
-    RenderData prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags) override;
+    RenderData prepare(RenderSurface* surface, RenderData data, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags) override;
     bool postUpdate() override;
     bool preRender() override;
     bool renderShape(RenderData data) override;


### PR DESCRIPTION
This patch introduces a new API `Picture::filter(FilterMethod)` that allows users to control the image filtering method when rendering raster images. Two filtering options are currently supported: Bilinear (default) and Nearest.

The filter method affects the visual quality and performance when images are scaled or transformed during rendering. This is especially useful for applications requiring fine-grained control over image sampling.

Note: This is an experimental API and currently applicable only to raster images.

C++ API
+ enum struct FilterMethod::Bilinear
+ enum struct FilterMethod::Nearest
+ Result Picture::filter(FilterMethod method)

C API
+ enum TVG_FILTER_METHOD_BILINEAR
+ enum TVG_FILTER_METHOD_NEAREST
+ Tvg_Result tvg_picture_set_filter(Tvg_Paint picture, Tvg_Filter_Method method)

issue: https://github.com/thorvg/thorvg/issues/4126