### PR TITLE
cpu_engine: fix strides in tvgSwPostEffect

### DIFF
--- a/src/renderer/cpu_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/cpu_engine/tvgSwPostEffect.cpp
@@ -513,8 +513,8 @@ bool effectFill(SwCompositor* cmp, const RenderEffectFill* params, bool direct)
                 auto tmp = ALPHA_BLEND(color, a);
                 *dst = tmp + ALPHA_BLEND(*dst, 255 - a);
             }
-            dbuffer += cmp->image.stride;
-            sbuffer += cmp->recoverSfc->stride;
+            dbuffer += cmp->recoverSfc->stride;
+            sbuffer += cmp->image.stride;
         }
         cmp->valid = true;  //no need the subsequent composition
     } else {
@@ -564,8 +564,8 @@ bool effectTint(SwCompositor* cmp, const RenderEffectTint* params, bool direct)
                 if (params->intensity < 255) val = INTERPOLATE(val, *src, params->intensity);
                 *dst = INTERPOLATE(val, *dst, MULTIPLY(opacity, A(*src)));
             }
-            dbuffer += cmp->image.stride;
-            sbuffer += cmp->recoverSfc->stride;
+            dbuffer += cmp->recoverSfc->stride;
+            sbuffer += cmp->image.stride;
         }
         cmp->valid = true;  //no need the subsequent composition
     } else {
@@ -635,8 +635,8 @@ bool effectTritone(SwCompositor* cmp, const RenderEffectTritone* params, bool di
                     *dst = INTERPOLATE(INTERPOLATE(*src, _trintone(shadow, midtone, highlight, luma((uint8_t*)src)), params->blender), *dst, MULTIPLY(opacity, A(*src)));
                 }
             }
-            dbuffer += cmp->image.stride;
-            sbuffer += cmp->recoverSfc->stride;
+            dbuffer += cmp->recoverSfc->stride;
+            sbuffer += cmp->image.stride;
         }
         cmp->valid = true;  //no need the subsequent composition
     } else {


### PR DESCRIPTION
- issue: #4325

#### Change

Match source/dest strides in the direct branch of post effects
`dbuffer` advances by `recoverSfc->stride`, `sbuffer` by `image.stride`.

#### issue

When `GifSaver` created a target with `height` greater than `width`, `image.stride` and `recoverSfc->stride` no longer matched, and the swapped  per-row advance walked the pointer out of bounds.

output file: 

<img src="https://github.com/user-attachments/assets/0862e66c-e362-49bb-bc01-43a0df691cbb" width="300">


