### PR TITLE
renderer: remove colinear merge and use thin-path flag

### DIFF
--- a/src/renderer/gl_engine/tvgGlCommon.h
+++ b/src/renderer/gl_engine/tvgGlCommon.h
@@ -91,7 +91,7 @@ struct GlGeometry
     void prepare(const RenderShape& rshape);
     bool tesselateShape(const RenderShape& rshape, float* opacityMultiplier = nullptr);
     bool tesselateStroke(const RenderShape& rshape);
-    bool tesselateLine(const RenderPath& path);
+    bool tesselateThinPath(const RenderPath& path);
     void tesselateImage(const RenderSurface* image);
     bool draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag);
     GlStencilMode getStencilMode(RenderUpdateFlag flag);
@@ -105,10 +105,11 @@ struct GlGeometry
     FillRule fillRule = FillRule::NonZero;
     RenderPath optPath;  //optimal path
     float strokeRenderWidth = 0.0f;
-    bool fillWorld = false;
-    bool convex;
     Matrix cachedInverseMatrix = {};
     bool inverseMatrixDirty = true;
+    bool fillWorld = false;
+    bool optPathThin = false;
+    bool convex;
 };
 
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -312,9 +312,9 @@ struct RenderPath
         return curr;
     }
 
-    /* Optimize path in screen space with merging collinear lines,
-       collapsing zero length lines, and removing unnecessary cubic beziers. */
-    void optimize(RenderPath& out, const Matrix& matrix) const;
+    /* Optimize path in screen space by collapsing zero length lines
+       and removing unnecessary cubic beziers. */
+    void optimize(RenderPath& out, const Matrix& matrix, bool& thin) const;
     bool bounds(const Matrix* m, BBox& box);
 };
 

--- a/src/renderer/wg_engine/tvgWgRenderData.cpp
+++ b/src/renderer/wg_engine/tvgWgRenderData.cpp
@@ -179,22 +179,23 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
 
     // optimize path
     RenderPath optPath;
+    bool optPathThin = false;
     if (rshape.trimpath()) {
         RenderPath trimmedPath;
         if (rshape.stroke->trim.trim(rshape.path, trimmedPath)) {
-            trimmedPath.optimize(optPath, matrix);
+            trimmedPath.optimize(optPath, matrix, optPathThin);
         } else {
             optPath.clear();
         }
-    } else rshape.path.optimize(optPath, matrix);
+    } else rshape.path.optimize(optPath, matrix, optPathThin);
 
     auto updatePath = flag & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path);
 
     // update fill shapes
     if (updatePath || (flag & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient))) {
         BBox bbox;
-        // in a case of single line shape we must tesselate it as a single line stroke with minimal width
-        if (optPath.pts.count == 2 && tvg::zero(rshape.strokeWidth())) {
+        // in a case of thin shape we must tesselate it as a stroke with minimal width
+        if (optPathThin && tvg::zero(rshape.strokeWidth())) {
             WgStroker stroker(&meshShape, MIN_WG_STROKE_WIDTH, StrokeCap::Butt, StrokeJoin::Bevel);
             stroker.run(optPath);
             bbox = stroker.getBBox();


### PR DESCRIPTION
## Root cause

A regression in transformed-path collinear reduction was introduced when model transforms moved to CPU geometry optimization.

In `processLineCollinear()`, we rewrote an earlier vertex (`out.pts[prevPrevIdx] = ptT`) instead of preserving that backward turn as an explicit segment.  
For thin/near-collinear contours, this could alter contour progression and winding, causing shape flip/backtracking artifacts (issue #4154).

This behavior was introduced in `7be22d20` and later affected both GL and WG after `7f758a4f` unified usage of the transformed optimizer.

## Resolution

- Remove only the colinear merge process in `RenderPath::optimize(...)
- Since colinear points are no longer merged, collect thinness during optimization and return it by call-by-reference.
Use that thinness result in GL/WG to choose stroke tessellation fallback, instead of relying on optPath.pts.count == 2.

(For cubic paths, thinness detection does not require a precise area once the cubic is confirmed non-degenerate and non-line-like.)

This keeps simplification benefits for forward collinear extension while preventing winding/shape flips in backward cases, resolving #4154.
<img width="1603" height="834" alt="image" src="https://github.com/user-attachments/assets/0f03b184-dc2a-46cd-bc1a-f85b95fe39a0" />

The SVG that accompanies the commit `7be22d20` also displays the correct rendering result.
<img width="1272" height="300" alt="image" src="https://github.com/user-attachments/assets/ce98b813-4126-4f6e-892e-47f7344f2e08" />


https://github.com/user-attachments/assets/2d4b1ef0-524e-4ae0-a493-b477fc2c8f3f




- The FPS of example Lottie is the same.
- No obvious regression during running all examples.
