### PR TITLE
gl_engine: fix GL scene blend blit source/extent mismatch

### DIFF
--- a/src/renderer/gl_engine/tvgGlRenderTask.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderTask.cpp
@@ -24,6 +24,15 @@
 #include "tvgGlProgram.h"
 #include "tvgGlRenderPass.h"
 
+#if !defined(THORVG_GL_TARGET_GL)
+static void clearColorTarget(uint32_t width, uint32_t height)
+{
+    GL_CHECK(glScissor(0, 0, width, height));
+    GL_CHECK(glClearColor(0, 0, 0, 0));
+    GL_CHECK(glClear(GL_COLOR_BUFFER_BIT));
+}
+#endif
+
 /************************************************************************/
 /* GlRenderTask Class Implementation                                    */
 /************************************************************************/
@@ -345,16 +354,17 @@ void GlSceneBlendTask::run()
     const auto height = mSrcFbo->height;
     if (width <= 0 || height <= 0) return;
 
-    GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, mSrcFbo->fbo));
-    GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mDstCopyFbo->resolvedFbo));
 
 #if defined(THORVG_GL_TARGET_GL)
-    const auto& srcVp = mSrcFbo->viewport;
-    // Copy current target into dstCopyFbo for blending.
-    GL_CHECK(glViewport(0, 0, srcVp.w(), srcVp.h()));
-    GL_CHECK(glScissor(0, 0, srcVp.w(), srcVp.h()));
+    GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, getTargetFbo()));
+    GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mDstCopyFbo->resolvedFbo));
+    GL_CHECK(glViewport(0, 0, mDstCopyFbo->width, mDstCopyFbo->height));
+    GL_CHECK(glScissor(0, 0, mDstCopyFbo->width, mDstCopyFbo->height));
     GL_CHECK(glBlitFramebuffer(vp.min.x, vp.min.y, vp.max.x, vp.max.y, 0, 0, vp.w(), vp.h(), GL_COLOR_BUFFER_BIT, GL_LINEAR));
 #else // TODO: create partial buffer when MSAA is disabled
+    GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mDstCopyFbo->resolvedFbo));
+    if (vp.min.x != 0 || vp.min.y != 0 || mDstCopyFbo->width != static_cast<uint32_t>(vp.w()) || mDstCopyFbo->height != static_cast<uint32_t>(vp.h())) clearColorTarget(mDstCopyFbo->width, mDstCopyFbo->height);
+    GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, mSrcFbo->fbo));
     GL_CHECK(glViewport(0, 0, width, height));
     GL_CHECK(glScissor(vp.min.x, vp.min.y, vp.w(), vp.h()));
     GL_CHECK(glBlitFramebuffer(vp.min.x, vp.min.y, vp.max.x, vp.max.y, vp.min.x, vp.min.y, vp.max.x, vp.max.y, GL_COLOR_BUFFER_BIT, GL_NEAREST));
@@ -449,6 +459,7 @@ void GlDirectBlendTask::run()
     GL_CHECK(glScissor(0, 0, width, height));
     GL_CHECK(glBlitFramebuffer(x, y, x + width, y + height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_LINEAR));
 #else // TODO: create partial buffer when MSAA is disabled
+    if (x != 0 || y != 0 || mDstCopyFbo->width != static_cast<uint32_t>(width) || mDstCopyFbo->height != static_cast<uint32_t>(height)) clearColorTarget(mDstCopyFbo->width, mDstCopyFbo->height);
     GL_CHECK(glViewport(0, 0, fboW, fboH));
     GL_CHECK(glScissor(x, y, width, height));
     GL_CHECK(glBlitFramebuffer(x, y, x + width, y + height, x, y, x + width, y + height, GL_COLOR_BUFFER_BIT, GL_NEAREST));
