### PR TITLE
wg_engine: bake model transform into geometry vertices

### DIFF
--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -155,12 +155,12 @@ void GlGeometry::prepare(const RenderShape& rshape)
     if (rshape.trimpath()) {
         RenderPath trimmedPath;
         if (rshape.stroke->trim.trim(rshape.path, trimmedPath)) {
-            trimmedPath.optimizeGL(optPath, matrix);
+            trimmedPath.optimize(optPath, matrix);
         } else {
             optPath.clear();
         }
     } else {
-        rshape.path.optimizeGL(optPath, matrix);
+        rshape.path.optimize(optPath, matrix);
     }
 }
 
@@ -229,9 +229,10 @@ bool GlGeometry::tesselateStroke(const RenderShape& rshape)
     } else {
         strokeWidth = rshape.strokeWidth();
     }
-    //run stroking only if it's valid
     auto strokeWidthWorld = strokeWidth * scaling(matrix);
     if (!std::isfinite(strokeWidthWorld)) strokeWidthWorld = strokeWidth;
+
+    //run stroking only if it's valid
 
     if (!tvg::zero(strokeWidthWorld)) {
         Stroker stroker(&stroke, strokeWidthWorld, rshape.strokeCap(), rshape.strokeJoin(), rshape.strokeMiterlimit());

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -103,9 +103,9 @@ bool RenderPath::bounds(const Matrix* m, BBox& box)
 }
 
 
-void RenderPath::optimizeGL(RenderPath& out, const Matrix& matrix) const
+void RenderPath::optimize(RenderPath& out, const Matrix& matrix) const
 {
-#if defined(THORVG_GL_RASTER_SUPPORT)
+#if defined(THORVG_GL_RASTER_SUPPORT) || defined (THORVG_WG_RASTER_SUPPORT)
     static constexpr auto PX_TOLERANCE = 0.25f;
 
     if (empty()) return;
@@ -249,153 +249,6 @@ void RenderPath::optimizeGL(RenderPath& out, const Matrix& matrix) const
     }
 #else
     TVGLOG("RENDERER", "RenderPath transformed optimization is disabled");
