### PR TITLE
lottie/expressions: register magic strings for faster property lookup

### DIFF
--- a/src/loaders/lottie/jerryscript/jerry-core/api/jerryscript.cpp
+++ b/src/loaders/lottie/jerryscript/jerry-core/api/jerryscript.cpp
@@ -628,6 +628,20 @@ jerry_object_set_native_ptr (jerry_value_t object, /**< object to set native poi
   }
 } /* jerry_object_set_native_ptr */
 
+/**
+ * Register external magic string array
+ */
+void
+jerry_register_magic_strings (const jerry_char_t *const *ext_strings_p, /**< character arrays, representing
+                                                                         *   external magic strings' contents */
+                              uint32_t count, /**< number of the strings */
+                              const jerry_length_t *str_lengths_p) /**< lengths of all strings */
+{
+  lit_magic_strings_ex_set ((const lit_utf8_byte_t *const *) ext_strings_p,
+                            count,
+                            (const lit_utf8_size_t *) str_lengths_p);
+} /* jerry_register_magic_strings */
+
 
 /**
  * @}

--- a/src/loaders/lottie/jerryscript/jerry-core/include/jerryscript-core.h
+++ b/src/loaders/lottie/jerryscript/jerry-core/include/jerryscript-core.h
@@ -60,6 +60,7 @@ jerry_value_t jerry_object_get_index (const jerry_value_t object, uint32_t index
 void *jerry_object_get_native_ptr (const jerry_value_t object, const jerry_object_native_info_t *native_info_p);
 jerry_value_t jerry_function_external (jerry_external_handler_t handler);
 void jerry_value_free (jerry_value_t value);
+void jerry_register_magic_strings (const jerry_char_t *const *ext_strings_p, uint32_t count, const jerry_length_t *str_lengths_p);
 
 JERRY_C_API_END
 

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -63,29 +63,39 @@ static const char* EXP_EFFECT= "effect";
 
 /**
  * external magic strings for the per-frame hot path (buildProperty, buildLayer, buildTransform, bm_rt).
- * magic pool: sorted by length, then lexicographically. null-separated,
- *             must be static, because 'jerry_register_magic_strings' does not copy
- *             update MAGIC_POOL_COUNT if this pool changes
- * pointers/lengths are computed once at init and stored in .bss (zero binary cost).
+ * magic pool: sorted by length, then lexicographically. packed in a single static blob,
+ *             because 'jerry_register_magic_strings' does not copy the string data.
+ * lengths/count are generated from a single list at compile time; pointers are built once at init.
  */
+#define TVG_LOTTIE_MAGIC_STRING_LIST(X) \
+    X("key") \
+    X("comp") X("name") X("time") \
+    X("index") X("layer") X("scale") X("speed") X("value") X("width") \
+    X("$bm_rt") X("effect") X("height") X("parent") X("toComp") X("wiggle") \
+    X("content") X("enabled") X("inPoint") X("numKeys") X("opacity") \
+    X("duration") X("hasAudio") X("hasVideo") X("outPoint") X("position") X("rotation") X("thisComp") X("velocity") \
+    X("hasParent") X("numLayers") X("startTime") X("thisLayer") X("timeRemap") X("transform") \
+    X("nearestKey") \
+    X("anchorPoint") X("audioActive") X("speedAtTime") X("valueAtTime") \
+    X("thisProperty") \
+    X("frameDuration") X("propertyIndex") \
+    X("velocityAtTime")
+
+#define TVG_LOTTIE_MAGIC_POOL_ENTRY(str) str
 static constexpr const char _magicPool[] =
-    "key\0" /* length: 3 */
-    "comp\0" "name\0" "time\0" /* length: 4 */
-    "index\0" "layer\0" "scale\0" "speed\0" "value\0" "width\0" /* length: 5 */
-    "$bm_rt\0" "effect\0" "height\0" "parent\0" "toComp\0" "wiggle\0" /* length: 6 */
-    "content\0" "enabled\0" "inPoint\0" "numKeys\0" "opacity\0" /* length: 7 */
-    "duration\0" "hasAudio\0" "hasVideo\0" "outPoint\0" "position\0" "rotation\0" "thisComp\0" "velocity\0" /* length: 8 */
-    "hasParent\0" "numLayers\0" "startTime\0" "thisLayer\0" "timeRemap\0" "transform\0" /* length: 9 */
-    "nearestKey\0" /* length: 10 */
-    "anchorPoint\0" "audioActive\0" "speedAtTime\0" "valueAtTime\0" /* length: 11 */
-    "thisProperty\0" /* length: 12 */
-    "frameDuration\0" "propertyIndex\0" /* length: 13 */
-    "velocityAtTime"; /* length: 14 */
+    TVG_LOTTIE_MAGIC_STRING_LIST(TVG_LOTTIE_MAGIC_POOL_ENTRY);
+#undef TVG_LOTTIE_MAGIC_POOL_ENTRY
 
-#define MAGIC_POOL_COUNT 44
+#define TVG_LOTTIE_MAGIC_LENGTH_ENTRY(str) (jerry_length_t)(sizeof(str) - 1),
+static constexpr jerry_length_t _magicLengths[] = {
+    TVG_LOTTIE_MAGIC_STRING_LIST(TVG_LOTTIE_MAGIC_LENGTH_ENTRY)
+};
+#undef TVG_LOTTIE_MAGIC_LENGTH_ENTRY
 
-static const jerry_char_t* _magicStrings[MAGIC_POOL_COUNT];
-static jerry_length_t _magicLengths[MAGIC_POOL_COUNT];
+#define MAGIC_STRING_COUNT (sizeof(_magicLengths) / sizeof(_magicLengths[0]))
+static const jerry_char_t* _magicStrings[MAGIC_STRING_COUNT];
+
+#undef TVG_LOTTIE_MAGIC_STRING_LIST
 
 static LottieExpressions* exps = nullptr;   //singleton instance engine
 
@@ -1513,15 +1523,13 @@ LottieExpressions::LottieExpressions()
 {
     jerry_init(JERRY_INIT_EMPTY);
 
-    //build pointer/length arrays from the magic pool
+    //build magic string arrays from the magic pool
     auto p = _magicPool;
-    for (uint32_t i = 0; i < MAGIC_POOL_COUNT; ++i) {
+    for (uint32_t i = 0; i < MAGIC_STRING_COUNT; ++i) {
         _magicStrings[i] = (const jerry_char_t*)p;
-        auto len = strlen(p);
-        _magicLengths[i] = (jerry_length_t)len;
-        p += len + 1;
+        p += _magicLengths[i];
     }
-    jerry_register_magic_strings(_magicStrings, MAGIC_POOL_COUNT, _magicLengths);
+    jerry_register_magic_strings(_magicStrings, MAGIC_STRING_COUNT, _magicLengths);
 
     _buildMath(buildGlobal());
 }

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -61,6 +61,32 @@ static const char* EXP_VALUE = "value";
 static const char* EXP_INDEX = "index";
 static const char* EXP_EFFECT= "effect";
 
+/**
+ * external magic strings for the per-frame hot path (buildProperty, buildLayer, buildTransform, bm_rt).
+ * magic pool: sorted by length, then lexicographically. null-separated,
+ *             must be static, because 'jerry_register_magic_strings' does not copy
+ *             update MAGIC_POOL_COUNT if this pool changes
+ * pointers/lengths are computed once at init and stored in .bss (zero binary cost).
+ */
+static constexpr const char _magicPool[] =
+    "key\0" /* length: 3 */
+    "comp\0" "name\0" "time\0" /* length: 4 */
+    "index\0" "layer\0" "scale\0" "speed\0" "value\0" "width\0" /* length: 5 */
+    "$bm_rt\0" "effect\0" "height\0" "parent\0" "toComp\0" "wiggle\0" /* length: 6 */
+    "content\0" "enabled\0" "inPoint\0" "numKeys\0" "opacity\0" /* length: 7 */
+    "duration\0" "hasAudio\0" "hasVideo\0" "outPoint\0" "position\0" "rotation\0" "thisComp\0" "velocity\0" /* length: 8 */
+    "hasParent\0" "numLayers\0" "startTime\0" "thisLayer\0" "timeRemap\0" "transform\0" /* length: 9 */
+    "nearestKey\0" /* length: 10 */
+    "anchorPoint\0" "audioActive\0" "speedAtTime\0" "valueAtTime\0" /* length: 11 */
+    "thisProperty\0" /* length: 12 */
+    "frameDuration\0" "propertyIndex\0" /* length: 13 */
+    "velocityAtTime"; /* length: 14 */
+
+#define MAGIC_POOL_COUNT 44
+
+static const jerry_char_t* _magicStrings[MAGIC_POOL_COUNT];
+static jerry_length_t _magicLengths[MAGIC_POOL_COUNT];
+
 static LottieExpressions* exps = nullptr;   //singleton instance engine
 
 
@@ -1486,6 +1512,17 @@ LottieExpressions::~LottieExpressions()
 LottieExpressions::LottieExpressions()
 {
     jerry_init(JERRY_INIT_EMPTY);
+
+    //build pointer/length arrays from the magic pool
+    auto p = _magicPool;
+    for (uint32_t i = 0; i < MAGIC_POOL_COUNT; ++i) {
+        _magicStrings[i] = (const jerry_char_t*)p;
+        auto len = strlen(p);
+        _magicLengths[i] = (jerry_length_t)len;
+        p += len + 1;
+    }
+    jerry_register_magic_strings(_magicStrings, MAGIC_POOL_COUNT, _magicLengths);
+
     _buildMath(buildGlobal());
 }
 


### PR DESCRIPTION
- Register 44 frequently used Lottie expression property names (e.g. `value`, `transform`, `position`, `$bm_rt`) as JerryScript external magic strings.      

- Magic strings are interned by the engine at init, so repeated lookups on the per-frame hot path (`buildProperty`, `buildLayer`, `buildTransform`, `buildGlobal`, `buildComp`), reducing **allocation/deallocation overhead** for expressions.

### **Change**

- Expose `jerry_register_magic_strings` API in the embedded JerryScript build
- Define a static string pool sorted by length, then lexicographically                                                    
- Build pointer/length arrays at init and register them once via `jerry_register_magic_strings`      

### **Result**

remove hot path: `jerry_string`

| before | after |
|-|-|
|<img width="1229" height="523" alt="image" src="https://github.com/user-attachments/assets/e787734f-5b18-49c6-a7db-ccc79cb04309" />| <img width="1229" height="523" alt="image" src="https://github.com/user-attachments/assets/2e0bf856-bcac-4332-a46d-c344bbde8365" />|


| | fps | binarySize|
|-|-|-|
|local machine(Mac M5 pro) | +21%  | |
|github action runner | [+15%~19%](https://github.com/Nor-s/perfaction/actions/runs/24214719236)| [+412~474](https://github.com/Nor-s/perfaction/actions/runs/24227349397)|



#### Reference

- [jerry_register_matic_strings](https://github.com/jerryscript-project/jerryscript/blob/master/docs/02.API-REFERENCE.md#jerry_register_magic_strings)

<details>                                                                                                                                
<summary>jerry_object_set_sz -> jerry_string -> ecma_find_special_string </summary>    

```c++
/**
 * Set a property to the specified object with the given name.
 *
 * Note:
 *      returned value must be freed with jerry_value_free, when it is no longer needed.
 *
 * @return true value - if the operation was successful
 *         value marked with error flag - otherwise
 */
jerry_value_t
jerry_object_set_sz (jerry_value_t object, /**< object value */
                     const char *key_p, /**< property key */
                     const jerry_value_t value) /**< value to set */
{
  jerry_value_t key_str = jerry_string_sz (key_p);
  jerry_value_t result = jerry_object_set (object, key_str, value);
  ecma_free_value (key_str);
  return result;
} /* jerry_object_set */


/**
 * Create string value from the input zero-terminated ASCII string.
 *
 * @return created string
 */
jerry_value_t
jerry_string_sz (const char *str_p) /**< pointer to string */
{
  const jerry_char_t *data_p = (const jerry_char_t *) str_p;
  return jerry_string (data_p, lit_zt_utf8_string_size (data_p), JERRY_ENCODING_CESU8);
} /* jerry_string_sz */



/**
 * Create a string value from the input buffer using the specified encoding.
 * The content of the buffer is assumed to be valid in the specified encoding, it's the callers responsibility to
 * validate the input.
 *
 * See also: jerry_validate_string
 *
 * @return created string
 */
jerry_value_t
jerry_string (const jerry_char_t *buffer_p, /**< pointer to buffer */
              jerry_size_t buffer_size, /**< buffer size */
              jerry_encoding_t encoding) /**< buffer encoding */
{
  ecma_string_t *ecma_str_p = NULL;
  //JERRY_ASSERT (jerry_validate_string (buffer_p, buffer_size, encoding));

  switch (encoding)
  {
    case JERRY_ENCODING_CESU8:
    {
      ecma_str_p = ecma_new_ecma_string_from_utf8 (buffer_p, buffer_size);
      
      

/**
 * Allocate new ecma-string and fill it with characters from the utf8 string
 *
 * @return pointer to ecma-string descriptor
 */
ecma_string_t *
ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *string_p, /**< utf-8 string */
                                lit_utf8_size_t string_size) /**< string size */
{
  JERRY_ASSERT (string_p != NULL || string_size == 0);
  JERRY_ASSERT (lit_is_valid_cesu8_string (string_p, string_size));

  ecma_string_t *string_desc_p = ecma_find_special_string (string_p, string_size);
  
  

/**
 * Checks whether a string has a special representation, that is, the string is either a magic string,
 * an external magic string, or an uint32 number, and creates an ecma string using the special representation,
 * if available.
 *
 * @return pointer to ecma string with the special representation
 *         NULL, if there is no special representation for the string
 */
static ecma_string_t *
ecma_find_special_string (const lit_utf8_byte_t *string_p, /**< utf8 string */
                          lit_utf8_size_t string_size) /**< string size */
{


```

</details>                                                                                                                               