### PR TITLE
lottie/expressions: fix memory leak

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -1076,8 +1076,12 @@ static jerry_value_t _key(const jerry_call_info_t* info, const jerry_value_t arg
     if (exp->property->type == LottieProperty::Type::Float) {
         jerry_object_set_index(obj, 0, value);
     } else if (exp->property->type == LottieProperty::Type::Scalar || exp->property->type == LottieProperty::Type::Vector) {
-        jerry_object_set_index(obj, 0, jerry_object_get_index(value, 0));
-        jerry_object_set_index(obj, 1, jerry_object_get_index(value, 1));
+        auto v0 = jerry_object_get_index(value, 0);
+        auto v1 = jerry_object_get_index(value, 1);
+        jerry_object_set_index(obj, 0, v0);
+        jerry_object_set_index(obj, 1, v1);
+        jerry_value_free(v0);
+        jerry_value_free(v1);
     }
 
     jerry_value_free(time);


### PR DESCRIPTION
## Fix Memory Leak in `jerry_object_get_index`

The return value of `jerry_object_get_index` must be freed with `jerry_value_free` 
when it is no longer needed.

<img width="2988" height="1678" alt="image" src="https://github.com/user-attachments/assets/aab887aa-4672-46f5-a775-4b086604ad50" />

Without proper cleanup, memory leaks may accumulate over time, causing exceptions 
in some expressions during long-running Expressions animations — eventually leading 
them to be disabled.


### Reference

- [JerryScript API – jerry_object_get_index](https://github.com/jerryscript-project/jerryscript/blob/master/docs/02.API-REFERENCE.md#jerry_object_get_index)

