### PR TITLE
Add support for retrieving accessor names

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1743,15 +1743,18 @@ struct TVG_API Picture : Paint
     Result filter(FilterMethod method) noexcept;
 
     /**
-     * @brief Retrieve a paint object from the Picture scene by its Unique ID.
+     * @brief Retrieve a Paint object from the Picture scene by its unique ID.
      *
-     * This function searches for a paint object within the Picture scene that matches the provided @p id.
+     * Searches for a Paint object within the Picture scene that matches the given @p id.
      *
-     * @param[in] id The Unique ID of the paint object.
+     * @param[in] id The unique identifier of the Paint object.
      *
-     * @return A pointer to the paint object that matches the given identifier, or @c nullptr if no matching paint object is found.
+     * @return A pointer to the matching Paint object, or @c nullptr if not found.
+     *
+     * @note Setting @ref Picture::accessible to @c true enables more efficient access.
      *
      * @see Accessor::id()
+     * @see Picture::accessible
      *
      * @since 1.0
      */
@@ -1779,6 +1782,8 @@ struct TVG_API Picture : Paint
      * @since 1.0
      */
     Type type() const noexcept override;
+
+    bool accessible = false;
 
     _TVG_DECLARE_ACCESSOR(Animation);
     _TVG_DECLARE_PRIVATE_DERIVE(Picture);
@@ -2712,7 +2717,6 @@ struct TVG_API Saver final
     _TVG_DECLARE_PRIVATE_BASE(Saver);
 };
 
-
 /**
  * @class Accessor
  *
@@ -2721,12 +2725,13 @@ struct TVG_API Saver final
  * The Accessor helps you search specific nodes to read the property information, figure out the structure of the scene tree and its size.
  *
  * @warning We strongly warn you not to change the paints of a scene unless you really know the design-structure.
+ * @warning This class is not designed for inheritance.
  *
  * @since 0.10
  */
