### PR TITLE
lottie: fine-tuning via composition Slimdown

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -208,13 +208,19 @@ void LottieBuilder::updateGroup(LottieGroup* parent, LottieObject** child, float
 
     if (!group->visible) return;
 
-    //Prepare render data
-    if (group->blendMethod == parent->blendMethod) {
+    // prepare render data
+
+    // special tune: sharing the context if the blending is compatible
+    // propagate the blending to its parent(layer) if possible. this potentially helps performance if the layer has mattes/maskings.
+    if (group->blendMethod == BlendMethod::Normal || group->blendMethod == parent->blendMethod) {
         group->scene = parent->scene;
+    } else if (parent->blendMethod == BlendMethod::Normal && parent->children.count == 1) {
+        group->scene = parent->scene;
+        group->scene->blend(group->blendMethod);
     } else {
         group->scene = tvg::Scene::gen();
-        group->scene->blend(group->blendMethod);
         parent->scene->add(group->scene);
+        group->scene->blend(group->blendMethod);
     }
 
     group->reqFragment |= ctx->reqFragment;
@@ -1456,6 +1462,8 @@ void LottieBuilder::updateLayer(LottieComposition* comp, Scene* scene, LottieLay
 
     if (!layer->matteSrc && !updateMatte(comp, frameNo, scene, layer)) return;
 
+    layer->scene->blend(layer->blendMethod);
+
     switch (layer->type) {
         case LottieLayer::Precomp: {
             if (!tweening()) updatePrecomp(comp, layer, frameNo);
@@ -1486,8 +1494,6 @@ void LottieBuilder::updateLayer(LottieComposition* comp, Scene* scene, LottieLay
     }
 
     updateMasks(layer, frameNo);
-
-    layer->scene->blend(layer->blendMethod);
 
     updateEffect(layer, frameNo, comp->quality);
 


### PR DESCRIPTION
Skip group compositions when the blending mode is compatible. This can help improve rendering performance.

If a parent has masking and only one child, and that child uses blending, the blending can be propagated to the parent.

This allows the parent to composite masking and blending in a single step, fps can be improved by ~2x at tops.

Further optimization may be possible later at the rendering pipeline level, it's not easy at the moment.