### PR TITLE
infra: add binary size diff reporter workflow

### DIFF
--- a/.github/workflows/binary_size.yml
+++ b/.github/workflows/binary_size.yml
@@ -1,0 +1,185 @@
+name: Binary Size
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # x86_64
+          - label: x86_64 gcc
+            key: x86_64-gcc
+            runs_on: ubuntu-24.04
+            extra_packages: 'libturbojpeg0-dev libpng-dev libwebp-dev libgles-dev'
+            cc: gcc
+            cxx: g++
+            c_args: ''
+            cpp_args: ''
+            c_link_args: ''
+            cpp_link_args: ''
+
+          - label: x86_64 clang
+            key: x86_64-clang
+            runs_on: ubuntu-24.04
+            extra_packages: 'clang lld libomp-dev libturbojpeg0-dev libpng-dev libwebp-dev libgles-dev'
+            cc: clang
+            cxx: clang++
+            c_args: ''
+            cpp_args: ''
+            c_link_args: ''
+            cpp_link_args: ''
+
+          # x86 32-bit 
+          - label: x86 gcc (32-bit)
+            key: x86-gcc
+            runs_on: ubuntu-24.04
+            extra_packages: 'gcc-multilib g++-multilib'
+            cc: gcc
+            cxx: g++
+            c_args: '-m32'
+            cpp_args: '-m32'
+            c_link_args: '-m32'
+            cpp_link_args: '-m32'
+
+          # arm64 (GitHub ARM runner)
+          - label: arm64 gcc
+            key: arm64-gcc
+            runs_on: ubuntu-24.04-arm
+            extra_packages: 'libturbojpeg0-dev libpng-dev libwebp-dev libgles-dev'
+            cc: gcc
+            cxx: g++
+            c_args: ''
+            cpp_args: ''
+            c_link_args: ''
+            cpp_link_args: ''
+
+          - label: arm64 clang
+            key: arm64-clang
+            runs_on: ubuntu-24.04-arm
+            extra_packages: 'clang lld libomp-dev libturbojpeg0-dev libpng-dev libwebp-dev libgles-dev'
+            cc: clang
+            cxx: clang++
+            c_args: ''
+            cpp_args: ''
+            c_link_args: ''
+            cpp_link_args: ''
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Cache apt archives
+      uses: actions/cache@v4
+      with:
+        path: .apt-cache/${{ matrix.key }}/archives
+        key: apt-${{ runner.os }}-${{ runner.arch }}-${{ matrix.key }}-${{ hashFiles('.github/workflows/binary_size.yml') }}
+        restore-keys: |
+          apt-${{ runner.os }}-${{ runner.arch }}-${{ matrix.key }}-
+
+    - name: Install Packages
+      env:
+        EXTRA_PACKAGES: ${{ matrix.extra_packages }}
+        APT_CACHE_DIR: ${{ github.workspace }}/.apt-cache/${{ matrix.key }}
+      run: |
+        packages=(meson ninja-build)
+        if [ -n "$EXTRA_PACKAGES" ]; then
+          for pkg in $EXTRA_PACKAGES; do
+            packages+=("$pkg")
+          done
+        fi
+
+        missing_packages=()
+        for pkg in "${packages[@]}"; do
+          if ! dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null | grep -q "install ok installed"; then
+            missing_packages+=("$pkg")
+          fi
+        done
+
+        if [ "${#missing_packages[@]}" -eq 0 ]; then
+          echo "All requested packages are already installed."
+          exit 0
+        fi
+
+        mkdir -p "$APT_CACHE_DIR/archives/partial"
+        echo "Installing missing packages: ${missing_packages[*]}"
+
+        sudo apt-get update -o Acquire::Retries=3
+        sudo apt-get install -y --no-install-recommends \
+          -o Acquire::Retries=3 \
+          -o Dir::Cache::archives="$APT_CACHE_DIR/archives" \
+          "${missing_packages[@]}"
+
+        sudo chown -R "$USER:$USER" "$APT_CACHE_DIR"
+
+    # Build both revisions, strip, and collect report files per matrix entry.
+    - name: Build and collect sizes
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+        C_ARGS: ${{ matrix.c_args }}
+        CPP_ARGS: ${{ matrix.cpp_args }}
+        C_LINK_ARGS: ${{ matrix.c_link_args }}
+        CPP_LINK_ARGS: ${{ matrix.cpp_link_args }}
+        MATRIX_KEY: ${{ matrix.key }}
+        MATRIX_LABEL: ${{ matrix.label }}
+      run: |
+        LIB_NAME="libthorvg-1.so.1.0.0"
+
+        build_thorvg() {
+          local src_dir="$1" build_dir="$2"
+          local meson_args=(
+            -Dloaders="all"
+            -Dengines="cpu, gl"
+            -Dsavers="all"
+            -Dbindings="capi"
+            -Dstatic=true
+            -Doptimization=s
+            -Derrorlogs=true
+          )
+          [ -n "$C_ARGS" ]        && meson_args+=("-Dc_args=$C_ARGS")
+          [ -n "$CPP_ARGS" ]      && meson_args+=("-Dcpp_args=$CPP_ARGS")
+          [ -n "$C_LINK_ARGS" ]   && meson_args+=("-Dc_link_args=$C_LINK_ARGS")
+          [ -n "$CPP_LINK_ARGS" ] && meson_args+=("-Dcpp_link_args=$CPP_LINK_ARGS")
+          echo "Compiler: $($CXX --version | head -1)"
+          echo "meson setup $build_dir $src_dir ${meson_args[*]}"
+          meson setup "$build_dir" "$src_dir" "${meson_args[@]}"
+          meson compile -C "$build_dir" -j $(nproc)
+        }
+
+        mkdir -p ci-report
+
+        PR_REF=$(git rev-parse HEAD)
+        BASE_REF=$(git merge-base HEAD origin/main)
+        echo "PR:   $PR_REF"
+        echo "BASE: $BASE_REF (baseline resolved from latest origin/main)"
+        git checkout "$BASE_REF"
+        build_thorvg . build-main
+
+        git checkout "$PR_REF"
+        build_thorvg . build-pr
+
+        # dump raw size output for debugging + report parsing
+        for tag_dir in pr:build-pr main:build-main; do
+          tag="${tag_dir%%:*}"
+          dir="${tag_dir##*:}"
+          lib="$dir/src/$LIB_NAME"
+          strip "$lib"
+          size "$lib" > "ci-report/${MATRIX_KEY}.${tag}.size"
+        done
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: size-${{ matrix.key }}
+        path: ci-report/

