### PR TITLE
lottie: support 3D orientation(or) property

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -37,23 +37,60 @@
 static bool _buildComposition(LottieComposition* comp, LottieLayer* parent);
 static bool _draw(LottieGroup* parent, LottieShape* shape, RenderContext* ctx);
 
+static void _dimension3d(LottieTransform* transform, float frameNo, Matrix& m, float angle, Tween& tween, LottieExpressions* exps)
+{
+    auto x = deg2rad(transform->ddd->rx(frameNo, tween, exps));
+    auto y = deg2rad(transform->ddd->ry(frameNo, tween, exps));
+    auto z = deg2rad(transform->rotation(frameNo, tween, exps)) + angle;
+
+    auto sx = sinf(x), sy = sinf(y), sz = sinf(z);
+    auto cx = cosf(x), cy = cosf(y), cz = cosf(z);
+
+    auto ri00 = cy * cz;
+    auto ri01 = -cy * sz;
+    auto ri10 = sx * sy * cz + cx * sz;
+    auto ri11 = -sx * sy * sz + cx * cz;
+
+    auto o = transform->ddd->orient(frameNo, tween, exps);
+
+    // fast-path
+    if (o.x == 0.0f && o.y == 0.0f && o.z == 0.0f) {
+        m.e11 = ri00;
+        m.e12 = ri01;
+        m.e21 = ri10;
+        m.e22 = ri11;
+        return;
+    }
+
+    auto ri02 = sy;
+    auto ri12 = -sx * cy;
+
+    auto ox = deg2rad(o.x);
+    auto oy = deg2rad(o.y);
+    auto oz = deg2rad(o.z);
+
+    auto sox = sinf(ox), soy = sinf(oy), soz = sinf(oz);
+    auto cox = cosf(ox), coy = cosf(oy), coz = cosf(oz);
+
+    auto ro00 = coy * coz;
+    auto ro01 = -coy * soz;
+    auto ro10 = sox * soy * coz + cox * soz;
+    auto ro11 = -sox * soy * soz + cox * coz;
+    auto ro20 = -cox * soy * coz + sox * soz;
+    auto ro21 = cox * soy * soz + sox * coz;
+
+    m.e11 = ri00 * ro00 + ri01 * ro10 + ri02 * ro20;
+    m.e12 = ri00 * ro01 + ri01 * ro11 + ri02 * ro21;
+    m.e21 = ri10 * ro00 + ri11 * ro10 + ri12 * ro20;
+    m.e22 = ri10 * ro01 + ri11 * ro11 + ri12 * ro21;
+}
 
 static void _rotate(LottieTransform* transform, float frameNo, Matrix& m, float angle, Tween& tween, LottieExpressions* exps)
 {
-    //rotation xyz
-    if (transform->rotationEx) {
-        auto radianX = deg2rad(transform->rotationEx->x(frameNo, tween, exps));
-        auto radianY = deg2rad(transform->rotationEx->y(frameNo, tween, exps));
-        auto radianZ = deg2rad(transform->rotation(frameNo, tween, exps)) + angle;
-        auto cx = cosf(radianX), sx = sinf(radianX);
-        auto cy = cosf(radianY), sy = sinf(radianY);;
-        auto cz = cosf(radianZ), sz = sinf(radianZ);;
-        m.e11 = cy * cz;
-        m.e12 = -cy * sz;
-        m.e21 = sx * sy * cz + cx * sz;
-        m.e22 = -sx * sy * sz + cx * cz;
-    //rotation z
+    if (transform->ddd) {
+        _dimension3d(transform, frameNo, m, angle, tween, exps);
     } else {
+        // rotation z
         auto degree = transform->rotation(frameNo, tween, exps) + angle;
         if (degree == 0.0f) return;
         auto radian = deg2rad(degree);

--- a/src/loaders/lottie/tvgLottieData.h
+++ b/src/loaders/lottie/tvgLottieData.h
@@ -130,6 +130,23 @@ static inline RGB32 lerp(const RGB32& s, const RGB32& e, float t)
     };
 }
 
+struct Point3
+{
+    float x = 0.0f, y = 0.0f, z = 0.0f;
+};
+
+static inline Point3 operator+(const Point3& a, const Point3& b)
+{
+    return {a.x + b.x, a.y + b.y, a.z + b.z};
+}
+static inline Point3 operator-(const Point3& a, const Point3& b)
+{
+    return {a.x - b.x, a.y - b.y, a.z - b.z};
+}
+static inline Point3 operator*(const Point3& a, float t)
+{
+    return {a.x * t, a.y * t, a.z * t};
+}
 }
 
 #endif //_TVG_LOTTIE_COMMON_

--- a/src/loaders/lottie/tvgLottieExpressions.h
+++ b/src/loaders/lottie/tvgLottieExpressions.h
@@ -69,6 +69,13 @@ struct LottieExpressions
     }
 
     template<typename Property>
+    bool result(float frameNo, Point3& out, LottieExpression* exp)
+    {
+        // TODO:
+        return false;
+    }
+
+    template<typename Property>
     bool result(float frameNo, RGB32& out, LottieExpression* exp)
     {
         auto bm_rt = evaluate(frameNo, exp);

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -705,16 +705,10 @@ struct LottieTransform : LottieObject
         return coords;
     }
 
-    struct RotationEx
-    {
-        LottieFloat x = 0.0f;
-        LottieFloat y = 0.0f;
-    };
-
     ~LottieTransform()
     {
         delete(coords);
-        delete(rotationEx);
+        delete (ddd);
     }
 
     LottieTransform()
