### PR TITLE
sw_engine: handle degenerate radial gradient with near-zero radius

### DIFF
--- a/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/src/renderer/sw_engine/tvgSwFill.cpp
@@ -248,7 +248,10 @@ bool _prepareRadial(SwFill* fill, const RadialGradient* radial, const Matrix& pT
     fill->radial.fx = fx;
     fill->radial.fy = fy;
     fill->radial.a = fill->radial.dr * fill->radial.dr - fill->radial.dx * fill->radial.dx - fill->radial.dy * fill->radial.dy;
-    constexpr float precision = 0.01f;
+
+    // relative epsilon
+    auto precision = std::max(1e-5f, std::max(fill->radial.dr * fill->radial.dr, 1.0f) * 1e-4f);
+
     if (fill->radial.a < precision) fill->radial.a = precision;
     fill->radial.invA = 1.0f / fill->radial.a;
 

--- a/src/renderer/tvgFill.h
+++ b/src/renderer/tvgFill.h
@@ -129,7 +129,7 @@ struct RadialGradientImpl : RadialGradient
     //clamp focal point and shrink start circle if needed to avoid invalid gradient setup
     bool correct(float& fx, float& fy, float& fr) const
     {
-        constexpr float PRECISION = 0.01f;
+        constexpr float PRECISION = 0.02f;
         if (r < PRECISION) return false;  // too small, treated as solid fill
 
         auto dist = tvg::length(center, focal);


### PR DESCRIPTION
- return solid color with last stop when r is near-zero
- applied relative epsilon for precision clamp in _prepareRadial to avoid rendering artifacts on small gradients

issue: #4253 #3803