### PR TITLE
svg_loader: keep group ids on group paints

### DIFF
--- a/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -955,11 +955,15 @@ static Scene* _sceneBuildHelper(SvgLoaderData& loaderData, const SvgNode* node, 
         auto child = *p;
         if (child->type == SvgNodeType::ClipPath || child->type == SvgNodeType::Filter) continue;
         if (_isGroupType(child->type)) {
+            Paint* paint = nullptr;
             if (child->type == SvgNodeType::Use)
-                scene->add(_useBuildHelper(loaderData, child, vBox, svgPath, depth + 1));
+                paint = _useBuildHelper(loaderData, child, vBox, svgPath, depth + 1);
             else if (!(child->type == SvgNodeType::Symbol && node->type != SvgNodeType::Use))
-                scene->add(_sceneBuildHelper(loaderData, child, vBox, svgPath, false, depth + 1));
-            if (child->id) scene->id = djb2Encode(child->id);
+                paint = _sceneBuildHelper(loaderData, child, vBox, svgPath, false, depth + 1);
+            if (paint) {
+                if (child->id) paint->id = djb2Encode(child->id);
+                scene->add(paint);
+            }
         } else {
             Paint* paint = nullptr;
             if (child->type == SvgNodeType::Image) paint = _imageBuildHelper(loaderData, child, vBox, svgPath);


### PR DESCRIPTION
Set the appropriate ID so that the Accessor can access the group's ID.

test code
```
const char *svg = R"(
<svg xmlns="http://www.w3.org/2000/svg" width="400" height="250">
  <rect   id="background" width="400" height="250" fill="#1a6bb5"/>
  <circle id="sun" cx="320" cy="60" r="45" fill="#f5c518"/>
  <g id="mountains">
    <polygon id="mountains_poly1" points="0,200 80,90 160,200" fill="#3a9e78" opacity=0.5/>
    <polygon id="mountains_poly2" points="80,200 180,70 280,200" fill="#3a9e78" opacity=0.5/>
  </g>
  <g id="foreground" opacity=0.5>
    <rect id="foreground_rect" x="0" y="210" width="400" height="40" fill="#0d2b1a" opacity=0.5/>
  </g>
</svg>)";

    auto acc = tvg::Accessor::gen();
    auto pic = tvg::Picture::gen();
    pic->load(svg, strlen(svg), "svg", nullptr, false);

    auto bg = pic->paint(acc->id("background"));  // OK — correct Shape
    auto sun = pic->paint(acc->id("sun"));        // OK — correct Shape
    auto mtns = pic->paint(acc->id("mountains")); // BUG — returns nullptr
    auto mtns_p1 = pic->paint(acc->id("mountains_poly1"));
    auto mtns_p2 = pic->paint(acc->id("mountains_poly2"));
    auto fg = pic->paint(acc->id("foreground")); // BUG — returns wrong node; setOpacity(0) hides everything
    auto fg_rect = pic->paint(acc->id("foreground_rect"));

    printf("%p\n", bg);
    printf("%p\n", sun);
    printf("%p\n", mtns);
    printf("%p %d\n", mtns_p1, mtns_p1->opacity());
    printf("%p %d\n", mtns_p2, mtns_p2->opacity());
    printf("%p %d\n", fg, fg->opacity());
    printf("%p %d\n", fg_rect, fg_rect->opacity());
```

related issue : https://github.com/thorvg/thorvg/issues/4218