### PR TITLE
lottie: Implement Set Matte(Matte3) effect

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1401,11 +1401,15 @@ bool LottieBuilder::updateMatte(LottieComposition* comp, float frameNo, Scene* s
     auto target = layer->matteTarget;
     if (!target || target->type == LottieLayer::Null) return true;
 
-    updateLayer(comp, scene, target, frameNo);
+    if (target->matteSrc) updateLayer(comp, scene, target, frameNo);
 
     if (target->scene) {
-        layer->scene->mask(target->scene, layer->matteType);
-    } else if (layer->matteType == MaskMethod::Alpha || layer->matteType == MaskMethod::Luma) {
+        auto mask = target->matteSrc ? target->scene : target->scene->duplicate();
+        if (mask) layer->scene->mask(mask, layer->matteType);
+        return true;
+    }
+
+    if (layer->matteType == MaskMethod::Alpha || layer->matteType == MaskMethod::Luma) {
         //matte target is not exist. alpha blending definitely bring an invisible result
         Paint::rel(layer->scene);
         layer->scene = nullptr;
@@ -1675,6 +1679,28 @@ static bool _buildComposition(LottieComposition* comp, LottieLayer* parent)
             //precomp referencing
             if (child->matteTarget->rid) _buildReference(comp, child->matteTarget);
         }
+
+        // Handle Set Matte effect
+        if (child->matteType == MaskMethod::None) {
+            ARRAY_FOREACH(ep, child->effects) {
+                auto effect = *ep;
+                if (effect->type != LottieEffect::SetMatte || !effect->enable) continue;
+                auto matteEffect = static_cast<LottieFxSetMatte*>(effect);
+                auto matteLayer = matteEffect->matteLayer(0);
+                if (matteLayer >= 0) {
+                    auto target = parent->layerByIdx(matteLayer);
+                    if (target && target != child) {
+                        child->matteTarget = target;
+                        child->matteType = MaskMethod::Alpha;
+                        if (matteEffect->composite(0) == 0) target->matteSrc = true;
+                        _buildHierarchy(parent, target);
+                        if (target->rid) _buildReference(comp, target);
+                    }
+                }
+                break;
+            }
+        }
+
         _buildHierarchy(parent, child);
 
         //attach the necessary font data

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1415,11 +1415,15 @@ bool LottieBuilder::updateMatte(LottieComposition* comp, float frameNo, Scene* s
     auto target = layer->matteTarget;
     if (!target || target->type == LottieLayer::Null) return true;
 
-    updateLayer(comp, scene, target, frameNo);
+    if (target->matteSrc) updateLayer(comp, scene, target, frameNo);
 
     if (target->scene) {
-        layer->scene->mask(target->scene, layer->matteType);
-    } else if (layer->matteType == MaskMethod::Alpha || layer->matteType == MaskMethod::Luma) {
+        auto mask = target->matteSrc ? target->scene : target->scene->duplicate();
+        if (mask) layer->scene->mask(mask, layer->matteType);
+        return true;
+    }
+
+    if (layer->matteType == MaskMethod::Alpha || layer->matteType == MaskMethod::Luma) {
         //matte target is not exist. alpha blending definitely bring an invisible result
         Paint::rel(layer->scene);
         layer->scene = nullptr;
@@ -1703,6 +1707,28 @@ static bool _buildComposition(LottieComposition* comp, LottieRootLayer* parent)
             //precomp referencing
             if (child->matteTarget->rid) _buildReference(comp, child->matteTarget);
         }
+
+        // Handle Set Matte effect
+        if (child->matteType == MaskMethod::None) {
+            ARRAY_FOREACH(ep, child->effects) {
+                auto effect = *ep;
+                if (effect->type != LottieEffect::SetMatte || !effect->enable) continue;
+                auto matteEffect = static_cast<LottieFxSetMatte*>(effect);
+                auto matteLayer = matteEffect->matteLayer(0);
+                if (matteLayer >= 0) {
+                    auto target = parent->layerByIdx(matteLayer);
+                    if (target && target != child) {
+                        child->matteTarget = target;
+                        child->matteType = MaskMethod::Alpha;
+                        if (matteEffect->composite(0) == 0) target->matteSrc = true;
+                        _buildHierarchy(parent, target);
+                        if (target->rid) _buildReference(comp, target);
+                    }
+                }
+                break;
+            }
+        }
+
         _buildHierarchy(parent, child);
 
         //attach the necessary font data

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -84,7 +84,17 @@ struct LottieStroke
 
 struct LottieEffect
 {
-    enum Type : uint8_t {Custom = 5, Tint = 20, Fill, Stroke, Tritone, DropShadow = 25, GaussianBlur = 29};
+    enum Type : uint8_t
+    {
+        Custom = 5,
+        Tint = 20,
+        Fill,
+        Stroke,
+        Tritone,
+        DropShadow = 25,
+        SetMatte = 28,
+        GaussianBlur = 29
+    };
 
     virtual ~LottieEffect() {}
 
@@ -239,6 +249,20 @@ struct LottieFxGaussianBlur : LottieEffect
     }
 };
 
+struct LottieFxSetMatte : LottieEffect
+{
+    LottieInteger matteLayer = -1;
+    LottieInteger useForMatte = 1;
+    LottieInteger invert = 0;
+    //LottieInteger layerSizeDiff;
+    LottieInteger composite = 1;
+    //LottieInteger premultiply;
+
+    LottieFxSetMatte()
+    {
+        type = LottieEffect::SetMatte;
+    }
+};
 
 struct LottieMask
 {

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -88,7 +88,17 @@ struct LottieStroke
 
 struct LottieEffect
 {
-    enum Type : uint8_t {Custom = 5, Tint = 20, Fill, Stroke, Tritone, DropShadow = 25, GaussianBlur = 29};
+    enum Type : uint8_t
+    {
+        Custom = 5,
+        Tint = 20,
+        Fill,
+        Stroke,
+        Tritone,
+        DropShadow = 25,
+        SetMatte = 28,
+        GaussianBlur = 29
+    };
 
     LottieEffect(Type type) : type(type) {}
     virtual ~LottieEffect() {}
@@ -223,6 +233,20 @@ struct LottieFxGaussianBlur : LottieEffect
     LottieFxGaussianBlur() : LottieEffect(LottieEffect::GaussianBlur) {}
 };
 
+struct LottieFxSetMatte : LottieEffect
+{
+    LottieInteger matteLayer = -1;
+    LottieInteger useForMatte = 1;
+    LottieInteger invert = 0;
+    //LottieInteger layerSizeDiff;
+    LottieInteger composite = 1;
+    //LottieInteger premultiply;
+
+    LottieFxSetMatte()
+    {
+        type = LottieEffect::SetMatte;
+    }
+};
 
 struct LottieMask
 {

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -66,6 +66,7 @@ LottieEffect* LottieParser::getEffect(int type)
         case LottieEffect::Stroke: return new LottieFxStroke;
         case LottieEffect::Tritone: return new LottieFxTritone;
         case LottieEffect::DropShadow: return new LottieFxDropShadow;
+        case LottieEffect::SetMatte: return new LottieFxSetMatte;
         case LottieEffect::GaussianBlur: return new LottieFxGaussianBlur;
         default: return nullptr;
     }
@@ -1495,6 +1496,15 @@ void LottieParser::parseStroke(LottieEffect* effect, int idx)
     else skip();
 }
 
+void LottieParser::parseSetMatte(LottieEffect* effect, int idx)
+{
+    auto matte = static_cast<LottieFxSetMatte*>(effect);
+    if (idx == 0) parsePropertyInternal(matte->matteLayer);
+    else if (idx == 1) parsePropertyInternal(matte->useForMatte);
+    else if (idx == 2) parsePropertyInternal(matte->invert);
+    else if (idx == 4) parsePropertyInternal(matte->composite);
+    else skip();
+}
 
 bool LottieParser::parseEffect(LottieEffect* effect)
 {
@@ -1505,6 +1515,7 @@ bool LottieParser::parseEffect(LottieEffect* effect)
         case LottieEffect::Stroke: return parseEffect(effect, &LottieParser::parseStroke);
         case LottieEffect::Tritone: return parseEffect(effect, &LottieParser::parseTritone);
         case LottieEffect::DropShadow: return parseEffect(effect, &LottieParser::parseDropShadow);
+        case LottieEffect::SetMatte: return parseEffect(effect, &LottieParser::parseSetMatte);
         case LottieEffect::GaussianBlur: return parseEffect(effect, &LottieParser::parseGaussianBlur);
         default: return false;
     }

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -66,6 +66,7 @@ LottieEffect* LottieParser::getEffect(int type)
         case LottieEffect::Stroke: return new LottieFxStroke;
         case LottieEffect::Tritone: return new LottieFxTritone;
         case LottieEffect::DropShadow: return new LottieFxDropShadow;
+        case LottieEffect::SetMatte: return new LottieFxSetMatte;
         case LottieEffect::GaussianBlur: return new LottieFxGaussianBlur;
         default: return nullptr;
     }
