### PR TITLE
sw_engine: improved the multi-canvas threading safety

### DIFF
--- a/src/common/tvgLock.h
+++ b/src/common/tvgLock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the ThorVG project. All rights reserved.
+ * Copyright (c) 2024 - 2026 ThorVG project. All rights reserved.
 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,10 @@ namespace tvg
         std::mutex mtx;
     };
 
+    struct StrictKey : Key
+    {
+    };
+
     struct ScopedLock
     {
         Key* key = nullptr;
@@ -46,19 +50,41 @@ namespace tvg
             }
         }
 
+        ScopedLock(StrictKey& k)
+        {
+            k.mtx.lock();
+            key = &k;
+        }
+
         ~ScopedLock()
         {
-            if (TaskScheduler::threads() > 0) {
-                key->mtx.unlock();
-            }
+            if (key) key->mtx.unlock();
         }
     };
 #else //THORVG_THREAD_SUPPORT
     struct Key {};
 
+    struct StrictKey : Key
+    {
+        std::mutex mtx;
+    };
+
     struct ScopedLock
     {
-        ScopedLock(Key& key) {}
+        StrictKey* key = nullptr;
+
+        ScopedLock(Key& k) {}
+
+        ScopedLock(StrictKey& k)
+        {
+            k.mtx.lock();
+            key = &k;
+        }
+
+        ~ScopedLock()
+        {
+            if (key) key->mtx.unlock();
+        }
     };
 #endif //THORVG_THREAD_SUPPORT
 }

--- a/src/renderer/sw_engine/tvgSwMemPool.cpp
+++ b/src/renderer/sw_engine/tvgSwMemPool.cpp
@@ -29,7 +29,7 @@
 static thread_local SwMpool* _pool = nullptr;
 static Array<SwMpool*> _pools;
 static uint32_t _threads = 0;
-static Key _key;
+static StrictKey _key;
 
 /************************************************************************/
 /* External Class Implementation                                        */


### PR DESCRIPTION
The previous lock mechanism was only active when
ThorVG threading support was enabled. To support multi-threaded ThorVG canvas usage, StrictLock is introduced to enforce locking regardless of the threading configuration.

This fixes a rare software multi-canvas threading issue when thread option is disabled.