-#endif
-}
-
-
-void RenderPath::optimizeWG(RenderPath& out, const Matrix& matrix) const
-{
-#if defined(THORVG_WG_RASTER_SUPPORT)
-    static constexpr auto PX_TOLERANCE = 0.25f;
-
-    if (empty()) return;
-
-    out.cmds.clear();
-    out.pts.clear();
-    out.cmds.reserve(cmds.count);
-    out.pts.reserve(pts.count);
-
-    auto cmds = this->cmds.data;
-    auto cmdCnt = this->cmds.count;
-    auto pts = this->pts.data;
-
-    Point lastOutT, prevOutT;   // The suffix "T" indicates that the point is transformed.
-    uint32_t prevIdx = 0;
-    uint32_t prevPrevIdx = 0;
-    auto hasPrevPrev = false;
-
-    //vecLen is guaranteed to be non-zero since closed points are already merged
-    auto point2Line = [](const Point& point, const Point& start, const Point& vec, float vecLen, float& maxDist, float& minT, float& maxT) {
-        Point offset = point - start;
-        auto dist = fabsf(tvg::cross(vec, offset)) / vecLen;
-        if (dist > maxDist) maxDist = dist;
-        auto t = tvg::dot(offset, vec) / (vecLen * vecLen);
-        if (t < minT) minT = t;
-        if (t > maxT) maxT = t;
-    };
-
-    auto validateCubic = [&point2Line](const Point& start, const Point& ctrl1, const Point& ctrl2, const Point& end, float& maxDist, float& minT, float& maxT, float& vecLen) {
-        auto vec = end - start;
-        vecLen = sqrtf(vec.x * vec.x + vec.y * vec.y);
-        maxDist = 0.0f;
-        minT = FLT_MAX;
-        maxT = FLT_MIN;
-        point2Line(ctrl1, start, vec, vecLen, maxDist, minT, maxT);
-        point2Line(ctrl2, start, vec, vecLen, maxDist, minT, maxT);
-    };
-
-    auto point2LineSimple = [](const Point& point, const Point& start, const Point& end, float& dist, float& t, float& vecLen) {
-        auto vec = end - start;
-        auto vecLenSq = vec.x * vec.x + vec.y * vec.y;
-        vecLen = sqrtf(vecLenSq);
-        Point offset = point - start;
-        dist = fabsf(tvg::cross(vec, offset)) / vecLen;
-        t = tvg::dot(offset, vec) / vecLenSq;
-    };
-
-    auto addLineCmd = [&](const Point& pt, const Point& ptT) {
-        out.cmds.push(PathCommand::LineTo);
-        out.pts.push(pt);
-        prevOutT = lastOutT;
-        lastOutT = ptT;
-        prevPrevIdx = prevIdx;
-        prevIdx = out.pts.count - 1;
-        hasPrevPrev = true;
-    };
-
-    auto processLineCollinear = [&](const Point& startT, const Point& pt, const Point& ptT) {
-        if (!hasPrevPrev || out.pts.count <= 1) {
-            addLineCmd(pt, ptT);
-            return;
-        }
-
-        float dist, t, vecLen;
-        point2LineSimple(ptT, prevOutT, startT, dist, t, vecLen);
-        if (dist > PX_TOLERANCE) {
-            addLineCmd(pt, ptT);
-            return;
-        }
-
-        auto tEps = PX_TOLERANCE / vecLen;
-        if (t <= -tEps) {
-            out.pts[prevPrevIdx] = pt;
-            lastOutT = ptT;
-        } else if (t >= 1.0f - tEps) {
-            out.pts[prevIdx] = pt;
-            lastOutT = ptT;
-        }
-    };
-
-    auto processCubicTo = [&](const Point* cubicPts, const Point& startT) {
-        auto endT = cubicPts[2] * matrix;
-        if (tvg::closed(startT, endT, PX_TOLERANCE)) return;
-        float maxDist, minT, maxT, vecLen;
-        validateCubic(startT, cubicPts[0] * matrix, cubicPts[1] * matrix, endT, maxDist, minT, maxT, vecLen);
-        auto flat = (maxDist <= PX_TOLERANCE);
-        auto tEps = PX_TOLERANCE / vecLen;
-        auto inSpan = (minT >= -tEps) && (maxT <= 1.0f + tEps);
-        if (flat && inSpan) {
-            processLineCollinear(startT, cubicPts[2], endT);
-        } else {
-            out.cmds.push(PathCommand::CubicTo);
-            out.pts.push(cubicPts[0]);
-            out.pts.push(cubicPts[1]);
-            out.pts.push(cubicPts[2]);
-            prevOutT = lastOutT;
-            lastOutT = endT;
-            prevPrevIdx = prevIdx;
-            prevIdx = out.pts.count - 1;
-            hasPrevPrev = true;
-        }
-    };
-
-    for (uint32_t i = 0; i < cmdCnt; i++) {
-        switch (cmds[i]) {
-            case PathCommand::MoveTo: {
-                out.cmds.push(PathCommand::MoveTo);
-                out.pts.push(*pts);
-                lastOutT = *pts * matrix;
-                prevIdx = out.pts.count - 1;
-                hasPrevPrev = false;
-                pts++;
-                break;
-            }
-            case PathCommand::LineTo: {
-                auto startT = lastOutT;
-                auto ptT = (*pts) * matrix;
-                if (tvg::closed(startT, ptT, PX_TOLERANCE)) {
-                    pts++;
-                    break;
-                }
-                processLineCollinear(startT, *pts, ptT);
-                pts++;
-                break;
-            }
-            case PathCommand::CubicTo: {
-                processCubicTo(pts, lastOutT);
-                pts += 3;
-                break;
-            }
-            case PathCommand::Close: {
-                out.cmds.push(PathCommand::Close);
-                hasPrevPrev = false;
-                break;
-            }
-            default: break;
-        }
-    }
-#else
-    TVGLOG("RENDERER", "RenderPath Optimization is disabled");
 #endif
 }
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -314,8 +314,7 @@ struct RenderPath
 
     /* Optimize path in screen space with merging collinear lines,
        collapsing zero length lines, and removing unnecessary cubic beziers. */
-    void optimizeWG(RenderPath& out, const Matrix& matrix) const;
-    void optimizeGL(RenderPath& out, const Matrix& matrix) const;
+    void optimize(RenderPath& out, const Matrix& matrix) const;
     bool bounds(const Matrix* m, BBox& box);
 };
 

