### PR TITLE
loader: introduced a convenient Loader Options interface

### DIFF
--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -54,8 +54,7 @@ JpgLoader::~JpgLoader()
     tjFree(surface.buf8);
 }
 
-
-bool JpgLoader::open(const char* path)
+bool JpgLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     if (!(data = (unsigned char*)Loader::open(path, size))) return false;
@@ -71,8 +70,7 @@ bool JpgLoader::open(const char* path)
 #endif
 }
 
-
-bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
+bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
     int width, height, subSample, colorSpace;
     if (tjDecompressHeader3(jpegDecompressor, (unsigned char *) data, size, &width, &height, &subSample, &colorSpace) < 0) return false;

--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -34,8 +34,8 @@ public:
     JpgLoader();
     ~JpgLoader();
 
-    bool open(const char* path) override;
-    bool open(const char* data, uint32_t size, const char* rpath, bool copy) override;
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     bool read() override;
 
 private:

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -50,8 +50,7 @@ PngLoader::~PngLoader()
     tvg::free(surface.buf32);
 }
 
-
-bool PngLoader::open(const char* path)
+bool PngLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
     image->opaque = nullptr;
 
@@ -63,8 +62,7 @@ bool PngLoader::open(const char* path)
     return true;
 }
 
-
-bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
+bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     image->opaque = nullptr;

--- a/src/loaders/external_png/tvgPngLoader.h
+++ b/src/loaders/external_png/tvgPngLoader.h
@@ -32,8 +32,8 @@ public:
     PngLoader();
     ~PngLoader();
 
-    bool open(const char* path) override;
-    bool open(const char* data, uint32_t size, const char* rpath, bool copy) override;
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     bool read() override;
 
 private:

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -64,8 +64,7 @@ WebpLoader::~WebpLoader()
     WebPFree(surface.buf8);
 }
 
-
-bool WebpLoader::open(const char* path)
+bool WebpLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     if (!(data = (unsigned char*)Loader::open(path, size))) return false;
@@ -81,8 +80,7 @@ bool WebpLoader::open(const char* path)
 #endif
 }
 
-
-bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
+bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
     if (copy) {
         this->data = tvg::malloc<unsigned char>(size);

--- a/src/loaders/external_webp/tvgWebpLoader.h
+++ b/src/loaders/external_webp/tvgWebpLoader.h
@@ -32,8 +32,8 @@ public:
     WebpLoader();
     ~WebpLoader();
 
-    bool open(const char* path) override;
-    bool open(const char* data, uint32_t size, const char* rpath, bool copy) override;
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     bool read() override;
 
     RenderSurface* bitmap() override;

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -67,8 +67,7 @@ JpgLoader::~JpgLoader()
     tvg::free(surface.buf8);
 }
 
-
-bool JpgLoader::open(const char* path)
+bool JpgLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     int width, height;
@@ -83,8 +82,7 @@ bool JpgLoader::open(const char* path)
 #endif
 }
 
-
-bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
+bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
     if (copy) {
         this->data = tvg::malloc<char>(size);

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -41,8 +41,8 @@ public:
     JpgLoader();
     ~JpgLoader();
 
-    bool open(const char* path) override;
-    bool open(const char* data, uint32_t size, const char* rpath, bool copy) override;
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -101,7 +101,6 @@ LottieLoader::~LottieLoader()
     tvg::free(dirName);
 }
 
-
 bool LottieLoader::header()
 {
     //A single thread doesn't need to perform intensive tasks.
@@ -208,32 +207,34 @@ bool LottieLoader::header()
     return true;
 }
 
