### PR TITLE
build: skip pthread lookup when targeting emscripten

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -57,7 +57,7 @@ subdir('savers')
 
 thorvg_lib_dep = [common_dep, utils_dep, loader_dep, saver_dep]
 
-if host_machine.system() != 'windows' and host_machine.system() != 'android'
+if host_machine.system() != 'windows' and host_machine.system() != 'android' and host_machine.system() != 'emscripten'
     thread_dep = meson.get_compiler('cpp').find_library('pthread')
     thorvg_lib_dep += [thread_dep]
 endif


### PR DESCRIPTION
Preventing WASM build error from pthread link error.

```
src/meson.build:61:43: ERROR: C++ shared or static library 'pthread' not found
```