@@ -500,6 +511,7 @@ void GlComplexBlendTask::run()
     GL_CHECK(glScissor(0, 0, dstVp.w(), dstVp.h()));
     GL_CHECK(glBlitFramebuffer(vp.min.x, vp.min.y, vp.max.x, vp.max.y, 0, 0, vp.w(), vp.h(), GL_COLOR_BUFFER_BIT, GL_LINEAR));
 #else // TODO: create partial buffer when MSAA is disabled
+    if (vp.min.x != 0 || vp.min.y != 0 || mDstCopyFbo->width != static_cast<uint32_t>(vp.w()) || mDstCopyFbo->height != static_cast<uint32_t>(vp.h())) clearColorTarget(mDstCopyFbo->width, mDstCopyFbo->height);
     GL_CHECK(glViewport(0, 0, width, height));
     GL_CHECK(glScissor(vp.min.x, vp.min.y, vp.w(), vp.h()));
     GL_CHECK(glBlitFramebuffer(vp.min.x, vp.min.y, vp.max.x, vp.max.y, vp.min.x, vp.min.y, vp.max.x, vp.max.y, GL_COLOR_BUFFER_BIT, GL_NEAREST));

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -568,12 +568,8 @@ void GlRenderer::endBlendingCompose(GlRenderTask* stencilTask)
     prepareCmpTask(task, vp, blendPass->getFboWidth(), blendPass->getFboHeight());
     task->setDrawDepth(currentPass()->nextDrawDepth());
 
-#if defined(THORVG_GL_TARGET_GL)
-    const auto& taskVp = task->getViewport();
-    float region[] = {float(taskVp.sx()), float(taskVp.sy()), float(dstCopyFbo->width), float(dstCopyFbo->height)};
-#else // TODO: create partial buffer when MSAA is disabled
+#if defined(THORVG_GL_TARGET_GLES)
     float region[] = {0.0f, 0.0f, float(dstCopyFbo->width), float(dstCopyFbo->height)};
-#endif
     task->addBindResource(GlBindingResource{
         0,
         task->getProgram()->getUniformBlockIndex("BlendRegion"),
@@ -581,6 +577,7 @@ void GlRenderer::endBlendingCompose(GlRenderTask* stencilTask)
         mGpuBuffer.push(region, 4 * sizeof(float), true),
         4 * sizeof(float),
     });
+#endif
 
     // src and dst texture
     task->addBindResource(GlBindingResource{1, blendPass->getFbo()->colorTex, task->getProgram()->getUniformLocation("uSrcTexture")});
@@ -833,12 +830,8 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
             task->setRenderSize(glCmp->bbox.w(), glCmp->bbox.h());
             prepareCmpTask(task, glCmp->bbox, renderPass->getFboWidth(), renderPass->getFboHeight());
             task->setDrawDepth(currentPass()->nextDrawDepth());
-#if defined(THORVG_GL_TARGET_GL)
-            const auto& taskVp = task->getViewport();
-            float region[] = {float(taskVp.sx()), float(taskVp.sy()), float(dstCopyFbo->width), float(dstCopyFbo->height)};
-#else // TODO: create partial buffer when MSAA is disabled
+#if defined(THORVG_GL_TARGET_GLES)
             float region[] = {0.0f, 0.0f, float(dstCopyFbo->width), float(dstCopyFbo->height)};
-#endif
             task->addBindResource(GlBindingResource{
                 1,
                 task->getProgram()->getUniformBlockIndex("BlendRegion"),
@@ -846,6 +839,7 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
                 mGpuBuffer.push(region, 4 * sizeof(float), true),
                 4 * sizeof(float),
             });
+#endif
             // info
             task->addBindResource(GlBindingResource{0, task->getProgram()->getUniformBlockIndex("ColorInfo"), mGpuBuffer.getBufferId(), mGpuBuffer.push(info, sizeof(info), true), sizeof(info)});
             // textures