-
-bool LottieLoader::open(const char* data, uint32_t size, const char* rpath, bool copy)
+bool LottieLoader::open(const char* data, uint32_t size, const LoaderOps* _ops, bool copy)
 {
+    auto ops = static_cast<const PictureOps*>(_ops);
+    if (ops->caller != tvg::Type::Picture) return false;
+
     if (copy) {
         content = tvg::malloc<char>(size + 1);
-        if (!content) return false;
         memcpy((char*)content, data, size);
         const_cast<char*>(content)[size] = '\0';
     } else content = data;
 
     this->size = size;
     this->copy = copy;
-
-    if (rpath) this->dirName = duplicate(rpath);
-    else this->dirName = duplicate(".");
+    dirName = ops->rpath ? duplicate(ops->rpath) : duplicate(".");
+    builder->resolver = ops->resolver;
 
     return header();
 }
 
-
-bool LottieLoader::open(const char* path)
+bool LottieLoader::open(const char* path, const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
+    if (ops->caller != tvg::Type::Picture) return false;
+
     if ((content = Loader::open(path, size, true))) {
         dirName = tvg::dirname(path);
         copy = true;
+        builder->resolver = static_cast<const PictureOps*>(ops)->resolver;
         return header();
     }
 #endif
@@ -527,10 +528,4 @@ bool LottieLoader::quality(uint8_t value)
         build = true;
     }
     return true;
-}
-
-
-void LottieLoader::set(const AssetResolver* resolver)
-{
-    builder->resolver = resolver;
 }

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -73,8 +73,8 @@ public:
     LottieLoader();
     ~LottieLoader();
 
-    bool open(const char* path) override;
-    bool open(const char* data, uint32_t size, const char* rpath, bool copy) override;
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     bool resize(Paint* paint, float w, float h) override;
     bool read() override;
     Paint* paint() override;
@@ -101,7 +101,6 @@ public:
     bool tween(float from, float to, float progress);
     bool assign(const char* layer, uint32_t ix, const char* var, float val);
     bool quality(uint8_t value);
-    void set(const AssetResolver* resolver) override;
 
 private:
     bool ready();

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -67,8 +67,7 @@ PngLoader::~PngLoader()
     lodepng_state_cleanup(&state);
 }
 
-
-bool PngLoader::open(const char* path)
+bool PngLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     if (!(data = (unsigned char*)Loader::open(path, size))) return false;
@@ -86,8 +85,7 @@ bool PngLoader::open(const char* path)
 #endif
 }
 
-
-bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
+bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
     unsigned int width, height;
     if (lodepng_inspect(&width, &height, &state, (unsigned char*)(data), size) > 0) return false;

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -41,8 +41,8 @@ public:
     PngLoader();
     ~PngLoader();
 
-    bool open(const char* path) override;
-    bool open(const char* data, uint32_t size, const char* rpath, bool copy) override;
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     bool read() override;
 
     RenderSurface* bitmap() override;

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -34,7 +34,6 @@ RawLoader::~RawLoader()
     if (copy) tvg::free(surface.buf32);
 }
 
-
 bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
 {
     if (!Loader::read()) return true;

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3843,8 +3843,7 @@ bool SvgLoader::header()
     return true;
 }
 
-
-bool SvgLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
+bool SvgLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
     if (copy) {
         content = tvg::malloc<char>(size + 1);
@@ -3858,8 +3857,7 @@ bool SvgLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpa
     return header();
 }
 
-
-bool SvgLoader::open(const char* path)
+bool SvgLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     if ((content = Loader::open(path, size, true))) {

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -38,8 +38,8 @@ struct SvgLoader : ImageLoader, Task
     SvgLoader();
     ~SvgLoader();
 
-    bool open(const char* path) override;
-    bool open(const char* data, uint32_t size, const char* rpath, bool copy) override;
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     bool resize(Paint* paint, float w, float h) override;
     bool read() override;
     bool close() override;

--- a/src/loaders/ttf/tvgTtfLoader.cpp
+++ b/src/loaders/ttf/tvgTtfLoader.cpp
@@ -507,8 +507,7 @@ TtfLoader::~TtfLoader()
     clear();
 }
 
