### PR TITLE
infra: added clang format script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,103 @@
+# ThorVG Clang-Format Configuration
+# Based on ThorVG coding style conventions
+# Requires clang-format == 18
+
+---
+Language: Cpp
+Standard: c++14
+
+# Base style
+BasedOnStyle: LLVM
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+ConstructorInitializerIndentWidth: 4
+AccessModifierOffset: -4
+NamespaceIndentation: None
+IndentCaseLabels: true
+IndentPPDirectives: None
+
+# Line length
+ColumnLimit: 0
+
+# Braces - same line style (Mix K&R and Allman styles)
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: true
+  AfterControlStatement: false
+  AfterClass: true
+  AfterStruct: true
+  AfterEnum: true
+  AfterNamespace: true
+  BeforeCatch: false
+  BeforeElse: false
+
+# Pointer/Reference alignment - left (type-attached)
+PointerAlignment: Left
+ReferenceAlignment: Left
+DerivePointerAlignment: false
+
+# Spacing
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInParentheses: false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceAfterTemplateKeyword: false
+SpacesInAngles: false
+SpaceBeforeSquareBrackets: false
+SpacesInSquareBrackets: false
+
+# Include sorting
+SortIncludes: false
+IncludeBlocks: Preserve
+
+# Function/class formatting
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Inline
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BreakConstructorInitializers: AfterColon
+PackConstructorInitializers: BinPack
+
+# Alignment
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: false
+AlignTrailingComments: true
+
+# Breaking
+BreakBeforeBinaryOperators: All
+BreakBeforeTernaryOperators: true
+BreakStringLiterals: true
+
+# Comments
+ReflowComments: true
+SpacesBeforeTrailingComments: 2
+
+# Empty lines
+MaxEmptyLinesToKeep: 2
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+# Penalties (to discourage certain formatting)
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+
+# Other
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+SortUsingDeclarations: true

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,37 @@
+name: Clang Format
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format 18
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-18
+          sudo ln -sf /usr/bin/clang-format-18 /usr/local/bin/clang-format
+
+      - name: Install reviewdog
+        uses: reviewdog/action-setup@v1
+
+      - name: Run clang-format check
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git diff -U0 ${{ github.event.pull_request.base.sha }} \
+          | clang-format-diff -p1 \
+          | reviewdog -f=diff \
+                      -reporter=github-pr-check \
+                      -filter-mode=added \
+                      -fail-on-error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,46 +1,62 @@
-We always appreciate your contribution. ThorVG doesn't expect patches to be perfect; instead, we value contributions that make ThorVG better than before. This page outlines the ThorVG contribution format.<br />
+We truly appreciate your contributions. While ThorVG does not expect patches to be perfect, we value changes that move the project forward. This document outlines our contribution guidelines and formatting requirements.<br />
 <br />
 
 ## Coding Convention
 Please read the [ThorVG Coding Convention Guidance](https://github.com/thorvg/thorvg/wiki/Coding-Convention) before writing your code.
+
+## Code Formatting
+ThorVG uses `.clang-format` (version 18) at the repository root to enforce a consistent C/C++ coding style. All contributions must be properly formatted before submitting a Pull Request.
+
+### Install clang-format
+**Ubuntu**
+```
+sudo apt install clang-format
+```
+**macOS**
+```
+brew install clang-format
+```
+**Windows**
+```
+Download and install LLVM from: https://llvm.org/builds/
+Make sure clang-format is added to your system PATH
+```
+
+### Recommended Workflow
+To keep the Git history clean, we recommend formatting your code after creating a commit and then amending it. You can use the ThorVG helper script (`tvg-format.sh`):
+```
+$ ./tvg-format.sh <git-sha>    # Run in the ThorVG root directory
+$ git commit --amend           # Amend the formatting changes after self-review
+```
 
 ## Reviewers
 ThorVG uses GitHub infrastructure to automatically assign code reviewers for your changes. To see the full list of reviewers, please refer to the [CODEOWNERS](https://github.com/thorvg/thorvg/blob/main/CODEOWNERS) file.
 <br />
 
 ## Self Test & Verification
-After updating the ThorVG code, please ensure your changes don't break the library. We recommend conducting unit tests. You can easily run them using the following build commands:
-<br/>
-`
-$meson setup build -Dtests=true -Dloaders="all" -Dsavers="all" -Dbindings="capi" -Dtools="all" -Dlog=true
-`
-<br />
-`
-$ninja -C build test
-`
-<br/>
-<br/>
-Please make it sure running all tests and no any fail case.<br/>
-<br/>
-Expected Fail:      0<br/>
-Fail:               0<br/>
-Unexpected Pass:    0<br/>
-Skipped:            0<br/>
-Timeout:            0<br/>
+After updating the ThorVG codebase, please ensure that your changes do not break the library. We recommend running unit tests using the following commands:
+```
+$ meson setup build -Dtests=true -Dloaders="all" -Dsavers="all" -Dbindings="capi" -Dtools="all" -Dlog=true -Db_sanitize="address,undefined"
+$ ninja -C build test
+```
+Please make sure that all tests pass without failures:
+```
+Expected Fail:      0
+Fail:               0
+Unexpected Pass:    0
+Skipped:            0
+Timeout:            0
+```
 
 ## Commit Message
 [Module][Feature]: [Title]
 
 [Description]
 
-- [Module] refers to the sub-module primarily affected by your change. Most of the time, this indicates the name of a sub-folder.
-This also suggests who might need to review your patch.
-If your change doesn't belong to any sub-modules, you can either replace this with a suitable name or skip it.
-The name should be written entirely in lowercase letters.
+- [Module] refers to the sub-module primarily affected by your change. Most of the time, this indicates the name of a sub-folder. This helps identify the appropriate reviewers for your change. If your change doesn't belong to any sub-modules, you can either replace this with a suitable name or skip it. The name should be written entirely in lowercase letters.
   - e.g., build, doc, infra, common, sw_engine, gl_engine, svg_loader, wasm, svg2png...
 
-- [Feature] indicates the primary function or feature you modified. Typically, this represents a class or file name.
-This is an optional.
+- [Feature] indicates the primary function or feature you modified. This field is optional.
   - e.g., canvas, shape, paint, scene, picture, task-scheduler, loader, builder, ...
 
 - [Title] provides a brief description of your change and should be encapsulated in a single sentence.
@@ -89,9 +105,9 @@ Here's a sample commit message for clarity:
 
 ## Pull Request
 
-Once you've submitted a pull request (PR), please ensure the following checklist is completed:
-- Reviewers: Check the Reviewers List.
-- Assignees: You should be assigned.
-- Labels: Mark the appropriate Patch Purpose.
-- Automated Integration Test: All must pass.
+Once you submit a Pull Request, please ensure the following:
+- Reviewers are automatically assigned.
+- You are listed as an assignee.
+- Appropriate labels are applied.
+- All automated integration tests pass.
 <p align="center"><img width="1000" height="auto" src="https://github.com/thorvg/thorvg.site/blob/main/readme/contribution.png"></p>

--- a/tvg-format.sh
+++ b/tvg-format.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------
+# ThorVG clang-format commit formatter
+# ------------------------------------------------------------------
+#
+# Description:
+#   Formats only the lines modified in a specific commit
+#   using clang-format-diff.
+#
+# Usage:
+#   ./tvg-format.sh <commit-hash>
+#
+# Example:
+#   ./tvg-format.sh HEAD
+#   ./tvg-format.sh 3f2a8b1
+#
+# Requirements:
+#   - git
+#   - clang-format
+#   - clang-format-diff
+#
+# Notes:
+#   - Must be run from repository root
+#   - .clang-format must exist at repo root
+#   - Works on macOS and Linux
+# ------------------------------------------------------------------
+
+set -euo pipefail
+
+# ------------------------------
+# Argument check
+# ------------------------------
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <commit-hash>"
+    exit 1
+fi
+
+COMMIT="$1"
+
+# ------------------------------
+# Tool existence checks
+# ------------------------------
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "Error: git is not installed or not in PATH."
+    exit 1
+fi
+
+if ! command -v clang-format >/dev/null 2>&1; then
+    echo "Error: clang-format is not installed or not in PATH."
+    exit 1
+fi
+
+if ! command -v clang-format-diff >/dev/null 2>&1; then
+    echo "Error: clang-format-diff is not installed or not in PATH."
+    echo "Hint: On macOS, install via: brew install clang-format"
+    exit 1
+fi
+
+# ------------------------------
+# Repository root check
+# ------------------------------
+
+if [ ! -f ".clang-format" ]; then
+    echo "Error: .clang-format not found in current directory."
+    echo "Please run this script from the repository root."
+    exit 1
+fi
+
+# ------------------------------
+# Commit existence check
+# ------------------------------
+
+if ! git rev-parse --verify "$COMMIT" >/dev/null 2>&1; then
+    echo "Error: Commit '$COMMIT' not found."
+    exit 1
+fi
+
+# ------------------------------
+# Run formatter
+# ------------------------------
+
+echo "Formatting changes in commit: $COMMIT"
+
+git show -U0 "$COMMIT" | clang-format-diff -p1 -i
+
+echo "Done."


### PR DESCRIPTION
Workflow:
 1. add a commit
 2. run the clang format script locally
 3. after self-review, ammend the formatting change
 4. push the commit

Script Usage:
```
 $ tvg-format.sh {git-sha}
```

See CONTRIBUTING.md guide

issue: https://github.com/thorvg/thorvg/issues/1519