@@ -1520,6 +1521,15 @@ void LottieParser::parseStroke(LottieEffect* effect, int idx)
     else skip();
 }
 
+void LottieParser::parseSetMatte(LottieEffect* effect, int idx)
+{
+    auto matte = static_cast<LottieFxSetMatte*>(effect);
+    if (idx == 0) parsePropertyInternal(matte->matteLayer);
+    else if (idx == 1) parsePropertyInternal(matte->useForMatte);
+    else if (idx == 2) parsePropertyInternal(matte->invert);
+    else if (idx == 4) parsePropertyInternal(matte->composite);
+    else skip();
+}
 
 bool LottieParser::parseEffect(LottieEffect* effect)
 {
@@ -1530,6 +1540,7 @@ bool LottieParser::parseEffect(LottieEffect* effect)
         case LottieEffect::Stroke: return parseEffect(effect, &LottieParser::parseStroke);
         case LottieEffect::Tritone: return parseEffect(effect, &LottieParser::parseTritone);
         case LottieEffect::DropShadow: return parseEffect(effect, &LottieParser::parseDropShadow);
+        case LottieEffect::SetMatte: return parseEffect(effect, &LottieParser::parseSetMatte);
         case LottieEffect::GaussianBlur: return parseEffect(effect, &LottieParser::parseGaussianBlur);
         default: return false;
     }

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -107,6 +107,7 @@ private:
     void parseFill(LottieEffect* effect, int idx);
     void parseGaussianBlur(LottieEffect* effect, int idx);
     void parseDropShadow(LottieEffect* effect, int idx);
