### PR TITLE
lottie: replace strdup with tvg::duplicate for portability

### DIFF
--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -144,7 +144,7 @@ struct LottieExpression
 
     LottieExpression(const LottieExpression* rhs)
     {
-        code = strdup(rhs->code);
+        code = tvg::duplicate(rhs->code);
         comp = rhs->comp;
         layer = rhs->layer;
         object = rhs->object;


### PR DESCRIPTION
## Summary

- Replace the only `strdup` call with `tvg::duplicate()` for portability — `strdup` is not available on all platforms
- Consistent with the rest of the codebase which already uses `tvg::duplicate()`