-
-bool TtfLoader::open(const char* path)
+bool TtfLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     clear();
@@ -522,8 +521,7 @@ bool TtfLoader::open(const char* path)
 #endif
 }
 
-
-bool TtfLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
+bool TtfLoader::open(const char* data, uint32_t size, const LoaderOps* ops, bool copy)
 {
     reader.size = size;
     nomap = true;

--- a/src/loaders/ttf/tvgTtfLoader.h
+++ b/src/loaders/ttf/tvgTtfLoader.h
@@ -53,8 +53,8 @@ struct TtfLoader : public FontLoader
     using FontLoader::open;
     using FontLoader::read;
 
-    bool open(const char* path) override;
-    bool open(const char *data, uint32_t size, const char* rpath, bool copy) override;
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     void transform(Paint* paint, FontMetrics& fm, float italicShear) override;
     bool get(FontMetrics& fm, char* text, uint32_t len, RenderPath& out) override;
     void copy(const FontMetrics& in, FontMetrics& out) override;

--- a/src/loaders/webp/tvgWebpLoader.cpp
+++ b/src/loaders/webp/tvgWebpLoader.cpp
@@ -69,8 +69,7 @@ WebpLoader::~WebpLoader()
     tvg::free(surface.buf8);
 }
 
-
-bool WebpLoader::open(const char* path)
+bool WebpLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     if (!(data = (uint8_t*)Loader::open(path, size))) return false;
@@ -86,8 +85,7 @@ bool WebpLoader::open(const char* path)
 #endif
 }
 
-
-bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const char* rpath, bool copy)
+bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
     if (copy) {
         this->data = tvg::malloc<uint8_t>(size);

--- a/src/loaders/webp/tvgWebpLoader.h
+++ b/src/loaders/webp/tvgWebpLoader.h
@@ -37,8 +37,8 @@ public:
     WebpLoader();
     ~WebpLoader();
 
-    bool open(const char* path) override;
-    bool open(const char* data, uint32_t size, const char* rpath, bool copy) override;
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     bool read() override;
     bool close() override;
 

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -37,6 +37,20 @@ struct AssetResolver
     void* data;
 };
 
+struct LoaderOps
+{
+    Type caller;  // which requests this?
+};
+
+struct PictureOps : LoaderOps
+{
+    AssetResolver* resolver;
+    const char* rpath;  // decide the relative path file if the file is loaded from memory
+
+    PictureOps(AssetResolver* resolver, const char* rpath) :
+        LoaderOps{Type::Picture}, resolver(resolver), rpath(rpath) {}
+};
+
 struct Loader
 {
     INLIST_ITEM(Loader);
@@ -69,8 +83,8 @@ struct Loader
         cached = true;
     }
 
-    virtual bool open(const char* path) { return false; }
-    virtual bool open(const char* data, uint32_t size, const char* rpath, bool copy) { return false; }
+    virtual bool open(const char* path, const LoaderOps* ops) { return false; }
+    virtual bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) { return false; }
     virtual bool resize(Paint* paint, float w, float h) { return false; }
     virtual void sync() {};  // finish immediately if any async update jobs.
 
@@ -126,7 +140,6 @@ struct ImageLoader : Loader
 
     virtual bool animatable() { return false; }  // true if this loader supports animation.
     virtual Paint* paint() { return nullptr; }
-    virtual void set(const AssetResolver* resolver) {}
 
     virtual RenderSurface* bitmap()
     {

--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -260,7 +260,7 @@ bool LoaderMgr::retrieve(Loader* loader)
     return true;
 }
 
