### PR TITLE
lottie/slot: fix slot override and reset regression

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -207,7 +207,8 @@ void LottieSlot::apply(LottieProperty* prop, bool byDefault)
 
     //apply slot object to all targets
     ARRAY_FOREACH(pair, pairs) {
-        pair->prop = pair->obj->override(prop, release);
+        auto backup = pair->obj->override(prop, release);
+        if (!release) pair->prop = backup;
     }
 
     if (!byDefault) overridden = true;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -472,6 +472,7 @@ void LottieParser::registerSlot(LottieObject* obj, const char* sid, LottieProper
     ARRAY_FOREACH(p, comp->slots) {
         if ((*p)->sid != val) continue;
         (*p)->pairs.push({obj});
+        prop.sid = val;
         return;
     }
     comp->slots.push(new LottieSlot(context.layer, context.parent, val, obj, prop.type));


### PR DESCRIPTION
- Preserve the original property backup when the same slot is overridden consecutively, preventing reset from losing the original state.

issue: https://github.com/thorvg/thorvg/issues/4146

- Set `prop.sid` when appending to an existing slot, so that sid-based dispatch in override() correctly matches the target property for duplicate slot registrations.