### PR TITLE
lottie: skip text layout when bbox size is not specified

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -974,8 +974,10 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     paint->size(doc.size * 75.0f); //1 pt = 1/72; 1 in = 96 px; -> 72/96 = 0.75
     if (text->font && text->font->style && strstr(text->font->style, "Italic")) paint->italic();
     paint->text(buf);
+
+    float lottieAscent = text->font->ascent * doc.size / 100.0f;
     paint->layout(doc.bbox.size.x, doc.bbox.size.y);
-    paint->translate(doc.bbox.pos.x, doc.bbox.pos.y);
+    paint->translate(doc.bbox.pos.x, doc.bbox.pos.y + (doc.bbox.size.y > 0.0f ? lottieAscent : 0.0f) - doc.shift);
 
     //align the text to the base line
     TextMetrics metrics;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -148,7 +148,12 @@ bool LottieParser::getValue(TextDocument& doc)
         else if (KEY_AS("ls")) doc.shift = getFloat();
         else if (KEY_AS("fc")) getValue(doc.color);
         else if (KEY_AS("ps")) getValue(doc.bbox.pos);
-        else if (KEY_AS("sz")) getValue(doc.bbox.size);
+        else if (KEY_AS("sz")) {
+            getValue(doc.bbox.size);
+            //bbox size is positive
+            doc.bbox.size.x = tvg::clamp(doc.bbox.size.x, 0.0f, FLT_MAX);
+            doc.bbox.size.y = tvg::clamp(doc.bbox.size.y, 0.0f, FLT_MAX);
+        }
         else if (KEY_AS("sc")) getValue(doc.stroke.color);
         else if (KEY_AS("sw")) doc.stroke.width = getFloat();
         else if (KEY_AS("of")) doc.stroke.below = !getBool();


### PR DESCRIPTION
Restore baseline offset for text layers without a bounding box. Use the layout only when a bounding box is specified.

Fix regression for 
[lottie.json](https://github.com/user-attachments/files/26039029/lottie.-.2026-03-17T082549.132.json)

This lottie doesn't have "sz"(bbx size), then previous layout and align logic made text shifed in negative direction.

culprit: https://github.com/thorvg/thorvg/commit/4d2830ca48bdd45a451a68f3509639f97cb77211


<img width="2046" height="1820" alt="Ghostty 2026-03-17 08 22 45" src="https://github.com/user-attachments/assets/fe84ffc7-2cf6-4326-9d38-9dbe924d3c83" />

Also verified test file from original issue.

<img width="2038" height="1832" alt="Ghostty 2026-03-17 08 20 06" src="https://github.com/user-attachments/assets/b9560287-c052-48fa-b602-ec8e0bcab49a" />