-tvg::Loader* LoaderMgr::loader(const char* filename, bool* invalid)
+tvg::Loader* LoaderMgr::loader(const char* filename, const LoaderOps* ops, bool* invalid)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     *invalid = false;
@@ -275,7 +275,7 @@ tvg::Loader* LoaderMgr::loader(const char* filename, bool* invalid)
     }
 
     if (auto loader = _findByPath(filename)) {
-        if (loader->open(filename)) {
+        if (loader->open(filename, ops)) {
             if (allowCache) {
                 loader->cache(duplicate(filename));
                 {
@@ -290,7 +290,7 @@ tvg::Loader* LoaderMgr::loader(const char* filename, bool* invalid)
     // Unknown MimeType. Try with the candidates in the order
     for (int i = 0; i < static_cast<int>(FileType::Raw); i++) {
         if (auto loader = _find(static_cast<FileType>(i))) {
-            if (loader->open(filename)) {
+            if (loader->open(filename, ops)) {
                 if (allowCache) {
                     loader->cache(duplicate(filename));
                     {
@@ -313,7 +313,7 @@ bool LoaderMgr::retrieve(const char* filename)
     return retrieve(_findFromCache(filename));
 }
 
-tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mimeType, const char* rpath, bool copy)
+tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy)
 {
     // Note that users could use the same data pointer with the different content.
     // Thus caching is only valid for shareable.
@@ -332,7 +332,7 @@ tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mime
     // Try with the given MimeType
     if (mimeType) {
         if (auto loader = _findByType(mimeType)) {
-            if (loader->open(data, size, rpath, copy)) {
+            if (loader->open(data, size, ops, copy)) {
                 if (allowCache) {
                     loader->cache(HASH_KEY(data));
                     ScopedLock lock(_key);
@@ -349,7 +349,7 @@ tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mime
     for (int i = 0; i < static_cast<int>(FileType::Raw); i++) {
         auto loader = _find(static_cast<FileType>(i));
         if (loader) {
-            if (loader->open(data, size, rpath, copy)) {
+            if (loader->open(data, size, ops, copy)) {
                 if (allowCache) {
                     loader->cache(HASH_KEY(data));
                     ScopedLock lock(_key);
@@ -387,7 +387,7 @@ tvg::Loader* LoaderMgr::loader(const uint32_t* data, uint32_t w, uint32_t h, Col
 }
 
 // loads fonts from memory - loader is cached (regardless of copy value) in order to access it while setting font
-tvg::Loader* LoaderMgr::loader(const char* name, const char* data, uint32_t size, TVG_UNUSED const char* mimeType, bool copy)
+tvg::Loader* LoaderMgr::loader(const char* name, const char* data, uint32_t size, TVG_UNUSED const char* mimeType, const LoaderOps* ops, bool copy)
 {
 #ifdef THORVG_TTF_LOADER_SUPPORT
     // TODO: add check for mimetype ?
@@ -395,7 +395,7 @@ tvg::Loader* LoaderMgr::loader(const char* name, const char* data, uint32_t size
 
     // function is dedicated for ttf loader (the only supported font loader)
     auto loader = new TtfLoader;
-    if (loader->open(data, size, "", copy)) {
+    if (loader->open(data, size, ops, copy)) {
         loader->name = duplicate(name);
         loader->cached = true;  // force it.
         ScopedLock lock(_key);

--- a/src/renderer/tvgLoaderMgr.h
+++ b/src/renderer/tvgLoaderMgr.h
@@ -32,10 +32,10 @@ struct LoaderMgr
 {
     static bool init();
     static bool term();
-    static Loader* loader(const char* filename, bool* invalid);
-    static Loader* loader(const char* data, uint32_t size, const char* mimeType, const char* rpath, bool copy);
+    static Loader* loader(const char* filename, const LoaderOps* ops, bool* invalid);
+    static Loader* loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy);
     static Loader* loader(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy);
-    static Loader* loader(const char* name, const char* data, uint32_t size, const char* mimeType, bool copy);
+    static Loader* loader(const char* name, const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy);
     static Loader* font(const char* name);
     static Loader* anyfont();
     static bool retrieve(const char* filename);

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -159,11 +159,9 @@ struct PictureImpl : Picture
         if (vector || bitmap) return Result::InsufficientCondition;
 
         bool invalid;  //Invalid Path
-        auto loader = static_cast<ImageLoader*>(LoaderMgr::loader(filename, &invalid));
-        if (!loader) {
-            if (invalid) return Result::InvalidArguments;
-            return Result::NonSupport;
-        }
+        PictureOps ops = {resolver, nullptr};
+        auto loader = LoaderMgr::loader(filename, &ops, &invalid);
+        if (invalid) return Result::InvalidArguments;
         return load(loader);
     }
 
@@ -171,20 +169,16 @@ struct PictureImpl : Picture
     {
         if (!data || size <= 0) return Result::InvalidArguments;
         if (vector || bitmap) return Result::InsufficientCondition;
-        auto loader = static_cast<ImageLoader*>(LoaderMgr::loader(data, size, mimeType, rpath, copy));
-        if (!loader) return Result::NonSupport;
-        return load(loader);
+
+        PictureOps ops = {resolver, rpath};
+        return load(LoaderMgr::loader(data, size, mimeType, &ops, copy));
     }
 
     Result load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
     {
         if (!data || w <= 0 || h <= 0 || cs == ColorSpace::Unknown)  return Result::InvalidArguments;
         if (vector || bitmap) return Result::InsufficientCondition;
-
-        auto loader = static_cast<ImageLoader*>(LoaderMgr::loader(data, w, h, cs, copy));
-        if (!loader) return Result::FailedAllocation;
-
-        return load(loader);
+        return load(LoaderMgr::loader(data, w, h, cs, copy));
     }
 
     Result set(std::function<bool(Paint* paint, const char* src, void* data)> resolver, void* data)
@@ -315,8 +309,16 @@ struct PictureImpl : Picture
         return impl.renderer->region(impl.rd);
     }
 
-    Result load(ImageLoader* loader)
+    Result load(Loader* loader)
     {
+        if (!loader) return Result::NonSupport;
+
+        // fonts are not expected in the picture
+        if (loader->type == FileType::Ttf) {
+            LoaderMgr::retrieve(loader);
+            return Result::InvalidArguments;
+        }
+
         //Same resource has been loaded.
         if (this->loader == loader) {
             this->loader->sharing--;  //make it sure the reference counting.
@@ -325,12 +327,11 @@ struct PictureImpl : Picture
             LoaderMgr::retrieve(this->loader);
         }
 
-        this->loader = loader;
-        loader->set(resolver);
+        this->loader = static_cast<ImageLoader*>(loader);
         if (!loader->read()) return Result::Unknown;
 
-        this->w = loader->w;
-        this->h = loader->h;
+        this->w = this->loader->w;
+        this->h = this->loader->h;
 
         impl.mark(RenderUpdateFlag::All);
 

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -49,7 +49,8 @@ Result Text::load(const char* filename) noexcept
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     bool invalid; //invalid path
-    auto loader = LoaderMgr::loader(filename, &invalid);
+    LoaderOps ops = {Type::Text};
+    auto loader = LoaderMgr::loader(filename, &ops, &invalid);
     if (loader) {
         if (loader->sharing > 0) --loader->sharing;   //font loading doesn't mean sharing.
         return Result::Success;
@@ -73,7 +74,8 @@ Result Text::load(const char* name, const char* data, uint32_t size, const char*
         return Result::InsufficientCondition;
     }
 
-    if (!LoaderMgr::loader(name, data, size, mimeType, copy)) return Result::NonSupport;
+    LoaderOps ops = {Type::Text};
+    if (!LoaderMgr::loader(name, data, size, mimeType, &ops, copy)) return Result::NonSupport;
     return Result::Success;
 }
 


### PR DESCRIPTION
Some loaders require building additional data at early file open time.
Previously, there was no way for Picture to pass such extra options to the loaders.
AssetResolver is one such case.

- By introducing Loader Options, Picture can now deliver AssetResolver during file opening.
- This also prevents Picture tries font loading.