### PR TITLE
renderer: fine-tune composition pipeline

### DIFF
--- a/src/renderer/sw_engine/tvgSwCommon.h
+++ b/src/renderer/sw_engine/tvgSwCommon.h
@@ -417,6 +417,7 @@ static inline RenderColor BLEND_UPRE(uint32_t c)
 static inline uint32_t BLEND_PRE(uint32_t c1, uint32_t c2, uint8_t a)
 {
     if (a == 255) return c1;
+    else if (a == 0) return c2;
     return ALPHA_BLEND(c1, a) + ALPHA_BLEND(c2, 255 - a);
 }
 
@@ -487,7 +488,6 @@ static inline uint32_t opBlendMultiply(uint32_t s, uint32_t d)
 
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
-
 
 static inline uint32_t opBlendOverlay(uint32_t s, uint32_t d)
 {

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -162,7 +162,7 @@ Paint* Paint::Impl::duplicate(Paint* ret)
 }
 
 
-bool Paint::Impl::render(RenderMethod* renderer)
+bool Paint::Impl::render(RenderMethod* renderer, CompositionFlag flag)
 {
     if (hidden || opacity == 0) return true;
 
@@ -188,7 +188,7 @@ bool Paint::Impl::render(RenderMethod* renderer)
     if (cmp) renderer->beginComposite(cmp, maskData->method, maskData->target->pImpl->opacity);
 
     bool ret;
-    PAINT_METHOD(ret, render(renderer));
+    PAINT_METHOD(ret, render(renderer, flag));
 
     if (cmp) renderer->endComposite(cmp);
 

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -148,12 +148,12 @@ struct Paint::Impl
 
     bool marked(CompositionFlag flag)
     {
-        return (uint8_t(cmpFlag) & uint8_t(flag)) ? true : false;
+        return (uint8_t(cmpFlag) & uint8_t(flag));
     }
 
     bool marked(RenderUpdateFlag flag)
     {
-        return (renderFlag & flag) ? true : false;
+        return (renderFlag & flag);
     }
 
     void mark(RenderUpdateFlag flag)
@@ -311,7 +311,7 @@ struct Paint::Impl
     bool bounds(Point* pt4, const Matrix* pm, bool obb);
     Iterator* iterator();
     RenderData update(RenderMethod* renderer, const Matrix& pm, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag pFlag, bool clipper = false);
-    bool render(RenderMethod* renderer);
+    bool render(RenderMethod* renderer, CompositionFlag flag = CompositionFlag::Invalid);
     Paint* duplicate(Paint* ret = nullptr);
 };
 

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -279,7 +279,7 @@ struct PictureImpl : Picture
         impl.mark(CompositionFlag::Opacity);
     }
 
-    bool render(RenderMethod* renderer)
+    bool render(RenderMethod* renderer, CompositionFlag flag)
     {
         auto ret = true;
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -40,7 +40,7 @@ struct ShapeImpl : Shape
     {
     }
 
-    bool render(RenderMethod* renderer)
+    bool render(RenderMethod* renderer, CompositionFlag flag)
     {
         if (!impl.rd) return false;
 

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -107,7 +107,7 @@ struct TextImpl : Text
         return to<ShapeImpl>(shape)->bounds();
     }
 
-    bool render(RenderMethod* renderer)
+    bool render(RenderMethod* renderer, CompositionFlag flag)
     {
         if (!loader || !fm.engine) return true;
         renderer->blend(impl.blendMethod);


### PR DESCRIPTION
Use direct composition when a scene can parasitize its parent compositor’s surface. Currently, this optimization is experimentally applied only to post-processing (parent) + blending (children) compositions.

Under this condition, CPU/GPU performance shows approximately a 25% FPS improvement.

This also fixes CPU broken premultiplied pixel issues under the condition.

Before:
<img width="1042" height="1053" alt="image" src="https://github.com/user-attachments/assets/cb306a89-de0f-4800-81ca-7a10409aeb2d" />


After: 
<img width="1039" height="1057" alt="image" src="https://github.com/user-attachments/assets/4c296a80-3a0d-45df-a37b-34a0cc4bf103" />