### PR TITLE
lottie: fix mask being ignored on precomp layers with compositor effects

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1287,7 +1287,7 @@ void LottieBuilder::updateMasks(LottieLayer* layer, float frameNo)
             to<ShapeImpl>(pShape)->reset();
             auto compMethod = (method == MaskMethod::Subtract || method == MaskMethod::InvAlpha) ? MaskMethod::InvAlpha : MaskMethod::Alpha;
             //Cheaper. Replace the masking with a clipper
-            if (layer->effects.empty() && layer->masks.count == 1 && compMethod == MaskMethod::Alpha) {
+            if (layer->effects.empty() && layer->masks.count == 1 && compMethod == MaskMethod::Alpha && layer->type != LottieLayer::Precomp) {
                 layer->scene->opacity(MULTIPLY(layer->scene->opacity(), opacity));
                 layer->scene->clip(pShape);
             } else {


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![](https://github.com/user-attachments/assets/2b940ed9-7b44-4bb7-a7cd-df6954a9abce) | ![](https://github.com/user-attachments/assets/e8568ea7-e3e2-4c13-827e-09c77aa17c53) |


When a Precomp layer has a mask and takes the cheap path, the mask is ignored during compositing of
child layers that create their own compositor,
causing child layers to bleed outside the mask boundary.

