### PR TITLE
lottie: fix solid fill color distortion with bezier easing

### DIFF
--- a/src/loaders/lottie/tvgLottieData.h
+++ b/src/loaders/lottie/tvgLottieData.h
@@ -23,9 +23,11 @@
 #ifndef _TVG_LOTTIE_COMMON_
 #define _TVG_LOTTIE_COMMON_
 
-#include <cmath>
-#include "tvgCommon.h"
 #include "tvgArray.h"
+#include "tvgMath.h"
+
+namespace tvg
+{
 
 struct PathSet
 {
@@ -118,5 +120,16 @@ static inline RGB32 operator*(const RGB32& lhs, float rhs)
     return {(int32_t)nearbyintf(lhs.r * rhs), (int32_t)nearbyintf(lhs.g * rhs), (int32_t)nearbyintf(lhs.b * rhs)};
 }
 
+
+static inline RGB32 lerp(const RGB32& s, const RGB32& e, float t)
+{
+    return {
+        tvg::clamp((int32_t)(s.r + (e.r - s.r) * t), 0, 255),
+        tvg::clamp((int32_t)(s.g + (e.g - s.g) * t), 0, 255),
+        tvg::clamp((int32_t)(s.b + (e.b - s.b) * t), 0, 255)
+    };
+}
+
+}
 
 #endif //_TVG_LOTTIE_COMMON_


### PR DESCRIPTION
When a fill color keyframe has Bezier easing with a negative Y tangent, the interpolator's progress() can return values outside [0, 1], causing the lerp result to exceed the valid RGB range [0, 255]. This overflow wraps on cast to uint8_t, producing incorrect colors. Add a `tvg::lerp` overload for RGB32 that clamps each channel to [0, 255].

issue(partly): https://github.com/thorvg/thorvg/issues/3801

---

test file:  [solid-fill-ezier easing overshoot.json](https://github.com/user-attachments/files/25479712/solid-fill-ezier.easing.overshoot.json)

> This file has out tangent with y=-1.471 (negative)

When I test lottie-web ignores this issue, since the Web HTML renderer/Canvas automatically clamps [RGB](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/rgb) values to 0-255.

<img width="480" height="414" alt="Ghostty 2026-02-23 18 17 12" src="https://github.com/user-attachments/assets/728a731d-591b-4f0d-bd79-6c60831dd5d7" />

> When the value exceeds over 255, discrepancy.


| Issue | Patched |
| --- | --- |
 | ![CleanShot 2026-02-23 at 18 31 32](https://github.com/user-attachments/assets/65c0d43d-4b38-420b-9db8-b059048c76db) | ![CleanShot 2026-02-23 at 18 30 56](https://github.com/user-attachments/assets/4c15197f-f67e-4b28-9fd6-7ee3856637b9) |