### PR TITLE
tools: Replace non-POSIX-compliant PATH_MAX usage with dynamic allocation

### DIFF
--- a/tools/lottie2gif/lottie2gif.cpp
+++ b/tools/lottie2gif/lottie2gif.cpp
@@ -28,13 +28,9 @@
 #ifdef _WIN32
     #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
-    #ifndef PATH_MAX
-        #define PATH_MAX MAX_PATH
-    #endif
 #else
     #include <dirent.h>
     #include <unistd.h>
-    #include <limits.h>
     #include <sys/stat.h>
 #endif
 
@@ -44,8 +40,11 @@ using namespace tvg;
 
 struct App
 {
+public:
+   ~App() { free(full); }  //free realpath() or _fullpath()
+
 private:
-   char full[PATH_MAX];    //full path
+   char *full = nullptr;   //full path
    uint32_t fps = 30;
    uint32_t width = 600;
    uint32_t height = 600;
@@ -111,11 +110,13 @@ private:
 
    const char* realPath(const char* path)
    {
+      free(full);          //free previous if exist
 #ifdef _WIN32
-      return _fullpath(full, path, PATH_MAX);
+      full = _fullpath(NULL, path, 0); //malloc inside; free'd in destructor
 #else
-      return realpath(path, full);
+      full = realpath(path, NULL);     //malloc inside; free'd in destructor
 #endif
+      return full;
    }
 
    bool isDirectory(const char* path)

--- a/tools/svg2png/svg2png.cpp
+++ b/tools/svg2png/svg2png.cpp
@@ -27,13 +27,9 @@
 #ifdef _WIN32
     #define WIN32_LEAN_AND_MEAN
     #include <windows.h>
-    #ifndef PATH_MAX
-        #define PATH_MAX MAX_PATH
-    #endif
 #else
     #include <dirent.h>
     #include <unistd.h>
-    #include <limits.h>
     #include <sys/stat.h>
 #endif
 #include "lodepng.h"
@@ -200,6 +196,8 @@ private:
 struct App
 {
 public:
+    ~App() { free(full); }  // free realpath() or _fullpath()
+
     int setup(int argc, char** argv)
     {
         vector<const char*> paths;
@@ -283,7 +281,7 @@ private:
     uint32_t bgColor = 0xffffffff;
     uint32_t width = 0;
     uint32_t height = 0;
-    char full[PATH_MAX];
+    char* full = nullptr;  // full path
 
 private:
     int help()
@@ -301,12 +299,13 @@ private:
     const char* realFile(const char* path)
     {
         //real path
+        free(full);  // free previous if exist
 #ifdef _WIN32
-        path = _fullpath(full, path, PATH_MAX);
+        full = _fullpath(NULL, path, 0);  // malloc inside; free'd in destructor
 #else
-        path = realpath(path, full);
+        full = realpath(path, NULL);  // malloc inside; free'd in destructor
 #endif
-        return path;
+        return full;
     }
 
     bool isDirectory(const char* path)


### PR DESCRIPTION
Hi team,

ThorVG tools used `PATH_MAX`-sized static buffers for `realpath()` and `_fullpath()` results, which fails to build on POSIX-compliant systems without `PATH_MAX` definition (e.g. GNU Hurd).

* [hurd-amd64 build failure log](https://buildd.debian.org/status/fetch.php?pkg=thorvg&arch=hurd-amd64&ver=1.0.3%2Bdfsg2-2&stamp=1774815084&raw=0)
* [hurd-i386 build failure log](https://buildd.debian.org/status/fetch.php?pkg=thorvg&arch=hurd-i386&ver=1.0.3%2Bdfsg2-2&stamp=1774861999&raw=0)
    ```
    ../tools/svg2png/svg2png.cpp:286:15: error: ‘PATH_MAX’ was not declared in this scope
      286 |     char full[PATH_MAX];
          |               ^~~~~~~~
    ../tools/svg2png/svg2png.cpp: In member function ‘const char* App::realFile(const char*)’:
    ../tools/svg2png/svg2png.cpp:307:31: error: ‘full’ was not declared in this scope
      307 |         path = realpath(path, full);
          |                               ^~~~
    ```

This patch replaces the non-POSIX-compliant **`PATH_MAX` usage with a dynamically allocation**, by passing `NULL` to `realpath()` and `_fullpath()`.

Since `realpath()` and `_fullpath()` use **malloc()** internally when passed `NULL`, the caller is responsible for freeing the returned buffer.

 * On POSIX systems, `realpath(path, NULL)` returns a `malloc()`-ed buffer (POSIX.1-2008).
 * On Windows, `_fullpath(NULL, path, 0)` does the same, and the third argument is ignored.

In this patch, the previous buffer is `free()`-ed before each call, and a destructor is added to release the final allocation when the App object is destroyed.