### PR TITLE
ttf: fix heap-buffer-overflow on truncated UTF-8 sequence

### DIFF
--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -171,13 +171,13 @@ static size_t _codepoints(const char** utf8)
     if (!(*p & 0x80U)) {
         (*utf8) += 1;
         return *p;
-    } else if ((*p & 0xe0U) == 0xc0U) {
+    } else if ((*p & 0xe0U) == 0xc0U && *(p + 1)) {
         (*utf8) += 2;
         return ((*p & 0x1fU) << 6) + (*(p + 1) & 0x3fU);
-    } else if ((*p & 0xf0U) == 0xe0U) {
+    } else if ((*p & 0xf0U) == 0xe0U && *(p + 1) && *(p + 2)) {
         (*utf8) += 3;
         return ((*p & 0x0fU) << 12) + ((*(p + 1) & 0x3fU) << 6) + (*(p + 2) & 0x3fU);
-    } else if ((*p & 0xf8U) == 0xf0U) {
+    } else if ((*p & 0xf8U) == 0xf0U && *(p + 1) && *(p + 2) && *(p + 3)) {
         (*utf8) += 4;
         return ((*p & 0x07U) << 18) + ((*(p + 1) & 0x3fU) << 12) + ((*(p + 2) & 0x3fU) << 6) + (*(p + 3) & 0x3fU);
     }


### PR DESCRIPTION
_codepoints() read continuation bytes unconditionally, causing a 1-byte out-of-bounds read when a multi-byte lead byte appeared at the end of the string.

```
text->text("hello\xF0\x9F");
```

<img width="2284" height="936" alt="CleanShot 2026-03-24 at 16 07 42@2x" src="https://github.com/user-attachments/assets/76c63835-9735-495d-8786-7fd93d90b6a0" />
