### PR TITLE
lottie/expressions: refactor _buildProperty

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -1101,106 +1101,95 @@ static void _buildProperty(float frameNo, jerry_value_t context, LottieExpressio
     jerry_object_set_sz(context, EXP_VALUE, value);
     jerry_value_free(value);
 
-    auto valueAtTime = jerry_function_external(_valueAtTime);
-    jerry_object_set_sz(context, "valueAtTime", valueAtTime);
-    jerry_object_set_native_ptr(valueAtTime, nullptr, exp);
-    jerry_value_free(valueAtTime);
+    //check if functions are already registered. If not (first build), set all functions.
+    //otherwise, update native_ptr and update shared data in ExpContent
+    auto check = jerry_object_get_sz(context, "valueAtTime");
+    auto init = jerry_value_is_undefined(check);
+    jerry_value_free(check);
 
-    auto velocity = jerry_number(0.0f);
-    jerry_object_set_sz(context, "velocity", velocity);
-    jerry_value_free(velocity);
+    //set or update a native function bound to exp
+    auto setFunction = [&context, init, exp](jerry_external_handler_t handler, const char* key) {
+        jerry_value_t obj;
+        if (init) {
+            obj = jerry_function_external(handler);
+            jerry_object_set_sz(context, key, obj);
+        } else {
+            obj = jerry_object_get_sz(context, key);
+        }
+        jerry_object_set_native_ptr(obj, nullptr, exp);
+        jerry_value_free(obj);
+    };
 
-    auto velocityAtTime = jerry_function_external(_velocityAtTime);
-    jerry_object_set_sz(context, "velocityAtTime", velocityAtTime);
-    jerry_object_set_native_ptr(velocityAtTime, nullptr, exp);
-    jerry_value_free(velocityAtTime);
+    //set a float Value
+    auto setValue = [&context](const char* key, float val) {
+        auto obj = jerry_number(val);
+        jerry_object_set_sz(context, key, obj);
+        jerry_value_free(obj);
+    };
 
-    auto speed = jerry_number(0.0f);
-    jerry_object_set_sz(context, "speed", speed);
-    jerry_value_free(speed);
+    //register a new native function with shared data
+    auto addFunction = [&context](jerry_external_handler_t handler, const char* key, ExpContent* data) {
+        auto obj = jerry_function_external(handler);
+        jerry_object_set_sz(context, key, obj);
+        jerry_object_set_native_ptr(obj, &freeCb, data);
+        jerry_value_free(obj);
+    };
 
-    auto speedAtTime = jerry_function_external(_speedAtTime);
-    jerry_object_set_sz(context, "speedAtTime", speedAtTime);
-    jerry_object_set_native_ptr(speedAtTime, nullptr, exp);
-    jerry_value_free(speedAtTime);
+    //update shared ExpContent in-place
+    auto updateContent = [&context, exp, frameNo](const char* key, void* target) {
+        auto obj = jerry_object_get_sz(context, key);
+        auto data = static_cast<ExpContent*>(jerry_object_get_native_ptr(obj, &freeCb));
+        if (data) {
+            data->exp = exp;
+            data->frameNo = frameNo;
+            data->data = target;
+        } else {
+            TVGERR("LOTTIE", "ExpContent lost due to function overwrite");
+        }
+        jerry_value_free(obj);
+    };
 
-    auto propertyIndex = jerry_number(exp->property->ix);
-    jerry_object_set_sz(context, "propertyIndex", propertyIndex);
-    jerry_value_free(propertyIndex);
-
-    {
-        auto data =  _expcontent(exp, frameNo, exp->object, 7);
-
-        auto wiggle = jerry_function_external(_wiggle);
-        jerry_object_set_sz(context, "wiggle", wiggle);
-        jerry_object_set_native_ptr(wiggle, &freeCb, data);
-        jerry_value_free(wiggle);
-
-        auto temporalWiggle = jerry_function_external(_temporalWiggle);
-        jerry_object_set_sz(context, "temporalWiggle", temporalWiggle);
-        jerry_object_set_native_ptr(temporalWiggle, &freeCb, data);
-        jerry_value_free(temporalWiggle);
-
-        auto propertyGroup = jerry_function_external(_propertyGroup);
-        jerry_object_set_native_ptr(propertyGroup, &freeCb, data);
-        jerry_object_set_sz(context, "propertyGroup", propertyGroup);
-        jerry_value_free(propertyGroup);
-
-        auto loopIn = jerry_function_external(_loopIn);
-        jerry_object_set_sz(context, "loopIn", loopIn);
-        jerry_object_set_native_ptr(loopIn, &freeCb, data);
-        jerry_value_free(loopIn);
-
-        auto loopOut = jerry_function_external(_loopOut);
-        jerry_object_set_sz(context, "loopOut", loopOut);
-        jerry_object_set_native_ptr(loopOut, &freeCb, data);
-        jerry_value_free(loopOut);
-
-        auto loopInDuration = jerry_function_external(_loopInDuration);
-        jerry_object_set_sz(context, "loopInDuration", loopInDuration);
-        jerry_object_set_native_ptr(loopInDuration, &freeCb, data);
-        jerry_value_free(loopInDuration);
-
-        auto loopOutDuration = jerry_function_external(_loopOutDuration);
-        jerry_object_set_sz(context, "loopOutDuration", loopOutDuration);
-        jerry_object_set_native_ptr(loopOutDuration, &freeCb, data);
-        jerry_value_free(loopOutDuration);
-
-    }
-
-    //smooth(width=.2, samples=5, t=time)
-
-    auto key = jerry_function_external(_key);
-    jerry_object_set_sz(context, "key", key);
-    jerry_object_set_native_ptr(key, nullptr, exp);
-    jerry_value_free(key);
-
+    setFunction(_valueAtTime,    "valueAtTime");
+    setFunction(_velocityAtTime, "velocityAtTime");
+    setFunction(_speedAtTime,    "speedAtTime");
+    setFunction(_key,            "key");
     //key(markerName)
+    setFunction(_nearestKey,     "nearestKey");
 
-    auto nearestKey = jerry_function_external(_nearestKey);
-    jerry_object_set_native_ptr(nearestKey, nullptr, exp);
-    jerry_object_set_sz(context, "nearestKey", nearestKey);
-    jerry_value_free(nearestKey);
+    setValue("velocity", 0.0f);
+    setValue("speed", 0.0f);
+    setValue("propertyIndex", static_cast<float>(exp->property->ix));
+    setValue("numKeys", static_cast<float>(exp->property->frameCnt()));
 
-    auto numKeys = jerry_number((float)exp->property->frameCnt());
-    jerry_object_set_sz(context, "numKeys", numKeys);
-    jerry_value_free(numKeys);
+    if (init) {
+        {
+            auto data =  _expcontent(exp, frameNo, exp->object, 7);
+            addFunction(_wiggle,          "wiggle",          data);
+            addFunction(_temporalWiggle,  "temporalWiggle",  data);
+            addFunction(_propertyGroup,   "propertyGroup",   data);
+            addFunction(_loopIn,          "loopIn",          data);
+            addFunction(_loopOut,         "loopOut",         data);
+            addFunction(_loopInDuration,  "loopInDuration",  data);
+            addFunction(_loopOutDuration, "loopOutDuration", data);
+        }
 
-    //name
+        //smooth(width=.2, samples=5, t=time)
 
-    {
-        auto data = _expcontent(exp, frameNo, exp->layer, 2);
+        //name
 
-        //content("name"), #look for the named property from a layer
-        auto content = jerry_function_external(_content);
-        jerry_object_set_sz(context, EXP_CONTENT, content);
-        jerry_object_set_native_ptr(content, &freeCb, data);
-        jerry_value_free(content);
+        {
+            auto data =  _expcontent(exp, frameNo, exp->layer, 2);
+            //content("name"), #look for the named property from a layer
+            addFunction(_content, EXP_CONTENT, data);
+            addFunction(_effect, EXP_EFFECT, data);
+        }
+    } else {
+        // since they share the same ExpContent, updating one of them is enough.
+        // update _wiggle, _temporalWiggle, _propertyGroup, _loopIn, _loopOut, _loopInDuration, _loopOutDuration
+        updateContent("wiggle",    exp->object);
 
-        auto effect = jerry_function_external(_effect);
-        jerry_object_set_sz(context, EXP_EFFECT, effect);
-        jerry_object_set_native_ptr(effect, &freeCb, data);
-        jerry_value_free(effect);
+        // update _content, _effect since they share the same ExpContent
+        updateContent(EXP_CONTENT, exp->layer);
     }
 
     //expansions per types


### PR DESCRIPTION

<img width="630" height="378" alt="image" src="https://github.com/user-attachments/assets/1808a3b7-d8af-4e90-b3b7-74b1fdf75c5a" />


`_buildProperty` recreated all function objects every frame
(takes 26% of total samples, 17,200 / 66,008). 

Now it creates them once per context and reuses them on subsequent calls by swapping native pointers in-place.

### Note

For functions sharing an `ExpContent`, `updateContent` retrieves the pointer via `jerry_object_get_native_ptr` and modifies the struct fields directly in C++. Since multiple function objects reference the same `ExpContent*`, updating one applies to all.

### Result

<img width="808" height="224" alt="image" src="https://github.com/user-attachments/assets/df9c478a-56cd-41b1-b1b9-118f545f8d3d" />

Own CPU samples for _buildProperty function, over 4000 ticks: 26% -> 12%


| | fps % | BinarySize |
|-|-|-|
| local machine (Mac M5 pro) | +13% | no check |
| github action runner | [+13%~18%](https://github.com/Nor-s/perfaction/actions/runs/24090103952) |[-190~+192](https://github.com/Nor-s/perfaction/actions/runs/24114433290) |