--- a/src/renderer/wg_engine/tvgWgCompositor.h
+++ b/src/renderer/wg_engine/tvgWgCompositor.h
@@ -41,6 +41,7 @@ private:
     WgPipelines pipelines{};
     // stage buffers
     WgStageBufferGeometry stageBufferGeometry{};
+    WgStageBufferSolidColor stageBufferSolidColor{};
     WgStageBufferUniform<WgShaderTypePaintSettings> stageBufferPaint;
     // global stencil/depth buffer handles
     WGPUTexture texDepthStencil{};
@@ -50,6 +51,8 @@ private:
     // global view matrix handles
     WGPUBuffer bufferViewMat{};
     WGPUBindGroup bindGroupViewMat{};
+    uint32_t viewMatWidth{};
+    uint32_t viewMatHeight{};
     // opacity value pool
     WGPUBuffer bufferOpacities[256]{};
     WGPUBindGroup bindGroupOpacities[256]{};
@@ -74,6 +77,7 @@ private:
 
     // base meshes draw
     void drawMesh(WgContext& context, WgMeshData* meshData);
+    void drawMeshSolid(WgContext& context, WgMeshData* meshData, uint32_t solidColorInd);
     void drawMeshImage(WgContext& context, WgMeshData* meshData);
 
     // shapes
@@ -99,6 +103,7 @@ private:
     void markupClipPath(WgContext& context, WgRenderDataShape* renderData);
     void renderClipPath(WgContext& context, WgRenderDataPaint* paint);
     void clearClipPath(WgContext& context, WgRenderDataPaint* paint);
+    void updateViewMat(WgContext& context, uint32_t width, uint32_t height);
 public:
     void initialize(WgContext& context, uint32_t width, uint32_t height);
     void initPools(WgContext& context);

--- a/src/renderer/wg_engine/tvgWgGeometry.cpp
+++ b/src/renderer/wg_engine/tvgWgGeometry.cpp
@@ -43,9 +43,13 @@ void WgMeshData::bbox(const Point pmin, const Point pmax)
 }
 
 
-void WgMeshData::imageBox(float w, float h)
+void WgMeshData::imageBox(float w, float h, const Matrix& transform)
 {
-    const float vdata[] = {0.0f, 0.0f, w, 0.0f, w, h, 0.0f, h};
+    const Point p0 = Point{0.0f, 0.0f} * transform;
+    const Point p1 = Point{w,    0.0f} * transform;
+    const Point p2 = Point{w,       h} * transform;
+    const Point p3 = Point{0.0f,    h} * transform;
+    const Point vdata[] = {p0, p1, p2, p3};
     const float tdata[] = {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};
     const uint32_t idata[] = {0, 1, 2, 0, 2, 3};
     // setup vertex data

--- a/src/renderer/wg_engine/tvgWgGeometry.h
+++ b/src/renderer/wg_engine/tvgWgGeometry.h
@@ -36,7 +36,7 @@ struct WgMeshData {
     size_t ioffset{};
 
     void bbox(const Point pmin, const Point pmax);
-    void imageBox(float w, float h);
+    void imageBox(float w, float h, const Matrix& transform);
     void blitBox();
     void clear();
 

--- a/src/renderer/wg_engine/tvgWgShaderSrc.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderSrc.cpp
@@ -30,15 +30,13 @@
 const char* cShaderSrc_Stencil = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position: vec4f };
-struct PaintSettings { transform: mat4x4f };
 
 @group(0) @binding(0) var<uniform> uViewMat  : mat4x4f;
-@group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
 
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.position = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    out.position = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
     return out;
 }
 
@@ -55,16 +53,14 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 const char* cShaderSrc_Depth = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position: vec4f };
-struct PaintSettings { transform: mat4x4f };
 
 @group(0) @binding(0) var<uniform> uViewMat  : mat4x4f;
-@group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
-@group(2) @binding(0) var<uniform> uDepth : f32;
+@group(1) @binding(0) var<uniform> uDepth : f32;
 
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.position = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    out.position = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
     out.position.z = uDepth;
     return out;
 }
@@ -80,24 +76,23 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 //************************************************************************
 
 const char* cShaderSrc_Solid = R"(
