### PR TITLE
lottie: modifiers robustness++

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -772,20 +772,20 @@ void LottieBuilder::updateRoundedCorner(TVG_UNUSED LottieGroup* parent, LottieOb
     auto roundedCorner = static_cast<LottieRoundedCorner*>(*child);
     auto r = roundedCorner->radius(frameNo, tween, exps);
     if (r < LottieRoundnessModifier::ROUNDNESS_EPSILON) return;
-    ctx->update(new LottieRoundnessModifier(&buffer, r));
+    ctx->update(new LottieRoundnessModifier(r));
 }
 
 
 void LottieBuilder::updateOffsetPath(TVG_UNUSED LottieGroup* parent, LottieObject** child, float frameNo, TVG_UNUSED Inlist<RenderContext>& contexts, RenderContext* ctx)
 {
     auto offset = static_cast<LottieOffsetPath*>(*child);
-    ctx->update(new LottieOffsetModifier(&buffer, offset->offset(frameNo, tween, exps), offset->miterLimit(frameNo, tween, exps), offset->join));
+    ctx->update(new LottieOffsetModifier(offset->offset(frameNo, tween, exps), offset->miterLimit(frameNo, tween, exps), offset->join));
 }
 
 void LottieBuilder::updatePuckerBloat(TVG_UNUSED LottieGroup* parent, LottieObject** child, float frameNo, TVG_UNUSED Inlist<RenderContext>& contexts, RenderContext* ctx)
 {
     auto puckerBloat = static_cast<LottiePuckerBloat*>(*child);
-    ctx->update(new LottiePuckerBloatModifier(&buffer, puckerBloat->amount(frameNo, tween, exps)));
+    ctx->update(new LottiePuckerBloatModifier(puckerBloat->amount(frameNo, tween, exps)));
 }
 
 void LottieBuilder::updateRepeater(TVG_UNUSED LottieGroup* parent, LottieObject** child, float frameNo, TVG_UNUSED Inlist<RenderContext>& contexts, RenderContext* ctx)
@@ -1382,7 +1382,7 @@ void LottieBuilder::updateMasks(LottieLayer* layer, float frameNo)
         //Masking with Expansion (Offset)
         } else {
             //TODO: Once path direction support is implemented, ensure that the direction is ignored here
-            auto offset = LottieOffsetModifier(&buffer, expand);
+            auto offset = LottieOffsetModifier(expand);
             mask->pathset(frameNo, to<ShapeImpl>(pShape)->rs.path, nullptr, tween, exps, &offset);
         }
         pOpacity = opacity;

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -111,17 +111,17 @@ struct RenderContext
             switch (m->type) {
                 case LottieModifier::Type::Roundness: {
                     auto roundness = static_cast<LottieRoundnessModifier*>(m);
-                    update(new LottieRoundnessModifier(roundness->buffer, roundness->r));
+                    update(new LottieRoundnessModifier(roundness->r));
                     break;
                 }
                 case LottieModifier::Type::Offset: {
                     auto offset = static_cast<LottieOffsetModifier*>(m);
-                    update(new LottieOffsetModifier(offset->buffer, offset->offset, offset->miterLimit, offset->join));
+                    update(new LottieOffsetModifier(offset->offset, offset->miterLimit, offset->join));
                     break;
                 }
                 case LottieModifier::Type::PuckerBloat: {
                     auto pucker = static_cast<LottiePuckerBloatModifier*>(m);
-                    update(new LottiePuckerBloatModifier(pucker->buffer, pucker->amount));
+                    update(new LottiePuckerBloatModifier(pucker->amount));
                     break;
                 }
             }
@@ -219,7 +219,6 @@ private:
     void updateOffsetPath(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updatePuckerBloat(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
 
-    RenderPath buffer;   //reusable path
     LottieExpressions* exps;
     Tween tween;
 };

--- a/src/loaders/lottie/tvgLottieData.h
+++ b/src/loaders/lottie/tvgLottieData.h
@@ -23,8 +23,8 @@
 #ifndef _TVG_LOTTIE_COMMON_
 #define _TVG_LOTTIE_COMMON_
 
-#include "tvgArray.h"
-#include "tvgMath.h"
+#include "tvgRender.h"
+#include "tvgStr.h"
 
 namespace tvg
 {
@@ -35,6 +35,14 @@ struct PathSet
     PathCommand* cmds = nullptr;
     uint16_t ptsCnt = 0;
     uint16_t cmdsCnt = 0;
+
+    void convert(RenderPath& to)
+    {
+        to.cmds.data = cmds;
+        to.cmds.count = cmdsCnt;
+        to.pts.data = pts;
+        to.pts.count = ptsCnt;
+    }
 };
 
 
@@ -83,8 +91,8 @@ struct TextDocument
 
     void copy(const TextDocument& rhs)
     {
-        text = duplicate(rhs.text);
-        name = duplicate(rhs.name);
+        text = tvg::duplicate(rhs.text);
+        name = tvg::duplicate(rhs.name);
     }
 };
 
@@ -147,6 +155,7 @@ static inline Point3 operator*(const Point3& a, float t)
 {
     return {a.x * t, a.y * t, a.z * t};
 }
