### PR TITLE
infra: fix cross build with opengl/es, link libGLESv3.so / OpenGL/ES framework directly

### DIFF
--- a/cross/android_aarch64.txt
+++ b/cross/android_aarch64.txt
@@ -2,6 +2,7 @@
 # https://developer.android.com/ndk/guides/other_build_systems
 
 [binaries]
+c       = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/aarch64-linux-androidAPI-clang'
 cpp     = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/aarch64-linux-androidAPI-clang++'
 ar      = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/llvm-ar'
 as      = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/llvm-as'
@@ -12,8 +13,19 @@ strip   = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/llvm-strip'
 [properties]
 sys_root = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/sysroot'
 
+[built-in options]
+c_args = ['-DANDROID=1', '-D__ANDROID__=1']
+cpp_args = ['-DANDROID=1', '-D__ANDROID__=1']
+cpp_link_args = ['-lGLESv3', '-Wl,-z,max-page-size=16384', '-Wl,-z,common-page-size=16384']
+
 [host_machine]
 system = 'android'
-cpu_family = 'arm'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[target_machine]
+system = 'android'
+cpu_family = 'aarch64'
 cpu = 'aarch64'
 endian = 'little'

--- a/cross/android_armv7a.txt
+++ b/cross/android_armv7a.txt
@@ -2,8 +2,8 @@
 # https://developer.android.com/ndk/guides/other_build_systems
 
 [binaries]
-c       = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/x86_64-linux-androidAPI-clang'
-cpp     = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/x86_64-linux-androidAPI-clang++'
+c       = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/armv7a-linux-androideabiAPI-clang'
+cpp     = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/armv7a-linux-androideabiAPI-clang++'
 ar      = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/llvm-ar'
 as      = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/llvm-as'
 ranlib  = 'NDK/toolchains/llvm/prebuilt/HOST_TAG/bin/llvm-ranlib'