-struct VertexInput { @location(0) position: vec2f };
-struct VertexOutput { @builtin(position) position: vec4f };
-struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f };
+struct VertexInput { @location(0) position: vec2f, @location(1) color: vec4f };
+struct VertexOutput { @builtin(position) position: vec4f, @location(0) color: vec4f };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
-@group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
 
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.position = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    out.position = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
+    out.color = in.color;
     return out;
 }
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {
-    let Sc = uPaintSettings.color;
-    let So = uPaintSettings.options.a;
+    let Sc = in.color;
+    let So = 1.0;
     return vec4f(Sc.rgb * Sc.a * So, Sc.a * So);
 }
 )";
@@ -110,7 +105,7 @@ const char* cShaderSrc_Linear = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position : vec4f, @location(0) vGradCoord : vec4f };
 struct GradSettings  { transform: mat4x4f, coords: vec4f, focal: vec4f };
-struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f, gradient: GradSettings };
+struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
 
 // uniforms
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
@@ -121,7 +116,7 @@ struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f, gradien
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.position = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    out.position = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
     out.vGradCoord = uPaintSettings.gradient.transform * vec4f(in.position.xy, 0.0, 1.0);
     return out;
 }
@@ -147,7 +142,7 @@ const char* cShaderSrc_Radial = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position : vec4f, @location(0) vGradCoord : vec4f };
 struct GradSettings  { transform: mat4x4f, coords: vec4f, focal: vec4f };
-struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f, gradient: GradSettings };
+struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
 @group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
@@ -157,7 +152,7 @@ struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f, gradien
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.position = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    out.position = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
     out.vGradCoord = uPaintSettings.gradient.transform * vec4f(in.position.xy, 0.0, 1.0);
     return out;
 }
@@ -189,7 +184,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 const char* cShaderSrc_Image = R"(
 struct VertexInput { @location(0) position: vec2f, @location(1) texCoord: vec2f };
 struct VertexOutput { @builtin(position) position: vec4f, @location(0) vTexCoord: vec2f };
-struct PaintSettings { transform: mat4x4f, options: vec4f };
+struct PaintSettings { options: vec4f };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
 @group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
@@ -199,7 +194,7 @@ struct PaintSettings { transform: mat4x4f, options: vec4f };
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.position = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    out.position = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
     out.vTexCoord = in.texCoord;
     return out;
 }
@@ -244,21 +239,19 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 //************************************************************************
 
 const char* cShaderSrc_Solid_Blend = R"(
-struct VertexInput { @location(0) position: vec2f };
-struct VertexOutput { @builtin(position) position: vec4f, @location(1) vScrCoord: vec2f };
-struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f };
+struct VertexInput { @location(0) position: vec2f, @location(1) color: vec4f };
+struct VertexOutput { @builtin(position) position: vec4f, @location(0) vColor: vec4f, @location(1) vScrCoord: vec2f };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
-@group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
-// @group(2) - empty
-@group(3) @binding(0) var uSamplerDst : sampler;
-@group(3) @binding(1) var uTextureDst : texture_2d<f32>;
+@group(1) @binding(0) var uSamplerDst : sampler;
+@group(1) @binding(1) var uTextureDst : texture_2d<f32>;
 
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    let pos = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    let pos = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
     out.position = pos;
+    out.vColor = in.color;
     out.vScrCoord = vec2f(0.5 + pos.x * 0.5, 0.5 - pos.y * 0.5);
     return out;
 }
@@ -266,13 +259,13 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 struct FragData { Sc: vec3f, Sa: f32, So: f32, Dc: vec3f, Da: f32 };
 fn getFragData(in: VertexOutput) -> FragData {
     // get source data
-    let colorSrc = uPaintSettings.color;
+    let colorSrc = in.vColor;
     let colorDst = textureSample(uTextureDst, uSamplerDst, in.vScrCoord.xy);
     // fill fragment data
     var data: FragData;
     data.Sc = colorSrc.rgb;
     data.Sa = colorSrc.a;
-    data.So = uPaintSettings.options.a;
+    data.So = 1.0;
     data.Dc = colorDst.rgb;
     data.Da = colorDst.a;
     data.Sc = data.Sa * data.So * data.Sc;
@@ -287,7 +280,7 @@ const char* cShaderSrc_Linear_Blend = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position: vec4f, @location(0) vGradCoord : vec4f, @location(1) vScrCoord: vec2f };
 struct GradSettings  { transform: mat4x4f, coords: vec4f, focal: vec4f };
-struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f, gradient: GradSettings };
+struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
 @group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
@@ -299,7 +292,7 @@ struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f, gradien
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    let pos = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    let pos = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
     out.position = pos;
     out.vGradCoord = uPaintSettings.gradient.transform * vec4f(in.position.xy, 0.0, 1.0);
     out.vScrCoord = vec2f(0.5 + pos.x * 0.5, 0.5 - pos.y * 0.5);
@@ -335,7 +328,7 @@ const char* cShaderSrc_Radial_Blend = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position: vec4f, @location(0) vGradCoord : vec4f, @location(1) vScrCoord: vec2f };
 struct GradSettings  { transform: mat4x4f, coords: vec4f, focal: vec4f };
-struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f, gradient: GradSettings };
+struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
 @group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
@@ -347,7 +340,7 @@ struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f, gradien
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    let pos = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    let pos = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
     out.position = pos;
     out.vGradCoord = uPaintSettings.gradient.transform * vec4f(in.position.xy, 0.0, 1.0);
     out.vScrCoord = vec2f(0.5 + pos.x * 0.5, 0.5 - pos.y * 0.5);
@@ -387,7 +380,7 @@ fn postProcess(d: FragData, R: vec4f) -> vec4f { return R; };
 const char* cShaderSrc_Image_Blend = R"(
 struct VertexInput { @location(0) position: vec2f, @location(1) texCoord: vec2f };
 struct VertexOutput { @builtin(position) position: vec4f, @location(0) vTexCoord : vec2f, @location(1) vScrCoord: vec2f };
-struct PaintSettings { transform: mat4x4f, options: vec4f };
+struct PaintSettings { options: vec4f };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
 @group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
@@ -399,7 +392,7 @@ struct PaintSettings { transform: mat4x4f, options: vec4f };
 @vertex
 fn vs_main(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    let pos = uViewMat * uPaintSettings.transform * vec4f(in.position.xy, 0.0, 1.0);
+    let pos = uViewMat * vec4f(in.position.xy, 0.0, 1.0);
     out.position = pos;
     out.vTexCoord = in.texCoord;
     out.vScrCoord = vec2f(0.5 + pos.x * 0.5, 0.5 - pos.y * 0.5);

--- a/src/renderer/wg_engine/tvgWgShaderTypes.cpp
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.cpp
@@ -129,14 +129,16 @@ void WgShaderTypeVec4f::update(const RenderRegion& r)
 // WgShaderTypeGradSettings
 //************************************************************************
 
-void WgShaderTypeGradSettings::update(const Fill* fill)
+void WgShaderTypeGradSettings::update(const Fill* fill, const Matrix* modelTransform)
 {
     assert(fill);
     // update transform matrix
     Matrix invTransform;
-    if (inverse(&fill->transform(), &invTransform))
+    if (inverse(&fill->transform(), &invTransform)) {
+        Matrix invModel;
+        if (modelTransform && inverse(modelTransform, &invModel)) invTransform = invTransform * invModel;
         transform.update(invTransform);
-    else transform.identity();
+    } else transform.identity();
     // update gradient base points
     if (fill->type() == Type::LinearGradient)
         ((LinearGradient*)fill)->linear(&coords.vec[0], &coords.vec[1], &coords.vec[2], &coords.vec[3]);

--- a/src/renderer/wg_engine/tvgWgShaderTypes.h
+++ b/src/renderer/wg_engine/tvgWgShaderTypes.h
@@ -66,14 +66,12 @@ struct WgShaderTypeGradSettings
     // radial: [0] - fx, [1] - fy, [2] - fr
     WgShaderTypeVec4f focal;
     
-    void update(const Fill* fill);
+    void update(const Fill* fill, const Matrix* modelTransform);
 };
 
-// WGSL: struct PaintSettings { transform: mat4x4f, options: vec4f, color: vec4f, gradient: GradSettings };
+// WGSL: struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
 struct WgShaderTypePaintSettings
 {
-    // paint transform matrix (must be at offset 0)
-    WgShaderTypeMat4x4f transform;
     // [0] - color space, [3] - opacity
     WgShaderTypeVec4f options;
     // solid color
@@ -81,7 +79,7 @@ struct WgShaderTypePaintSettings
     // gradient settings (linear/radial)
     WgShaderTypeGradSettings gradient;
     // align to 256 bytes (see webgpu spec: minUniformBufferOffsetAlignment)
-    uint8_t _padding[256 - sizeof(transform) - sizeof(options) - sizeof(color) - sizeof(gradient)];
+    uint8_t _padding[256 - sizeof(options) - sizeof(color) - sizeof(gradient)];
 };
 // see webgpu spec: 3.6.2. Limits - minUniformBufferOffsetAlignment (256)
 static_assert(sizeof(WgShaderTypePaintSettings) == 256, "Uniform shader data type size must be aligned to 256 bytes");

--- a/src/renderer/wg_engine/tvgWgTessellator.h
+++ b/src/renderer/wg_engine/tvgWgTessellator.h
@@ -39,13 +39,11 @@ class WgStroker
         Point prevPtDir;
     };
 public:
