### PR TITLE
gl_engine: tvgPicture support load texture directly

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -113,6 +113,7 @@ enum struct ColorSpace : uint8_t
     ABGR8888S,         ///< The channels are joined in the order: alpha, blue, green, red. Colors are un-alpha-premultiplied. @since 0.12
     ARGB8888S,         ///< The channels are joined in the order: alpha, red, green, blue. Colors are un-alpha-premultiplied. @since 0.12
     Grayscale8,        ///< One single channel data.
+    TextureRGBA,       ///< Opengl texture data
     Unknown = 255      ///< Unknown channel data. This is reserved for an initial ColorSpace value. @since 1.0
 };
 
@@ -1619,6 +1620,15 @@ struct TVG_API Picture : Paint
      * @since 0.5
      */
     Result load(const char* data, uint32_t size, const char* mimeType, const char* rpath = nullptr, bool copy = false) noexcept;
+
+    /**
+     * @brief Loads a picture data from a texture id.
+     *
+     * @param textureId The texture id of the picture.
+     * @param width The width of the picture in pixels.
+     * @param height The height of the picture in pixels.
+     */
+    Result load(uint32_t textureId, uint32_t width, uint32_t height) noexcept;
 
     /**
      * @brief Resizes the picture content to the given width and height.

--- a/src/common/tvgCommon.h
+++ b/src/common/tvgCommon.h
@@ -72,7 +72,11 @@ void operator delete(void* ptr) noexcept;
 
 namespace tvg {
 
-    enum class FileType { Png = 0, Jpg, Webp, Svg, Lot, Ttf, Raw, Gif, Unknown };
+    enum class FileType { Png = 0, Jpg, Webp, Svg, Lot, Ttf, Raw, Gif,
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+        Texture,
+#endif
+        Unknown };
 
     #ifdef THORVG_LOG_ENABLED
         constexpr auto ErrorColor = "\033[31m";  //red

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -24,7 +24,7 @@
 #include "tvgRawLoader.h"
 
 
-RawLoader::RawLoader() : ImageLoader(FileType::Raw)
+RawLoader::RawLoader(FileType type) : ImageLoader(type)
 {
 }
 
@@ -62,6 +62,30 @@ bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs
 
     return true;
 }
+
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+bool RawLoader::open(uint32_t textureId, uint32_t w, uint32_t h, ColorSpace cs)
+{
+    if (!LoadModule::read()) return true;
+
+    if (!textureId || w == 0 || h == 0 || cs != ColorSpace::TextureRGBA) return false;
+
+    this->w = (float)w;
+    this->h = (float)h;
+
+    surface.textureId = textureId;
+
+    //setup the surface
+    surface.stride = w;
+    surface.w = w;
+    surface.h = h;
+    surface.cs = cs;
+    surface.channelSize = sizeof(uint32_t);
+    surface.premultiplied = true;
+
+    return true;
+}
+#endif
 
 
 bool RawLoader::read()

--- a/src/loaders/raw/tvgRawLoader.h
+++ b/src/loaders/raw/tvgRawLoader.h
@@ -28,11 +28,14 @@ class RawLoader : public ImageLoader
 public:
     bool copy = false;
 
-    RawLoader();
+    RawLoader(FileType type=FileType::Raw);
     ~RawLoader();
 
     using LoadModule::open;
     bool open(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy);
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+    bool open(uint32_t textureId, uint32_t w, uint32_t h, ColorSpace cs = ColorSpace::TextureRGBA);
+#endif
     bool read() override;
 };
 

--- a/src/renderer/gl_engine/tvgGlRenderer.cpp
+++ b/src/renderer/gl_engine/tvgGlRenderer.cpp
@@ -1229,7 +1229,7 @@ void GlRenderer::dispose(RenderData data)
     auto sdata = static_cast<GlShape*>(data);
 
     //dispose the non thread-safety resources on clearDisposes() call
-    if (sdata->texId) {
+    if (sdata->texId && sdata->texColorSpace != ColorSpace::TextureRGBA) {
         ScopedLock lock(mDisposed.key);
         mDisposed.textures.push(sdata->texId);
     }
@@ -1252,15 +1252,18 @@ RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matr
 
     //generate a texture
     if (sdata->texId == 0) {
-        GL_CHECK(glGenTextures(1, &sdata->texId));
-        GL_CHECK(glBindTexture(GL_TEXTURE_2D, sdata->texId));
-        GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, image->w, image->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, image->data));
-        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
-        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
-        GL_CHECK(glBindTexture(GL_TEXTURE_2D, 0));
-
+        if (image->cs == ColorSpace::TextureRGBA) {
+            sdata->texId = image->textureId;
+        } else {
+            GL_CHECK(glGenTextures(1, &sdata->texId));
+            GL_CHECK(glBindTexture(GL_TEXTURE_2D, sdata->texId));
+            GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, image->w, image->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, image->data));
+            GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+            GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+            GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
+            GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
+            GL_CHECK(glBindTexture(GL_TEXTURE_2D, 0));
+        }
         sdata->texColorSpace = image->cs;
         sdata->texFlipY = 1;
         sdata->geometry = GlGeometry();

--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -108,6 +108,9 @@ static tvg::LoadModule* _find(FileType type)
 #endif
             break;
         }
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+        case FileType::Texture:
+#endif
         case FileType::Raw: {
             return new RawLoader;
             break;
@@ -190,6 +193,9 @@ static FileType _convert(const char* mimeType)
     else if (!strcmp(mimeType, "png")) type = FileType::Png;
     else if (!strcmp(mimeType, "jpg") || !strcmp(mimeType, "jpeg")) type = FileType::Jpg;
     else if (!strcmp(mimeType, "webp")) type = FileType::Webp;
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+    else if (!strcmp(mimeType, "texture")) type = FileType::Texture;
+#endif
     else TVGLOG("RENDERER", "Given mimetype is unknown = \"%s\".", mimeType);
 
     return type;
@@ -232,6 +238,25 @@ static tvg::LoadModule* _findFromCache(const char* data, uint32_t size, const ch
     }
     return nullptr;
 }
+
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+static tvg::LoadModule* _findFromCache(const uint32_t textureId)
+{
+    auto type = FileType::Texture;
+
+    auto key = textureId;
+
+    ScopedLock lock(_key);
+
+    INLIST_FOREACH(_activeLoaders, loader) {
+        if (loader->type == type && loader->hashkey == key) {
+            ++loader->sharing;
+            return loader;
+        }
+    }
+    return nullptr;
+}
+#endif
 
 
 /************************************************************************/
