### PR TITLE
loader/ttf: fix scale calculation in metrics

### DIFF
--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -590,7 +590,7 @@ void TtfLoader::copy(const FontMetrics& in, FontMetrics& out)
 
 void TtfLoader::metrics(const FontMetrics& fm, TextMetrics& out)
 {
-    auto scale = reader.metrics.unitsPerEm / (fm.fontSize * FontLoader::DPI);
+    auto scale = (fm.fontSize * FontLoader::DPI) / reader.metrics.unitsPerEm;
 
     out.advance = reader.metrics.hhea.advance * scale;
     out.ascent = reader.metrics.hhea.ascent * scale;


### PR DESCRIPTION
Correct the scale computation in TtfLoader::metrics: the previous expression inverted the ratio `(unitsPerEm / (fontSize * DPI))`, producing incorrect metric values.

The scale is now `(fontSize * DPI) / unitsPerEm` so advance, ascent, descent and linegap are scaled correctly.