### PR TITLE
lottie: correct line height application for url font text

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1025,7 +1025,7 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
 
     //apply spacing
     auto hspacing = (doc.tracking > 0.0f) ? (1.0f + doc.tracking * doc.size / metrics.ascent) : 1.0f;
-    auto vspacing = (doc.height > 0.0f && doc.bbox.size.y > 0.0f) ? (doc.height / metrics.advance) : 1.0f;
+    auto vspacing = (doc.height > 0.0f && paint->lines() > 1) ? (doc.height / metrics.advance) : 1.0f;
     paint->spacing(hspacing, vspacing);
 
     layer->scene->add(paint);


### PR DESCRIPTION
Apply line height (lh) when there are multiple lines.

<img width="2554" height="1276" alt="CleanShot 2026-04-13 at 20 01 08@2x" src="https://github.com/user-attachments/assets/0cb2cbd9-985a-4f0f-9497-03b81b969947" />


issue: https://github.com/thorvg/thorvg/issues/4331