@@ -783,7 +777,12 @@ struct LottieTransform : LottieObject
     LottieFloat skewAxis = 0.0f;
 
     SeparateCoord* coords = nullptr;       //either a position or separate coordinates
-    RotationEx* rotationEx = nullptr;      //extension for 3d rotation
+
+    struct Dimension3
+    {
+        LottieFloat rx = 0.0f, ry = 0.0f;  // use the rotation for z rotation
+        LottieScalar3 orient = Point3{0.0f, 0.0f, 0.0f};
+    }* ddd = nullptr;
 };
 
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -313,6 +313,23 @@ bool LottieParser::getValue(Point& pt)
     return true;
 }
 
+bool LottieParser::getValue(Point3& pt)
+{
+    if (peekType() == kNullType) return false;
+    if (peekType() == kArrayType) {
+        enterArray();
+        if (!nextArrayValue()) return false;
+    }
+
+    pt.x = getFloat();
+    pt.y = getFloat();
+    pt.z = getFloat();
+
+    while (nextArrayValue())
+        getFloat();  // drop
+
+    return true;
+}
 
 bool LottieParser::getValue(RGB32& color)
 {
@@ -565,7 +582,6 @@ LottieEllipse* LottieParser::parseEllipse()
     return ellipse;
 }
 
-
 LottieTransform* LottieParser::parseTransform(bool ddd)
 {
     auto transform = new LottieTransform;
@@ -573,7 +589,7 @@ LottieTransform* LottieParser::parseTransform(bool ddd)
     context.parent = transform;
 
     if (ddd) {
-        transform->rotationEx = new LottieTransform::RotationEx;
+        transform->ddd = new LottieTransform::Dimension3;
         TVGLOG("LOTTIE", "3D transform(ddd) is not totally compatible.");
     }
 
@@ -601,9 +617,10 @@ LottieTransform* LottieParser::parseTransform(bool ddd)
         else if (KEY_AS("s")) parseProperty(transform->scale, transform);
         else if (KEY_AS("r")) parseProperty(transform->rotation, transform);
         else if (KEY_AS("o")) parseProperty(transform->opacity, transform);
-        else if (transform->rotationEx && KEY_AS("rx")) parseProperty(transform->rotationEx->x);
-        else if (transform->rotationEx && KEY_AS("ry")) parseProperty(transform->rotationEx->y);
-        else if (transform->rotationEx && KEY_AS("rz")) parseProperty(transform->rotation);
+        else if (transform->ddd && KEY_AS("rx")) parseProperty(transform->ddd->rx);
+        else if (transform->ddd && KEY_AS("ry")) parseProperty(transform->ddd->ry);
+        else if (transform->ddd && KEY_AS("rz")) parseProperty(transform->rotation);
+        else if (transform->ddd && KEY_AS("or")) parseProperty(transform->ddd->orient);
         else if (KEY_AS("sk")) parseProperty(transform->skewAngle, transform);
         else if (KEY_AS("sa")) parseProperty(transform->skewAxis, transform);
         else skip();

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -65,6 +65,7 @@ private:
     bool getValue(int8_t& val);
     bool getValue(RGB32& color);
     bool getValue(Point& pt);
+    bool getValue(Point3& pt);
 
     template<typename T> bool parseTangent(const char *key, LottieVectorFrame<T>& value);
     template<typename T> bool parseTangent(const char *key, LottieScalarFrame<T>& value);

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -178,7 +178,21 @@ struct LottieExpression
 //Property would have an either keyframes or single value.
 struct LottieProperty
 {
-    enum class Type : uint8_t {Invalid = 0, Integer, Float, Scalar, Vector, PathSet, Color, Opacity, ColorStop, TextDoc, Image};
+    enum class Type : uint8_t
+    {
+        Invalid = 0,
+        Integer,
+        Float,
+        Scalar,
+        Vector,
+        PathSet,
+        Color,
+        Opacity,
+        ColorStop,
+        TextDoc,
+        Image,
+        Scalar3
+    };
     enum class Loop : uint8_t {None = 0, InCycle = 1, InPingPong, InOffset, InContinue, OutCycle, OutPingPong, OutOffset, OutContinue};
 
     LottieExpression* exp = nullptr;
@@ -1036,6 +1050,7 @@ using LottieFloat = LottieGenericProperty<LottieScalarFrame<float>, float, Lotti
 using LottieInteger = LottieGenericProperty<LottieScalarFrame<int8_t>, int8_t, LottieProperty::Type::Integer>;
 using LottieScalar = LottieGenericProperty<LottieScalarFrame<Point>, Point, LottieProperty::Type::Scalar>;
 using LottieVector = LottieGenericProperty<LottieVectorFrame<Point>, Point, LottieProperty::Type::Vector, 0>;
+using LottieScalar3 = LottieGenericProperty<LottieScalarFrame<Point3>, Point3, LottieProperty::Type::Scalar3>;
 using LottieColor = LottieGenericProperty<LottieScalarFrame<RGB32>, RGB32, LottieProperty::Type::Color>;
 using LottieOpacity = LottieGenericProperty<LottieScalarFrame<uint8_t>, uint8_t, LottieProperty::Type::Opacity>;
 


### PR DESCRIPTION
Support the "or" (orientation) property in 3D layer transforms, which was the only unsupported transform key from the Lottie spec.

Orientation provides a base 3D rotation [x, y, z] that is applied before individual rx/ry/rz rotations. The implementation references lottie-web's rotation order:
> Rz(rz) * Ry(ry) * Rx(rx) * Rz(or.z) * Ry(or.y) * Rx(or.x)