@@ -20,12 +20,12 @@ cpp_link_args = ['-lGLESv3', '-Wl,-z,max-page-size=16384', '-Wl,-z,common-page-s
 
 [host_machine]
 system = 'android'
-cpu_family = 'x86_64'
-cpu = 'x86_64'
+cpu_family = 'arm'
+cpu = 'armv7a'
 endian = 'little'
 
 [target_machine]
 system = 'android'
-cpu_family = 'x86_64'
-cpu = 'x86_64'
+cpu_family = 'arm'
+cpu = 'armv7a'
 endian = 'little'

--- a/cross/ios_arm64.txt
+++ b/cross/ios_arm64.txt
@@ -1,6 +1,7 @@
 # build for the ios devices (Apple Silicon)
 
 [binaries]
+c   = ['clang', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
 cpp = ['clang++', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
 ar = 'ar'
 strip = 'strip'
@@ -16,6 +17,13 @@ cpp_link_args = ['-miphoneos-version-min=11.0']
 [host_machine]
 system = 'darwin'
 subsystem = 'ios'
+kernel = 'xnu'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[target_machine]
+system = 'ios'
 kernel = 'xnu'
 cpu_family = 'aarch64'
 cpu = 'aarch64'

--- a/cross/ios_simulator_arm64.txt
+++ b/cross/ios_simulator_arm64.txt
@@ -1,6 +1,7 @@
 # build for the ios simulator (Apple Silicon)
 
 [binaries]
+c   = ['clang', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk']
 cpp = ['clang++', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk']
 ar = 'ar'
 strip = 'strip'
@@ -21,3 +22,9 @@ cpu_family = 'aarch64'
 cpu = 'aarch64'
 endian = 'little'
 
+[target_machine]
+system = 'ios'
+kernel = 'xnu'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'

--- a/cross/ios_simulator_x86_64.txt
+++ b/cross/ios_simulator_x86_64.txt
@@ -1,6 +1,7 @@
 # build for the ios simulator (Intel)
 
 [binaries]
+c   = ['clang', '-arch', 'x86_64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk']
 cpp = ['clang++', '-arch', 'x86_64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk']
 ar = 'ar'
 strip = 'strip'
@@ -16,6 +17,13 @@ cpp_link_args = ['-mios-simulator-version-min=11.0']
 [host_machine]
 system = 'darwin'
 subsystem = 'ios'
+kernel = 'xnu'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[target_machine]
+system = 'ios'
 kernel = 'xnu'
 cpu_family = 'x86_64'
 cpu = 'x86_64'

--- a/cross/ohos_aarch64.txt
+++ b/cross/ohos_aarch64.txt
@@ -1,0 +1,31 @@
+# OpenHarmony developer (Use the NDK with other build systems)
+# https://developer.huawei.com/consumer/cn/doc/harmonyos-guides/ndk-development-overview
+
+[binaries]
+c       = 'OHOS_NDK/llvm/bin/aarch64-unknown-linux-ohos-clang'
+cpp     = 'OHOS_NDK/llvm/bin/aarch64-unknown-linux-ohos-clang++'
+ar      = 'OHOS_NDK/llvm/bin/llvm-ar'
+as      = 'OHOS_NDK/llvm/bin/llvm-as'
+ranlib  = 'OHOS_NDK/llvm/bin/llvm-ranlib'
+ld      = 'OHOS_NDK/llvm/bin/ld.lld'
+strip   = 'OHOS_NDK/llvm/bin/llvm-strip'
+
+[properties]
+sys_root = 'OHOS_NDK/sysroot'
+
+[built-in options]
+c_args = ['-D__OHOS__=1','-D__HARMONYOS__=1','--sysroot=OHOS_NDK/sysroot', '-IOHOS_NDK/sysroot/usr/include/', '-IOHOS_NDK/sysroot/usr/include/aarch64-linux-ohos', '-fdata-sections', '-ffunction-sections', '-funwind-tables', '-fstack-protector-strong', '-no-canonical-prefixes', '-fno-addrsig', '-Wa,--noexecstack']
+cpp_args = ['-D__OHOS__=1','-D__HARMONYOS__=1','--sysroot=OHOS_NDK/sysroot', '-IOHOS_NDK/sysroot/usr/include/', '-IOHOS_NDK/sysroot/usr/include/aarch64-linux-ohos', '-fdata-sections', '-ffunction-sections', '-funwind-tables', '-fstack-protector-strong', '-no-canonical-prefixes', '-fno-addrsig', '-Wa,--noexecstack']
+cpp_link_args = ['-lGLESv3']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[target_machine]
+system = 'ohos'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'

--- a/src/renderer/gl_engine/meson.build
+++ b/src/renderer/gl_engine/meson.build
@@ -28,14 +28,32 @@ source_file = [
 ]
 
 #force to use gles
-if cc.get_id() == 'emscripten'
+if cc.get_id() == 'emscripten' or target_machine.system() == 'ios' or target_machine.system() == 'android' or target_machine.system() == 'ohos'
     gl_variant = 'OpenGL ES'
+    message('Force to use OpenGL ES variant, cc.get_id() = ' + cc.get_id() + ', target_machine.system() = ' + target_machine.system())
 endif
 
 if gl_variant == 'OpenGL ES'
     compiler_flags += ['-DTHORVG_GL_TARGET_GLES=1']
 else
     compiler_flags += ['-DTHORVG_GL_TARGET_GL=1']
+endif
+
+message('target_machine.system() = ' + target_machine.system())
+if target_machine.system() == 'ios'
+   message('Detected iOS platform, linking OpenGLES.framework')
+   gles_dep = dependency(
+      'OpenGLES',
+      required: true
+   )
+   engine_dep += gles_dep
+elif target_machine.system() == 'darwin'
+   message('Detected macOS platform, linking OpenGL.framework')
+   gles_dep = dependency(
+      'OpenGL',
+      required: true
+   )
+   engine_dep += gles_dep
 endif
 
 engine_dep += [declare_dependency(

--- a/src/renderer/gl_engine/tvgGl.cpp
+++ b/src/renderer/gl_engine/tvgGl.cpp
@@ -36,6 +36,19 @@ bool glTerm()
     return true;
 }
 
+#elif defined(__APPLE__) || defined(__ANDROID__) || defined(__OHOS__)
+
+bool glInit()
+{
+    return true;
+}
+
+
+bool glTerm()
+{
+    return true;
+}
+
 #else //__EMSCRIPTEN__
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
@@ -82,7 +95,7 @@ static PROC _getProcAddress(const char* procName)
     return procHandle;
 }
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__ANDROID__) || defined(__OHOS__)
 
 #include <dlfcn.h>
 

--- a/src/renderer/gl_engine/tvgGl.h
+++ b/src/renderer/gl_engine/tvgGl.h
@@ -23,7 +23,37 @@
  #ifndef _TVG_GL_H_
  #define _TVG_GL_H_
 
-#ifdef __EMSCRIPTEN__
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+
+#include <OpenGLES/ES3/gl.h>
+#include <OpenGLES/ES3/glext.h>
+
+#define GL_CHECK(stmt) stmt
+
+#define TVG_REQUIRE_GL_MAJOR_VER 3
+#define TVG_REQUIRE_GL_MINOR_VER 0
+
+#elif defined(__APPLE__)
+#define GL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED
+#include <OpenGL/gl.h>
+#include <OpenGL/gl3.h>
+
+#define GL_CHECK(stmt) stmt
+
+#define TVG_REQUIRE_GL_MAJOR_VER 3
+#define TVG_REQUIRE_GL_MINOR_VER 0
+
+#elif defined(__ANDROID__) || defined(__OHOS__)
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <GLES3/gl3.h>
+
+#define GL_CHECK(stmt) stmt
+
+#define TVG_REQUIRE_GL_MAJOR_VER 3
+#define TVG_REQUIRE_GL_MINOR_VER 0
+
+#elif defined(__EMSCRIPTEN__)
     #include <GLES3/gl3.h>
     #include <emscripten/html5_webgl.h>
     #define GL_CHECK(stmt) stmt

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -78,9 +78,16 @@ bool GlRenderer::currentContext()
 #elif defined(_WIN32) && !defined(__CYGWIN__) && defined(THORVG_GL_TARGET_GL)
     if (tvgWglGetCurrentContext() == static_cast<HGLRC>(mContext)) return true;
     return (bool) tvgWglMakeCurrent((HDC)mSurface, static_cast<HGLRC>(mContext));
+#elif defined(__APPLE__) || defined(__ANDROID__) || defined(__OHOS__)
+    // ignore context, user manage context
+    return true;
 #elif defined(THORVG_GL_TARGET_GLES)
-    if (tvgEglGetCurrentContext() == static_cast<EGLContext>(mContext)) return true;
-    if (mDisplay && mSurface) return (bool) tvgEglMakeCurrent((EGLDisplay)mDisplay, (EGLSurface)mSurface, (EGLSurface)mSurface, (EGLContext)mContext);
+    if (tvgEglGetCurrentContext && tvgEglMakeCurrent) {
+        if (tvgEglGetCurrentContext() == static_cast<EGLContext>(mContext)) return true;
+        if (mDisplay && mSurface) return (bool) tvgEglMakeCurrent((EGLDisplay)mDisplay, (EGLSurface)mSurface, (EGLSurface)mSurface, (EGLContext)mContext);
+    }
+    // ignore context
+    return true;
 #endif
     TVGLOG("GL_ENGINE", "Maybe missing currentContext()?");
     return true;
@@ -882,8 +889,7 @@ bool GlRenderer::clear()
 
 bool GlRenderer::target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs)
 {
-    //assume the context zero is invalid
-    if (!context || w == 0 || h == 0) return false;
+    if (w == 0 || h == 0) return false;
 
     if (mContext) currentContext();
 


### PR DESCRIPTION
Currently, the gl_engine of thorvg relies on dlopen/dlsym, which cannot run on the iOS system. Even on Android and macOS, runtime crashes occur after I compile the static library and link it into my application.

Therefore, for better compatibility, I believe it is necessary to link the system's GL/ES dynamic libraries. I have modified the cross file and gl_engine/meson.build. Meanwhile, I have added ohos_aarch64.txt to support cross-platform compilation for OpenHarmonyOS.

* Android

```
[built-in options]
c_args = ['-DANDROID=1', '-D__ANDROID__=1']
cpp_args = ['-DANDROID=1', '-D__ANDROID__=1']
cpp_link_args = ['-lGLESv3', '-Wl,-z,max-page-size=16384', '-Wl,-z,common-page-size=16384']
```

Added the `ANDROID` and `__ANDROID__` macro definitions
`-lGLESv3` links the system GLESv3 dynamic library directly
`'-Wl,-z,max-page-size=16384', '-Wl,-z,common-page-size=16384'` is adapted for Android 16KB page size

* iOS

Directly link OpenGLES.framework in `src/renderer/gl_engine/meson.build`

```
if target_machine.system() == 'ios'
   message('Detected iOS platform, linking OpenGLES.framework')
   gles_dep = dependency(
      'OpenGLES',
      required: true
   )
   engine_dep += gles_dep
```

* macOS

Directly link OpenGL.framework in `src/renderer/gl_engine/meson.build`

```
elif target_machine.system() == 'darwin'
   message('Detected macOS platform, linking OpenGL.framework')
   gles_dep = dependency(
      'OpenGL',
      required: true
   )
   engine_dep += gles_dep
endif
```

In addition, I have modified the following code:
```
bool GlRenderer::target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs)
{
    if (w == 0 || h == 0) return false;
    ....
}
```
I removed the `if (!context || ...)` judgment for the context. I hold the view that we do not need to check the validity of the context, which should be managed by the caller. Especially on the iOS system, the context type is EAGLContext. At present, the only purpose of this context is to call glMakeCurrent, and I think glMakeCurrent should be implemented by the caller instead of us managing or using this context.