### PR TITLE
lottie: added pucker/bloat support

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -414,7 +414,7 @@ static void _repeat(LottieGroup* parent, Shape* path, LottieRenderPooler<Shape>*
 
 void LottieBuilder::appendRect(Shape* shape, Point& pos, Point& size, float r, bool clockwise, RenderContext* ctx)
 {
-    auto temp = (ctx->offset) ? Shape::gen() : shape;
+    auto temp = (ctx->offset || ctx->puckerBloat) ? Shape::gen() : shape;
     auto cnt = to<ShapeImpl>(temp)->rs.path.pts.count;
 
     temp->appendRect(pos.x, pos.y, size.x, size.y, r, r, clockwise);
@@ -425,7 +425,12 @@ void LottieBuilder::appendRect(Shape* shape, Point& pos, Point& size, float r, b
         }
     }
 
-    if (ctx->offset) {
+    if (ctx->puckerBloat) {
+        //apply full modifier chain starting from puckerBloat
+        auto& path = to<ShapeImpl>(temp)->rs.path;
+        ctx->modifier->modifyPath(path.cmds.data, path.cmds.count, path.pts.data, path.pts.count, nullptr, to<ShapeImpl>(shape)->rs.path);
+        Paint::rel(temp);
+    } else if (ctx->offset) {
         ctx->offset->modifyRect(to<ShapeImpl>(temp)->rs.path, to<ShapeImpl>(shape)->rs.path);
         Paint::rel(temp);
     }
@@ -459,6 +464,21 @@ void LottieBuilder::updateRect(LottieGroup* parent, LottieObject** child, float 
 
 static void _appendCircle(Shape* shape, Point& center, Point& radius, bool clockwise, RenderContext* ctx)
 {
+    //puckerBloat requires path-level processing: generate into a temp then apply full modifier chain
+    if (ctx->puckerBloat) {
+        auto temp = Shape::gen();
+        temp->appendCircle(center.x, center.y, radius.x, radius.y, clockwise);
+        auto& tempPath = to<ShapeImpl>(temp)->rs.path;
+        if (ctx->transform) {
+            for (uint32_t i = 0; i < tempPath.pts.count; ++i) {
+                tempPath.pts[i] *= *ctx->transform;
+            }
+        }
+        ctx->modifier->modifyPath(tempPath.cmds.data, tempPath.cmds.count, tempPath.pts.data, tempPath.pts.count, nullptr, to<ShapeImpl>(shape)->rs.path);
+        Paint::rel(temp);
+        return;
+    }
+
     if (ctx->offset) ctx->offset->modifyEllipse(radius);
 
     auto cnt = to<ShapeImpl>(shape)->rs.path.pts.count;
@@ -753,6 +773,15 @@ void LottieBuilder::updateOffsetPath(TVG_UNUSED LottieGroup* parent, LottieObjec
 }
 
 
+void LottieBuilder::updatePuckerBloat(TVG_UNUSED LottieGroup* parent, LottieObject** child, float frameNo, TVG_UNUSED Inlist<RenderContext>& contexts, RenderContext* ctx)
+{
+    auto puckerBloat = static_cast<LottiePuckerBloat*>(*child);
+    if (!ctx->puckerBloat) ctx->puckerBloat = new LottiePuckerBloatModifier(&buffer, puckerBloat->amount(frameNo, tween, exps));
+
+    ctx->update(ctx->puckerBloat);
+}
+
+
 void LottieBuilder::updateRepeater(TVG_UNUSED LottieGroup* parent, LottieObject** child, float frameNo, TVG_UNUSED Inlist<RenderContext>& contexts, RenderContext* ctx)
 {
     auto repeater = static_cast<LottieRepeater*>(*child);
@@ -858,6 +887,10 @@ void LottieBuilder::updateChildren(LottieGroup* parent, float frameNo, Inlist<Re
                 }
                 case LottieObject::OffsetPath: {
                     updateOffsetPath(parent, child, frameNo, contexts, ctx);
+                    break;
+                }
+                case LottieObject::PuckerBloat: {
+                    updatePuckerBloat(parent, child, frameNo, contexts, ctx);
                     break;
                 }
                 default: break;

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -83,6 +83,7 @@ struct RenderContext
     Matrix* transform = nullptr;
     LottieRoundnessModifier* roundness = nullptr;
     LottieOffsetModifier* offset = nullptr;
+    LottiePuckerBloatModifier* puckerBloat = nullptr;
     LottieModifier* modifier = nullptr;
     RenderFragment fragment = ByNone;  //render context has been fragmented
     bool reqFragment = false;  //requirement to fragment the render context
@@ -100,6 +101,7 @@ struct RenderContext
         delete(transform);
         delete(roundness);
         delete(offset);
+        delete(puckerBloat);
     }
 
     RenderContext(const RenderContext& rhs, Shape* propagator, bool mergeable = false) : propagator(propagator)
@@ -115,6 +117,10 @@ struct RenderContext
         if (rhs.offset) {
             offset = new LottieOffsetModifier(rhs.offset->offset, rhs.offset->miterLimit, rhs.offset->join);
             update(offset);
+        }
+        if (rhs.puckerBloat) {
+            puckerBloat = new LottiePuckerBloatModifier(rhs.puckerBloat->buffer, rhs.puckerBloat->amount);
+            update(puckerBloat);
         }
         if (rhs.transform) {
             transform = new Matrix;
@@ -204,6 +210,7 @@ private:
     void updateRepeater(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updateRoundedCorner(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updateOffsetPath(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
+    void updatePuckerBloat(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
 
     RenderPath buffer;   //reusable path
     LottieExpressions* exps;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -272,6 +272,7 @@ struct LottieObject
         Repeater,
         RoundedCorner,
         OffsetPath,
+        PuckerBloat,
         TextRange
     };
 
@@ -1000,6 +1001,23 @@ struct LottieOffsetPath : LottieObject
     LottieFloat offset = 0.0f;
     LottieFloat miterLimit = 4.0f;
     StrokeJoin join = StrokeJoin::Miter;
+};
+
+
+struct LottiePuckerBloat : LottieObject
+{
+    LottiePuckerBloat()
+    {
+        LottieObject::type = LottieObject::PuckerBloat;
+    }
+
+    LottieProperty* property(uint16_t ix) override
+    {
+        if (amount.ix == ix) return &amount;
+        return nullptr;
+    }
+
+    LottieFloat amount = 0.0f;
 };
 
 

--- a/src/loaders/lottie/tvgLottieModifier.cpp
+++ b/src/loaders/lottie/tvgLottieModifier.cpp
@@ -79,6 +79,45 @@ static Line _offset(Point& p1, Point& p2, float offset)
 }
 
 
+static Point _center(const PathCommand* cmds, uint32_t cmdsCnt, const Point* pts)
+{
+    Point center{};
+    auto count = 0;
+    const auto* p = pts;
+    const auto* startP = p;
+
+    for (uint32_t i = 0; i < cmdsCnt; ++i) {
+        switch (cmds[i]) {
+            case PathCommand::MoveTo: {
+                startP = p;
+                ++p;
+                break;
+            }
+            case PathCommand::CubicTo: {
+                center = center + *(p - 1) + *p + *(p + 1) + *(p + 2);
+                p += 3;
+                count += 4;
+                break;
+            }
+            case PathCommand::LineTo: {
+                center = center + *(p - 1) + *p;
+                ++p;
+                count += 2;
+                break;
+            }
+            case PathCommand::Close: {
+                if (!tvg::zero(*(p - 1) - *startP)) {
+                    center = center + *(p - 1) + *startP;
+                    count += 2;
+                }
+                break;
+            }
+        }
+    }
+    return count > 0 ? center / (float)count : Point{0, 0};
+}
+
+
 static bool _clockwise(Point* pts, uint32_t n)
 {
     auto area = 0.0f;
@@ -386,4 +425,79 @@ bool LottieOffsetModifier::modifyEllipse(Point& radius)
     radius.x += offset;
     radius.y += offset;
     return true;
+}
+
+
+bool LottiePuckerBloatModifier::modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out)
+{
+    buffer->clear();
+
+    auto& path = next ? *buffer : out;
+
+    //LineTo segments are expanded to CubicTo, so pts capacity can grow up to 3x
+    path.cmds.reserve(inCmdsCnt);
+    path.pts.reserve(inPtsCnt * 3);
+
+    auto center = _center(inCmds, inCmdsCnt, inPts);
+    auto a = amount * 0.01f;
+    auto pts = inPts;
+    auto startPts = pts;
+
+    for (uint32_t i = 0; i < inCmdsCnt; ++i) {
+        switch (inCmds[i]) {
+            case PathCommand::MoveTo: {
+                startPts = pts;
+                //anchor points move toward center
+                path.pts.push(*pts + (center - *pts) * a);
+                path.cmds.push(PathCommand::MoveTo);
+                ++pts;
+                break;
+            }
+            case PathCommand::CubicTo: {
+                //control points move away from center, end (anchor) moves toward center
+                path.pts.push(*pts - (center - *pts) * a);
+                path.pts.push(*(pts + 1) - (center - *(pts + 1)) * a);
+                path.pts.push(*(pts + 2) + (center - *(pts + 2)) * a);
+                path.cmds.push(PathCommand::CubicTo);
+                pts += 3;
+                break;
+            }
+            case PathCommand::LineTo: {
+                //convert to CubicTo: prev and curr as control points (away), curr as end (toward)
+                path.pts.push(*(pts - 1) - (center - *(pts - 1)) * a);
+                path.pts.push(*pts - (center - *pts) * a);
+                path.pts.push(*pts + (center - *pts) * a);
+                path.cmds.push(PathCommand::CubicTo);
+                ++pts;
+                break;
+            }
+            case PathCommand::Close: {
+                //if last pt != start pt, add implicit closing segment as CubicTo
+                if (!tvg::zero(*(pts - 1) - *startPts)) {
+                    path.pts.push(*(pts - 1) - (center - *(pts - 1)) * a);
+                    path.pts.push(*startPts - (center - *startPts) * a);
+                    path.pts.push(*startPts + (center - *startPts) * a);
+                    path.cmds.push(PathCommand::CubicTo);
+                }
+                path.cmds.push(PathCommand::Close);
+                break;
+            }
+        }
+    }
+
+    if (transform) {
+        for (uint32_t i = 0; i < path.pts.count; ++i) {
+            path.pts[i] *= *transform;
+        }
+    }
+
+    if (next) return next->modifyPath(path.cmds.data, path.cmds.count, path.pts.data, path.pts.count, transform, out);
+
+    return true;
+}
+
+
+bool LottiePuckerBloatModifier::modifyPolystar(RenderPath& in, RenderPath& out, TVG_UNUSED float, TVG_UNUSED bool)
+{
+    return modifyPath(in.cmds.data, in.cmds.count, in.pts.data, in.pts.count, nullptr, out);
 }

--- a/src/loaders/lottie/tvgLottieModifier.h
+++ b/src/loaders/lottie/tvgLottieModifier.h
@@ -31,7 +31,7 @@
 
 struct LottieModifier
 {
-    enum Type : uint8_t {Roundness = 0, Offset};
+    enum Type : uint8_t {Roundness = 0, Offset, PuckerBloat};
 
     LottieModifier* next = nullptr;
     Type type;
@@ -44,15 +44,17 @@ struct LottieModifier
     LottieModifier* decorate(LottieModifier* next)
     {
         /* TODO: build the decorative chaining here.
-           currently we only have roundness and offset. */
+           currently we only have pucker/bloat, roundness and offset. */
 
-        //roundness -> offset
-        if (next->type == Roundness) {
+        //pucker/bloat -> roundness -> offset
+        if (type == Offset && (next->type == Roundness || next->type == PuckerBloat)) {
             next->next = this;
             return next;
         }
-
-        //just in the order.
+        if (type == Roundness && next->type == PuckerBloat) {
+            next->next = this;
+            return next;
+        }
         this->next = next;
         return this;
     }
@@ -104,6 +106,21 @@ private:
 
     void line(RenderPath& out, PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t& curPt, uint32_t curCmd, State& state, float offset, bool degenerated);
     void corner(RenderPath& out, Line& line, Line& nextLine, uint32_t movetoIndex, bool nextClose);
+};
+
+
+struct LottiePuckerBloatModifier : LottieModifier
+{
+    RenderPath* buffer;
+    float amount;
+
+    LottiePuckerBloatModifier(RenderPath* buffer, float amount) : buffer(buffer), amount(amount)
+    {
+        type = PuckerBloat;
+    }
+
+    bool modifyPath(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out) override;
+    bool modifyPolystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
 };
 
 #endif

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -740,6 +740,21 @@ LottieRoundedCorner* LottieParser::parseRoundedCorner()
 }
 
 
+LottiePuckerBloat* LottieParser::parsePuckerBloat()
+{
+    auto puckerBloat = new LottiePuckerBloat;
+
+    context.parent = puckerBloat;
+
+    while (auto key = nextObjectKey()) {
+        if (parseCommon(puckerBloat, key)) continue;
+        else if (KEY_AS("a")) parseProperty(puckerBloat->amount);
+        else skip();
+    }
+    return puckerBloat;
+}
+
+
 void LottieParser::parseColorStop(LottieGradient* gradient)
 {
     enterObject();
@@ -885,7 +900,7 @@ LottieObject* LottieParser::parseObject(const char* type)
     else if (!strcmp(type, "tm")) return parseTrimpath();
     else if (!strcmp(type, "rp")) return parseRepeater();
     else if (!strcmp(type, "mm")) TVGLOG("LOTTIE", "MergePath(mm) is not supported yet");
-    else if (!strcmp(type, "pb")) TVGLOG("LOTTIE", "Puker/Bloat(pb) is not supported yet");
+    else if (!strcmp(type, "pb")) return parsePuckerBloat();
     else if (!strcmp(type, "tw")) TVGLOG("LOTTIE", "Twist(tw) is not supported yet");
     else if (!strcmp(type, "op")) return parseOffsetPath();
     else if (!strcmp(type, "zz")) TVGLOG("LOTTIE", "ZigZag(zz) is not supported yet");

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -93,6 +93,7 @@ private:
     LottieTrimpath* parseTrimpath();
     LottieRepeater* parseRepeater();
     LottieOffsetPath* parseOffsetPath();
+    LottiePuckerBloat* parsePuckerBloat();
     LottieFont* parseFont();
     void parseFontData(LottieFont* font, const char* data);
     LottieMarker* parseMarker();


### PR DESCRIPTION
see: https://lottiefiles.github.io/lottie-docs/shapes/#pucker-bloat


test files:
- [test (11).json](https://github.com/user-attachments/files/25932736/test.11.json)
- [data (4).json](https://github.com/user-attachments/files/25932742/data.4.json)

| Sample 1 | Sample 2 |
|---------|---------|
| ![CleanShot 2026-03-12 at 20 01 09](https://github.com/user-attachments/assets/e14b74b4-7b6d-43d4-979c-246737568633) | ![CleanShot 2026-03-12 at 20 01 39](https://github.com/user-attachments/assets/65165ee1-4c59-4242-a390-de26de915f24) |



original PR: https://github.com/thorvg/thorvg/pull/3378
related: https://github.com/thorvg/thorvg/issues/3801
issue: https://github.com/thorvg/thorvg/issues/2681