### PR TITLE
svg_loader: Prevent unnecessary shapes from being drawn on the scene

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -953,6 +953,7 @@ static Scene* _sceneBuildHelper(SvgLoaderData& loaderData, const SvgNode* node, 
 
     ARRAY_FOREACH(p, node->child) {
         auto child = *p;
+        if (child->type == SvgNodeType::ClipPath || child->type == SvgNodeType::Filter) continue;
         if (_isGroupType(child->type)) {
             if (child->type == SvgNodeType::Use)
                 scene->add(_useBuildHelper(loaderData, child, vBox, svgPath, depth + 1));


### PR DESCRIPTION
When SceneBuilder build a child into a scene, it excludes ClipPaths and Filters from the "render targets." This prevents unnecessary shapes from being drawn on the screen.

sample
```html
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1000" height="700" viewBox="-2100 -1470 4200 2940">
  <defs>
    <path id="b" fill-rule="evenodd" d="M0 0a31.5 35 0 0 0 0-70A31.5 35 0 0 0 0 0m0-13a18.5 22 0 0 0 0-44 18.5 22 0 0 0 0 44" />
    <g id="n">
      <clipPath id="a">
        <path d="M-31.5 0v-70h63V0zM0-47v12h31.5v-12z" />
      </clipPath>
      <use xlink:href="#b" clip-path="url(#a)" />
      <path d="M5-35h26.5v10H5z" />
      <path d="M21.5-35h10V0h-10z" />
    </g>
  </defs>

  <g fill="#009440" transform="translate(-420 1470)">
    <use xlink:href="#n" y="-1697.5" transform="rotate(23.5)" />
  </g>

</svg>
```

related issue : https://github.com/thorvg/thorvg/issues/4213