+    void parseSetMatte(LottieEffect* effect, int idx);
 
     bool parseDirection(LottieShape* shape, const char* key);
     bool parseCommon(LottieObject* obj, const char* key);

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -111,6 +111,7 @@ private:
     void parseFill(LottieEffect* effect, int idx);
     void parseGaussianBlur(LottieEffect* effect, int idx);
     void parseDropShadow(LottieEffect* effect, int idx);
+    void parseSetMatte(LottieEffect* effect, int idx);
 
     bool parseDirection(LottieShape* shape, const char* key);
     bool parseCommon(LottieObject* obj, const char* key);


### PR DESCRIPTION

Test file: [lottie - 2026-04-07T060138.300.json](https://github.com/user-attachments/files/26520697/lottie.-.2026-04-07T060138.300.json)

Also resolves:
- [10624.json](https://github.com/user-attachments/files/26532424/10624.json)
- [16465.json](https://github.com/user-attachments/files/26532425/16465.json)




<img width="964" height="748" alt="CleanShot 2026-04-07 at 06 01 57@2x" src="https://github.com/user-attachments/assets/d7123349-5567-4ca9-9373-1549897f5abf" />

see: https://lottiefiles.github.io/lottie-docs/effects/#matte3-effect


![CleanShot 2026-04-07 at 06 00 37](https://github.com/user-attachments/assets/e6cf5f27-3691-4063-b8bc-fe94d865946f)

related: https://github.com/thorvg/thorvg/issues/4158

issue: https://github.com/thorvg/thorvg/issues/3115