### PR TITLE
lottie: fix custom effect index mismatch on unsupported types

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1340,16 +1340,14 @@ bool LottieParser::parseEffect(LottieEffect* effect, void(LottieParser::*func)(L
 {
     //custom effect expects dynamic property allocations
     auto custom = (effect->type == LottieEffect::Custom) ? true : false;
-    LottieFxCustom::Property* property = nullptr;
-
     enterArray();
     int idx = 0;
     while (nextArrayValue()) {
         enterObject();
+        LottieFxCustom::Property* property = nullptr;
         while (auto key = nextObjectKey()) {
             if (custom && KEY_AS("ty")) property = static_cast<LottieFxCustom*>(effect)->property(getInt());
-            else if (KEY_AS("v"))
-            {
+            else if (KEY_AS("v") && (!custom || property)) {
                 if (peekType() == kObjectType) {
                     enterObject();
                     while (auto key = nextObjectKey()) {


### PR DESCRIPTION
When parsing Lottie custom effects,
unsupported property types are skipped.

However, the parser was still updating the index,
and causing an index mismatch.

issue: https://github.com/thorvg/thorvg/issues/4215