### PR TITLE
gl/wg: reject unsafe convex tessellation paths

### DIFF
--- a/src/common/tvgMath.cpp
+++ b/src/common/tvgMath.cpp
@@ -101,7 +101,6 @@ float _bezAt(const Bezier& bz, float at, float length, LengthFunc lineLengthFunc
 
 namespace tvg {
 
-
 uint8_t lerp(const uint8_t &start, const uint8_t &end, float t)
 {
     return static_cast<uint8_t>(tvg::clamp(static_cast<int>(start + (end - start) * t), 0, 255));
@@ -510,4 +509,4 @@ Bezier Bezier::operator*(const Matrix& m)
     return Bezier{start * m, ctrl1* m, ctrl2 * m, end * m};
 }
 
-}
+}  // namespace tvg

--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -468,6 +468,117 @@ struct Bezier
     static void bounds(BBox& box, const Point& start, const Point& ctrl1, const Point& ctrl2, const Point& end);
 };
 
+static inline bool edgesCross(const Point& p0, const Point& p1, const Point& p2, const Point& p3)
+{
+    auto orientSign = [](const Point& a, const Point& b, const Point& c) {
+        auto value = cross(b - a, c - a);
+        if (zero(value)) return int8_t{0};
+        return (value > 0.0f) ? int8_t{1} : int8_t{-1};
+    };
+
+    auto straddlesLine = [&](const Point& a, const Point& b, const Point& c, const Point& d) {
+        return orientSign(a, b, c) * orientSign(a, b, d) < 0;
+    };
+
+    return straddlesLine(p0, p1, p2, p3) && straddlesLine(p2, p3, p0, p1);
+}
+
+// Conservative triangle-fan safety check
+// The fill is emitted as (v0,v1,v2), (v0,v2,v3), (v0,v3,v4), ...
+// Usage:
+// 1. Setup: default-construct `ConvexProbe probe` for one tessellation pass.
+// 2. Feed one contour at a time: call `nextContour()` on MoveTo, then stream
+//    each contour edge with `addEdge(curr - prev)`, and finish with
+//    `addContourClose(first - prev)` on Close. For cubic segments, callers may
+//    pre-reject looping control polygons with `edgesCross(start, ctrl1, ctrl2, end)`.
+// 3. Read `probe.convex` as the result. `true` means the contour stayed within
+//    the cheap triangle-fan fast-path assumptions; `false` means fall back.
+// Cost: O(1) work per edge and O(1) memory.
+struct ConvexProbe
+{
+    bool convex = true;
+    int8_t winding = 0;
+    Point firstEdge = {};
+    Point prevEdge = {};
+    int8_t prevXDir = 0;
+    int8_t prevYDir = 0;
+    uint8_t xDirChanges = 0;
+    uint8_t yDirChanges = 0;
+    uint8_t reversals = 0;
+    bool contourHasEdges = false;
+
+    void nextContour()
+    {
+        if (contourHasEdges) convex = false;
+        resetContour();
+    }
+
+    void addEdge(const Point& edge)
+    {
+        if (zero(edge)) return;
+
+        contourHasEdges = true;
+        if (!convex) return;
+
+        if (zero(firstEdge)) firstEdge = edge;
+
+        updateDir(edge.x, prevXDir, xDirChanges);
+        updateDir(edge.y, prevYDir, yDirChanges);
+        if (!convex) return;
+
+        if (zero(prevEdge)) {
+            prevEdge = edge;
+            return;
+        }
+
+        auto turn = cross(prevEdge, edge);
+        if (zero(turn)) {
+            if (dot(prevEdge, edge) < 0.0f && ++reversals > MaxCollinearReversals) convex = false;
+        } else {
+            auto sign = (turn > 0.0f) ? int8_t{1} : int8_t{-1};
+            if (winding == 0) winding = sign;
+            else if (sign != winding) convex = false;
+        }
+
+        prevEdge = edge;
+    }
+
+    void addContourClose(const Point& edge)
+    {
+        addEdge(edge);
+        if (convex && !zero(firstEdge)) addEdge(firstEdge);
+    }
+
+private:
+    enum : uint8_t
+    {
+        MaxAxisDirChanges = 3,
+        MaxCollinearReversals = 2
+    };
+
+    void resetContour()
+    {
+        firstEdge = {};
+        prevEdge = {};
+        prevXDir = prevYDir = 0;
+        xDirChanges = yDirChanges = 0;
+        reversals = 0;
+        contourHasEdges = false;
+    }
+
+    void updateDir(float value, int8_t& prevDir, uint8_t& changes)
+    {
+        int8_t dir = 0;
+        if (!zero(value)) dir = (value > 0.0f) ? int8_t{1} : int8_t{-1};
+        if (dir == 0 || !convex) return;
+
+        if (prevDir != 0 && prevDir != dir && ++changes > MaxAxisDirChanges) {
+            convex = false;
+            return;
+        }
+        prevDir = dir;
+    }
+};
 
 /************************************************************************/
 /* Interpolation functions                                              */
