### PR TITLE
wg_engine: share image textures across duplicated draws

### DIFF
--- a/src/renderer/gpu_engine/wg/meson.build
+++ b/src/renderer/gpu_engine/wg/meson.build
@@ -10,6 +10,7 @@ source_file = [
     'tvgWgRenderTask.h',
     'tvgWgShaderSrc.h',
     'tvgWgShaderTypes.h',
+    'tvgWgTextureMgr.h',
     'tvgWgTessellator.h',
     'tvgWgBindGroups.cpp',
     'tvgWgCommon.cpp',
@@ -22,6 +23,7 @@ source_file = [
     'tvgWgRenderTask.cpp',
     'tvgWgShaderSrc.cpp',
     'tvgWgShaderTypes.cpp',
+    'tvgWgTextureMgr.cpp',
     'tvgWgTessellator.cpp'
 ]
 

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
@@ -63,23 +63,22 @@ WGPUSampler WgContext::createSampler(WGPUFilterMode filter, WGPUMipmapFilterMode
     return wgpuDeviceCreateSampler(device, &samplerDesc);
 }
 
-
-bool WgContext::allocateTexture(WGPUTexture& texture, uint32_t width, uint32_t height, WGPUTextureFormat format, void* data)
+bool WgContext::allocateTexture(WGPUTexture& texture, uint32_t width, uint32_t height, WGPUTextureFormat format, const void* data, uint32_t bytesPerRow, uint64_t dataSize)
 {
-    if ((texture) && (wgpuTextureGetWidth(texture) == width) && (wgpuTextureGetHeight(texture) == height)) {
+    if ((texture) && (wgpuTextureGetWidth(texture) == width) && (wgpuTextureGetHeight(texture) == height) && (wgpuTextureGetFormat(texture) == format)) {
         // update texture data
         const WGPUTexelCopyTextureInfo copyTextureInfo{ .texture = texture };
-        const WGPUTexelCopyBufferLayout copyBufferLayout{ .bytesPerRow = 4 * width, .rowsPerImage = height };
+        const WGPUTexelCopyBufferLayout copyBufferLayout{.bytesPerRow = bytesPerRow, .rowsPerImage = height};
         const WGPUExtent3D writeSize{ .width = width, .height = height, .depthOrArrayLayers = 1 };
-        wgpuQueueWriteTexture(queue, &copyTextureInfo, data, 4 * width * height, &copyBufferLayout, &writeSize);
+        wgpuQueueWriteTexture(queue, &copyTextureInfo, data, dataSize, &copyBufferLayout, &writeSize);
     } else {
         releaseTexture(texture);
         texture = createTexture(width, height, format);
         // update texture data
         const WGPUTexelCopyTextureInfo copyTextureInfo{ .texture = texture };
-        const WGPUTexelCopyBufferLayout copyBufferLayout{ .bytesPerRow = 4 * width, .rowsPerImage = height };
+        const WGPUTexelCopyBufferLayout copyBufferLayout{.bytesPerRow = bytesPerRow, .rowsPerImage = height};
         const WGPUExtent3D writeSize{ .width = width, .height = height, .depthOrArrayLayers = 1 };
-        wgpuQueueWriteTexture(queue, &copyTextureInfo, data, 4 * width * height, &copyBufferLayout, &writeSize);
+        wgpuQueueWriteTexture(queue, &copyTextureInfo, data, dataSize, &copyBufferLayout, &writeSize);
         return true;
     }
     return false;

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.h
@@ -47,7 +47,7 @@ struct WgContext {
     WGPUTexture createTexStorage(uint32_t width, uint32_t height, WGPUTextureFormat format);
     WGPUTexture createTexAttachement(uint32_t width, uint32_t height, WGPUTextureFormat format, uint32_t sc);
     WGPUTextureView createTextureView(WGPUTexture texture);
-    bool allocateTexture(WGPUTexture& texture, uint32_t width, uint32_t height, WGPUTextureFormat format, void* data);
+    bool allocateTexture(WGPUTexture& texture, uint32_t width, uint32_t height, WGPUTextureFormat format, const void* data, uint32_t bytesPerRow, uint64_t dataSize);
 
     // release common objects
     void releaseTextureView(WGPUTextureView& textureView);

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -673,7 +673,7 @@ void WgCompositor::drawImage(WgContext& context, WgRenderDataPicture* renderData
 {
     assert(renderData);
     assert(renderPassEncoder);
-    if (renderData->viewport.invalid()) return;
+    if (renderData->viewport.invalid() || !renderData->imageBindGroup) return;
     WgRenderSettings& settings = renderData->renderSettings;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
     // draw stencil
@@ -685,7 +685,7 @@ void WgCompositor::drawImage(WgContext& context, WgRenderDataPicture* renderData
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderData->imageData.bindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderData->imageBindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image);
     drawMeshImage(context, &renderData->meshData);
 }
@@ -695,7 +695,7 @@ void WgCompositor::blendImage(WgContext& context, WgRenderDataPicture* renderDat
 {
     assert(renderData);
     assert(renderPassEncoder);
-    if (renderData->viewport.invalid()) return;
+    if (renderData->viewport.invalid() || !renderData->imageBindGroup) return;
     WgRenderSettings& settings = renderData->renderSettings;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
     // copy current render target data to dst target
@@ -713,7 +713,7 @@ void WgCompositor::blendImage(WgContext& context, WgRenderDataPicture* renderDat
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderData->imageData.bindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderData->imageBindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image_blend[blendMethodInd]);
     drawMeshImage(context, &renderData->meshData);
@@ -724,7 +724,7 @@ void WgCompositor::clipImage(WgContext& context, WgRenderDataPicture* renderData
 {
     assert(renderData);
     assert(renderPassEncoder);
-    if (renderData->viewport.invalid()) return;
+    if (renderData->viewport.invalid() || !renderData->imageBindGroup) return;
     WgRenderSettings& settings = renderData->renderSettings;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
     // setup stencil rules
@@ -741,7 +741,7 @@ void WgCompositor::clipImage(WgContext& context, WgRenderDataPicture* renderData
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderData->imageData.bindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderData->imageBindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image);
     drawMeshImage(context, &renderData->meshData);
 }

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -26,6 +26,7 @@
 #include "tvgCommon.h"
 #include "tvgWgTessellator.h"
 #include "tvgWgRenderData.h"
+#include "tvgWgTextureMgr.h"
 #include "tvgWgShaderTypes.h"
 
 //***********************************************************************
@@ -40,8 +41,10 @@ void WgImageData::update(WgContext& context, const RenderSurface* surface, Filte
         texFormat = WGPUTextureFormat_RGBA8Unorm;
     if (surface->cs == ColorSpace::Grayscale8)
         texFormat = WGPUTextureFormat_R8Unorm;
+    auto bytesPerRow = surface->stride * CHANNEL_SIZE(surface->cs);
+    auto dataSize = static_cast<uint64_t>(bytesPerRow) * surface->h;
     // allocate new texture handle
-    bool texHandleChanged = context.allocateTexture(texture, surface->w, surface->h, texFormat, surface->data);
+    bool texHandleChanged = context.allocateTexture(texture, surface->w, surface->h, texFormat, surface->data, bytesPerRow, dataSize);
     // update texture view of texture handle was changed
     if (texHandleChanged) {
         context.releaseTextureView(textureView);
@@ -60,7 +63,8 @@ void WgImageData::update(WgContext& context, const Fill* fill)
     WgShaderTypeGradientData gradientData;
     gradientData.update(fill);
     // allocate new texture handle
-    bool texHandleChanged = context.allocateTexture(texture, WG_TEXTURE_GRADIENT_SIZE, 1, WGPUTextureFormat_RGBA8Unorm, gradientData.data);
+    auto bytesPerRow = WG_TEXTURE_GRADIENT_SIZE * sizeof(uint32_t);
+    bool texHandleChanged = context.allocateTexture(texture, WG_TEXTURE_GRADIENT_SIZE, 1, WGPUTextureFormat_RGBA8Unorm, gradientData.data, bytesPerRow, bytesPerRow);
     // update texture view of texture handle was changed
     if (texHandleChanged) {
         context.releaseTextureView(textureView);
@@ -310,17 +314,39 @@ void WgRenderDataShapePool::release(WgContext& context)
 // WgRenderDataPicture
 //***********************************************************************
 
-void WgRenderDataPicture::updateSurface(WgContext& context, const RenderSurface* surface, const Matrix& transform, FilterMethod filter, bool updateTexture)
+void WgRenderDataPicture::updateSurface(const RenderSurface* surface, const Matrix& transform)
 {
     meshData.imageBox(surface->w, surface->h, transform);
-    if (updateTexture) imageData.update(context, surface, filter);
 }
 
+void WgRenderDataPicture::setImage(WGPUTexture texture, WGPUBindGroup bindGroup, const RenderSurface* surface, FilterMethod filter, uint16_t stamp)
+{
+    imageTexture = texture;
+    imageBindGroup = bindGroup;
+    imageSource = texture ? surface : nullptr;
+    imageFilter = filter;
+    imageStamp = texture ? stamp : 0;
+}
+
+void WgRenderDataPicture::releaseTexture(WgTextureMgr& textures, WgContext& context)
+{
+    if (imageTexture && imageStamp == textures.stamp) textures.release(context, imageSource, imageFilter, imageTexture);
+    clearImage();
+}
+
+void WgRenderDataPicture::clearImage()
+{
+    imageTexture = nullptr;
+    imageBindGroup = nullptr;
+    imageSource = nullptr;
+    imageFilter = FilterMethod::Bilinear;
+    imageStamp = 0;
+}
 
 void WgRenderDataPicture::release(WgContext& context)
 {
     renderSettings.release(context);
-    imageData.release(context);
+    clearImage();
     WgRenderDataPaint::release(context);
 }
 

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.h
@@ -27,6 +27,8 @@
 #include "tvgWgGeometry.h"
 #include "tvgWgShaderTypes.h"
 
+struct WgTextureMgr;
+
 struct WgImageData {
     WGPUTexture texture{};
     WGPUTextureView textureView{};
@@ -111,10 +113,17 @@ public:
 struct WgRenderDataPicture: public WgRenderDataPaint
 {
     WgRenderSettings renderSettings{};
-    WgImageData imageData{};
+    WGPUTexture imageTexture{};
+    WGPUBindGroup imageBindGroup{};
+    const RenderSurface* imageSource = nullptr;
+    FilterMethod imageFilter = FilterMethod::Bilinear;
+    uint16_t imageStamp = 0;
     WgMeshData meshData{};
 
-    void updateSurface(WgContext& context, const RenderSurface* surface, const Matrix& transform, FilterMethod filter, bool updateTexture);
+    void updateSurface(const RenderSurface* surface, const Matrix& transform);
+    void setImage(WGPUTexture texture, WGPUBindGroup bindGroup, const RenderSurface* surface, FilterMethod filter, uint16_t stamp);
+    void releaseTexture(WgTextureMgr& textures, WgContext& context);
+    void clearImage();
     void release(WgContext& context) override;
     Type type() override { return Type::Picture; };
 };

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -37,6 +37,7 @@ void WgRenderer::release()
     if (!mContext.queue) return;
 
     disposeObjects();
+    mTextures.clear(mContext);
 
     // clear render data paint pools
     mRenderDataShapePool.release(mContext);
@@ -67,7 +68,9 @@ void WgRenderer::disposeObjects()
         if (renderData->type() == Type::Shape) {
             mRenderDataShapePool.free(mContext, (WgRenderDataShape*)renderData);
         } else {
-            mRenderDataPicturePool.free(mContext, (WgRenderDataPicture*)renderData);
+            auto* renderDataPicture = (WgRenderDataPicture*)renderData;
+            renderDataPicture->releaseTexture(mTextures, mContext);
+            mRenderDataPicturePool.free(mContext, renderDataPicture);
         }
     }
     mDisposeRenderDatas.clear();
@@ -177,6 +180,12 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
 RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Matrix& transform, const Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags)
 {
     auto renderDataPicture = data ? (WgRenderDataPicture*)data : mRenderDataPicturePool.allocate(mContext);
+    auto cacheStale = renderDataPicture->imageTexture && (renderDataPicture->imageStamp != mTextures.stamp);
+    auto updateGeometry = !data || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path | RenderUpdateFlag::Image));
+    auto refreshTexture = ((flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Image)) != RenderUpdateFlag::None);
+    auto sourceChanged = (renderDataPicture->imageSource != surface);
+    auto filterChanged = (renderDataPicture->imageFilter != filter);
+    auto needsImage = !renderDataPicture->imageTexture || sourceChanged || filterChanged || refreshTexture || cacheStale;
 
     // update paint settings
     renderDataPicture->viewport = vport;
@@ -186,9 +195,13 @@ RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
     }
 
     // update image data
-    if (!data || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path | RenderUpdateFlag::Image))) {
-        auto updateTexture = !data || ((flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Image)) != RenderUpdateFlag::None);
-        renderDataPicture->updateSurface(mContext, surface, transform, filter, updateTexture);
+    if (updateGeometry) {
+        renderDataPicture->updateSurface(surface, transform);
+    }
+    if (needsImage) {
+        renderDataPicture->releaseTexture(mTextures, mContext);
+        auto* entry = mTextures.retain(mContext, surface, filter, refreshTexture);
+        renderDataPicture->setImage(entry->texture, entry->bindGroup, surface, filter, mTextures.stamp);
     }
 
     if (flags & RenderUpdateFlag::Clip) renderDataPicture->updateClips(clips);

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -24,6 +24,7 @@
 #define _TVG_WG_RENDERER_H_
 
 #include "tvgWgRenderTask.h"
+#include "tvgWgTextureMgr.h"
 
 struct WgRenderer : RenderMethod
 {
@@ -89,6 +90,7 @@ private:
     WgRenderDataShapePool mRenderDataShapePool;
     WgRenderDataPicturePool mRenderDataPicturePool;
     WgRenderDataEffectParamsPool mRenderDataEffectParamsPool;
+    WgTextureMgr mTextures;
 
     // rendering context
     WgContext mContext;

--- a/src/renderer/gpu_engine/wg/tvgWgTextureMgr.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgTextureMgr.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgTextureMgr.h"
+
+static tvg::Inlist<WgTextureEntry>& _entries(WgTextureMgr::SurfaceEntry& surfaceEntry, FilterMethod filter)
+{
+    return (filter == FilterMethod::Bilinear) ? surfaceEntry.bilinear : surfaceEntry.nearest;
+}
+
+static WgTextureEntry* _findEntry(tvg::Inlist<WgTextureEntry>& entries, WGPUTexture texture)
+{
+    INLIST_FOREACH(entries, entry)
+    {
+        if (entry->texture == texture) return entry;
+    }
+    return nullptr;
+}
+
+static bool _matches(const WgTextureEntry& entry, const RenderSurface* surface, WGPUTextureFormat format)
+{
+    return entry.texture && (wgpuTextureGetWidth(entry.texture) == surface->w) && (wgpuTextureGetHeight(entry.texture) == surface->h) && (wgpuTextureGetFormat(entry.texture) == format);
+}
+
+WgTextureMgr::SurfaceEntry* WgTextureMgr::find(const RenderSurface* surface)
+{
+    INLIST_FOREACH(surfaces, entry)
+    {
+        if (entry->surface == surface) return entry;
+    }
+    return nullptr;
+}
+
+WGPUTextureFormat WgTextureMgr::textureFormat(const RenderSurface* surface)
+{
+    if (surface->cs == ColorSpace::ABGR8888S) return WGPUTextureFormat_RGBA8Unorm;
+    if (surface->cs == ColorSpace::Grayscale8) return WGPUTextureFormat_R8Unorm;
+    return WGPUTextureFormat_BGRA8Unorm;
+}
+
+void WgTextureMgr::upload(WgContext& context, WgTextureEntry& entry, const RenderSurface* surface, FilterMethod filter)
+{
+    auto bytesPerRow = surface->stride * CHANNEL_SIZE(surface->cs);
+    auto dataSize = static_cast<uint64_t>(bytesPerRow) * surface->h;
+    auto texHandleChanged = context.allocateTexture(entry.texture, surface->w, surface->h, textureFormat(surface), surface->data, bytesPerRow, dataSize);
+    if (!texHandleChanged) return;
+
+    context.releaseTextureView(entry.textureView);
+    entry.textureView = context.createTextureView(entry.texture);
+
+    context.layouts.releaseBindGroup(entry.bindGroup);
+    auto sampler = (filter == FilterMethod::Bilinear) ? context.samplerLinearClamp : context.samplerNearestClamp;
+    entry.bindGroup = context.layouts.createBindGroupTexSampled(sampler, entry.textureView);
+}
+
+void WgTextureMgr::releaseEntry(WgContext& context, WgTextureEntry& entry)
+{
+    context.layouts.releaseBindGroup(entry.bindGroup);
+    context.releaseTextureView(entry.textureView);
+    context.releaseTexture(entry.texture);
+    entry.refCnt = 0;
+}
+
+const WgTextureEntry* WgTextureMgr::retain(WgContext& context, const RenderSurface* surface, FilterMethod filter, bool refreshTexture)
+{
+    auto* surfaceEntry = find(surface);
+    if (!surfaceEntry) {
+        surfaceEntry = new SurfaceEntry;
+        surfaceEntry->surface = surface;
+        surfaces.back(surfaceEntry);
+    }
+
+    auto& entries = _entries(*surfaceEntry, filter);
+    auto* entry = entries.tail;
+    auto format = textureFormat(surface);
+    if (entry && refreshTexture && !_matches(*entry, surface, format) && entry->refCnt > 0) {
+        entry = new WgTextureEntry;
+        entries.back(entry);
+    } else if (!entry) {
+        entry = new WgTextureEntry;
+        entries.back(entry);
+    }
+    if (!entry->texture || refreshTexture) upload(context, *entry, surface, filter);
+
+    ++entry->refCnt;
+    return entry;
+}
+
+void WgTextureMgr::release(WgContext& context, const RenderSurface* surface, FilterMethod filter, WGPUTexture texture)
+{
+    auto* surfaceEntry = find(surface);
+    if (!surfaceEntry) return;
+
+    auto& entries = _entries(*surfaceEntry, filter);
+    auto* entry = _findEntry(entries, texture);
+    if (!entry) return;
+
+    if (entry->refCnt > 0) --entry->refCnt;
+    if (entry->refCnt > 0) return;
+
+    releaseEntry(context, *entry);
+    entries.remove(entry);
+    delete (entry);
+    if (surfaceEntry->bilinear.empty() && surfaceEntry->nearest.empty()) {
+        surfaces.remove(surfaceEntry);
+        delete (surfaceEntry);
+    }
+}
+
+void WgTextureMgr::clear(WgContext& context)
+{
+    while (auto* surfaceEntry = surfaces.front()) {
+        while (auto* entry = surfaceEntry->bilinear.front()) {
+            releaseEntry(context, *entry);
+            delete (entry);
+        }
+        while (auto* entry = surfaceEntry->nearest.front()) {
+            releaseEntry(context, *entry);
+            delete (entry);
+        }
+        delete (surfaceEntry);
+    }
+    if (++stamp == 0) stamp = 1;
+}

--- a/src/renderer/gpu_engine/wg/tvgWgTextureMgr.h
+++ b/src/renderer/gpu_engine/wg/tvgWgTextureMgr.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_TEXTURE_MGR_H_
+#define _TVG_WG_TEXTURE_MGR_H_
+
+#include "tvgWgCommon.h"
+#include "tvgInlist.h"
+
+struct WgTextureEntry
+{
+    INLIST_ITEM(WgTextureEntry);
+    WGPUTexture texture{};
+    WGPUTextureView textureView{};
+    WGPUBindGroup bindGroup{};
+    uint32_t refCnt = 0;
+};
+
+struct WgTextureMgr
+{
+    const WgTextureEntry* retain(WgContext& context, const RenderSurface* surface, FilterMethod filter, bool refreshTexture);
+    void release(WgContext& context, const RenderSurface* surface, FilterMethod filter, WGPUTexture texture);
+    void clear(WgContext& context);
+
+    struct SurfaceEntry
+    {
+        INLIST_ITEM(SurfaceEntry);
+        const RenderSurface* surface = nullptr;
+        tvg::Inlist<WgTextureEntry> bilinear;
+        tvg::Inlist<WgTextureEntry> nearest;
+    };
+
+    SurfaceEntry* find(const RenderSurface* surface);
+    static void upload(WgContext& context, WgTextureEntry& entry, const RenderSurface* surface, FilterMethod filter);
+    static void releaseEntry(WgContext& context, WgTextureEntry& entry);
+    static WGPUTextureFormat textureFormat(const RenderSurface* surface);
+
+    tvg::Inlist<SurfaceEntry> surfaces;
+    uint16_t stamp = 1;
+};
+
+#endif /* _TVG_WG_TEXTURE_MGR_H_ */


### PR DESCRIPTION
### Summary
Cache WebGPU bitmap textures per (RenderSurface*, FilterMethod) so duplicated pictures reuse a single upload instead of allocating one texture per WgRenderDataPicture.

Move bitmap texture ownership out of WgRenderDataPicture and into a renderer-level texture manager. Picture render data now keeps only borrowed texture metadata, refreshes cache refs when the source, filter, or image/path state changes, and releases refs when deferred disposals run or the WG context is recreated.

Keep gradient textures on the existing per-object path, avoid redundant bitmap reuploads on transform/opacity/clip-only updates, and switch the WG compositor image passes to bind the cached image bind group.

### Changes
2.47x FPS improvement in the example: `ManyImages` on the machine with 5080.
1.68x FPS improvement in the example: `ManyImages` on the Mac M1.
No FPS regression in the example: `Lottie`.
+928 bytes

### Validation
No observable regression during execution of all.sh in the thorvg.example
