### PR TITLE
lottie/slot: fix heap-buffer-overflow in LottieGradient::override()

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -887,10 +887,16 @@ struct LottieGradient : LottieObject
     LottieProperty* override(LottieProperty* prop, bool release) override
     {
         LottieProperty* backup = nullptr;
-        if (release) colorStops.release();
-        else backup = new LottieColorStop(colorStops);
-        colorStops.copy(*static_cast<LottieColorStop*>(prop), false);
-        prepare();
+        if (colorStops.sid == prop->sid) {
+            if (release) colorStops.release();
+            else backup = new LottieColorStop(colorStops);
+            colorStops.copy(*static_cast<LottieColorStop*>(prop), false);
+            prepare();
+        } else if (opacity.sid == prop->sid) {
+            if (release) opacity.release();
+            else backup = new LottieOpacity(opacity);
+            opacity.copy(*static_cast<LottieOpacity*>(prop), false);
+        }
         return backup;
     }
 


### PR DESCRIPTION
Previously, in LottieGradient, the override() function always cast the incoming LottieProperty* to LottieColorStop*. However, gradients can also contain an opacity property, which is slottable. When a slot targeted that opacity property, it was incorrectly interpreted as a LottieColorStop, leading to a heap buffer overflow.

This patch corrects the behavior by allowing users to override the opacity property within a gradient.

<p align="center">
  <img src="https://github.com/user-attachments/assets/a14a6276-7ad4-4a36-a79d-0a2ee55ec35b" width="48%" />
  <img src="https://github.com/user-attachments/assets/e376ea33-9b70-4afc-8615-240c25871701" width="48%" />
</p>

| Before(Crash) | Patched |
|----------|----------|
| <img src="https://github.com/user-attachments/assets/b42e11e0-2f3d-45e8-afd3-9ed21021bcaf" width="100%"> | <img src="https://github.com/user-attachments/assets/14562b6b-fc6d-4671-aca4-10f4ef1eb862" width="100%"> |

test file: [main_scene.json](https://github.com/user-attachments/files/26609152/main_scene.json)


issue: https://github.com/thorvg/thorvg/issues/4315