### PR TITLE
ttf: allow Apple TrueType fonts

### DIFF
--- a/src/loaders/ttf/tvgTtfReader.cpp
+++ b/src/loaders/ttf/tvgTtfReader.cpp
@@ -302,8 +302,11 @@ bool TtfReader::header()
 {
     if (!validate(0, 12)) return false;
 
-    //verify ttf(scalable font)
+    //verify scalable fonts
     auto type = _u32(data, 0);
+
+    // ttf: 0x00010000
+    // true(apple): 0x74727565
     if (type != 0x00010000 && type != 0x74727565) return false;
 
     //header


### PR DESCRIPTION
TrueType (0x00010000) and Apple TrueType ('true') share the same glyf-based outline structure. Accept the Apple TrueType signature to improve font compatibility.

ref: https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html