--- a/.github/workflows/binary_size_comment.yml
+++ b/.github/workflows/binary_size_comment.yml
@@ -1,0 +1,158 @@
+name: Binary Size Comment
+
+on:
+  workflow_run:
+    workflows: ["Binary Size"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request' 
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Download size artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: ci-report
+        pattern: size-*
+        merge-multiple: true
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Render report
+      run: |
+        python3 -u - <<'PY'
+        import pathlib, re
+
+        root = pathlib.Path("ci-report")
+
+        SAFE_RE = re.compile(r"[^A-Za-z0-9 ._/+\-=(),:]")
+        def sanitize(s, limit=200):
+            s = s.replace("`", "'").replace("\n", " ")
+            s = SAFE_RE.sub("", s)
+            return s[:limit]
+
+        def parse_size_file(path):
+            try:
+                lines = path.read_text().splitlines()
+                cols = lines[1].split()
+                text, data = int(cols[0]), int(cols[1])
+                if text < 0 or data < 0:
+                    return None
+                return {"text": text, "data": data, "total": text + data}
+            except Exception:
+                return None
+
+        results = {}
+        for f in sorted(root.glob("*.size")):
+            key, tag = f.stem.rsplit(".", 1)
+            results.setdefault(sanitize(key, 64), {})[tag] = parse_size_file(f)
+
+        if not results:
+            pathlib.Path("report.md").write_text("## Binary Size Report\n\nNo data collected.\n")
+            raise SystemExit(0)
+
+        def delta(base, pr):
+            diff = pr - base
+            pct = (diff / base * 100) if base else 0
+            sign = "+" if diff > 0 else ""
+            return f"{sign}{diff} ({sign}{pct:.2f}%)"
+
+        lines = ["## Binary Size Report", ""]
+
+        lines += [
+            "| Config | main | PR | Delta |",
+            "|--------|-----:|---:|------:|",
+        ]
+        for key, sizes in sorted(results.items()):
+            m, p = sizes.get("main"), sizes.get("pr")
+            if not m or not p:
+                lines.append(f"| {key} | n/a | n/a | n/a |")
+                continue
+            lines.append(f"| {key} | {m['total']:,} | {p['total']:,} | {delta(m['total'], p['total'])} |")
+
+        lines += [
+            "", "<details><summary>Details</summary>", "",
+            "| Config | main text | main data | PR text | PR data | Delta |",
+            "|--------|----------:|----------:|--------:|--------:|------:|",
+        ]
+        for key, sizes in sorted(results.items()):
+            m, p = sizes.get("main"), sizes.get("pr")
+            if not m or not p:
+                lines.append(f"| {key} | n/a | n/a | n/a | n/a | n/a |")
+                continue
+            lines.append(
+                f"| {key} | {m['text']:,} | {m['data']:,} "
+                f"| {p['text']:,} | {p['data']:,} | {delta(m['total'], p['total'])} |"
+            )
+
+        lines += ["", "</details>"]
+
+        pathlib.Path("report.md").write_text("\n".join(lines) + "\n")
+        PY
+
+    - name: Post comment
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const body = fs.readFileSync('report.md', 'utf8');
+
+          // Resolve the PR number from workflow metadata, with a head
+          // owner/branch lookup fallback so fork PRs are handled too.
+          const workflowRun = context.payload.workflow_run;
+
+          // Return the PR number from workflow_run.pull_requests when it is uniquely present.
+          function extractPayloadPrNumber() {
+            const prs = Array.isArray(workflowRun.pull_requests) ? workflowRun.pull_requests : [];
+            const numbers = prs
+              .map(pr => Number(pr.number))
+              .filter(n => Number.isInteger(n) && n > 0);
+            return numbers.length === 1 ? numbers[0] : null;
+          }
+
+          // Look up the open PR number by matching the workflow run's head owner and branch.
+          async function lookupPrNumberByHeadBranch() {
+            const headOwner = workflowRun.head_repository?.owner?.login;
+            const headBranch = workflowRun.head_branch;
+
+            if (!headOwner || !headBranch) {
+              return null;
+            }
+
+            const response = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${headOwner}:${headBranch}`,
+              per_page: 10,
+            });
+
+            const prs = response.data;
+            if (prs.length === 1) return prs[0].number;
+            return null;
+          }
+
+          let prNumber = extractPayloadPrNumber();
+          if (!prNumber) {
+            prNumber = await lookupPrNumberByHeadBranch();
+          }
+
+          if (!Number.isInteger(prNumber) || prNumber <= 0) {
+            core.setFailed(
+              `Could not resolve a unique PR number for workflow run ${workflowRun.id} ` +
+              `(head=${workflowRun.head_repository?.full_name || 'unknown'}:${workflowRun.head_branch || 'unknown'})`
+            );
+            return;
+          }
+
+          await github.rest.issues.createComment({
+            issue_number: prNumber,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body
+          });


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflows to report binary size changes for `libthorvg-1.so.1.0.0` on every pull request.


## Workflow

### `binary_size.yml`

- Check out the pull request as merged into `main`.
- Resolve the current `main` baseline from `origin/main`.
- Build `libthorvg-1.so.1.0.0` from both revisions.
- Strip both binaries.
- Collect the raw `size` output as artifacts.

### `binary_size_comment.yml`

- Download the artifacts from the build workflow.
- Parse the raw `size` outputs and compute the delta.
- Render the markdown summary.
- Post the result as a pull request comment.
  - For pull requests from the same repository, resolve the PR number from workflow context metadata.
  - For pull requests from forks, fall back to resolving the PR by head repository owner and branch.

## Matrix

- x86_64 gcc / clang
- x86 gcc (32-bit)
- arm64 gcc / clang

## Notes

- the comparison reflects the final size impact if the PR were merged into the latest `main`
- the `workflow_run` pattern is used so pull request comments can still be posted for forked PRs
- a new comment is posted on every re-run
- example: 
    - https://github.com/Nor-s/sizecheck-action-test/pull/7
    - https://github.com/Nor-s/sizecheck-action-test/pull/8
    - https://github.com/Nor-s/sizecheck-action-test/pull/5
    - https://github.com/Nor-s/sizecheck-action-test/pull/16 

