### PR TITLE
lottie/expressions: replace jerry_eval with jerry_parse/jerry_run and use compiled code

### DIFF
--- a/src/loaders/lottie/jerryscript/jerry-core/api/jerryscript.cpp
+++ b/src/loaders/lottie/jerryscript/jerry-core/api/jerryscript.cpp
@@ -17,13 +17,15 @@
 
 #include <math.h>
 
-#include "ecma-eval.h"
+#include "ecma-builtins.h"
+#include "ecma-exceptions.h"
 #include "ecma-function-object.h"
 #include "ecma-gc.h"
 #include "ecma-init-finalize.h"
 #include "ecma-objects-general.h"
 #include "ecma-objects.h"
 #include "jcontext.h"
+#include "js-parser.h"
 
 /** \addtogroup jerry Jerry engine interface
  * @{
@@ -149,24 +151,57 @@ jerry_cleanup (void)
 } /* jerry_cleanup */
 
 /**
- * Perform eval
+ * Parse a script and create a compiled code using a character string
  *
- * Note:
- *      returned value must be freed with jerry_value_free, when it is no longer needed.
- *
- * @return result of eval, may be error value.
+ * @return script object value - if script was parsed successfully,
+ *         thrown error - otherwise
  */
 jerry_value_t
-jerry_eval (const jerry_char_t *source_p, /**< source code */
-            size_t source_size, /**< length of source code */
-            uint32_t flags) /**< jerry_parse_opts_t flags */
+jerry_parse (const jerry_char_t *source_p, /**< source code */
+             size_t source_size, /**< length of source code */
+             uint32_t flags) /**< jerry_parse_opts_t flags */
 {
   parser_source_char_t source_char;
   source_char.source_p = source_p;
   source_char.source_size = source_size;
 
-  return jerry_return (ecma_op_eval_chars_buffer ((void *) &source_char, flags));
-} /* jerry_eval */
+  /* Originally jerry_parse called jerry_parse_common, which handled parsing options.
+   * Since ThorVG does not use parsing options, the essential logic is inlined here directly. */
+  ecma_compiled_code_t *bytecode_data_p = parser_parse_script ((void *) &source_char, flags, NULL);
+
+  if (JERRY_UNLIKELY (bytecode_data_p == NULL))
+  {
+    return ecma_create_exception_from_context ();
+  }
+
+  ecma_object_t *object_p = ecma_create_object (NULL, sizeof (ecma_extended_object_t), ECMA_OBJECT_TYPE_CLASS);
+
+  ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
+  ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_SCRIPT;
+  ECMA_SET_INTERNAL_VALUE_POINTER (ext_object_p->u.cls.u3.value, bytecode_data_p);
+
+  return ecma_make_object_value (object_p);
+} /* jerry_parse */
+
+/**
+ * Run a Script created by jerry_parse.
+ *
+ * Note:
+ *      returned value must be freed with jerry_value_free, when it is no longer needed.
+ *
+ * @return result of bytecode - if run was successful
+ *         thrown error - otherwise
+ */
+jerry_value_t
+jerry_run (const jerry_value_t script) /**< script to run */
+{
+  ecma_object_t *object_p = ecma_get_object_from_value (script);
+  ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
+  const ecma_compiled_code_t *bytecode_data_p;
+  bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_compiled_code_t, ext_object_p->u.cls.u3.value);
+
+  return jerry_return (vm_run_global (bytecode_data_p, object_p));
+} /* jerry_run */
 
 /**
  * Get global object

--- a/src/loaders/lottie/jerryscript/jerry-core/include/jerryscript-core.h
+++ b/src/loaders/lottie/jerryscript/jerry-core/include/jerryscript-core.h
@@ -24,7 +24,7 @@ void jerry_init (jerry_init_flag_t flags);
 void jerry_cleanup (void);
 jerry_value_t jerry_current_realm (void);
 jerry_value_t jerry_set_realm (jerry_value_t realm);
-jerry_value_t jerry_eval (const jerry_char_t *source_p, size_t source_size, uint32_t flags);
+jerry_value_t jerry_parse (const jerry_char_t *source_p, size_t source_size, uint32_t flags);
 jerry_value_t jerry_run (const jerry_value_t script);
 bool jerry_value_is_undefined (const jerry_value_t value);
 bool jerry_value_is_number (const jerry_value_t value);

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -1500,6 +1500,17 @@ jerry_value_t LottieExpressions::evaluate(float frameNo, LottieExpression* exp)
     if (exp->disabled) return jerry_undefined();
 
     auto& context = this->context();
+    //clear caches if needed
+    bool clear = false;
+    {
+        ScopedLock lock(_lockKey);
+        clear = context.clearCache;
+        context.clearCache = false;
+    }
+    if (clear) {
+        for (auto& code : context.compiledCodes) jerry_value_free(code.code);
+        context.compiledCodes.clear();
+    }
 
     buildGlobal(context, frameNo, exp);
 
@@ -1523,17 +1534,42 @@ jerry_value_t LottieExpressions::evaluate(float frameNo, LottieExpression* exp)
     //expansions per object type
     if (exp->object->type == LottieObject::Transform) _buildTransform(context.global, frameNo, static_cast<LottieTransform*>(exp->object));
 
-    //evaluate the code
-    auto eval = jerry_eval((jerry_char_t *) exp->code, strlen(exp->code), JERRY_PARSE_NO_OPTS);
+    //reuse cached code, or parse and cache the expression before running it
+    //skip caching expressions for slot properties
+    auto cacheable = exp->property->sid == 0;
+    jerry_value_t code = jerry_undefined();
+    if (cacheable) {
+        for (auto& p : context.compiledCodes) {
+            if (p.exp == exp) {
+                code = p.code;
+                break;
+            }
+        }
+    }
 
-    if (jerry_value_is_exception(eval)) {
+    if (jerry_value_is_undefined(code)) {
+        code = jerry_parse((jerry_char_t *) exp->code, strlen(exp->code), JERRY_PARSE_NO_OPTS);
+        if (jerry_value_is_exception(code)) {
+            TVGERR("LOTTIE", "Failed to parse the expressions!");
+            jerry_value_free(code);
+            exp->disabled = true;
+            return jerry_undefined();
+        }
+        if (cacheable) context.compiledCodes.push({exp, code});
+    }
+
+    auto result = jerry_run(code);
+
+    if (jerry_value_is_exception(result)) {
         TVGERR("LOTTIE", "Failed to dispatch the expressions!");
-        jerry_value_free(eval);
         exp->disabled = true;
+        jerry_value_free(result);
+        if (!cacheable) jerry_value_free(code);
         return jerry_undefined();
     }
 
-    jerry_value_free(eval);
+    jerry_value_free(result);
+    if (!cacheable) jerry_value_free(code);
 
     return jerry_object_get_sz(context.global, "$bm_rt");
 }
@@ -1557,6 +1593,9 @@ void LottieExpressions::retrieve(LottieExpressions* instance)
     if (!instance) return;
 
     ScopedLock lock(_lockKey);
+    ARRAY_FOREACH(context, instance->contexts) {
+        (*context)->clearCache = true;
+    }
     if (--_refCnt == 0) {
         delete(instance);
         _exps = nullptr;
@@ -1606,6 +1645,11 @@ void LottieExpressions::clear(Context& context)
 #ifdef THORVG_THREAD_SUPPORT
     jerry_port_context_set(context.ctx);
 #endif
+    for (auto& code : context.compiledCodes) {
+        jerry_value_free(code.code);
+    }
+    context.compiledCodes.clear();
+
     jerry_value_free(context.thisProperty);
     jerry_value_free(context.thisLayer);
     jerry_value_free(context.thisComp);

--- a/src/loaders/lottie/tvgLottieExpressions.h
+++ b/src/loaders/lottie/tvgLottieExpressions.h
@@ -166,6 +166,15 @@ private:
         jerry_value_t thisComp;
         jerry_value_t thisLayer;
         jerry_value_t thisProperty;
+
+        //compiled cache: avoids re-parsing the same expression in this context
+        struct CompiledCode
+        {
+            const LottieExpression* exp;
+            jerry_value_t code;
+        };
+        Array<CompiledCode> compiledCodes;
+        bool clearCache = false;
 #ifdef THORVG_THREAD_SUPPORT
         jerry_context_t* ctx;
         thread::id tid;
@@ -197,13 +206,14 @@ struct LottieExpressions
     static LottieExpressions* instance() { return nullptr; }
     static void retrieve(TVG_UNUSED LottieExpressions*) {}
 
+    void update(TVG_UNUSED float) {}
+
     template<typename Property, typename NumType> bool result(TVG_UNUSED float, TVG_UNUSED NumType&, TVG_UNUSED LottieExpression*) { return false; }
     template<typename Property> bool result(TVG_UNUSED float, TVG_UNUSED Point&, LottieExpression*) { return false; }
     template<typename Property> bool result(TVG_UNUSED float, TVG_UNUSED RGB32&, TVG_UNUSED LottieExpression*) { return false; }
     template<typename Property> bool result(TVG_UNUSED float, TVG_UNUSED Fill*, TVG_UNUSED LottieExpression*) { return false; }
     template<typename Property> bool result(TVG_UNUSED float, TVG_UNUSED RenderPath&, TVG_UNUSED Matrix*, TVG_UNUSED LottieModifier*, TVG_UNUSED LottieExpression*) { return false; }
     bool result(TVG_UNUSED float, TVG_UNUSED TextDocument& doc, TVG_UNUSED LottieExpression*) { return false; }
-    void update(TVG_UNUSED float) {}
 };
 
 #endif //THORVG_LOTTIE_EXPRESSIONS_SUPPORT

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -307,7 +307,9 @@ bool LottieLoader::apply(uint32_t slotcode, bool byDefault)
         }
     }
     curSlot = slotcode;
-    if (applied) build = true;
+    if (applied) {
+        build = true;
+    }
     return applied;
 }
 


### PR DESCRIPTION
#### Summary

- Replace `jerry_eval` (parse + execute combined) with separate `jerry_parse` and `jerry_run` APIs
- Cache compiled code per expression to avoid redundant parsing on every frame



### result

| Mac m5pro | github action runner, thread=4 | github action runner, thread=0 |
|-|-|-|
| + 10% | [6% ~12%](https://github.com/Nor-s/perfaction/actions/runs/27230513274) | [11%~14%](https://github.com/Nor-s/perfaction/actions/runs/27230393391)|

