### PR TITLE
lottie: support italic text rendering for URL fonts

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -969,6 +969,7 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     auto color = doc.color;
     paint->fill(color.r, color.g, color.b);
     paint->size(doc.size * 75.0f); //1 pt = 1/72; 1 in = 96 px; -> 72/96 = 0.75
+    if (text->font && text->font->style && strstr(text->font->style, "Italic")) paint->italic();
     paint->text(buf);
     paint->layout(doc.bbox.size.x, doc.bbox.size.y);
     paint->translate(doc.bbox.pos.x, doc.bbox.pos.y);


### PR DESCRIPTION
Lottie loader parsed the `fStyle` from the font definition but italic style never used during rendering.

> Apply italic rendering when the font style (fStyle) indicates an italic variant (e.g. "Italic", "Bold Italic", "Light
  Italic"). [refer](https://lottiefiles.github.io/lottie-docs/text/#text-document)

| Before | After |
| --- | --- |
| <img width="2048" height="1894" alt="CleanShot 2026-02-25 at 12 32 29@2x" src="https://github.com/user-attachments/assets/1443f423-e112-46a4-a704-e49d661b225b" /> | <img width="2048" height="1894" alt="CleanShot 2026-02-25 at 12 32 15@2x" src="https://github.com/user-attachments/assets/cf185749-9e91-4fb4-8e8d-32cbe8784dd6" /> |