### PR TITLE
svg_loader: Add a log message to unsupported nested <svg> elements

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3229,7 +3229,10 @@ static void _svgLoaderParserXmlOpen(SvgParserContext* ctx, const char* content, 
             node = method(ctx, nullptr, attrs, attrsLength, xmlParseAttributes);
             ctx->doc = node;
         } else {
-            if (STR_AS(tagName, "svg")) return; //Already loaded <svg>(SvgNodeType::Doc) tag
+            if (STR_AS(tagName, "svg")) {
+                TVGLOG("SVG", "Nested <svg> element is not supported.");
+                method = _createGNode;
+            }
             if (ctx->stack.count > 0) parent = ctx->stack.last();
             else parent = ctx->doc;
             if (STR_AS(tagName, "style")) {


### PR DESCRIPTION
Nested <svg> elements are an SVG Full feature and are not part of the SVG Tiny spec that thorvg follows.
Subsequently, to prevent unexpected crashes that may occur in stack.pop(), `<svg>` is treated as `<g>`

issues: #2239