### PR TITLE
lottie: skip dirName prefix for http/https image asset paths

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -964,6 +964,9 @@ void LottieParser::parseImage(LottieImage* image, const char* data, const char* 
         auto b64Data = strstr(data, ",") + 1;
         size_t length = dlen - (b64Data - data);
         image->bitmap.size = b64Decode(b64Data, length, &image->bitmap.data);
+    //remote image resource (https:// or http://)
+    } else if (!strncmp(data, "https://", 8) || !strncmp(data, "http://", 7)) {
+        image->bitmap.path = duplicate(data);
     //external image resource
     } else {
         auto subPathLen = subPath ? strlen(subPath) : 0;


### PR DESCRIPTION
issue: https://github.com/thorvg/thorvg/issues/4208

This condition may be simpler, but just in case for file name like `http_logo.png`, I used explicit condition.
```cpp
else if (!strncmp(data, "http", 4)) 
```

Nowadays, the remote URL is strongly recommended to start with `https://` protocal header instead of `http`, the condition order aligns like this.
```cpp
else if (!strncmp(data, "https://", 8) || !strncmp(data, "http://", 7))
```