-struct TVG_API Accessor final
+struct TVG_API Accessor
 {
-    ~Accessor();
+    virtual ~Accessor();
 
     /**
      * @brief Set the access function for traversing the Picture scene tree nodes.
@@ -2752,10 +2757,33 @@ struct TVG_API Accessor final
      * @return The generated unique identifier value.
      *
      * @see Paint::id
+     * @see Picture::paint()
      *
      * @since 1.0
      */
     static uint32_t id(const char* name) noexcept;
+
+    /**
+     * @brief Retrieve the original name string from a given unique ID.
+     *
+     * Returns the name associated with the specified identifier.
+     *
+     * This method is only valid when @ref Picture::accessible is set to @c true
+     * for the Picture associated with the given @p paint in @ref Accessor::set() Otherwise, the name
+     * information may not be available.
+     *
+     * @param[in] id The unique identifier.
+     *
+     * @return The corresponding name string, or @c nullptr if not found or unavailable.
+     *
+     * @see Accessor::id()
+     * @see Accessor::set()
+     * @see Picture::accessible
+     *
+     * @note This function is only availble within Accessor callbacks registered via @ref Accessor::set().
+     * @note Experimental API
+     */
+    const char* name(uint32_t id) noexcept;
 
     /**
      * @brief Creates a new Accessor object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2055,6 +2055,8 @@ TVG_API Tvg_Result tvg_picture_get_origin(const Tvg_Paint picture, float* x, flo
  *
  * @return The paint object that matches the given identifier, or @c nullptr if no matching paint object is found.
  *
+ * @note Setting @ref tvg_picture_set_accessible() to @c true enables more efficient access.
+ *
  * @see tvg_accessor_generate_id()
  * @since 1.0
  */
@@ -2073,6 +2075,27 @@ TVG_API const Tvg_Paint tvg_picture_get_paint(Tvg_Paint picture, uint32_t id);
  * @note Experimental API
  */
 TVG_API Tvg_Result tvg_picture_set_filter(Tvg_Paint picture, Tvg_Filter_Method method);
+
+/**
+ * @brief Enable or disable accessible mode for a Picture.
+ *
+ * When accessible mode is enabled, the Picture maintains an internal mapping
+ * of ID-accessible vector assets nodes (such as SVG), allowing efficient access to Paint objects
+ * and their associated identifier information via Accessor APIs.
+ *
+ * When disabled, no additional mapping is maintained and all nodes are treated
+ * as general traversal targets.
+ *
+ * @param[in] picture The target Picture object.
+ * @param[in] accessible Set to @c true to enable accessible mode, or @c false to disable it.
+ *
+ * @see tvg_accessor_generate_id()
+ * @see tvg_accessor_get_name()
+ * @see tvg_picture_get_paint()
+ *
+ * @since 1.0
+ */
+TVG_API Tvg_Result tvg_picture_set_accessible(Tvg_Paint picture, bool accessible);
 
 /** \} */   // end defgroup ThorVGCapi_Picture
 
@@ -2949,6 +2972,29 @@ TVG_API Tvg_Result tvg_accessor_set(Tvg_Accessor accessor, Tvg_Paint paint, bool
  * @since 1.0
  */
 TVG_API uint32_t tvg_accessor_generate_id(const char* name);
+
+/**
+ * @brief Retrieve the original name string from a given unique ID.
+ *
+ * Returns the name associated with the specified identifier.
+ *
+ * This method is only valid when @ref tvg_picture_set_accessible() is set to @c true
+ * for the Picture associated with the given @p paint in @ref tvg_accessor_set() Otherwise, the name
+ * information may not be available.
+ *
+ * @param[in] accessor An accessor object.
+ * @param[in] id The unique identifier.
+ *
+ * @return The corresponding name string, or @c nullptr if not found or unavailable.
+ *
+ * @see tvg_accessor_generate_id()
+ * @see tvg_accessor_set()
+ * @see tvg_picture_set_accessible()
+ *
+ * @note This function is only available within Accessor callbacks registered via @ref tvg_accessor_set().
+ * @note Experimental API
+ */
+TVG_API const char* tvg_accessor_get_name(Tvg_Accessor accessor, uint32_t id);
 
 /** \} */   // end defgroup ThorVGCapi_Accessor
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -668,6 +668,14 @@ TVG_API const Tvg_Paint tvg_picture_get_paint(Tvg_Paint picture, uint32_t id)
     return nullptr;
 }
 
+TVG_API Tvg_Result tvg_picture_set_accessible(Tvg_Paint picture, bool accessible)
+{
+    if (picture) {
+        reinterpret_cast<Picture*>(picture)->accessible = accessible;
+        return TVG_RESULT_SUCCESS;
+    }
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
 
 TVG_API Tvg_Result tvg_picture_set_origin(Tvg_Paint picture, float x, float y)
 {
@@ -1169,6 +1177,11 @@ TVG_API uint32_t tvg_accessor_generate_id(const char* name)
     return Accessor::id(name);
 }
 
+TVG_API const char* tvg_accessor_get_name(Tvg_Accessor accessor, uint32_t id)
+{
+    if (accessor) return reinterpret_cast<Accessor*>(accessor)->name(id);
+    return nullptr;
+}
 
 /************************************************************************/
 /* Lottie Animation API                                                 */

--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -942,41 +942,33 @@ static Scene* _sceneBuildHelper(SvgParserContext& ctx, const SvgNode* node, cons
 
     auto scene = Scene::gen();
     // For a Symbol node, the viewBox transformation has to be applied first - see _useBuildHelper()
-    if (!mask && node->transform && node->type != SvgNodeType::Symbol && node->type != SvgNodeType::Use) {
-        scene->transform(*node->transform);
-    }
-
+    if (!mask && node->transform && node->type != SvgNodeType::Symbol && node->type != SvgNodeType::Use) scene->transform(*node->transform);
     if (!node->style->display || node->style->opacity == 0) return scene;
 
     ARRAY_FOREACH(p, node->child) {
         auto child = *p;
+        Paint* paint = nullptr;
         if (child->type == SvgNodeType::ClipPath || child->type == SvgNodeType::Filter) continue;
         if (_isGroupType(child->type)) {
-            Paint* paint = nullptr;
-            if (child->type == SvgNodeType::Use)
-                paint = _useBuildHelper(ctx, child, vBox, svgPath, depth + 1);
-            else if (!(child->type == SvgNodeType::Symbol && node->type != SvgNodeType::Use))
-                paint = _sceneBuildHelper(ctx, child, vBox, svgPath, false, depth + 1);
-            if (paint) {
-                if (child->id) paint->id = djb2Encode(child->id);
-                scene->add(paint);
-            }
+            if (child->type == SvgNodeType::Use) paint = _useBuildHelper(ctx, child, vBox, svgPath, depth + 1);
+            else if (!(child->type == SvgNodeType::Symbol && node->type != SvgNodeType::Use)) paint = _sceneBuildHelper(ctx, child, vBox, svgPath, false, depth + 1);
         } else {
-            Paint* paint = nullptr;
             if (child->type == SvgNodeType::Image) paint = _imageBuildHelper(ctx, child, vBox, svgPath);
             else if (child->type == SvgNodeType::Text) paint = _textBuildHelper(ctx, child, vBox, svgPath);
             else if (child->type != SvgNodeType::Mask) paint = _shapeBuildHelper(ctx, child, vBox, svgPath);
-            if (paint) {
-                if (child->id) paint->id = djb2Encode(child->id);
-                scene->add(paint);
+        }
+        if (paint) {
+            // TODO: enable this only when accessible is enabled at thorvg v2 (for backward compat)
+            if (child->id) {
+                paint->id = djb2Encode(child->id);
+                if (ctx.accessible) ctx.access.push({paint->id, paint, tvg::duplicate(child->id)});
             }
+            scene->add(paint);
         }
     }
     scene->opacity(node->style->opacity);
 
-    auto p = _applyFilter(ctx, scene, node, vBox, svgPath);
-    p = _applyComposition(ctx, p, node, vBox, svgPath);
-    return static_cast<Scene*>(_applyBlend(p, node));
+    return (Scene*)_applyBlend(_applyComposition(ctx, _applyFilter(ctx, scene, node, vBox, svgPath), node, vBox, svgPath), node);
 }
 
 

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -27,6 +27,7 @@
 #include "tvgArray.h"
 #include "tvgInlist.h"
 #include "tvgColor.h"
+#include "tvgAccessor.h"
 
 using SvgColor = tvg::RGB;
 
@@ -610,7 +611,13 @@ struct SvgParserContext
     Array<SvgNodeIdPair> nodesToStyle;
     Array<char*> images;        //embedded images
     Array<FontFace> fonts;
+
+    // TODO: We can remove map and directly use the name instead of id in ThorVG v2
+    // TODO: Maybe we can replace this with std::map. Currently, ArrayList seems fast enough.
+    Array<AccessorEntity> access;
+
     OpenedTagType openedTag = OpenedTagType::Other;
+    bool accessible;  // allow the Accessor to retain the SVG node names
 
     void clear(bool all);
 };

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3752,14 +3752,14 @@ void SvgParserContext::clear(bool all)
     ARRAY_FOREACH(p, images) {
         tvg::free(*p);
     }
-    images.reset();
-
     ARRAY_FOREACH(p, fonts) {
         Text::unload(p->name);
         tvg::free(p->decoded);
         tvg::free(p->name);
     }
-    fonts.reset();
+    ARRAY_FOREACH(a, access) {
+        tvg::free(a->name);
+    }
 }
 
 SvgLoader::SvgLoader() : ImageLoader(FileType::Svg)
@@ -3843,8 +3843,10 @@ bool SvgLoader::header()
     return true;
 }
 
