### PR TITLE
test: relax Bounding Box checks for precision variance

### DIFF
--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -164,10 +164,10 @@ TEST_CASE("Bounding Box", "[tvgPaint]")
 
         //Positive
         REQUIRE(shape->bounds(&x, &y, &w, &h) == Result::Success);
-        REQUIRE(x == 100.0f);
-        REQUIRE(y == 121.0f);
-        REQUIRE(w == 20.0f);
-        REQUIRE(h == 100.0f);
+        REQUIRE(x == Approx(100.0f).margin(0.001f));
+        REQUIRE(y == Approx(121.0f).margin(0.001f));
+        REQUIRE(w == Approx(20.0f).margin(0.001f));
+        REQUIRE(h == Approx(100.0f).margin(0.001f));
 
         Point pts[4];
         REQUIRE(shape->bounds(pts) == Result::Success);


### PR DESCRIPTION
- issue: #4280


On 32-bit x86 with -mfpmath=387 -O2, Debian reproduces a small x87 floating-point variance (100.00002f vs 100.0f) in the Bounding Box test.

I tested an x86 32-bit x87 build on Ubuntu with -m32 -mfpmath=387, but could not reproduce the failure. This suggests the issue may be environment-specific floating-point variance rather than a deterministic ThorVG logic bug.

Given the small magnitude of the difference, relaxing exact float comparisons in the test may be worth considering.


| before | after |
| - | - |
| <img width="612" height="368" alt="image" src="https://github.com/user-attachments/assets/376b4561-9071-4612-9b6c-0b7691e27bfc" />| <img width="610" height="89" alt="image" src="https://github.com/user-attachments/assets/b57d442f-f312-48d2-802d-54414a92d48e" />|


```
  export CFLAGS='-O2 -g3 -fno-omit-frame-pointer -m32 -march=i686 -mfpmath=387'
  export CXXFLAGS='-O2 -g3 -fno-omit-frame-pointer -m32 -march=i686 -mfpmath=387'
  export LDFLAGS='-m32'
  meson setup build-x87-dbgopt -Dtests=true -Dengines=sw -Dloaders=all -Dsavers=gif -Dsimd=false -Dstatic=true --buildtype=debugoptimized --wipe
  meson compile -C build-x87-dbgopt
  ./build-x87-dbgopt/test/tvgUnitTests "Bounding Box" --success
```