### PR TITLE
capi: add Paint ID setter/getter

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -921,6 +921,33 @@ TVG_API Tvg_Result tvg_paint_set_visible(Tvg_Paint paint, bool visible);
 TVG_API bool tvg_paint_get_visible(const Tvg_Paint paint);
 
 /**
+ * @brief Gets the ID of the Paint object
+ *
+ * @param[in] paint The paint object to return its ID.
+ *
+ * @return the hash ID of a paint object or 0 if the ID is not set
+ *
+ * @see tvg_picture_get_paint()
+ * @see tvg_accessor_generate_id()
+ * @see tvg_paint_set_id()
+ * @note Experimental API
+ */
+TVG_API uint32_t tvg_paint_get_id(const Tvg_Paint paint);
+
+/**
+ * @brief Sets the ID of the Paint object
+ *
+ * @param[in] paint The paint object to set
+ * @param[in] id The ID to set
+ *
+ * @see tvg_picture_get_paint()
+ * @see tvg_accessor_generate_id()
+ * @see tvg_paint_get_id()
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_paint_set_id(Tvg_Paint paint, uint32_t id);
+
+/**
  * @brief Scales the given Tvg_Paint object by the given factor.
  *
  * @param[in] paint The paint object to be scaled.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -190,6 +190,20 @@ TVG_API bool tvg_paint_get_visible(const Tvg_Paint paint)
     return false;
 }
 
+TVG_API uint32_t tvg_paint_get_id(const Tvg_Paint paint)
+{
+    if (paint) return reinterpret_cast<const Paint*>(paint)->id;
+    return 0;
+}
+
+TVG_API Tvg_Result tvg_paint_set_id(Tvg_Paint paint, uint32_t id)
+{
+    if (paint) {
+        reinterpret_cast<Paint*>(paint)->id = id;
+        return TVG_RESULT_SUCCESS;
+    }
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
 
 TVG_API uint16_t tvg_paint_ref(Tvg_Paint paint)
 {


### PR DESCRIPTION
See: https://github.com/thorvg/thorvg.web/issues/240

This PR adds `tvg_paint_get_id()`, which later I need it for adding the object ID lookup function in the ThorVG WebCanvas WASM library.

CC @tinyjin 