-bool SvgLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
+bool SvgLoader::open(const char* data, uint32_t size, const LoaderOps* ops, bool copy)
 {
+    if (ops->caller != tvg::Type::Picture) return false;
+
     if (copy) {
         content = tvg::malloc<char>(size + 1);
         memcpy((char*)content, data, size);
@@ -3854,13 +3856,18 @@ bool SvgLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps
     this->size = size;
     this->copy = copy;
 
+    ctx.accessible = static_cast<const PictureOps*>(ops)->accessible;
+
     return header();
 }
 
 bool SvgLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
+    if (ops->caller != tvg::Type::Picture) return false;
+
     if ((content = Loader::open(path, size, true))) {
+        ctx.accessible = static_cast<const PictureOps*>(ops)->accessible;
         copy = true;
         return header();
     }
@@ -3898,7 +3905,6 @@ bool SvgLoader::close()
 {
     if (!Loader::close()) return false;
     this->done();
-    clear();
     return true;
 }
 
@@ -3912,4 +3918,26 @@ Paint* SvgLoader::paint()
         return root->duplicate();
     }
     return nullptr;
+}
+
+const AccessorEntity* SvgLoader::access(uint32_t id)
+{
+    // TODO: binary search
+    if (ctx.accessible) {
+        this->done();
+        ARRAY_FOREACH(a, ctx.access) {
+            if (a->id == id) return a;
+        }
+    }
+    return nullptr;
+}
+
+void SvgLoader::access(AccessorCallback& cb)
+{
+    if (ctx.accessible) {
+        this->done();
+        ARRAY_FOREACH(a, ctx.access) {
+            if (!cb.func(a->paint, cb.data)) return;
+        }
+    }
 }

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -44,6 +44,9 @@ struct SvgLoader : ImageLoader, Task
     bool read() override;
     bool close() override;
 
