### PR TITLE
gpu_engine: fix hue blend mismatch in SVG blend example

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -27,7 +27,6 @@
 #include "tvgGlRenderTask.h"
 #include "tvgGlProgram.h"
 #include "tvgGlShaderSrc.h"
-#include "tvgShape.h"
 #include "tvgRender.h"
 
 /************************************************************************/
@@ -121,12 +120,12 @@ void GlRenderer::initShaders()
 #if 1  //for optimization
     #define LINEAR_TOTAL_LENGTH 2831
     #define RADIAL_TOTAL_LENGTH 5315
-    #define BLEND_TOTAL_LENGTH 5369
+    #define BLEND_TOTAL_LENGTH 5096
 #else
     #define COMMON_TOTAL_LENGTH strlen(STR_GRADIENT_FRAG_COMMON_VARIABLES) + strlen(STR_GRADIENT_FRAG_COMMON_FUNCTIONS) + 1
     #define LINEAR_TOTAL_LENGTH strlen(STR_LINEAR_GRADIENT_VARIABLES) + strlen(STR_LINEAR_GRADIENT_FUNCTIONS) + strlen(STR_LINEAR_GRADIENT_MAIN) + COMMON_TOTAL_LENGTH
     #define RADIAL_TOTAL_LENGTH strlen(STR_RADIAL_GRADIENT_VARIABLES) + strlen(STR_RADIAL_GRADIENT_FUNCTIONS) + strlen(STR_RADIAL_GRADIENT_MAIN) + COMMON_TOTAL_LENGTH
-    #define BLEND_TOTAL_LENGTH strlen(BLEND_SCENE_FRAG_HEADER) + (strlen(BLEND_FRAG_HUE) > strlen(BLEND_FRAG_LUM) ? strlen(BLEND_FRAG_HUE) : strlen(BLEND_FRAG_LUM)) + strlen(COLOR_BURN_BLEND_FRAG) + 1
+    #define BLEND_TOTAL_LENGTH strlen(BLEND_SCENE_FRAG_HEADER) + strlen(BLEND_FRAG_LUM_HELPER) + strlen(BLEND_FRAG_SAT_HELPER) + strlen(COLOR_BURN_BLEND_FRAG) + 1
 #endif
 
     char linearGradientFragShader[LINEAR_TOTAL_LENGTH];
@@ -621,11 +620,13 @@ GlProgram* GlRenderer::getBlendProgram(BlendMethod method, BlendSource source)
 
     if (mPrograms[shaderInd]) return mPrograms[shaderInd];
 
-    const char* helpers = "";
+    const char* lumHelper = "";
+    const char* satHelper = "";
     if (method == BlendMethod::Hue) {
-        helpers = BLEND_FRAG_HUE;
+        lumHelper = BLEND_FRAG_LUM_HELPER;
+        satHelper = BLEND_FRAG_SAT_HELPER;
     } else if ((method == BlendMethod::Saturation) || (method == BlendMethod::Color) || (method == BlendMethod::Luminosity)) {
-        helpers = BLEND_FRAG_LUM;
+        lumHelper = BLEND_FRAG_LUM_HELPER;
     }
 
     const char* vertShader;
@@ -634,7 +635,7 @@ GlProgram* GlRenderer::getBlendProgram(BlendMethod method, BlendSource source)
     if (source == BlendSource::Scene || source == BlendSource::Image) {
         vertShader = BLIT_VERT_SHADER;
         const char* header = (source == BlendSource::Scene) ? BLEND_SCENE_FRAG_HEADER : BLEND_IMAGE_FRAG_HEADER;
-        snprintf(fragShader, BLEND_TOTAL_LENGTH, "%s%s%s", header, helpers, shaderFunc[methodInd]);
+        snprintf(fragShader, BLEND_TOTAL_LENGTH, "%s%s%s%s", header, lumHelper, satHelper, shaderFunc[methodInd]);
         mPrograms[shaderInd] = new GlProgram(vertShader, fragShader);
         return mPrograms[shaderInd];
     }
