### PR TITLE
lottie: fix tvg::clamp template deduction on Xtensa

### DIFF
--- a/src/loaders/lottie/tvgLottieData.h
+++ b/src/loaders/lottie/tvgLottieData.h
@@ -124,9 +124,9 @@ static inline RGB32 operator*(const RGB32& lhs, float rhs)
 static inline RGB32 lerp(const RGB32& s, const RGB32& e, float t)
 {
     return {
-        tvg::clamp((int32_t)(s.r + (e.r - s.r) * t), 0, 255),
-        tvg::clamp((int32_t)(s.g + (e.g - s.g) * t), 0, 255),
-        tvg::clamp((int32_t)(s.b + (e.b - s.b) * t), 0, 255)
+        tvg::clamp((int32_t)(s.r + (e.r - s.r) * t), (int32_t)0, (int32_t)255),
+        tvg::clamp((int32_t)(s.g + (e.g - s.g) * t), (int32_t)0, (int32_t)255),
+        tvg::clamp((int32_t)(s.b + (e.b - s.b) * t), (int32_t)0, (int32_t)255)
     };
 }
 


### PR DESCRIPTION
## Summary

- Fix `tvg::clamp<T>` template deduction failure on Xtensa (ESP32) where `int32_t` is `long` rather than `int`
- Cast literal arguments `0`/`255` to `int32_t` to match the first argument's type, ensuring consistent deduction across all platforms