+    const AccessorEntity* access(uint32_t id) override;
+    void access(AccessorCallback& cb) override;
+
     Paint* paint() override;
 
 private:

--- a/src/renderer/tvgAccessor.cpp
+++ b/src/renderer/tvgAccessor.cpp
@@ -22,29 +22,53 @@
 
 #include "tvgAccessor.h"
 #include "tvgCompressor.h"
+#include "tvgPicture.h"
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static bool accessChildren(AccessorIterator* it, function<bool(const Paint* paint, void* data)> func, void* data)
-{
-    while (auto child = it->next()) {
-        //Access the child
-        if (!func(child, data)) return false;
+#define IMPL static_cast<AccessorImpl*>(this)
 
-        //Access the children of the child
-        if (auto it2 = AccessorIterator::iterator(child)) {
-            if (!accessChildren(it2, func, data)) {
+Accessor::Accessor() = default;
+
+struct AccessorImpl : Accessor
+{
+    Paint* paint;
+    AccessorCallback cb;
+    bool accessible = false;  // special searching for picture nested scenes with id maps
+
+    bool access(AccessorIterator* it)
+    {
+        while (auto child = it->next()) {
+            // access the child
+            if (!cb.func(child, cb.data)) return false;
+
+            // access the children of the child
+            if (auto it2 = AccessorIterator::iterator(child)) {
+                if (!access(it2)) {
+                    delete (it2);
+                    return false;
+                }
                 delete(it2);
-                return false;
             }
-            delete(it2);
+        }
+        return true;
+    }
+
+    // pre-order tree search
+    void search()
+    {
+        // root
+        if (!cb.func(paint, cb.data)) return;
+
+        // children
+        if (auto it = AccessorIterator::iterator(paint)) {
+            access(it);
+            delete (it);
         }
     }
-    return true;
-}
-
+};
 
 /************************************************************************/
 /* External Class Implementation                                        */
@@ -52,49 +76,44 @@ static bool accessChildren(AccessorIterator* it, function<bool(const Paint* pain
 
 Result Accessor::set(Paint* paint, function<bool(const Paint* paint, void* data)> func, void* data) noexcept
 {
-    if (!paint || !func) return Result::InvalidArguments;
+    if (paint && func) {
+        IMPL->paint = paint;
+        IMPL->cb = {func, data};
+        IMPL->accessible = (paint->type() == Type::Picture && static_cast<Picture*>(paint)->accessible);
 
-    //Use the Preorder Tree-Search
+        paint->ref();
 
-    paint->ref();
+        if (IMPL->accessible) to<PictureImpl>(IMPL->paint)->access(IMPL->cb);
+        else IMPL->search();
 
-    //Root
-    if (!func(paint, data)) {
         paint->unref(false);
+
+        IMPL->accessible = false;
+
         return Result::Success;
     }
-
-    //Children
-    if (auto it = AccessorIterator::iterator(paint)) {
-        accessChildren(it, func, data);
-        delete(it);
-    }
-
-    paint->unref(false);
-
-    return Result::Success;
+    return Result::InvalidArguments;
 }
 
+const char* Accessor::name(uint32_t id) noexcept
+{
+    if (IMPL->accessible) {
+        auto entity = to<PictureImpl>(IMPL->paint)->access(id);
+        if (entity) return entity->name;
+    }
+    return nullptr;
+}
 
 uint32_t Accessor::id(const char* name) noexcept
 {
     return djb2Encode(name);
 }
 
-
 Accessor::~Accessor()
 {
-
 }
-
-
-Accessor::Accessor() : pImpl(nullptr)
-{
-
-}
-
 
 Accessor* Accessor::gen() noexcept
 {
-    return new Accessor;
+    return new AccessorImpl;
 }

--- a/src/renderer/tvgAccessor.h
+++ b/src/renderer/tvgAccessor.h
@@ -28,6 +28,19 @@
 namespace tvg
 {
 
+struct AccessorEntity
+{
+    uint32_t id;  // for fast access (equal to paint->id)
+    Paint* paint;
+    char* name;
+};
+
+struct AccessorCallback
+{
+    function<bool(const Paint* paint, void* data)> func;
+    void* data;
+};
+
 struct AccessorIterator
 {
     virtual ~AccessorIterator() {}

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -27,6 +27,7 @@
 #include "tvgCommon.h"
 #include "tvgRender.h"
 #include "tvgInlist.h"
+#include "tvgAccessor.h"
 
 namespace tvg
 {
@@ -46,9 +47,10 @@ struct PictureOps : LoaderOps
 {
     AssetResolver* resolver;
     const char* rpath;  // decide the relative path file if the file is loaded from memory
+    bool accessible;    // allow the accessor
 
-    PictureOps(AssetResolver* resolver, const char* rpath) :
-        LoaderOps{Type::Picture}, resolver(resolver), rpath(rpath) {}
+    PictureOps(AssetResolver* resolver, const char* rpath, bool accessible) :
+        LoaderOps{Type::Picture}, resolver(resolver), rpath(rpath), accessible(accessible) {}
 };
 
 struct Loader
@@ -140,6 +142,8 @@ struct ImageLoader : Loader
 
     virtual bool animatable() { return false; }  // true if this loader supports animation.
     virtual Paint* paint() { return nullptr; }
+    virtual const AccessorEntity* access(uint32_t id) { return nullptr; }
+    virtual void access(AccessorCallback& cb) {}
 
     virtual RenderSurface* bitmap()
     {

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -99,6 +99,12 @@ Result Picture::origin(float* x, float* y) const noexcept
 
 const Paint* Picture::paint(uint32_t id) noexcept
 {
+    if (accessible) {
+        auto entity = to<PictureImpl>(this)->access(id);
+        return entity ? entity->paint : nullptr;
+    }
+
+    // TODO: remove at thorvg v2 release (for backward compat)
     struct Value
     {
         uint32_t id;

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -133,7 +133,7 @@ struct PictureImpl : Picture
         if (vector || bitmap) return Result::InsufficientCondition;
 
         bool invalid;  //Invalid Path
-        PictureOps ops = {resolver, nullptr};
+        PictureOps ops = {resolver, nullptr, accessible};
         auto loader = LoaderMgr::loader(filename, &ops, &invalid);
         if (invalid) return Result::InvalidArguments;
         return load(loader);
@@ -144,7 +144,7 @@ struct PictureImpl : Picture
         if (!data || size <= 0) return Result::InvalidArguments;
         if (vector || bitmap) return Result::InsufficientCondition;
 
-        PictureOps ops = {resolver, rpath};
+        PictureOps ops = {resolver, rpath, accessible};
         return load(LoaderMgr::loader(data, size, mimeType, &ops, copy));
     }
 
@@ -325,6 +325,17 @@ struct PictureImpl : Picture
         impl.mark(RenderUpdateFlag::All);
 
         return Result::Success;
+    }
+
+    const AccessorEntity* access(uint32_t id)
+    {
+        if (loader) return loader->access(id);
+        return nullptr;
+    }
+
+    void access(AccessorCallback& cb)
+    {
+        if (loader) loader->access(cb);
     }
 };
 


### PR DESCRIPTION
- Introduce Accessor APIs to retrieve original ID names
  of corresponding SVG nodes.
- Improve access performance by maintaining a accessible targets.
- APIs are Experimental (beta) version.

Later we can only assign the svg paint id onlt if the accessible is enabled
for now we leave it as it does for backward compatibility.

```
C++ APIs:
 + const char* Accessor::name(uint32_t id)
  + bool Picture::accessible

C APIs:
 + const char* tvg_accessor_name(Tvg_Accessor, uint32_t id)
 + tvg_picture_set_accessible(Tvg_Picture picture, bool accessible)
```

issue: #421