### PR TITLE
lottie/slot: fix stale scene data on slot override/reset while paused

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -427,7 +427,10 @@ void LottieLoader::sync()
 {
     done();
 
-    if (build) run(0);
+    if (build) {
+        if (comp) comp->clear();
+        run(0);
+    }
 }
 
 


### PR DESCRIPTION
When the animation is paused (no active `frame()` calls), triggering a scene rebuild via `apply()` or `del()` left stale layer data visible after re-rendering.

`comp->clear()` was only called inside `frame()` and `tween()`, so rebuild paths never cleared the previous scene.

Move `comp->clear()` into `run()`, directly before `builder->update()`, and remove it from `frame()` and `tween()`. Since `run()` is the single execution point for all rebuilds.

issue: https://github.com/thorvg/thorvg/issues/4169

| Before | After |
|------|-------|
| ![CleanShot 2026-02-23 at 17 12 28](https://github.com/user-attachments/assets/a7c280e4-709c-402a-8fc8-6232b9459130) | ![CleanShot 2026-02-23 at 17 12 02](https://github.com/user-attachments/assets/d153c500-4474-470d-bf7d-b8b140f13984) |