@@ -483,4 +594,4 @@ uint8_t lerp(const uint8_t &start, const uint8_t &end, float t);
 
 }
 
-#endif //_TVG_MATH_H_
+#endif  //_TVG_MATH_H_

--- a/src/renderer/gl_engine/tvgGlGeometry.cpp
+++ b/src/renderer/gl_engine/tvgGlGeometry.cpp
@@ -25,90 +25,6 @@
 #include "tvgGlRenderTask.h"
 #include "tvgGlTessellator.h"
 
-enum class PathKind : uint8_t
-{
-    None,
-    Rect,
-    Circle,
-    RoundRectCW,
-    RoundRectCCW
-};
-
-template<size_t N>
-static inline bool _matchCommandPattern(const Array<PathCommand>& cmds, const PathCommand (&pattern)[N])
-{
-    constexpr auto count = static_cast<uint32_t>(N);
-
-    if (cmds.count != count) return false;
-    auto data = cmds.data;
-    // `count` is a compile-time constant.
-    for (uint32_t i = 0; i < count; ++i)
-        if (data[i] != pattern[i]) return false;
-    return true;
-}
-
-template<size_t N>
-static inline bool _matchPrimitivePattern(const RenderPath& path, const PathCommand (&pattern)[N], uint32_t pointCount)
-{
-    if (path.pts.count != pointCount) return false;
-    return _matchCommandPattern(path.cmds, pattern);
-}
-
-static PathKind _pathKind(const RenderPath& path)
-{
-    static constexpr uint32_t RECT_POINT_COUNT = 4;
-    static constexpr uint32_t RECT_CMD_COUNT = 5;
-    static constexpr uint32_t CIRCLE_POINT_COUNT = 13;
-    static constexpr uint32_t CIRCLE_CMD_COUNT = 6;
-    static constexpr uint32_t ROUND_RECT_POINT_COUNT = 17;
-    static constexpr uint32_t ROUND_RECT_CMD_COUNT = 10;
-
-    static constexpr PathCommand RECT_CMDS[] = {PathCommand::MoveTo, PathCommand::LineTo, PathCommand::LineTo, PathCommand::LineTo, PathCommand::Close};
-    static constexpr PathCommand CIRCLE_CMDS[] = {PathCommand::MoveTo, PathCommand::CubicTo, PathCommand::CubicTo, PathCommand::CubicTo, PathCommand::CubicTo, PathCommand::Close};
-    static constexpr PathCommand ROUND_RECT_CW_CMDS[] = {PathCommand::MoveTo, PathCommand::LineTo, PathCommand::CubicTo, PathCommand::LineTo, PathCommand::CubicTo, PathCommand::LineTo, PathCommand::CubicTo, PathCommand::LineTo, PathCommand::CubicTo, PathCommand::Close};
-    static constexpr PathCommand ROUND_RECT_CCW_CMDS[] = {PathCommand::MoveTo, PathCommand::CubicTo, PathCommand::LineTo, PathCommand::CubicTo, PathCommand::LineTo, PathCommand::CubicTo, PathCommand::LineTo, PathCommand::CubicTo, PathCommand::LineTo, PathCommand::Close};
-
-    switch (path.cmds.count) {
-        case RECT_CMD_COUNT:
-            return _matchPrimitivePattern(path, RECT_CMDS, RECT_POINT_COUNT) ? PathKind::Rect : PathKind::None;
-        case CIRCLE_CMD_COUNT:
-            return _matchPrimitivePattern(path, CIRCLE_CMDS, CIRCLE_POINT_COUNT) ? PathKind::Circle : PathKind::None;
-        case ROUND_RECT_CMD_COUNT: {
-            if (path.pts.count != ROUND_RECT_POINT_COUNT) return PathKind::None;
-            if (_matchCommandPattern(path.cmds, ROUND_RECT_CW_CMDS)) return PathKind::RoundRectCW;
-            if (_matchCommandPattern(path.cmds, ROUND_RECT_CCW_CMDS)) return PathKind::RoundRectCCW;
-            return PathKind::None;  // Unknown pattern: convexity check keeps fixed CCW winding (-1), no auto-detect.
-        }
-        default: break;
-    }
-    return PathKind::None;  // Unknown pattern: convexity check keeps fixed CCW winding (-1), no auto-detect.
-}
-
-static inline int8_t _orient(const Point& a, const Point& b, const Point& c)
-{
-    auto value = tvg::cross(b - a, c - a);
-    if (tvg::zero(value)) return 0;
-    return (value > 0.0f) ? 1 : -1;
-}
-
-// If control polygon edges P0-P1 and P2-P3 cross, the cubic can loop.
-static inline bool _edgesCross(const Point& p0, const Point& p1, const Point& p2, const Point& p3)
-{
-    auto straddlesLine = [](const Point& a, const Point& b, const Point& c, const Point& d) {
-        return _orient(a, b, c) * _orient(a, b, d) < 0;
-    };
-    return straddlesLine(p0, p1, p2, p3) && straddlesLine(p2, p3, p0, p1);
-}
-
-// Round-rect corners are cubic segments. A crossing control polygon can make a loop.
-static bool _rrCubicLoop(const RenderPath& path, PathKind kind)
-{
-    if (kind != PathKind::RoundRectCW && kind != PathKind::RoundRectCCW) return false;
-    auto pts = path.pts.data;
-    if (kind == PathKind::RoundRectCW) return _edgesCross(pts[1], pts[2], pts[3], pts[4]) || _edgesCross(pts[5], pts[6], pts[7], pts[8]) || _edgesCross(pts[9], pts[10], pts[11], pts[12]) || _edgesCross(pts[13], pts[14], pts[15], pts[16]);
-    return _edgesCross(pts[0], pts[1], pts[2], pts[3]) || _edgesCross(pts[4], pts[5], pts[6], pts[7]) || _edgesCross(pts[8], pts[9], pts[10], pts[11]) || _edgesCross(pts[12], pts[13], pts[14], pts[15]);
-}
-
 static RenderRegion _transformBounds(const RenderRegion& bounds, const Matrix& matrix)
 {
     if (bounds.invalid()) return bounds;
@@ -276,15 +192,12 @@ bool GlGeometry::tesselateShape(const RenderShape& rshape, float* opacityMultipl
         return false;
     }
 
-    auto kind = _pathKind(optPath);
-    auto defaultWinding = int8_t(kind != PathKind::None ? 0 : -1);
     // Handle normal shapes with more than 2 points
     BWTessellator bwTess{&fill};
-    bwTess.tessellate(optPath, defaultWinding);
+    bwTess.tessellate(optPath);
     fillRule = rshape.rule;
     fillBounds = bwTess.bounds();
     convex = bwTess.convex;
-    if (defaultWinding == 0 && convex && _rrCubicLoop(optPath, kind)) convex = false;
     if (opacityMultiplier) *opacityMultiplier = 1.0f;
     return true;
 }