@@ -401,6 +426,22 @@ tvg::LoadModule* LoaderMgr::loader(const uint32_t *data, uint32_t w, uint32_t h,
     return nullptr;
 }
 
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+tvg::LoadModule* LoaderMgr::loader(uint32_t textureId, uint32_t w, uint32_t h, ColorSpace cs)
+{
+    if (auto loader = _findFromCache(textureId)) return loader;
+
+    auto loader = new RawLoader(FileType::Texture);
+    if (loader->open(textureId, w, h, cs)) {
+        loader->cache(textureId);
+        ScopedLock lock(_key);
+        _activeLoaders.back(loader);
+        return loader;
+    }
+    delete(loader);
+    return nullptr;
+}
+#endif
 
 //loads fonts from memory - loader is cached (regardless of copy value) in order to access it while setting font
 tvg::LoadModule* LoaderMgr::loader(const char* name, const char* data, uint32_t size, TVG_UNUSED const char* mimeType, bool copy)

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -35,6 +35,9 @@ struct LoaderMgr
     static LoadModule* loader(const char* filename, bool* invalid);
     static LoadModule* loader(const char* data, uint32_t size, const char* mimeType, const char* rpath, bool copy);
     static LoadModule* loader(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy);
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+    static LoadModule* loader(uint32_t textureId, uint32_t w, uint32_t h, ColorSpace cs = ColorSpace::TextureRGBA);
+#endif
     static LoadModule* loader(const char* name, const char* data, uint32_t size, const char* mimeType, bool copy);
     static LoadModule* font(const char* name);
     static LoadModule* anyfont();

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -55,6 +55,11 @@ Result Picture::load(const char* data, uint32_t size, const char* mimeType, cons
     return to<PictureImpl>(this)->load(data, size, mimeType, rpath, copy);
 }
 
+Result Picture::load(uint32_t textureId, uint32_t width, uint32_t height) noexcept
+{
+    return to<PictureImpl>(this)->load(textureId, width, height);
+}
+
 
 Result Picture::load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy) noexcept
 {

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -176,6 +176,21 @@ struct PictureImpl : Picture
         return load(loader);
     }
 
+    Result load(uint32_t textureId, uint32_t width, uint32_t height)
+    {
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+        if (!textureId || width <= 0 || height <= 0) return Result::InvalidArguments;
+        if (vector || bitmap) return Result::InsufficientCondition;
+
+        auto loader = static_cast<ImageLoader*>(LoaderMgr::loader(textureId, width, height));
+        if (!loader) return Result::FailedAllocation;
+
+        return load(loader);
+#else
+        return Result::NonSupport;
+#endif
+    }
+
     Result load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
     {
         if (!data || w <= 0 || h <= 0 || cs == ColorSpace::Unknown)  return Result::InvalidArguments;

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -60,6 +60,9 @@ struct RenderSurface
         pixel_t* data = nullptr;    //system based data pointer
         uint32_t* buf32;            //for explicit 32bits channels
         uint8_t*  buf8;             //for explicit 8bits grayscale
+#if defined(THORVG_GL_TARGET_GL) || defined(THORVG_GL_TARGET_GLES)
+        uint32_t textureId;         //for explicit texture id
+#endif
     };
     Key key;                        //a reserved lock for the thread safety
     uint32_t stride = 0;


### PR DESCRIPTION
Since my usage scenario involves real-time OpenGL rendering, all effects are implemented via OpenGL shaders, and data is transmitted through textures. Therefore, I have added a tvg::Picture interface.

```
Result load(uint32_t textureId, uint32_t width, uint32_t height) noexcept;
```

Added `Colorspace::TextureRGBA` and `FileType::Texture`

issue: https://github.com/thorvg/thorvg/issues/3365