+
 }
 
 #endif //_TVG_LOTTIE_COMMON_

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -703,7 +703,7 @@ static jerry_value_t _pointOnPath(const jerry_call_info_t* info, const jerry_val
     auto data = static_cast<ExpContent*>(jerry_object_get_native_ptr(info->function, &freeCb));
     auto pathset = static_cast<LottiePathSet*>(data->property);
     auto progress = _number(args[0]);
-    RenderPath out;
+    auto& out = RenderPath::scratch();
     (*pathset)(data->frameNo, out, nullptr, nullptr);
     return _point2d(out.point(progress));
 }
@@ -713,7 +713,7 @@ static jerry_value_t _tangentOnPath(const jerry_call_info_t* info, const jerry_v
     auto data = static_cast<ExpContent*>(jerry_object_get_native_ptr(info->function, &freeCb));
     auto pathset = static_cast<LottiePathSet*>(data->property);
     auto progress = _number(args[0]);
-    RenderPath out;
+    auto& out = RenderPath::scratch();
     (*pathset)(data->frameNo, out, nullptr, nullptr);
 
     auto a = out.point(std::max(0.0f, progress - 0.001f));

--- a/src/loaders/lottie/tvgLottieModifier.cpp
+++ b/src/loaders/lottie/tvgLottieModifier.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include "tvgLottieData.h"
 #include "tvgLottieModifier.h"
 
 /************************************************************************/
@@ -55,7 +56,7 @@ LottieModifier* LottieModifier::decorate(LottieModifier* next)
 /* LottieRoundnessModifier                                              */
 /************************************************************************/
 
-Point LottieRoundnessModifier::rounding(RenderPath& out, Point& prev, Point& curr, Point& next, float r)
+Point LottieRoundnessModifier::rounding(RenderPath& out, const Point& prev, const Point& curr, const Point& next, float r)
 {
     auto lenPrev = length(prev - curr);
     auto rPrev = lenPrev > 0.0f ? 0.5f * std::min(lenPrev * 0.5f, r) / lenPrev : 0.0f;
@@ -70,11 +71,11 @@ Point LottieRoundnessModifier::rounding(RenderPath& out, Point& prev, Point& cur
     return ret;
 }
 
-RenderPath& LottieRoundnessModifier::modify(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out)
+RenderPath& LottieRoundnessModifier::modify(const RenderPath& in, RenderPath& out, Matrix* transform)
 {
     auto& path = (next) ? RenderPath::scratch() : out;
-    path.cmds.reserve(inCmdsCnt * 2);
-    path.pts.reserve((uint32_t)(inPtsCnt * 1.5));
+    path.cmds.reserve(in.cmds.count * 2);
+    path.pts.reserve((uint32_t)(in.pts.count * 1.5));
     auto pivot = path.pts.count;
     uint32_t startIndex = 0;
     auto rounded = false;
@@ -82,31 +83,31 @@ RenderPath& LottieRoundnessModifier::modify(PathCommand* inCmds, uint32_t inCmds
 
     // TODO: the line case is omitted.
 
-    for (uint32_t iCmds = 0, iPts = 0; iCmds < inCmdsCnt; ++iCmds) {
-        switch (inCmds[iCmds]) {
+    for (uint32_t iCmds = 0, iPts = 0; iCmds < in.cmds.count; ++iCmds) {
+        switch (in.cmds[iCmds]) {
             case PathCommand::MoveTo: {
                 startIndex = path.pts.count;
-                path.moveTo(inPts[iPts++]);
+                path.moveTo(in.pts[iPts++]);
                 break;
             }
             case PathCommand::CubicTo: {
-                if (iCmds < inCmdsCnt - 1 && _colinear(inPts + iPts - 1)) {
-                    auto& prev = inPts[iPts - 1];
-                    auto& curr = inPts[iPts + 2];
-                    if (inCmds[iCmds + 1] == PathCommand::CubicTo && _colinear(inPts + iPts + 2)) {
-                        roundTo = rounding(path, prev, curr, inPts[iPts + 5], r);
+                if (iCmds < in.cmds.count - 1 && _colinear(&in.pts[iPts - 1])) {
+                    auto& prev = in.pts[iPts - 1];
+                    auto& curr = in.pts[iPts + 2];
+                    if (in.cmds[iCmds + 1] == PathCommand::CubicTo && _colinear(&in.pts[iPts + 2])) {
+                        roundTo = rounding(path, prev, curr, in.pts[iPts + 5], r);
                         iPts += 3;
                         rounded = true;
                         continue;
-                    } else if (inCmds[iCmds + 1] == PathCommand::Close) {
-                        roundTo = rounding(path, prev, curr, inPts[2], r);
+                    } else if (in.cmds[iCmds + 1] == PathCommand::Close) {
+                        roundTo = rounding(path, prev, curr, in.pts[2], r);
                         path.pts[startIndex] = path.pts.last();
                         iPts += 3;
                         rounded = true;
                         continue;
                     }
                 }
-                path.cubicTo(rounded ? roundTo : inPts[iPts], inPts[iPts + 1], inPts[iPts + 2]);
+                path.cubicTo(rounded ? roundTo : in.pts[iPts], in.pts[iPts + 1], in.pts[iPts + 2]);
                 iPts += 3;
                 break;
             }
@@ -127,18 +128,17 @@ RenderPath& LottieRoundnessModifier::modify(PathCommand* inCmds, uint32_t inCmds
     return path;
 }
 
-void LottieRoundnessModifier::path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out)
+void LottieRoundnessModifier::path(const RenderPath& in, RenderPath& out, Matrix* transform)
 {
-    auto& result = modify(inCmds, inCmdsCnt, inPts, inPtsCnt, transform, out);
-    if (next) return next->path(result.cmds.data, result.cmds.count, result.pts.data, result.pts.count, nullptr, out);
+    auto& result = modify(in, out, transform);
+    if (next) return next->path(result, out, nullptr);
 }
 
-void LottieRoundnessModifier::polystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness)
+void LottieRoundnessModifier::polystar(const RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness)
 {
     constexpr auto ROUNDED_POLYSTAR_MAGIC_NUMBER = 0.47829f;
 
     auto& path = (next) ? RenderPath::scratch(): out;
-
     auto len = length(in.pts[1] - in.pts[2]);
     auto r = len > 0.0f ? ROUNDED_POLYSTAR_MAGIC_NUMBER * std::min(len * 0.5f, this->r) / len : 0.0f;
 
@@ -195,7 +195,7 @@ void LottieRoundnessModifier::polystar(RenderPath& in, RenderPath& out, float ou
     if (next) return next->polystar(path, out, outerRoundness, hasRoundness);
 }
 
-void LottieRoundnessModifier::rect(RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise)
+void LottieRoundnessModifier::rect(const RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise)
 {
     auto& path = (next) ? RenderPath::scratch() : out;
 
@@ -204,10 +204,10 @@ void LottieRoundnessModifier::rect(RenderPath& in, RenderPath& out, const Point&
     // we know this is the first request in the chain because other modifers would not trigger rect() call
     path.addRect(pos.x, pos.y, size.x, size.y, r, r, clockwise);
 
-    if (next) return next->path(path.cmds.data, path.cmds.count, path.pts.data, path.pts.count, nullptr, out);
+    if (next) return next->path(path, out, nullptr);
 }
 
-void LottieRoundnessModifier::ellipse(RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise)
+void LottieRoundnessModifier::ellipse(const RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise)
 {
     // bypass because it's already a circle.
     if (next) return next->ellipse(in, out, center, radius, clockwise);
@@ -368,9 +368,10 @@ void LottieOffsetModifier::cubic(RenderPath& path, Point* pts, State& state, flo
     }
 }
 
-
-RenderPath& LottieOffsetModifier::modify(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, TVG_UNUSED Matrix* transform, RenderPath& out)
+RenderPath& LottieOffsetModifier::modify(const RenderPath& in, RenderPath& out, TVG_UNUSED Matrix* transform)
 {
+    printf("LottieOffsetModifier(%p) in = %p %d(%d) -> next(%p)\n", this, in.pts.data, in.pts.count, in.pts.reserved, next);
+
     auto clockwise = [](Point* pts, uint32_t n) {
         auto area = 0.0f;
         for (uint32_t i = 0; i < n - 1; i++) {
@@ -381,39 +382,39 @@ RenderPath& LottieOffsetModifier::modify(PathCommand* inCmds, uint32_t inCmdsCnt
     };
 
     auto& path = (next) ? RenderPath::scratch() : out;
-    path.cmds.reserve(inCmdsCnt * 2);
-    path.pts.reserve(inPtsCnt * (join == StrokeJoin::Round ? 4 : 2));
+    path.cmds.reserve(in.cmds.count * 2);
+    path.pts.reserve(in.pts.count * (join == StrokeJoin::Round ? 4 : 2));
 
     State state;
-    auto offset = clockwise(inPts, inPtsCnt) ? this->offset : -this->offset;
+    auto offset = clockwise(in.pts.data, in.pts.count) ? this->offset : -this->offset;
     auto threshold = 1.0f / fabsf(offset) + 1.0f;
     bool degeneratedLine3{};
 
-    for (uint32_t iCmd = 0, iPt = 0; iCmd < inCmdsCnt; ++iCmd) {
-        switch (inCmds[iCmd]) {
+    for (uint32_t iCmd = 0, iPt = 0; iCmd < in.cmds.count; ++iCmd) {
+        switch (in.cmds[iCmd]) {
             case PathCommand::MoveTo: {
                 state.moveto = true;
                 state.movetoInIndex = iPt++;
                 break;
             }
             case PathCommand::LineTo: {
-                line(out, inCmds, inCmdsCnt, inPts, iPt, iCmd, state, offset, false);
+                line(out, in.cmds.data, in.cmds.count, in.pts.data, iPt, iCmd, state, offset, false);
                 break;
             }
             case PathCommand::CubicTo: {
                 //cubic degenerated to a line
-                if (_colinear(inPts + iPt - 1)) {
+                if (_colinear(in.pts.data + iPt - 1)) {
                     ++iPt;
-                    line(out, inCmds, inCmdsCnt, inPts, iPt, iCmd, state, offset, true);
+                    line(out, in.cmds.data, in.cmds.count, in.pts.data, iPt, iCmd, state, offset, true);
                     ++iPt;
                     continue;
                 }
-                cubic(path, inPts + iPt - 1, state, offset, threshold, degeneratedLine3);
+                cubic(path, in.pts.data + iPt - 1, state, offset, threshold, degeneratedLine3);
                 iPt += 3;
                 break;
             }
             default: {
-                if (!tvg::zero(inPts[iPt - 1] - inPts[state.movetoInIndex])) {
+                if (!tvg::zero(in.pts[iPt - 1] - in.pts[state.movetoInIndex])) {
                     path.cmds.push(PathCommand::LineTo);
                     corner(out, state.line, state.firstLine, state.movetoOutIndex, true);
                 }
@@ -424,24 +425,24 @@ RenderPath& LottieOffsetModifier::modify(PathCommand* inCmds, uint32_t inCmdsCnt
     return path;
 }
 
-void LottieOffsetModifier::path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out)
+void LottieOffsetModifier::path(const RenderPath& in, RenderPath& out, Matrix* transform)
 {
-    auto& result = modify(inCmds, inCmdsCnt, inPts, inPtsCnt, transform, out);
-    if (next) next->path(result.cmds.data, result.cmds.count, result.pts.data, result.pts.count, nullptr, out);
+    auto& result = modify(in, out, nullptr);
+    if (next) next->path(result, out, nullptr);
 }
 
-void LottieOffsetModifier::polystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness)
+void LottieOffsetModifier::polystar(const RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness)
 {
-    auto& result = modify(in.cmds.data, in.cmds.count, in.pts.data, in.pts.count, nullptr, out);
+    auto& result = modify(in, out, nullptr);
     if (next) next->polystar(result, out, outerRoundness, hasRoundness);
 }
 
-void LottieOffsetModifier::rect(RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise)
+void LottieOffsetModifier::rect(const RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise)
 {
-    path(in.cmds.data, in.cmds.count, in.pts.data, in.pts.count, nullptr, out);
+    path(in, out, nullptr);
 }
 
-void LottieOffsetModifier::ellipse(RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise)
+void LottieOffsetModifier::ellipse(const RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise)
 {
     auto& path = (next) ? RenderPath::scratch() : out;
     // we know this is the first request in the chain because other modifers would not trigger ellipse() call
@@ -491,21 +492,21 @@ Point LottiePuckerBloatModifier::center(const PathCommand* cmds, uint32_t cmdsCn
     return count > 0 ? center / (float)count : Point{0, 0};
 }
 
-void LottiePuckerBloatModifier::path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out)
+void LottiePuckerBloatModifier::path(const RenderPath& in, RenderPath& out, Matrix* transform)
 {
     auto& path = next ? RenderPath::scratch() : out;
 
     // LineTo segments are expanded to CubicTo, so pts capacity can grow up to 3x
-    path.cmds.reserve(inCmdsCnt);
-    path.pts.reserve(inPtsCnt * 3);
+    path.cmds.reserve(in.cmds.count);
+    path.pts.reserve(in.pts.count * 3);
 
-    auto center = this->center(inCmds, inCmdsCnt, inPts);
+    auto center = this->center(in.cmds.data, in.cmds.count, in.pts.data);
     auto a = amount * 0.01f;
-    auto pts = inPts;
+    auto pts = in.pts.data;
     auto startPts = pts;
 
-    for (uint32_t i = 0; i < inCmdsCnt; ++i) {
-        switch (inCmds[i]) {
+    for (uint32_t i = 0; i < in.cmds.count; ++i) {
+        switch (in.cmds[i]) {
             case PathCommand::MoveTo: {
                 startPts = pts;
                 // anchor points move toward center
@@ -552,20 +553,20 @@ void LottiePuckerBloatModifier::path(PathCommand* inCmds, uint32_t inCmdsCnt, Po
         }
     }
 
-    if (next) return next->path(path.cmds.data, path.cmds.count, path.pts.data, path.pts.count, transform, out);
+    if (next) return next->path(path, out, transform);
 }
 
-void LottiePuckerBloatModifier::polystar(RenderPath& in, RenderPath& out, TVG_UNUSED float, TVG_UNUSED bool)
+void LottiePuckerBloatModifier::polystar(const RenderPath& in, RenderPath& out, TVG_UNUSED float, TVG_UNUSED bool)
 {
-    path(in.cmds.data, in.cmds.count, in.pts.data, in.pts.count, nullptr, out);
+    path(in, out, nullptr);
 }
 
-void LottiePuckerBloatModifier::rect(RenderPath& in, RenderPath& out, TVG_UNUSED const Point&, TVG_UNUSED const Point&, TVG_UNUSED float, TVG_UNUSED bool)
+void LottiePuckerBloatModifier::rect(const RenderPath& in, RenderPath& out, TVG_UNUSED const Point&, TVG_UNUSED const Point&, TVG_UNUSED float, TVG_UNUSED bool)
 {
-    path(in.cmds.data, in.cmds.count, in.pts.data, in.pts.count, nullptr, out);
+    path(in, out, nullptr);
 }
 
-void LottiePuckerBloatModifier::ellipse(RenderPath& in, RenderPath& out, TVG_UNUSED const Point&, TVG_UNUSED const Point&, TVG_UNUSED bool)
+void LottiePuckerBloatModifier::ellipse(const RenderPath& in, RenderPath& out, TVG_UNUSED const Point&, TVG_UNUSED const Point&, TVG_UNUSED bool)
 {
-    path(in.cmds.data, in.cmds.count, in.pts.data, in.pts.count, nullptr, out);
+    path(in, out, nullptr);
 }

--- a/src/loaders/lottie/tvgLottieModifier.cpp
+++ b/src/loaders/lottie/tvgLottieModifier.cpp
@@ -72,9 +72,7 @@ Point LottieRoundnessModifier::rounding(RenderPath& out, Point& prev, Point& cur
 
 RenderPath& LottieRoundnessModifier::modify(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out)
 {
-    buffer->clear();
-
-    auto& path = (next) ? *buffer : out;
+    auto& path = (next) ? RenderPath::scratch() : out;
     path.cmds.reserve(inCmdsCnt * 2);
     path.pts.reserve((uint32_t)(inPtsCnt * 1.5));
     auto pivot = path.pts.count;
@@ -139,9 +137,7 @@ void LottieRoundnessModifier::polystar(RenderPath& in, RenderPath& out, float ou
 {
     constexpr auto ROUNDED_POLYSTAR_MAGIC_NUMBER = 0.47829f;
 
-    buffer->clear();
-
-    auto& path = (next) ? *buffer : out;
+    auto& path = (next) ? RenderPath::scratch(): out;
 
     auto len = length(in.pts[1] - in.pts[2]);
     auto r = len > 0.0f ? ROUNDED_POLYSTAR_MAGIC_NUMBER * std::min(len * 0.5f, this->r) / len : 0.0f;
@@ -201,9 +197,7 @@ void LottieRoundnessModifier::polystar(RenderPath& in, RenderPath& out, float ou
 
 void LottieRoundnessModifier::rect(RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise)
 {
-    buffer->clear();
-
-    auto& path = (next) ? *buffer : out;
+    auto& path = (next) ? RenderPath::scratch() : out;
 
     if (r == 0.0f) r = std::min(this->r, std::max(size.x, size.y) * 0.5f);
 
@@ -386,9 +380,7 @@ RenderPath& LottieOffsetModifier::modify(PathCommand* inCmds, uint32_t inCmdsCnt
         return area < 0.0f;
     };
 
-    buffer->clear();
-
-    auto& path = (next) ? *buffer : out;
+    auto& path = (next) ? RenderPath::scratch() : out;
     path.cmds.reserve(inCmdsCnt * 2);
     path.pts.reserve(inPtsCnt * (join == StrokeJoin::Round ? 4 : 2));
 
@@ -451,8 +443,7 @@ void LottieOffsetModifier::rect(RenderPath& in, RenderPath& out, const Point& po
 
 void LottieOffsetModifier::ellipse(RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise)
 {
-    buffer->clear();
-    auto& path = (next) ? *buffer : out;
+    auto& path = (next) ? RenderPath::scratch() : out;
     // we know this is the first request in the chain because other modifers would not trigger ellipse() call
     path.addCircle(center.x, center.y, radius.x + offset, radius.y + offset, clockwise);
     if (next) return next->ellipse(path, out, center, radius, clockwise);
@@ -502,9 +493,7 @@ Point LottiePuckerBloatModifier::center(const PathCommand* cmds, uint32_t cmdsCn
 
 void LottiePuckerBloatModifier::path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out)
 {
-    buffer->clear();
-
-    auto& path = next ? *buffer : out;
+    auto& path = next ? RenderPath::scratch() : out;
 
     // LineTo segments are expanded to CubicTo, so pts capacity can grow up to 3x
     path.cmds.reserve(inCmdsCnt);

--- a/src/loaders/lottie/tvgLottieModifier.h
+++ b/src/loaders/lottie/tvgLottieModifier.h
@@ -38,11 +38,10 @@ struct LottieModifier
     };
 
     LottieModifier* next = nullptr;
-    RenderPath* buffer;
     Type type;
 
-    LottieModifier(RenderPath* buffer, Type type) :
-        buffer(buffer), type(type) {}
+    LottieModifier(Type type) :
+        type(type) {}
 
     virtual ~LottieModifier()
     {
@@ -62,8 +61,8 @@ struct LottieRoundnessModifier : LottieModifier
     static constexpr float ROUNDNESS_EPSILON = 1.0f;
     float r;
 
-    LottieRoundnessModifier(RenderPath* buffer, float r) :
-        LottieModifier(buffer, Roundness), r(r) {}
+    LottieRoundnessModifier(float r) :
+        LottieModifier(Roundness), r(r) {}
 
     void path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out) override;
     void polystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
@@ -81,8 +80,8 @@ struct LottieOffsetModifier : LottieModifier
     float miterLimit;
     StrokeJoin join;
 
-    LottieOffsetModifier(RenderPath* buffer, float offset, float miter = 4.0f, StrokeJoin join = StrokeJoin::Round) :
-        LottieModifier(buffer, Offset), offset(offset), miterLimit(miter), join(join) {}
+    LottieOffsetModifier(float offset, float miter = 4.0f, StrokeJoin join = StrokeJoin::Round) :
+        LottieModifier(Offset), offset(offset), miterLimit(miter), join(join) {}
 
     void path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out) override;
     void polystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
@@ -111,8 +110,8 @@ struct LottiePuckerBloatModifier : LottieModifier
 {
     float amount;
 
-    LottiePuckerBloatModifier(RenderPath* buffer, float amount) :
-        LottieModifier(buffer, PuckerBloat), amount(amount) {}
+    LottiePuckerBloatModifier(float amount) :
+        LottieModifier(PuckerBloat), amount(amount) {}
 
     void path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out) override;
     void polystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;

--- a/src/loaders/lottie/tvgLottieModifier.h
+++ b/src/loaders/lottie/tvgLottieModifier.h
@@ -48,10 +48,10 @@ struct LottieModifier
         delete (next);
     }
 
-    virtual void path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out) = 0;
-    virtual void polystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) = 0;
-    virtual void rect(RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise) = 0;
-    virtual void ellipse(RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise) = 0;
+    virtual void path(const RenderPath& in, RenderPath& out, Matrix* transform) = 0;
+    virtual void polystar(const RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) = 0;
+    virtual void rect(const RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise) = 0;
+    virtual void ellipse(const RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise) = 0;
 
     LottieModifier* decorate(LottieModifier* next);
 };
@@ -64,14 +64,14 @@ struct LottieRoundnessModifier : LottieModifier
     LottieRoundnessModifier(float r) :
         LottieModifier(Roundness), r(r) {}
 
-    void path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out) override;
-    void polystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
-    void rect(RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise) override;
-    void ellipse(RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise) override;
+    void path(const RenderPath& in, RenderPath& out, Matrix* transform) override;
+    void polystar(const RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
+    void rect(const RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise) override;
+    void ellipse(const RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise) override;
 
 private:
-    RenderPath& modify(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out);
-    Point rounding(RenderPath& out, Point& prev, Point& curr, Point& next, float r);
+    RenderPath& modify(const RenderPath& in, RenderPath& out, Matrix* transform);
+    Point rounding(RenderPath& out, const Point& prev, const Point& curr, const Point& next, float r);
 };
 
 struct LottieOffsetModifier : LottieModifier
@@ -83,10 +83,10 @@ struct LottieOffsetModifier : LottieModifier
     LottieOffsetModifier(float offset, float miter = 4.0f, StrokeJoin join = StrokeJoin::Round) :
         LottieModifier(Offset), offset(offset), miterLimit(miter), join(join) {}
 
-    void path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out) override;
-    void polystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
-    void rect(RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise) override;
-    void ellipse(RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise) override;
+    void path(const RenderPath& in, RenderPath& out, Matrix* transform) override;
+    void polystar(const RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
+    void rect(const RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise) override;
+    void ellipse(const RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise) override;
 
 private:
     struct State
@@ -98,7 +98,7 @@ private:
         bool moveto = false;
     };
 
-    RenderPath& modify(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out);
+    RenderPath& modify(const RenderPath& in, RenderPath& out, Matrix* transform);
     void cubic(RenderPath& path, Point* pts, State& state, float offset, float threshold, bool& degeneratedLine3);
     bool intersected(Line& line1, Line& line2, Point& intersection, bool& inside);
     Line shift(Point& p1, Point& p2, float offset);
@@ -113,10 +113,10 @@ struct LottiePuckerBloatModifier : LottieModifier
     LottiePuckerBloatModifier(float amount) :
         LottieModifier(PuckerBloat), amount(amount) {}
 
-    void path(PathCommand* inCmds, uint32_t inCmdsCnt, Point* inPts, uint32_t inPtsCnt, Matrix* transform, RenderPath& out) override;
-    void polystar(RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
-    void rect(RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise) override;
-    void ellipse(RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise) override;
+    void path(const RenderPath& in, RenderPath& out, Matrix* transform) override;
+    void polystar(const RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
+    void rect(const RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise) override;
+    void ellipse(const RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise) override;
 
 private:
     Point center(const PathCommand* cmds, uint32_t cmdsCnt, const Point* pts);

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -190,36 +190,35 @@ bool LottieParser::getValue(PathSet& path)
     auto pt = pts.begin();
 
     //Store manipulated results
-    RenderPath temp;
+    RenderPath swap;
 
     //Reuse the buffers
-    temp.pts.data = path.pts;
-    temp.pts.reserved = path.ptsCnt;
-    temp.cmds.data = path.cmds;
-    temp.cmds.reserved = path.cmdsCnt;
+    swap.pts.data = path.pts;
+    swap.pts.reserved = path.ptsCnt;
+    swap.cmds.data = path.cmds;
+    swap.cmds.reserved = path.cmdsCnt;
 
     size_t extra = closed ? 3 : 0;
-    temp.pts.reserve(pts.count * 3 + 1 + extra);
-    temp.cmds.reserve(pts.count + 2);
+    swap.pts.reserve(pts.count * 3 + 1 + extra);
+    swap.cmds.reserve(pts.count + 2);
 
-    temp.moveTo(*pt);
+    swap.moveTo(*pt);
 
     for (++pt, ++out, ++in; pt < pts.end(); ++pt, ++out, ++in) {
-        temp.cubicTo(*(pt - 1) + *(out - 1), *pt + *in, *pt);
+        swap.cubicTo(*(pt - 1) + *(out - 1), *pt + *in, *pt);
     }
 
     if (closed) {
-        temp.cubicTo(pts.last() + outs.last(), pts.first() + ins.first(), pts.first());
-        temp.close();
+        swap.cubicTo(pts.last() + outs.last(), pts.first() + ins.first(), pts.first());
+        swap.close();
     }
 
-    path.pts = temp.pts.data;
-    path.cmds = temp.cmds.data;
-    path.ptsCnt = temp.pts.count;
-    path.cmdsCnt = temp.cmds.count;
+    path.pts = swap.pts.data;
+    path.cmds = swap.cmds.data;
+    path.ptsCnt = swap.pts.count;
+    path.cmdsCnt = swap.cmds.count;
 
-    temp.pts.data = nullptr;
-    temp.cmds.data = nullptr;
+    swap.dismiss();
 
     return false;
 }

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -568,28 +568,38 @@ struct LottiePathSet : LottieProperty
 
         if (dispatch(frameNo, path, frame, t)) {
             if (modifier) {
-                modifier->path(path->cmds, path->cmdsCnt, path->pts, path->ptsCnt, transform, out);
-                return true;
+                RenderPath in;
+                path->convert(in);
+                modifier->path(in, out, transform);
+                in.dismiss();
+            } else {
+                _copy(path, out.cmds);
+                _copy(path, out.pts, transform);
             }
-            _copy(path, out.cmds);
-            _copy(path, out.pts, transform);
             return true;
         }
 
-        //interpolate 2 frames
+        // interpolation
         auto s = frame->value.pts;
         auto e = (frame + 1)->value.pts;
-        auto interpPts = tvg::malloc<Point>(frame->value.ptsCnt * sizeof(Point));
-        auto p = interpPts;
+        auto backup = frame->value.pts;
+        frame->value.pts = tvg::malloc<Point>(frame->value.ptsCnt * sizeof(Point));
+        auto p = frame->value.pts;
 
         for (auto i = 0; i < frame->value.ptsCnt; ++i, ++s, ++e, ++p) {
             *p = tvg::lerp(*s, *e, t);
             if (transform) *p *= *transform;
         }
 
-        if (modifier) modifier->path(frame->value.cmds, frame->value.cmdsCnt, interpPts, frame->value.ptsCnt, nullptr, out);
+        if (modifier) {
+            RenderPath in;
+            frame->value.convert(in);
+            modifier->path(in, out, nullptr);
+            in.dismiss();
+        }
 
-        tvg::free(interpPts);
+        std::swap(frame->value.pts, backup);
+        tvg::free(backup);
 
         return true;
     }
@@ -621,22 +631,25 @@ struct LottiePathSet : LottieProperty
 
     bool tweening(float frameNo, RenderPath& out, Matrix* transform, LottieModifier* modifier, Tween& tween, LottieExpressions* exps)
     {
-        auto& to = RenderPath::scratch();
+        auto& tmp = RenderPath::scratch();
         auto pivot = out.pts.count;
         if (!operator()(frameNo, out, transform, exps)) return false;
-        if (!operator()(tween.frameNo, to, transform, exps)) return false;
+        if (!operator()(tween.frameNo, tmp, transform, exps)) return false;
 
+        if (tmp.pts.count != out.pts.count - pivot) TVGLOG("LOTTIE", "Tweening has different numbers of points in consecutive frames.");
+
+        // tweening interpolation
         auto from = out.pts.data + pivot;
-        if (to.pts.count != out.pts.count - pivot) TVGLOG("LOTTIE", "Tweening has different numbers of points in consecutive frames.");
+        auto interp = modifier ? tmp.pts.data : from;  // the result must be resued as the input of the modifier
+        auto count = std::min(tmp.pts.count, (out.pts.count - pivot));
 
-        for (uint32_t i = 0; i < std::min(to.pts.count, (out.pts.count - pivot)); ++i) {
-            from[i] = tvg::lerp(from[i], to.pts[i], tween.progress);
+        for (uint32_t i = 0; i < count; ++i) {
+            interp[i] = tvg::lerp(from[i], tmp.pts[i], tween.progress);
         }
 
-        if (!modifier) return true;
+        // apply modifiers
+        if (modifier) modifier->path(tmp, out, transform);
 
-        //Apply modifiers
-        modifier->path(to.cmds.data, to.cmds.count, to.pts.data, to.pts.count, transform, out);
         return true;
     }
 

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -564,7 +564,6 @@ struct LottiePathSet : LottieProperty
     {
         PathSet* path;
         LottieScalarFrame<PathSet>* frame;
-        RenderPath temp;
         float t;
 
         if (dispatch(frameNo, path, frame, t)) {
@@ -622,7 +621,7 @@ struct LottiePathSet : LottieProperty
 
     bool tweening(float frameNo, RenderPath& out, Matrix* transform, LottieModifier* modifier, Tween& tween, LottieExpressions* exps)
     {
-        RenderPath to;  //used as temp as well.
+        auto& to = RenderPath::scratch();
         auto pivot = out.pts.count;
         if (!operator()(frameNo, out, transform, exps)) return false;
         if (!operator()(tween.frameNo, to, transform, exps)) return false;
@@ -637,7 +636,6 @@ struct LottiePathSet : LottieProperty
         if (!modifier) return true;
 
         //Apply modifiers
-        to.clear();
         modifier->path(to.cmds.data, to.cmds.count, to.pts.data, to.pts.count, transform, out);
         return true;
     }

--- a/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
@@ -238,11 +238,10 @@ bool GlGeometry::tesselateStroke(const RenderShape& rshape)
     if (!std::isfinite(strokeWidthWorld)) strokeWidthWorld = strokeWidth;
 
     //run stroking only if it's valid
-
     if (!tvg::zero(strokeWidthWorld)) {
         Stroker stroker(&stroke, strokeWidthWorld, rshape.strokeCap(), rshape.strokeJoin(), rshape.strokeMiterlimit());
-        RenderPath dashedPathWorld;
-        if (gpuStrokeDash(rshape, dashedPathWorld, &matrix)) stroker.run(dashedPathWorld);
+        auto& dashed = RenderPath::scratch();
+        if (gpuStrokeDash(rshape, dashed, &matrix)) stroker.run(dashed);
         else stroker.run(optPath);
         strokeBounds = stroker.bounds();
         strokeRenderWidth = strokeWidthWorld;

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -178,12 +178,12 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
     renderSettingsStroke.opacityMultiplier = 1.0f;
 
     // optimize path
-    RenderPath optPath;
+    auto& optPath = RenderPath::scratch();
     bool optPathThin = false;
     bool optPathSkipFill = false;
     if (rshape.trimpath()) {
-        RenderPath trimmedPath;
-        if (rshape.stroke->trim.trim(rshape.path, trimmedPath)) gpuOptimize(trimmedPath, optPath, matrix, optPathThin, optPathSkipFill);
+        auto& trimmed = RenderPath::scratch();
+        if (rshape.stroke->trim.trim(rshape.path, trimmed)) gpuOptimize(trimmed, optPath, matrix, optPathThin, optPathSkipFill);
         else optPath.clear();
     } else {
         gpuOptimize(rshape.path, optPath, matrix, optPathThin, optPathSkipFill);
@@ -228,8 +228,8 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
         //run stroking only if it's valid
         if (!tvg::zero(strokeWidthWorld)) {
             WgStroker stroker(&meshStrokes, strokeWidthWorld, rshape.strokeCap(), rshape.strokeJoin(), rshape.strokeMiterlimit());
-            RenderPath dashedPathWorld;
-            if (gpuStrokeDash(rshape, dashedPathWorld, &matrix)) stroker.run(dashedPathWorld);
+            auto& dashed = RenderPath::scratch();
+            if (gpuStrokeDash(rshape, dashed, &matrix)) stroker.run(dashed);
             else stroker.run(optPath);
             renderSettingsStroke.opacityMultiplier = 1.0f;
             if (meshStrokes.ibuffer.empty()) {

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -58,6 +58,16 @@ bool RenderMethod::viewport(const RenderRegion& vp)
 /* RenderPath Class Implementation                                      */
 /************************************************************************/
 
+// used as a temporary buffer
+RenderPath& RenderPath::scratch()
+{
+    static thread_local RenderPath dbuffers[3];   // tripple-buffering
+    static thread_local int idx = 0;
+    if (++idx > 2) idx =0;
+    dbuffers[(idx)].clear();
+    return dbuffers[(int)idx];
+}
+
 void RenderPath::addCircle(float cx, float cy, float rx, float ry, bool cw)
 {
     auto rxKappa = rx * PATH_KAPPA;

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -223,6 +223,12 @@ struct RenderPath
     Array<PathCommand> cmds;
     Array<Point> pts;
 
+    void dismiss()
+    {
+        cmds.data = nullptr;
+        pts.data = nullptr;
+    }
+
     bool empty() const
     {
         return pts.empty();
@@ -311,6 +317,8 @@ struct RenderPath
     bool bounds(const Matrix* m, BBox& box);
     void addCircle(float cx, float cy, float rx, float ry, bool cw);
     void addRect(float x, float y, float w, float h, float rx, float ry, bool cw);
+
+    static RenderPath& scratch();
 };
 
 struct RenderTrimPath


### PR DESCRIPTION
- clean up ShapeModifers interfaces with a neat RenderPath for a better readibility
- make it up corner cases
- removed the resuable buffer because the modifiers in/out memory could be identical during modifier chaning.