--- a/src/renderer/gl_engine/tvgGlShaderSrc.cpp
+++ b/src/renderer/gl_engine/tvgGlShaderSrc.cpp
@@ -689,6 +689,71 @@ void getFragData() {
 vec4 postProcess(vec4 R) { return R; }
 )";
 
+// GL keeps a viewport-sized dst copy, so src/dst can share vUV.
+// GLES/WebGL must keep a full resolved dst copy because MSAA resolve/blit is only valid for the
+// full buffer there; down-blitting into a smaller FBO would add another full copy pass. Rebuild
+// dst UV from gl_FragCoord + BlendRegion instead of reusing vUV.
+#if defined(THORVG_GL_TARGET_GL)
+const char* BLEND_IMAGE_FRAG_HEADER = R"(
+uniform sampler2D uSrcTexture;
+uniform sampler2D uDstTexture;
+
+in vec2 vUV;
+out vec4 FragColor;
+
+vec3 One = vec3(1.0, 1.0, 1.0);
+struct FragData { vec3 Sc; float Sa; float So; vec3 Dc; float Da; };
+FragData d;
+
+void getFragData() {
+    // get source data
+    vec4 colorSrc = texture(uSrcTexture, vUV);
+    vec4 colorDst = texture(uDstTexture, vUV);
+    // fill fragment data
+    d.Sc = colorSrc.rgb;
+    d.Sa = colorSrc.a;
+    d.So = 1.0;
+    d.Dc = colorDst.rgb;
+    d.Da = colorDst.a;
+    if (d.Sa > 0.0) { d.Sc = d.Sc / d.Sa; }
+}
+
+vec4 postProcess(vec4 R) { return mix(vec4(d.Dc, d.Da), R, d.Sa * d.So); }
+)";
+
+const char* BLEND_SCENE_FRAG_HEADER = R"(
+layout(std140) uniform ColorInfo {
+    int format;
+    int flipY;
+    int opacity;
+    int dummy;
+} uColorInfo;
+uniform sampler2D uSrcTexture;
+uniform sampler2D uDstTexture;
+
+in vec2 vUV;
+out vec4 FragColor;
+
+vec3 One = vec3(1.0, 1.0, 1.0);
+struct FragData { vec3 Sc; float Sa; float So; vec3 Dc; float Da; };
+FragData d;
+
+void getFragData() {
+    // get source data
+    vec4 colorSrc = texture(uSrcTexture, vUV);
+    vec4 colorDst = texture(uDstTexture, vUV);
+    // fill fragment data
+    d.Sc = colorSrc.rgb;
+    d.Sa = colorSrc.a;
+    d.So = float(uColorInfo.opacity) / 255.0;
+    d.Dc = colorDst.rgb;
+    d.Da = colorDst.a;
+    if (d.Sa > 0.0) {d.Sc = d.Sc / d.Sa; }
+}
+
+vec4 postProcess(vec4 R) { return mix(vec4(d.Dc, d.Da), R, d.Sa * d.So); }
+)";
+#else
 const char* BLEND_IMAGE_FRAG_HEADER = R"(
 layout(std140) uniform BlendRegion {
     vec4 region;
@@ -759,6 +824,7 @@ void getFragData() {
 
 vec4 postProcess(vec4 R) { return mix(vec4(d.Dc, d.Da), R, d.Sa * d.So); }
 )";
+#endif
 
 const char* BLEND_FRAG_HSL = R"(
 // RGB to HSL conversion


### PR DESCRIPTION
In GlSceneBlendTask::run() (GL path), the blit target is mDstCopyFbo->resolvedFbo but viewport/scissor were configured from mSrcFbo->viewport.

This can mismatch destination buffer space and clip the copy, leaving stale pixels that show up as blend artifacts.

Set GL viewport/scissor from mDstCopyFbo->width/height before blitting.

Related issue: https://github.com/thorvg/thorvg/issues/4187


https://github.com/user-attachments/assets/bbc2a647-3812-4cd4-a73e-bd884146adac

