### PR TITLE
lottie: add marker segment query API

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -3202,6 +3202,22 @@ TVG_API Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation, uint
 
 
 /**
+ * @brief Gets the marker information by a given index.
+ *
+ * @param[in] animation The Lottie animation object.
+ * @param[in] idx The index of the animation marker, starts from 0.
+ * @param[out] name The name of the marker. Pass @c NULL to not receive this value.
+ * @param[out] begin The start frame of the marker. Pass @c NULL to not receive this value.
+ * @param[out] end The end frame of the marker. Pass @c NULL to not receive this value.
+ *
+ * @retval TVG_RESULT_INVALID_ARGUMENT In case @p animation is invalid, @c idx is out of range, or all output parameters are @c NULL.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_lottie_animation_get_marker_info(Tvg_Animation animation, uint32_t idx, const char** name, float* begin, float* end);
+
+
+/**
  * @brief Interpolates between two frames over a specified duration.
  *
  * This method performs tweening, a process of generating intermediate frame

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -1235,6 +1235,19 @@ TVG_API Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation, uint
 }
 
 
+TVG_API Tvg_Result tvg_lottie_animation_get_marker_info(Tvg_Animation animation, uint32_t idx, const char** name, float* begin, float* end)
+{
+#ifdef THORVG_LOTTIE_LOADER_SUPPORT
+    if (!animation || (!name && !begin && !end)) return TVG_RESULT_INVALID_ARGUMENT;
+    auto n = reinterpret_cast<LottieAnimation*>(animation)->marker(idx, begin, end);
+    if (!n) return TVG_RESULT_INVALID_ARGUMENT;
+    if (name) *name = n;
+    return TVG_RESULT_SUCCESS;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+
 TVG_API Tvg_Result tvg_lottie_animation_tween(Tvg_Animation animation, float from, float to, float progress)
 {
 #ifdef THORVG_LOTTIE_LOADER_SUPPORT

--- a/src/loaders/lottie/thorvg_lottie.h
+++ b/src/loaders/lottie/thorvg_lottie.h
@@ -74,11 +74,25 @@ public:
      * @param[in] idx The index of the animation marker, starts from 0.
      *
      * @retval The name of marker when succeed, @c nullptr otherwise.
-     * 
+     *
      * @see LottieAnimation::markersCnt()
      * @since 1.0
      */
     const char* marker(uint32_t idx) noexcept;
+
+    /**
+     * @brief Gets the marker name and segment range by a given index.
+     *
+     * @param[in] idx The index of the animation marker, starts from 0.
+     * @param[out] begin The start frame of the marker. Pass @c nullptr to not receive this value.
+     * @param[out] end The end frame of the marker. Pass @c nullptr to not receive this value.
+     *
+     * @retval The name of marker when succeed, @c nullptr otherwise.
+     *
+     * @see LottieAnimation::markersCnt()
+     * @note Experimental API
+     */
+    const char* marker(uint32_t idx, float* begin, float* end) noexcept;
 
     /**
      * @brief Updates the value of an expression variable for a specific layer.

--- a/src/loaders/lottie/tvgLottieAnimation.cpp
+++ b/src/loaders/lottie/tvgLottieAnimation.cpp
@@ -103,9 +103,15 @@ uint32_t LottieAnimation::markersCnt() noexcept
 
 const char* LottieAnimation::marker(uint32_t idx) noexcept
 {
+    return marker(idx, nullptr, nullptr);
+}
+
+
+const char* LottieAnimation::marker(uint32_t idx, float* begin, float* end) noexcept
+{
     auto loader = to<PictureImpl>(pImpl->picture)->loader;
     if (!loader) return nullptr;
-    return static_cast<LottieLoader*>(loader)->markers(idx);
+    return static_cast<LottieLoader*>(loader)->markers(idx, begin, end);
 }
 
 

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -440,11 +440,13 @@ uint32_t LottieLoader::markersCnt()
 }
 
 
-const char* LottieLoader::markers(uint32_t index)
+const char* LottieLoader::markers(uint32_t index, float* begin, float* end)
 {
     if (!ready() || index >= comp->markers.count) return nullptr;
-    auto marker = comp->markers.begin() + index;
-    return (*marker)->name;
+    auto marker = comp->markers[index];
+    if (begin) *begin = marker->time;
+    if (end) *end = marker->time + marker->duration;
+    return marker->name;
 }
 
 

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -94,7 +94,7 @@ public:
 
     //Marker Supports
     uint32_t markersCnt();
-    const char* markers(uint32_t index);
+    const char* markers(uint32_t index, float* begin = nullptr, float* end = nullptr);
     bool segment(const char* marker, float& begin, float& end);
     Result segment(float begin, float end) override;
 

--- a/test/testLottie.cpp
+++ b/test/testLottie.cpp
@@ -176,6 +176,10 @@ TEST_CASE("Lottie Marker", "[tvgLottie]")
         //Set marker name before loaded
         REQUIRE(animation->segment("sectionC") == Result::InsufficientCondition);
 
+        //Get marker info before loaded
+        float markerBegin, markerEnd;
+        REQUIRE(animation->marker(0, &markerBegin, &markerEnd) == nullptr);
+
         //Animation load
         REQUIRE(picture->load(TEST_DIR"/segment.lot") == Result::Success);
 
@@ -191,8 +195,30 @@ TEST_CASE("Lottie Marker", "[tvgLottie]")
         //Get marker name by index
         REQUIRE(!strcmp(animation->marker(1), "sectionB"));
 
-        //Get marker name by invalid index
+        //Get marker name and segment by index
+        REQUIRE(!strcmp(animation->marker(0, &markerBegin, &markerEnd), "sectionA"));
+        REQUIRE(markerBegin == 0.0f);
+        REQUIRE(markerEnd == 22.0f);
+
+        REQUIRE(!strcmp(animation->marker(1, &markerBegin, &markerEnd), "sectionB"));
+        REQUIRE(markerBegin == 22.0f);
+        REQUIRE(markerEnd == 33.0f);
+
+        REQUIRE(!strcmp(animation->marker(2, &markerBegin, &markerEnd), "sectionC"));
+        REQUIRE(markerBegin == 33.0f);
+        REQUIRE(markerEnd == 63.0f);
+
+        //Get marker with only begin
+        REQUIRE(!strcmp(animation->marker(0, &markerBegin, nullptr), "sectionA"));
+        REQUIRE(markerBegin == 0.0f);
+
+        //Get marker with only end
+        REQUIRE(!strcmp(animation->marker(0, nullptr, &markerEnd), "sectionA"));
+        REQUIRE(markerEnd == 22.0f);
+
+        //Get marker by invalid index
         REQUIRE(animation->marker(-1) == nullptr);
+        REQUIRE(animation->marker(-1, &markerBegin, &markerEnd) == nullptr);
 
         REQUIRE(animation->segment(nullptr) == Result::Success);
     }


### PR DESCRIPTION
## Summary
- **C++**: Unified `const char* marker(uint32_t idx, float* begin = nullptr, float* end = nullptr)` — replaces old `const char* marker(uint32_t idx)` overload, returns marker name and optionally outputs begin/end frame values
- **CAPI**: Add `tvg_lottie_animation_get_marker_info()` with `name`, `begin`, and `end` out-params; deprecate old `tvg_lottie_animation_get_marker()` (kept for ABI compatibility)
- Tests updated to cover begin/end frame queries (26 assertions)

Resolves #4167