-    WgStroker(WgMeshData* buffer, float width, StrokeCap cap, StrokeJoin join = StrokeJoin::Bevel);
-    void run(const RenderShape& rshape, const RenderPath& path, const Matrix& m);
+    WgStroker(WgMeshData* buffer, float width, StrokeCap cap, StrokeJoin join = StrokeJoin::Bevel, float miterLimit = 4.0f);
+    void run(const RenderPath& path);
     RenderRegion bounds() const;
     BBox getBBox() const;
 private:
-    void run(const RenderPath& path, const Matrix& m);
-
     float radius() const
     {
         return mWidth * 0.5f;
@@ -53,7 +51,7 @@ private:
 
     void cap();
     void lineTo(const Point& curr);
-    void cubicTo(const Point& cnt1, const Point& cnt2, const Point& end, const Matrix& m);
+    void cubicTo(const Point& cnt1, const Point& cnt2, const Point& end);
     void close();
     void join(const Point& dir);
     void round(const Point& prev, const Point& curr, const Point& center);
@@ -72,14 +70,13 @@ private:
     State mState = {};
     Point mLeftTop = {0.0f, 0.0f};
     Point mRightBottom = {0.0f, 0.0f};
-    float mScale;
 };
 
 class WgBWTessellator
 {
 public:
     WgBWTessellator(WgMeshData* buffer);
-    void tessellate(const RenderPath& path, const Matrix& matrix);
+    void tessellate(const RenderPath& path);
     RenderRegion bounds() const;
     BBox getBBox() const;
     bool convex = true;


### PR DESCRIPTION
# PR Description

## Summary
This PR combines two renderer refactors and related plumbing updates:
1. Bake model transforms into geometry (instead of per-object transform uniforms) in WG paths.
2. Decouple WG solid fill/stroke from per-draw paint UBO slices using an aux color vertex stream.

It also unifies shared path optimization APIs and updates GL call sites accordingly.

## Motivation
- Reduce per-draw uniform/bind-group overhead in WG.
- Simplify stencil/depth shader interfaces after transform baking.
- Remove duplicated path optimization logic (`optimizeGL` / `optimizeWG`).

## Key Changes
- Shared render core:
  - Replace `RenderPath::optimizeGL()` and `RenderPath::optimizeWG()` with `RenderPath::optimize()`.
- WG transform model:
  - Pre-transform geometry during path processing/tessellation.
  - Remove paint-transform dependency from WG paint uniform usage.
  - Update related bounds/intersection flow and compositor/pipeline binding expectations.
- WG solid path:
  - Bake opacity on CPU (`alpha *= So`) and use shader-side `So = 1.0`.
  - Add staged solid-color stream (`vec4` per draw) + GPU buffer.
  - Bind solid color as an instance-rate aux vertex slot for solid pipelines.
  - Update solid normal/blend shaders and solid pipeline layouts/bind flow.
- GL alignment:
  - Migrate GL geometry prep to shared `optimize()`.
  - Minor transform/bounds and stroke-width handling cleanups for consistency.

## Limitations
- Transform changes can increase CPU work when geometry must be regenerated.
- Solid color stream is still one `vec4` per draw item (no dedup/packing optimization yet).
- The commit groups multiple refactors, reducing bisect granularity.


## FPS gain in the Example Lottie:
- ≈ 10% on Windows11, RTX 5080 Laptop
- ≈ 2% on macOS, M1