### PR TITLE
lottie: fix gradient position in fragmented rendering context

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -189,6 +189,16 @@ void LottieBuilder::updateTransform(LottieGroup* parent, LottieObject** child, f
         auto denominator = sqrtf(m.e11 * m.e11 + m.e12 * m.e12);
         if (denominator > 1.0f) ctx->propagator->strokeWidth(ctx->propagator->strokeWidth() / denominator);
     }
+
+    //FIXME: compensate gradient fills when the propagator enters a group scope.
+    if (ctx->fragment) {
+        Matrix im;
+        if (inverse(&m, &im)) {
+            auto& rs = to<ShapeImpl>(ctx->propagator)->rs;
+            if (rs.fill) rs.fill->transform(rs.fill->transform() * im);
+            if (rs.stroke && rs.stroke->fill) rs.stroke->fill->transform(rs.stroke->fill->transform() * im);
+        }
+    }
 }
 
 


### PR DESCRIPTION
When a style (fill/stroke with gradient) is defined outside a group, its gradient coordinates are in the parent's coordinate space. If the group triggers `reqFragment` (e.g. because it has its own fill), the propagator inherits the group transform, incorrectly shifting the gradient coordinates.

### Reproduction

Lottie structure:
```
ShapeLayer (T_layer)
  ├─ GradientStroke (coords in layer space)     ← style, OUTSIDE group
  ├─ Fill                                        ← style, OUTSIDE group
  └─ GroupShape (T_group: translate 76, 0)
       ├─ Fill          ← INSIDE group (triggers reqFragment)
       └─ Ellipse       ← shape, INSIDE group
```

The group's inner fill makes it non-mergeable → `reqFragment = true` → fragmentation occurs. The propagator carrying the gradient stroke enters the group scene and inherits the group transform. When `_prepareLinear()` computes `pTransform * linear->transform()`, `pTransform` now incorrectly includes the group transform, shifting the gradient.

**Expected** (per Lottie spec — style outside group should use `T_layer` only):
```
gradient rendered at: T_layer × gradient_coords  ✓
```

**Actual** (bug):
```
gradient rendered at: T_layer × T_group × gradient_coords  ✗
                               ─────────
                               should not be here
```

### Fix

After applying the group transform to the propagator in `updateTransform()`, check if `ctx->fragment` is set. If so, apply the inverse group transform to any gradient fill's own transform. When ThorVG later renders with `pTransform * linear->transform()`, the group transform component cancels out, leaving only the layer transform as intended.

### Before / After

**Before**

<img width="1438" height="738" alt="CleanShot 2026-02-14 at 14 39 26@2x" src="https://github.com/user-attachments/assets/8d718ab5-5b81-4551-9948-6318d16f2e2e" />

**After**

<img width="1422" height="738" alt="CleanShot 2026-02-14 at 14 40 34@2x" src="https://github.com/user-attachments/assets/eeb11fd8-2f45-49cf-94a8-2b4fe49079e4" />


Minimal reproduction Lottie JSON:

<details>
<summary>test-gradient-fragment.json</summary>

```json
{"v":"5.7.4","fr":60,"ip":0,"op":60,"w":512,"h":512,"layers":[{"ty":4,"nm":"Shape Stroke + Fill","sr":1,"ks":{"o":{"a":0,"k":100},"r":{"a":0,"k":0},"p":{"a":0,"k":[256,256,0]},"a":{"a":0,"k":[0,0,0]},"s":{"a":0,"k":[100,100,100]}},"ao":0,"shapes":[{"ty":"gr","nm":"Group + Fill","it":[{"ty":"el","d":1,"s":{"a":0,"k":[49,49]},"p":{"a":0,"k":[0,0]},"nm":"Ellipse"},{"ty":"fl","c":{"a":0,"k":[0,0.8,0,1]},"o":{"a":0,"k":50},"r":1,"nm":"Fill Inside Group"},{"ty":"tr","p":{"a":0,"k":[76.36,0]},"a":{"a":0,"k":[0,0]},"s":{"a":0,"k":[100,100]},"r":{"a":0,"k":0},"o":{"a":0,"k":100}}]},{"ty":"fl","c":{"a":0,"k":[0,0.8,0,1]},"o":{"a":0,"k":50},"r":1,"nm":"Fill Outside"},{"ty":"gs","o":{"a":0,"k":100},"w":{"a":0,"k":100},"g":{"p":5,"k":{"a":0,"k":[0,1,0,0,0.25,1,0.5,0,0.5,0,0,1,0.75,0.8,0,0.8,1,0,0,0]}},"s":{"a":0,"k":[940,0]},"e":{"a":0,"k":[-68,24]},"t":1,"lc":2,"lj":2,"nm":"GradientStroke"}],"ip":0,"op":60,"st":0}]}
```

</details>

### Reference

- [Lottie Spec - Shapes](https://lottiefiles.github.io/lottie-spec/specs/shapes/) — T_shape vs T_style scope
- lottie-web renders this correctly (gradient not affected by group transform)