### PR TITLE
lottie: fix text range selector factor and world-space translation

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1107,6 +1107,11 @@ bool LottieBuilder::updateTextRange(LottieText* text, float frameNo, Shape* shap
         auto pivot = align * -1;
         transform.e13 += (pivot.x * transform.e11 + pivot.x * transform.e12);
         transform.e23 += (pivot.y * transform.e21 + pivot.y * transform.e22);
+
+        //world space translation
+        transform.e13 += translation.x / ctx.scale;
+        transform.e23 += translation.y / ctx.scale;
+
         ctx.lineScene->transform(transform);
     }
     auto& matrix = shape->transform();

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -360,9 +360,9 @@ struct LottieTextRange : LottieObject
     LottieFloat maxEase = 0.0f;
     LottieFloat minEase = 0.0f;
     LottieFloat maxAmount = 0.0f;
-    LottieFloat smoothness = 0.0f;
+    LottieFloat smoothness = 100.0f;
     LottieFloat start = 0.0f;
-    LottieFloat end = FLT_MAX;
+    LottieFloat end = 100.0f;
     LottieInterpolator* interpolator = nullptr;
     Based based = Chars;
     Shape shape = Square;


### PR DESCRIPTION
issue: https://github.com/thorvg/thorvg/issues/4158

Aligned default factor as lottie-web to correct unexpected behavior.
- smoothness: lottie-web = 100% (100.0f)
- end: lottie-web = 100% (100.0f)

Previously, when a glyph was rotating, its position was also being rotated. Fixed by applying translation in correct space after rotation.

### <ThorVG | Patched>

![CleanShot 2026-03-31 at 17 40 53](https://github.com/user-attachments/assets/c6515d84-0054-4ae3-9393-88ce7f21e002)


### <lottie-web>

![CleanShot 2026-03-31 at 17 41 13](https://github.com/user-attachments/assets/5f5695cf-3e23-49c3-be5c-e8359ea50f60)