--- a/src/renderer/gl_engine/tvgGlTessellator.cpp
+++ b/src/renderer/gl_engine/tvgGlTessellator.cpp
@@ -32,7 +32,6 @@ static uint32_t _pushVertex(Array<float>& array, float x, float y)
     return (array.count - 2) / 2;
 }
 
-
 Stroker::Stroker(GlGeometryBuffer* buffer, float width, StrokeCap cap, StrokeJoin join, float miterLimit) : mBuffer(buffer), mWidth(width), mMiterLimit(miterLimit), mCap(cap), mJoin(join)
 {
 }
@@ -417,7 +416,7 @@ BWTessellator::BWTessellator(GlGeometryBuffer* buffer): mBuffer(buffer)
 {
 }
 
-void BWTessellator::tessellate(const RenderPath& path, int8_t defaultWinding)
+void BWTessellator::tessellate(const RenderPath& path)
 {
     auto cmds = path.cmds.data;
     auto cmdCnt = path.cmds.count;
@@ -426,41 +425,41 @@ void BWTessellator::tessellate(const RenderPath& path, int8_t defaultWinding)
 
     if (ptsCnt <= 2) return;
 
-    winding = defaultWinding;
-
     uint32_t firstIndex = 0;
     uint32_t prevIndex = 0;
+    Point firstPt = {};
+    Point prevPt = {};
+    tvg::ConvexProbe probe;
+    bool contourClosed = false;
 
     mBuffer->vertex.reserve(ptsCnt * 2);
     mBuffer->index.reserve((ptsCnt - 2) * 3);
 
-    auto updateConvexity = [&](const Point& edge) {
-        if (!convex) return;
-        if (prevEdge.x == 0.0f && prevEdge.y == 0.0f) { prevEdge = edge; return; }
-        auto c = cross(prevEdge, edge);
-        if (zero(c)) { prevEdge = edge; return; }
-        auto sign = (c > 0) ? 1 : -1;
-        if (winding == 0) winding = sign;  // Unknown winding: lock to the first non-collinear turn.
-        else if (sign != winding) convex = false;
-        prevEdge = edge;
+    auto finishContour = [&]() {
+        if (prevIndex == 0 || contourClosed) return;
+        probe.addContourClose(firstPt - prevPt);
+        contourClosed = true;
     };
 
     for (uint32_t i = 0; i < cmdCnt; i++) {
         switch(cmds[i]) {
             case PathCommand::MoveTo: {
+                finishContour();
+                probe.nextContour();
                 firstIndex = pushVertex(pts->x, pts->y);
                 firstPt = prevPt = *pts;
-                prevEdge = {};
                 prevIndex = 0;
+                contourClosed = false;
                 pts++;
             } break;
             case PathCommand::LineTo: {
+                auto edge = *pts - prevPt;
                 if (prevIndex == 0) {
                     prevIndex = pushVertex(pts->x, pts->y);
-                    prevEdge = *pts - prevPt;
+                    probe.addEdge(edge);
                     prevPt = *pts++;
                 } else {
-                    updateConvexity(*pts - prevPt);
+                    probe.addEdge(edge);
                     auto currIndex = pushVertex(pts->x, pts->y);
                     pushTriangle(firstIndex, prevIndex, currIndex);
                     prevIndex = currIndex;
@@ -469,23 +468,18 @@ void BWTessellator::tessellate(const RenderPath& path, int8_t defaultWinding)
             } break;
             case PathCommand::CubicTo: {
                 Bezier curve{pts[-1], pts[0], pts[1], pts[2]};
-                if (convex) {
-                    auto e1 = curve.ctrl1 - curve.start;
-                    auto e2 = curve.ctrl2 - curve.ctrl1;
-                    auto e3 = curve.end - curve.ctrl2;
-                    if (prevIndex != 0) updateConvexity(e1);
-                    else prevEdge = e1;
-                    updateConvexity(e2);
-                    updateConvexity(e3);
-                }
+                if (probe.convex && tvg::edgesCross(curve.start, curve.ctrl1, curve.ctrl2, curve.end)) probe.convex = false;
 
                 auto stepCount = curve.segments();
                 if (stepCount <= 1) stepCount = 2;
                 float step = 1.f / stepCount;
+                auto curvePrevPt = prevPt;
 
                 for (uint32_t s = 1; s <= static_cast<uint32_t>(stepCount); s++) {
                     auto pt = curve.at(step * s);
+                    probe.addEdge(pt - curvePrevPt);
                     auto currIndex = pushVertex(pt.x, pt.y);
+                    curvePrevPt = pt;
                     if (prevIndex == 0) { prevIndex = currIndex; continue; }
                     pushTriangle(firstIndex, prevIndex, currIndex);
                     prevIndex = currIndex;
@@ -494,19 +488,15 @@ void BWTessellator::tessellate(const RenderPath& path, int8_t defaultWinding)
                 pts += 3;
             } break;
             case PathCommand::Close: {
-                if (convex && prevIndex != 0) {
-                    updateConvexity(firstPt - prevPt);
-                    if (convex && winding != 0) {
-                        auto& v = mBuffer->vertex;
-                        auto secondPt = Point{v[firstIndex * 2 + 2], v[firstIndex * 2 + 3]};
-                        updateConvexity(secondPt - firstPt);
-                    }
-                }
+                finishContour();
             } break;
             default:
                 break;
         }
     }
+
+    finishContour();
+    convex = probe.convex;
 }
 
 

--- a/src/renderer/gl_engine/tvgGlTessellator.h
+++ b/src/renderer/gl_engine/tvgGlTessellator.h
@@ -76,7 +76,7 @@ class BWTessellator
 {
 public:
     BWTessellator(GlGeometryBuffer* buffer);
-    void tessellate(const RenderPath& path, int8_t defaultWinding = -1);
+    void tessellate(const RenderPath& path);
     RenderRegion bounds() const;
     bool convex = true;
 
@@ -86,10 +86,6 @@ private:
 
     GlGeometryBuffer* mBuffer;
     BBox bbox = {};
-    Point firstPt = {};
-    Point prevPt = {};
-    Point prevEdge = {};
-    int8_t winding = -1;   //0: unknown, 1: CW, -1: CCW
 };
 
 }  // namespace tvg

--- a/src/renderer/wg_engine/tvgWgTessellator.cpp
+++ b/src/renderer/wg_engine/tvgWgTessellator.cpp
@@ -408,7 +408,6 @@ void WgStroker::round(const Point& p, const Point& outDir)
     round(c, b, p);
 }
 
-
 WgBWTessellator::WgBWTessellator(WgMeshData* buffer): mBuffer(buffer)
 {
 }
@@ -425,37 +424,39 @@ void WgBWTessellator::tessellate(const RenderPath& path)
 
     uint32_t firstIndex = 0;
     uint32_t prevIndex = 0;
+    Point firstPt = {};
+    Point prevPt = {};
+    tvg::ConvexProbe probe;
+    bool contourClosed = false;
 
     mBuffer->vbuffer.reserve(ptsCnt * 2);
     mBuffer->ibuffer.reserve((ptsCnt - 2) * 3);
 
-    auto updateConvexity = [&](const Point& edge) {
-        if (!convex) return;
-        if (prevEdge.x == 0.0f && prevEdge.y == 0.0f) { prevEdge = edge; return; }
-        auto c = cross(prevEdge, edge);
-        if (zero(c)) { prevEdge = edge; return; }
-        auto sign = (c > 0) ? 1 : -1;
-        if (winding == 0) winding = sign; // The default winding is CCW, but it might be otherwise once we support unordered points.Expand commentComment on line R453ResolvedCode has comments. Press enter to view.
-        else if (sign != winding) convex = false;
-        prevEdge = edge;
+    auto finishContour = [&]() {
+        if (prevIndex == 0 || contourClosed) return;
+        probe.addContourClose(firstPt - prevPt);
+        contourClosed = true;
     };
 
     for (uint32_t i = 0; i < cmdCnt; i++) {
         switch(cmds[i]) {
             case PathCommand::MoveTo: {
+                finishContour();
+                probe.nextContour();
                 firstIndex = pushVertex(pts->x, pts->y);
                 firstPt = prevPt = *pts;
-                prevEdge = {};
                 prevIndex = 0;
+                contourClosed = false;
                 pts++;
             } break;
             case PathCommand::LineTo: {
+                auto edge = *pts - prevPt;
                 if (prevIndex == 0) {
                     prevIndex = pushVertex(pts->x, pts->y);
-                    prevEdge = *pts - prevPt;
+                    probe.addEdge(edge);
                     prevPt = *pts++;
                 } else {
-                    updateConvexity(*pts - prevPt);
+                    probe.addEdge(edge);
                     auto currIndex = pushVertex(pts->x, pts->y);
                     pushTriangle(firstIndex, prevIndex, currIndex);
                     prevIndex = currIndex;
@@ -464,23 +465,18 @@ void WgBWTessellator::tessellate(const RenderPath& path)
             } break;
             case PathCommand::CubicTo: {
                 Bezier curve{pts[-1], pts[0], pts[1], pts[2]};
-                if (convex) {
-                    auto e1 = curve.ctrl1 - curve.start;
-                    auto e2 = curve.ctrl2 - curve.ctrl1;
-                    auto e3 = curve.end - curve.ctrl2;
-                    if (prevIndex != 0) updateConvexity(e1);
-                    else prevEdge = e1;
-                    updateConvexity(e2);
-                    updateConvexity(e3);
-                }
+                if (probe.convex && tvg::edgesCross(curve.start, curve.ctrl1, curve.ctrl2, curve.end)) probe.convex = false;
 
                 auto stepCount = curve.segments();
                 if (stepCount <= 1) stepCount = 2;
                 float step = 1.f / stepCount;
+                auto curvePrevPt = prevPt;
 
                 for (uint32_t s = 1; s <= static_cast<uint32_t>(stepCount); s++) {
                     auto pt = curve.at(step * s);
+                    probe.addEdge(pt - curvePrevPt);
                     auto currIndex = pushVertex(pt.x, pt.y);
+                    curvePrevPt = pt;
                     if (prevIndex == 0) { prevIndex = currIndex; continue; }
                     pushTriangle(firstIndex, prevIndex, currIndex);
                     prevIndex = currIndex;
@@ -488,19 +484,16 @@ void WgBWTessellator::tessellate(const RenderPath& path)
                 prevPt = curve.end;
                 pts += 3;
             } break;
-                case PathCommand::Close: {
-                if (convex && prevIndex != 0) {
-                    updateConvexity(firstPt - prevPt);
-                    if (convex && winding != 0) {
-                        auto secondPt = mBuffer->vbuffer[firstIndex+1];
-                        updateConvexity(secondPt - firstPt);
-                    }
-                }
+            case PathCommand::Close: {
+                finishContour();
             } break;
             default:
                 break;
         }
     }
+
+    finishContour();
+    convex = probe.convex;
 }
 
 

--- a/src/renderer/wg_engine/tvgWgTessellator.h
+++ b/src/renderer/wg_engine/tvgWgTessellator.h
@@ -86,10 +86,6 @@ private:
 
     WgMeshData* mBuffer;
     BBox bbox = {};
-    Point firstPt = {};
-    Point prevPt = {};
-    Point prevEdge = {};
-    int8_t winding = -1;   //0: unknown, 1: CW, -1: CCW
 };
 
 #endif /* _TVG_WG_TESSELLATOR_H_ */


### PR DESCRIPTION
## Summary

`main` already uses a turn-sign check to decide whether the BW tessellator can stay on the convex triangle-fan fast path. This patch keeps that approach and tightens it with a few extra cheap checks, instead of adding a broader bbox-based approximate self-intersection pass.

The bbox approach was tested first, but it regressed FPS, so it was dropped.

This change only extends the existing streaming classifier also to reject:
- extra contours
- excessive x/y direction flips
- repeated collinear backtracking
- obvious cubic loop cases

As a result, contours that are unsafe for the fast fan path now fall back more conservatively, while simple convex paths keep the existing fast path.


Increase the FPS by 1-2% in the Lottie Example.  
Increase the FPS by 8-9% in the Stress Example.

Binary size: 
In clang compiler
Main
__TEXT	__DATA	__OBJC	others	dec	hex
825,792 	540672	0	81920	1523712	174000
This branch
__TEXT	__DATA	__OBJC	others	dec	hex
824,524 	540672	0	81920	1523712	174000
-1268 Bytes
Related issue: https://github.com/thorvg/thorvg/issues/4141