@@ -642,29 +643,32 @@ GlProgram* GlRenderer::getBlendProgram(BlendMethod method, BlendSource source)
     vertShader = (source == BlendSource::Solid) ? COLOR_VERT_SHADER : GRADIENT_VERT_SHADER;
     switch (source) {
         case BlendSource::Solid:
-            snprintf(fragShader, BLEND_TOTAL_LENGTH, "%s%s%s",
+            snprintf(fragShader, BLEND_TOTAL_LENGTH, "%s%s%s%s",
                      BLEND_SHAPE_SOLID_FRAG_HEADER,
-                     helpers,
+                     lumHelper,
+                     satHelper,
                      shaderFunc[methodInd]);
             break;
         case BlendSource::LinearGradient:
-            snprintf(fragShader, BLEND_TOTAL_LENGTH, "%s%s%s%s%s%s%s",
+            snprintf(fragShader, BLEND_TOTAL_LENGTH, "%s%s%s%s%s%s%s%s",
                      STR_GRADIENT_FRAG_COMMON_VARIABLES,
                      STR_LINEAR_GRADIENT_VARIABLES,
                      STR_GRADIENT_FRAG_COMMON_FUNCTIONS,
                      STR_LINEAR_GRADIENT_FUNCTIONS,
                      BLEND_SHAPE_LINEAR_FRAG_HEADER,
-                     helpers,
+                     lumHelper,
+                     satHelper,
                      shaderFunc[methodInd]);
             break;
         case BlendSource::RadialGradient:
-            snprintf(fragShader, BLEND_TOTAL_LENGTH, "%s%s%s%s%s%s%s",
+            snprintf(fragShader, BLEND_TOTAL_LENGTH, "%s%s%s%s%s%s%s%s",
                      STR_GRADIENT_FRAG_COMMON_VARIABLES,
                      STR_RADIAL_GRADIENT_VARIABLES,
                      STR_GRADIENT_FRAG_COMMON_FUNCTIONS,
                      STR_RADIAL_GRADIENT_FUNCTIONS,
                      BLEND_SHAPE_RADIAL_FRAG_HEADER,
-                     helpers,
+                     lumHelper,
+                     satHelper,
                      shaderFunc[methodInd]);
             break;
         default:

--- a/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
@@ -819,53 +819,7 @@ vec4 postProcess(vec4 R) { return mix(vec4(d.Dc, d.Da), R, d.Sa * d.So); }
 )";
 #endif
 
-const char* BLEND_FRAG_HUE = R"(
-// RGB to HSL conversion
-vec3 rgbToHsl(vec3 color) {
-    float minVal = min(color.r, min(color.g, color.b));
-    float maxVal = max(color.r, max(color.g, color.b));
-    float delta = maxVal - minVal;
-
-    float h = 0.0;
-    if (delta > 0.0) {
-             if (maxVal == color.r) { h = (color.g - color.b) / delta - trunc(h / 6.0) * 6.0; }
-        else if (maxVal == color.g) { h = (color.b - color.r) / delta + 2.0;
-        } else                      { h = (color.r - color.g) / delta + 4.0; }
-        h = h * 60.0;
-        if (h < 0.0) { h += 360.0; }
-    }
-
-    float l = (maxVal + minVal) * 0.5;
-    float s = delta > 0.0 ? delta / (1.0 - abs(2.0 * l - 1.0)) : 0.0;
-    
-    return vec3(h, s, l);
-}
-
-// HSL to RGB conversion
-vec3 hslToRgb(vec3 color) {
-    float h = color.x;
-    float s = color.y;
-    float l = color.z;
-
-    float C = (1.0 - abs(2.0 * l - 1.0)) * s;
-    float h_prime = h / 60.0;
-    float X = C * (1.0 - abs(h_prime - 2.0 * trunc(h_prime / 2.0) - 1.0));
-    float m = l - C / 2.0;
-
-    vec3 rgb = vec3(0.0);
-         if (h_prime >= 0.0 && h_prime < 1.0) { rgb = vec3(C, X, 0.0); }
-    else if (h_prime >= 1.0 && h_prime < 2.0) { rgb = vec3(X, C, 0.0); }
-    else if (h_prime >= 2.0 && h_prime < 3.0) { rgb = vec3(0.0, C, X); }
-    else if (h_prime >= 3.0 && h_prime < 4.0) { rgb = vec3(0.0, X, C); }
-    else if (h_prime >= 4.0 && h_prime < 5.0) { rgb = vec3(X, 0.0, C); }
-    else                                      { rgb = vec3(C, 0.0, X); }
-
-    return rgb + vec3(m);
-}
-)";
-
-//  helpers related to luminance adjustment
-const char* BLEND_FRAG_LUM = R"(
+const char* BLEND_FRAG_LUM_HELPER = R"(
 const vec3 LUM_W = vec3(0.3, 0.59, 0.11);
 
 vec3 setLum(vec3 color, float l) {
@@ -877,6 +831,32 @@ vec3 setLum(vec3 color, float l) {
     if (n < 0.0) color = ll + (color - ll) * (ll / (ll - n));
     if (x > 1.0) color = ll + (color - ll) * ((1.0 - ll) / (x - ll));
     return color;
+}
+)";
+
+const char* BLEND_FRAG_SAT_HELPER = R"(
+float sat(vec3 color) {
+    return max(color.r, max(color.g, color.b)) - min(color.r, min(color.g, color.b));
+}
+
+vec3 setSat(vec3 color, float s) {
+    float rMin = step(color.r, color.g) * step(color.r, color.b);
+    float gMin = (1.0 - rMin) * step(color.g, color.r) * step(color.g, color.b);
+    vec3 minMask = vec3(rMin, gMin, 1.0 - rMin - gMin);
+
+    float bMax = step(color.r, color.b) * step(color.g, color.b);
+    float gMax = (1.0 - bMax) * step(color.r, color.g) * step(color.b, color.g);
+    vec3 maxMask = vec3(1.0 - bMax - gMax, gMax, bMax);
+    vec3 midMask = vec3(1.0) - minMask - maxMask;
+
+    float cMin = dot(color, minMask);
+    float cMid = dot(color, midMask);
+    float cMax = dot(color, maxMask);
+    float delta = cMax - cMin;
+    float deltaMask = sign(delta);
+    float scale = deltaMask * s / max(delta, 1e-6);
+
+    return maxMask * (s * deltaMask) + midMask * ((cMid - cMin) * scale);
 }
 )";
 
@@ -1034,11 +1014,8 @@ void main()
     vec3 Rc = d.Sc;
     if (d.Da > 0.0) {
         vec3 Dc = min(One, d.Dc / d.Da);
-
-        vec3 Shsl = rgbToHsl(d.Sc);
-        vec3 Dhsl = rgbToHsl(Dc);
-        Rc = hslToRgb(vec3(Shsl.r, Dhsl.g, Dhsl.b)); // sh, ds, dl
-        
+        Rc = setSat(d.Sc, sat(Dc));
+        Rc = setLum(Rc, dot(Dc, LUM_W));
         Rc = mix(d.Sc, Rc, d.Da);
     }
     FragColor = postProcess(vec4(Rc, 1.0));

--- a/src/renderer/gpu_engine/gl/tvgGlShaderSrc.h
+++ b/src/renderer/gpu_engine/gl/tvgGlShaderSrc.h
@@ -58,8 +58,8 @@ extern const char* BLEND_SHAPE_SOLID_FRAG_HEADER;
 extern const char* BLEND_SHAPE_LINEAR_FRAG_HEADER;
 extern const char* BLEND_SHAPE_RADIAL_FRAG_HEADER;
 
-extern const char* BLEND_FRAG_HUE;
-extern const char* BLEND_FRAG_LUM;
+extern const char* BLEND_FRAG_LUM_HELPER;
+extern const char* BLEND_FRAG_SAT_HELPER;
 
 extern const char* NORMAL_BLEND_FRAG;
 extern const char* MULTIPLY_BLEND_FRAG;

--- a/src/renderer/gpu_engine/wg/tvgWgShaderSrc.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgShaderSrc.cpp
@@ -457,49 +457,6 @@ fn postProcess(d: FragData, R: vec4f) -> vec4f { return mix(vec4(d.Dc, d.Da), R,
 const char* cShaderSrc_BlendFuncs = R"(
 const One = vec3f(1.0, 1.0, 1.0);
 
-// RGB to HSL conversion
-fn rgbToHsl(color: vec3f) -> vec3f {
-    let minVal = min(color.r, min(color.g, color.b));
-    let maxVal = max(color.r, max(color.g, color.b));
-    let delta = maxVal - minVal;
-
-    var h = 0.0;
-    if (delta > 0.0) {
-             if (maxVal == color.r) { h = (color.g - color.b) / delta - trunc(h / 6.0) * 6.0; }
-        else if (maxVal == color.g) { h = (color.b - color.r) / delta + 2.0;
-        } else                      { h = (color.r - color.g) / delta + 4.0; }
-        h = h * 60.0;
-        if (h < 0.0) { h += 360.0; }
-    }
-
-    let l = (maxVal + minVal) * 0.5;
-    var s = select(0.0, delta / (1.0 - abs(2.0 * l - 1.0)), delta > 0.0);
-    
-    return vec3f(h, s, l);
-};
-
-// HSL to RGB conversion
-fn hslToRgb(color: vec3f) -> vec3f {
-    let h = color.x;
-    let s = color.y;
-    let l = color.z;
-
-    let C = (1.0 - abs(2.0 * l - 1.0)) * s;
-    let h_prime = h / 60.0;
-    let X = C * (1.0 - abs(h_prime - 2.0 * trunc(h_prime / 2.0) - 1.0));
-    let m = l - C / 2.0;
-
-    var rgb = vec3f(0.0);
-         if (h_prime >= 0.0 && h_prime < 1.0) { rgb = vec3f(C, X, 0.0); }
-    else if (h_prime >= 1.0 && h_prime < 2.0) { rgb = vec3f(X, C, 0.0); }
-    else if (h_prime >= 2.0 && h_prime < 3.0) { rgb = vec3f(0.0, C, X); }
-    else if (h_prime >= 3.0 && h_prime < 4.0) { rgb = vec3f(0.0, X, C); }
-    else if (h_prime >= 4.0 && h_prime < 5.0) { rgb = vec3f(X, 0.0, C); }
-    else                                      { rgb = vec3f(C, 0.0, X); }
-
-    return rgb + vec3f(m);
-};
-
 const LUM_W = vec3f(0.3, 0.59, 0.11);
 
 fn setLum(colorIn: vec3f, l: f32) -> vec3f {
@@ -515,6 +472,30 @@ fn setLum(colorIn: vec3f, l: f32) -> vec3f {
         color = vec3f(ll) + (color - vec3f(ll)) * ((1.0 - ll) / (x - ll));
     }
     return color;
+};
+
+fn sat(color: vec3f) -> f32 {
+    return max(color.r, max(color.g, color.b)) - min(color.r, min(color.g, color.b));
+};
+
+fn setSat(colorIn: vec3f, s: f32) -> vec3f {
+    let rMin = step(colorIn.r, colorIn.g) * step(colorIn.r, colorIn.b);
+    let gMin = (1.0 - rMin) * step(colorIn.g, colorIn.r) * step(colorIn.g, colorIn.b);
+    let minMask = vec3f(rMin, gMin, 1.0 - rMin - gMin);
+
+    let bMax = step(colorIn.r, colorIn.b) * step(colorIn.g, colorIn.b);
+    let gMax = (1.0 - bMax) * step(colorIn.r, colorIn.g) * step(colorIn.b, colorIn.g);
+    let maxMask = vec3f(1.0 - bMax - gMax, gMax, bMax);
+    let midMask = vec3f(1.0) - minMask - maxMask;
+
+    let cMin = dot(colorIn, minMask);
+    let cMid = dot(colorIn, midMask);
+    let cMax = dot(colorIn, maxMask);
+    let delta = cMax - cMin;
+    let deltaMask = sign(delta);
+    let scale = deltaMask * s / max(delta, 1e-6);
+
+    return maxMask * vec3f(s * deltaMask) + midMask * vec3f((cMid - cMin) * scale);
 };
 
 @fragment
@@ -654,11 +635,8 @@ fn fs_main_Hue(in: VertexOutput) -> @location(0) vec4f {
     var Rc = d.Sc;
     if (d.Da > 0.0) {
         let Dc = min(One, d.Dc / d.Da);
-
-        let Shsl = rgbToHsl(d.Sc);
-        let Dhsl = rgbToHsl(Dc);
-        Rc = hslToRgb(vec3(Shsl.r, Dhsl.g, Dhsl.b)); // sh, ds, dl
-
+        Rc = setSat(d.Sc, sat(Dc));
+        Rc = setLum(Rc, dot(Dc, LUM_W));
         Rc = mix(d.Sc, Rc, d.Da);
     };
     return postProcess(d, vec4f(Rc, 1.0));


### PR DESCRIPTION
## Summary

Fix the GPU `hue` blend result used in the SVG blend example added around #4255.

The previous GPU shader still used a legacy HSL round-trip for `hue`, which produced a different result than the expected example output. This change switches the GPU `hue` path to a non-separable formulation and keeps the saturation remap branch-light with stable min/max masks.

**This PR only resolves non-grouped blending**

- WG
<img width="865" height="1235" alt="Screenshot 2026-04-13 at 10 14 25 AM" src="https://github.com/user-attachments/assets/e15e3e3c-58d6-4c43-a138-a9d38f2259ca" />

- GL
<img width="873" height="1242" alt="Screenshot 2026-04-13 at 10 14 07 AM" src="https://github.com/user-attachments/assets/d9b8d854-8305-41a3-906c-465d22daa51b" />

## Changes

- update the GL `hue` blend shader helper
- update the WG `hue` blend shader helper
- remove the old HSL round-trip from the GPU `hue` path
- keep the saturation remap logic lower-branch for shader execution
- Size: +4 bytes
- FPS: No changes

## Why

While validating the SVG blend example from #4255, `hue` produced an inconsistent GPU result. This PR fixes that specific mismatch.

Related issue: #4190 