### PR TITLE
sw_engine: align special blend helpers with raster-local formulas

### DIFF
--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -26,7 +26,6 @@
 #include <algorithm>
 #include "tvgCommon.h"
 #include "tvgMath.h"
-#include "tvgColor.h"
 #include "tvgRender.h"
 
 #define SW_CURVE_TYPE_POINT 0
@@ -599,73 +598,130 @@ static inline uint32_t opBlendHardLight(uint32_t s, uint32_t d)
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
 
+static inline float LUM(float r, float g, float b)
+{
+    return ((0.3f * r) + (0.59f * g) + (0.11f * b));
+}
+
+static inline void CLIP_COLOR(float& r, float& g, float& b)
+{
+    auto l = LUM(r, g, b);
+    auto n = std::min(r, std::min(g, b));
+    auto x = std::max(r, std::max(g, b));
+
+    if (n < 0.0f) {
+        r = l + (((r - l) * l) / (l - n));
+        g = l + (((g - l) * l) / (l - n));
+        b = l + (((b - l) * l) / (l - n));
+    }
+
+    if (x > 1.0f) {
+        r = l + (((r - l) * (1.0f - l)) / (x - l));
+        g = l + (((g - l) * (1.0f - l)) / (x - l));
+        b = l + (((b - l) * (1.0f - l)) / (x - l));
+    }
+}
+
+static inline void SET_LUM(float& r, float& g, float& b, float l)
+{
+    auto d = l - LUM(r, g, b);
+    r += d;
+    g += d;
+    b += d;
+    CLIP_COLOR(r, g, b);
+}
+
+static inline float SAT(float r, float g, float b)
+{
+    return (std::max(r, std::max(g, b)) - std::min(r, std::min(g, b)));
+}
+
+static inline float NORM8(uint8_t c)
+{
+    return c * (1.0f / 255.0f);  //mul reciprocal: cheaper than scalar fdiv in blend hot path
+}
+
+static inline void SET_SAT(float& r, float& g, float& b, float s)
+{
+    float *min, *mid, *max;
+
+    if (r <= g) {
+        if (g <= b) min = &r, mid = &g, max = &b;
+        else if (r <= b) min = &r, mid = &b, max = &g;
+        else min = &b, mid = &r, max = &g;
+    } else {
+        if (r <= b) min = &g, mid = &r, max = &b;
+        else if (g <= b) min = &g, mid = &b, max = &r;
+        else min = &b, mid = &g, max = &r;
+    }
+
+    if (*max > *min) {
+        *mid = ((*mid - *min) * s) / (*max - *min);
+        *max = s;
+    } else *mid = *max = 0.0f;
+    *min = 0.0f;
+}
+
 static inline uint32_t opBlendSoftLight(uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
     auto f = [](uint8_t s, uint8_t d) {
-        return MULTIPLY(255 - std::min(255, 2 * s), MULTIPLY(d, d)) + std::min(255, 2 * MULTIPLY(s, d));
+        auto src = NORM8(s);
+        auto dst = NORM8(d);
+
+        if (src <= 0.5f) return (uint8_t)nearbyint((dst - (1.0f - 2.0f * src) * dst * (1.0f - dst)) * 255.0f);
+
+        auto base = (dst <= 0.25f) ? (((16.0f * dst - 12.0f) * dst + 4.0f) * dst) : sqrtf(dst);
+        return (uint8_t)nearbyint((dst + (2.0f * src - 1.0f) * (base - dst)) * 255.0f);
     };
 
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
 
-void rasterRGB2HSL(uint8_t r, uint8_t g, uint8_t b, float* h, float* s, float* l);
-
 static inline uint32_t opBlendHue(uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
-    float sh, ds, dl;
-    rasterRGB2HSL(C1(s), C2(s), C3(s), &sh, 0, 0);
-    rasterRGB2HSL(o.r, o.g, o.b, 0, &ds, &dl);
+    auto r = NORM8(C1(s)), g = NORM8(C2(s)), b = NORM8(C3(s));
+    auto dr = NORM8(o.r), dg = NORM8(o.g), db = NORM8(o.b);
+    SET_SAT(r, g, b, SAT(dr, dg, db));
+    SET_LUM(r, g, b, LUM(dr, dg, db));
 
-    uint8_t r, g, b;
-    hsl2rgb(sh, ds, dl, r, g, b);
-
-    return BLEND_PRE(JOIN(255, r, g, b), s, o.a);
+    return BLEND_PRE(JOIN(255, (uint8_t)nearbyint(r * 255.0f), (uint8_t)nearbyint(g * 255.0f), (uint8_t)nearbyint(b * 255.0f)), s, o.a);
 }
 
 static inline uint32_t opBlendSaturation(uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
-    float dh, ss, dl;
-    rasterRGB2HSL(C1(s), C2(s), C3(s), 0, &ss, 0);
-    rasterRGB2HSL(o.r, o.g, o.b, &dh, 0, &dl);
+    auto r = NORM8(o.r), g = NORM8(o.g), b = NORM8(o.b);
+    auto l = LUM(r, g, b);
+    SET_SAT(r, g, b, SAT(NORM8(C1(s)), NORM8(C2(s)), NORM8(C3(s))));
+    SET_LUM(r, g, b, l);
 
-    uint8_t r, g, b;
-    hsl2rgb(dh, ss, dl, r, g, b);
-
-    return BLEND_PRE(JOIN(255, r, g, b), s, o.a);
+    return BLEND_PRE(JOIN(255, (uint8_t)nearbyint(r * 255.0f), (uint8_t)nearbyint(g * 255.0f), (uint8_t)nearbyint(b * 255.0f)), s, o.a);
 }
 
 static inline uint32_t opBlendColor(uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
-    float sh, ss, dl;
-    rasterRGB2HSL(C1(s), C2(s), C3(s), &sh, &ss, 0);
-    rasterRGB2HSL(o.r, o.g, o.b, 0, 0, &dl);
+    auto r = NORM8(C1(s)), g = NORM8(C2(s)), b = NORM8(C3(s));
+    auto dr = NORM8(o.r), dg = NORM8(o.g), db = NORM8(o.b);
+    SET_LUM(r, g, b, LUM(dr, dg, db));
 
-    uint8_t r, g, b;
-    hsl2rgb(sh, ss, dl, r, g, b);
-
-    return BLEND_PRE(JOIN(255, r, g, b), s, o.a);
+    return BLEND_PRE(JOIN(255, (uint8_t)nearbyint(r * 255.0f), (uint8_t)nearbyint(g * 255.0f), (uint8_t)nearbyint(b * 255.0f)), s, o.a);
 }
 
 static inline uint32_t opBlendLuminosity(uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
-    float dh, ds, sl;
-    rasterRGB2HSL(C1(s), C2(s), C3(s), 0, 0, &sl);
-    rasterRGB2HSL(o.r, o.g, o.b, &dh, &ds, 0);
+    auto r = NORM8(o.r), g = NORM8(o.g), b = NORM8(o.b);
+    SET_LUM(r, g, b, LUM(NORM8(C1(s)), NORM8(C2(s)), NORM8(C3(s))));
 
-    uint8_t r, g, b;
-    hsl2rgb(dh, ds, sl, r, g, b);
-
-    return BLEND_PRE(JOIN(255, r, g, b), s, o.a);
+    return BLEND_PRE(JOIN(255, (uint8_t)nearbyint(r * 255.0f), (uint8_t)nearbyint(g * 255.0f), (uint8_t)nearbyint(b * 255.0f)), s, o.a);
 }
 
 int64_t mathMultiply(int64_t a, int64_t b);

--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -26,7 +26,6 @@
 #include <algorithm>
 #include "tvgCommon.h"
 #include "tvgMath.h"
-#include "tvgColor.h"
 #include "tvgRender.h"
 
 #define SW_CURVE_TYPE_POINT 0
@@ -278,17 +277,20 @@ struct SwImage
     bool         scaled = false;  //draw scaled image
 };
 
-typedef uint8_t(*SwMask)(uint8_t s, uint8_t d, uint8_t a);                  //src, dst, alpha
-typedef uint32_t(*SwBlender)(uint32_t s, uint32_t d);                       //src, dst
-typedef uint32_t(*SwBlenderA)(uint32_t s, uint32_t d, uint8_t a);           //src, dst, alpha
-typedef uint32_t(*SwJoin)(uint8_t r, uint8_t g, uint8_t b, uint8_t a);      //color channel join
-typedef uint8_t(*SwAlpha)(uint8_t*);                                        //blending alpha
-
+struct SwSurface;
 struct SwCompositor;
+
+typedef uint8_t(*SwMask)(uint8_t s, uint8_t d, uint8_t a);                            //src, dst, alpha
+typedef uint32_t (*SwBlender)(const SwSurface* surface, uint32_t s, uint32_t d);      // surface, src, dst
+typedef uint32_t(*SwBlenderA)(uint32_t s, uint32_t d, uint8_t a);                     //src, dst, alpha
+typedef uint32_t(*SwJoin)(uint8_t r, uint8_t g, uint8_t b, uint8_t a);                //color channel join
+typedef void (*SwSplit)(uint32_t c, uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a);  // color channel split
+typedef uint8_t(*SwAlpha)(uint8_t*);                                                  //blending alpha
 
 struct SwSurface : RenderSurface
 {
     SwJoin  join;
+    SwSplit split;
     SwAlpha alphas[4];                    //Alpha:2, InvAlpha:3, Luma:4, InvLuma:5
     SwBlender blender = nullptr;          //blender (optional)
     SwCompositor* compositor = nullptr;   //compositor (optional)
@@ -307,6 +309,7 @@ struct SwSurface : RenderSurface
     SwSurface(const SwSurface* rhs) : RenderSurface(rhs)
     {
         join = rhs->join;
+        split = rhs->split;
         memcpy(alphas, rhs->alphas, sizeof(alphas));
         blender = rhs->blender;
         compositor = rhs->compositor;
@@ -467,6 +470,87 @@ static inline uint32_t BLEND_PRE(uint32_t c1, uint32_t c2, uint8_t a)
     return ALPHA_BLEND(c1, a) + ALPHA_BLEND(c2, 255 - a);
 }
 
+static inline int32_t LUM(int32_t r, int32_t g, int32_t b)
+{
+    return ((77 * r) + (151 * g) + (28 * b)) / 256;
+}
+
+static inline int32_t SAT(int32_t r, int32_t g, int32_t b)
+{
+    return (std::max(r, std::max(g, b)) - std::min(r, std::min(g, b)));
+}
+
+static inline uint8_t CLAMP8(int32_t c)
+{
+    return static_cast<uint8_t>(tvg::clamp(c, 0, 255));
+}
+
+static inline void UNPREMULTIPLY(int32_t& r, int32_t& g, int32_t& b, uint8_t a)
+{
+    if (a > 0 && a < 255) {
+        auto ia = ((255u << 16) + a - 1) / a;
+        auto rb = (((uint64_t)b << 32) | uint32_t(r)) * ia;
+        r = std::min<uint32_t>(uint32_t((rb >> 16) & 0xffff), 255u);
+        g = std::min<uint32_t>((uint32_t(g) * ia) >> 16, 255u);
+        b = std::min<uint32_t>(uint32_t(rb >> 48), 255u);
+    }
+}
+
+static inline void CLIP_COLOR(int32_t& r, int32_t& g, int32_t& b)
+{
+    auto n = std::min(r, std::min(g, b));
+    auto x = std::max(r, std::max(g, b));
+
+    if (n >= 0 && x <= 255) return;
+
+    auto l = LUM(r, g, b);
+
+    if (n < 0) {
+        auto denom = l - n;
+        r = l + (((r - l) * l) / denom);
+        g = l + (((g - l) * l) / denom);
+        b = l + (((b - l) * l) / denom);
+    }
+
+    if (x > 255) {
+        auto scale = 255 - l;
+        auto denom = x - l;
+        r = l + (((r - l) * scale) / denom);
+        g = l + (((g - l) * scale) / denom);
+        b = l + (((b - l) * scale) / denom);
+    }
+}
+
+static inline void SET_LUM(int32_t& r, int32_t& g, int32_t& b, int32_t l)
+{
+    auto d = l - LUM(r, g, b);
+    r += d;
+    g += d;
+    b += d;
+    CLIP_COLOR(r, g, b);
+}
+
+static inline void SET_SAT(int32_t& r, int32_t& g, int32_t& b, int32_t s)
+{
+    int32_t *min, *mid, *max;
+
+    if (r <= g) {
+        if (g <= b) min = &r, mid = &g, max = &b;
+        else if (r <= b) min = &r, mid = &b, max = &g;
+        else min = &b, mid = &r, max = &g;
+    } else {
+        if (r <= b) min = &g, mid = &r, max = &b;
+        else if (g <= b) min = &g, mid = &b, max = &r;
+        else min = &b, mid = &g, max = &r;
+    }
+
+    if (*max > *min) {
+        *mid = ((*mid - *min) * s) / (*max - *min);
+        *max = s;
+    } else *mid = *max = 0;
+    *min = 0;
+}
+
 static inline uint32_t opBlendInterp(uint32_t s, uint32_t d, uint8_t a)
 {
     return INTERPOLATE(s, d, a);
@@ -488,7 +572,7 @@ static inline uint32_t opBlendSrcOver(uint32_t s, TVG_UNUSED uint32_t d, TVG_UNU
     return s;
 }
 
-static inline uint32_t opBlendDifference(uint32_t s, uint32_t d)
+static inline uint32_t opBlendDifference(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto f = [](uint8_t s, uint8_t d) {
         return (s > d) ? (s - d) : (d - s);
@@ -497,7 +581,7 @@ static inline uint32_t opBlendDifference(uint32_t s, uint32_t d)
     return JOIN(255, f(C1(s), C1(d)), f(C2(s), C2(d)), f(C3(s), C3(d)));
 }
 
-static inline uint32_t opBlendExclusion(uint32_t s, uint32_t d)
+static inline uint32_t opBlendExclusion(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto f = [](uint8_t s, uint8_t d) {
         return tvg::clamp(s + d - 2 * MULTIPLY(s, d), 0, 255);
@@ -506,7 +590,7 @@ static inline uint32_t opBlendExclusion(uint32_t s, uint32_t d)
     return JOIN(255, f(C1(s), C1(d)), f(C2(s), C2(d)), f(C3(s), C3(d)));
 }
 
-static inline uint32_t opBlendAdd(uint32_t s, uint32_t d)
+static inline uint32_t opBlendAdd(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto f = [](uint8_t s, uint8_t d) {
         return std::min(s + d, 255);
@@ -515,7 +599,7 @@ static inline uint32_t opBlendAdd(uint32_t s, uint32_t d)
     return JOIN(255, f(C1(s), C1(d)), f(C2(s), C2(d)), f(C3(s), C3(d)));
 }
 
-static inline uint32_t opBlendScreen(uint32_t s, uint32_t d)
+static inline uint32_t opBlendScreen(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto f = [](uint8_t s, uint8_t d) {
         return s + d - MULTIPLY(s, d);
@@ -524,7 +608,7 @@ static inline uint32_t opBlendScreen(uint32_t s, uint32_t d)
     return JOIN(255, f(C1(s), C1(d)), f(C2(s), C2(d)), f(C3(s), C3(d)));
 }
 
-static inline uint32_t opBlendMultiply(uint32_t s, uint32_t d)
+static inline uint32_t opBlendMultiply(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
@@ -535,7 +619,7 @@ static inline uint32_t opBlendMultiply(uint32_t s, uint32_t d)
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
 
-static inline uint32_t opBlendOverlay(uint32_t s, uint32_t d)
+static inline uint32_t opBlendOverlay(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
@@ -546,7 +630,7 @@ static inline uint32_t opBlendOverlay(uint32_t s, uint32_t d)
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
 
-static inline uint32_t opBlendDarken(uint32_t s, uint32_t d)
+static inline uint32_t opBlendDarken(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
@@ -557,7 +641,7 @@ static inline uint32_t opBlendDarken(uint32_t s, uint32_t d)
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
 
-static inline uint32_t opBlendLighten(uint32_t s, uint32_t d)
+static inline uint32_t opBlendLighten(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto f = [](uint8_t s, uint8_t d) {
         return std::max(s, d);
@@ -566,7 +650,7 @@ static inline uint32_t opBlendLighten(uint32_t s, uint32_t d)
     return JOIN(255, f(C1(s), C1(d)), f(C2(s), C2(d)), f(C3(s), C3(d)));
 }
 
-static inline uint32_t opBlendColorDodge(uint32_t s, uint32_t d)
+static inline uint32_t opBlendColorDodge(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
@@ -577,7 +661,7 @@ static inline uint32_t opBlendColorDodge(uint32_t s, uint32_t d)
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
 
-static inline uint32_t opBlendColorBurn(uint32_t s, uint32_t d)
+static inline uint32_t opBlendColorBurn(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
@@ -588,7 +672,7 @@ static inline uint32_t opBlendColorBurn(uint32_t s, uint32_t d)
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
 
-static inline uint32_t opBlendHardLight(uint32_t s, uint32_t d)
+static inline uint32_t opBlendHardLight(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
 
@@ -599,73 +683,93 @@ static inline uint32_t opBlendHardLight(uint32_t s, uint32_t d)
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
 
-static inline uint32_t opBlendSoftLight(uint32_t s, uint32_t d)
+static inline uint32_t opBlendSoftLight(TVG_UNUSED const SwSurface* surface, uint32_t s, uint32_t d)
 {
     auto o = BLEND_UPRE(d);
+    // LUT optimization for soft-light blend is also used by jQuery Canvas Effects:
+    // https://0.s3.envato.com/files/26317668/index.html
+    static constexpr uint16_t dc[256] = {
+        0, 1012, 2000, 2965, 3907, 4827, 5724, 6599, 7453, 8286, 9098, 9890, 10662, 11414, 12148, 12862,
+        13558, 14236, 14896, 15539, 16165, 16775, 17368, 17946, 18508, 19055, 19587, 20106, 20610, 21101, 21578, 22043,
+        22496, 22936, 23365, 23783, 24190, 24586, 24972, 25349, 25716, 26074, 26424, 26765, 27099, 27425, 27744, 28056,
+        28362, 28662, 28956, 29245, 29530, 29810, 30086, 30358, 30627, 30893, 31156, 31417, 31677, 31935, 32192, 32448,
+        32704, 32958, 33211, 33462, 33710, 33957, 34203, 34446, 34688, 34928, 35166, 35403, 35638, 35872, 36104, 36335,
+        36564, 36792, 37018, 37243, 37467, 37689, 37910, 38130, 38349, 38566, 38782, 38997, 39211, 39423, 39635, 39845,
+        40054, 40262, 40469, 40675, 40880, 41084, 41287, 41489, 41690, 41889, 42088, 42287, 42484, 42680, 42875, 43070,
+        43263, 43456, 43648, 43839, 44029, 44218, 44407, 44595, 44782, 44968, 45153, 45338, 45522, 45705, 45888, 46069,
+        46250, 46431, 46610, 46789, 46967, 47145, 47322, 47498, 47674, 47849, 48023, 48197, 48370, 48542, 48714, 48885,
+        49056, 49226, 49395, 49564, 49733, 49900, 50067, 50234, 50400, 50566, 50731, 50895, 51059, 51222, 51385, 51548,
+        51709, 51871, 52032, 52192, 52352, 52511, 52670, 52829, 52986, 53144, 53301, 53457, 53614, 53769, 53924, 54079,
+        54233, 54387, 54541, 54694, 54846, 54998, 55150, 55301, 55452, 55603, 55753, 55902, 56052, 56201, 56349, 56497,
+        56645, 56792, 56939, 57086, 57232, 57378, 57523, 57668, 57813, 57957, 58101, 58245, 58388, 58531, 58674, 58816,
+        58958, 59099, 59241, 59382, 59522, 59662, 59802, 59942, 60081, 60220, 60358, 60497, 60635, 60772, 60910, 61047,
+        61183, 61320, 61456, 61592, 61727, 61863, 61997, 62132, 62266, 62400, 62534, 62668, 62801, 62934, 63066, 63199,
+        63331, 63463, 63594, 63725, 63856, 63987, 64118, 64248, 64378, 64507, 64637, 64766, 64895, 65023, 65152, 65280
+    };
 
-    auto f = [](uint8_t s, uint8_t d) {
-        return MULTIPLY(255 - std::min(255, 2 * s), MULTIPLY(d, d)) + std::min(255, 2 * MULTIPLY(s, d));
+    auto f = [&](uint8_t s, uint8_t d) {
+        if (s < 128) return d - (((255 - 2 * s) * d * (255 - d) + 32512) / 65025);
+        return d + (((2 * s - 255) * (dc[d] - d * 256) + 32640) / 65280);
     };
 
     return BLEND_PRE(JOIN(255, f(C1(s), o.r), f(C2(s), o.g), f(C3(s), o.b)), s, o.a);
 }
 
-void rasterRGB2HSL(uint8_t r, uint8_t g, uint8_t b, float* h, float* s, float* l);
-
-static inline uint32_t opBlendHue(uint32_t s, uint32_t d)
+static inline uint32_t opBlendHue(const SwSurface* surface, uint32_t s, uint32_t d)
 {
-    auto o = BLEND_UPRE(d);
+    uint8_t sr, sg, sb, dr, dg, db, a;
+    surface->split(s, sr, sg, sb, a);
+    surface->split(d, dr, dg, db, a);
 
-    float sh, ds, dl;
-    rasterRGB2HSL(C1(s), C2(s), C3(s), &sh, 0, 0);
-    rasterRGB2HSL(o.r, o.g, o.b, 0, &ds, &dl);
+    int32_t r = sr, g = sg, b = sb;
+    int32_t lr = dr, lg = dg, lb = db;
+    UNPREMULTIPLY(lr, lg, lb, a);
+    SET_SAT(r, g, b, SAT(lr, lg, lb));
+    SET_LUM(r, g, b, LUM(lr, lg, lb));
 
-    uint8_t r, g, b;
-    hsl2rgb(sh, ds, dl, r, g, b);
-
-    return BLEND_PRE(JOIN(255, r, g, b), s, o.a);
+    return BLEND_PRE(surface->join(CLAMP8(r), CLAMP8(g), CLAMP8(b), 255), s, a);
 }
 
-static inline uint32_t opBlendSaturation(uint32_t s, uint32_t d)
+static inline uint32_t opBlendSaturation(const SwSurface* surface, uint32_t s, uint32_t d)
 {
-    auto o = BLEND_UPRE(d);
+    uint8_t sr, sg, sb, dr, dg, db, a;
+    surface->split(s, sr, sg, sb, a);
+    surface->split(d, dr, dg, db, a);
 
-    float dh, ss, dl;
-    rasterRGB2HSL(C1(s), C2(s), C3(s), 0, &ss, 0);
-    rasterRGB2HSL(o.r, o.g, o.b, &dh, 0, &dl);
+    int32_t r = dr, g = dg, b = db;
+    UNPREMULTIPLY(r, g, b, a);
+    auto l = LUM(r, g, b);
+    SET_SAT(r, g, b, SAT(sr, sg, sb));
+    SET_LUM(r, g, b, l);
 
-    uint8_t r, g, b;
-    hsl2rgb(dh, ss, dl, r, g, b);
-
-    return BLEND_PRE(JOIN(255, r, g, b), s, o.a);
+    return BLEND_PRE(surface->join(CLAMP8(r), CLAMP8(g), CLAMP8(b), 255), s, a);
 }
 
-static inline uint32_t opBlendColor(uint32_t s, uint32_t d)
+static inline uint32_t opBlendColor(const SwSurface* surface, uint32_t s, uint32_t d)
 {
-    auto o = BLEND_UPRE(d);
+    uint8_t sr, sg, sb, dr, dg, db, a;
+    surface->split(s, sr, sg, sb, a);
+    surface->split(d, dr, dg, db, a);
 
-    float sh, ss, dl;
-    rasterRGB2HSL(C1(s), C2(s), C3(s), &sh, &ss, 0);
-    rasterRGB2HSL(o.r, o.g, o.b, 0, 0, &dl);
+    int32_t r = sr, g = sg, b = sb;
+    int32_t lr = dr, lg = dg, lb = db;
+    UNPREMULTIPLY(lr, lg, lb, a);
+    SET_LUM(r, g, b, LUM(lr, lg, lb));
 
-    uint8_t r, g, b;
-    hsl2rgb(sh, ss, dl, r, g, b);
-
-    return BLEND_PRE(JOIN(255, r, g, b), s, o.a);
+    return BLEND_PRE(surface->join(CLAMP8(r), CLAMP8(g), CLAMP8(b), 255), s, a);
 }
 
-static inline uint32_t opBlendLuminosity(uint32_t s, uint32_t d)
+static inline uint32_t opBlendLuminosity(const SwSurface* surface, uint32_t s, uint32_t d)
 {
-    auto o = BLEND_UPRE(d);
+    uint8_t sr, sg, sb, dr, dg, db, a;
+    surface->split(s, sr, sg, sb, a);
+    surface->split(d, dr, dg, db, a);
 
-    float dh, ds, sl;
-    rasterRGB2HSL(C1(s), C2(s), C3(s), 0, 0, &sl);
-    rasterRGB2HSL(o.r, o.g, o.b, &dh, &ds, 0);
+    int32_t r = dr, g = dg, b = db;
+    UNPREMULTIPLY(r, g, b, a);
+    SET_LUM(r, g, b, LUM(sr, sg, sb));
 
-    uint8_t r, g, b;
-    hsl2rgb(dh, ds, sl, r, g, b);
-
-    return BLEND_PRE(JOIN(255, r, g, b), s, o.a);
+    return BLEND_PRE(surface->join(CLAMP8(r), CLAMP8(g), CLAMP8(b), 255), s, a);
 }
 
 int64_t mathMultiply(int64_t a, int64_t b);
@@ -720,13 +824,13 @@ void fillFree(SwFill* fill);
 void fillLinear(const SwFill* fill, uint8_t* dst, uint32_t y, uint32_t x, uint32_t len, SwMask maskOp, uint8_t opacity);                                   //composite masking ver.
 void fillLinear(const SwFill* fill, uint8_t* dst, uint32_t y, uint32_t x, uint32_t len, uint8_t* cmp, SwMask maskOp, uint8_t opacity);                     //direct masking ver.
 void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, uint8_t a);                                        //blending ver.
-void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, uint8_t a);                         //blending + BlendingMethod(op2) ver.
+void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, const SwSurface* surface, uint8_t a);  // blending + BlendingMethod(op2) ver.
 void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, uint8_t* cmp, SwAlpha alpha, uint8_t csize, uint8_t opacity);     //matting ver.
 
 void fillRadial(const SwFill* fill, uint8_t* dst, uint32_t y, uint32_t x, uint32_t len, SwMask op, uint8_t a);                                             //composite masking ver.
 void fillRadial(const SwFill* fill, uint8_t* dst, uint32_t y, uint32_t x, uint32_t len, uint8_t* cmp, SwMask op, uint8_t a) ;                              //direct masking ver.
 void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, uint8_t a);                                        //blending ver.
-void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, uint8_t a);                         //blending + BlendingMethod(op2) ver.
+void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, const SwSurface* surface, uint8_t a);  // blending + BlendingMethod(op2) ver.
 void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, uint8_t* cmp, SwAlpha alpha, uint8_t csize, uint8_t opacity);     //matting ver.
 
 SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox, SwMpool* mpool, unsigned tid, bool antiAlias);

--- a/src/renderer/cpu_engine/tvgSwFill.cpp
+++ b/src/renderer/cpu_engine/tvgSwFill.cpp
@@ -444,8 +444,7 @@ void fillRadial(const SwFill* fill, uint8_t* dst, uint32_t y, uint32_t x, uint32
     }
 }
 
-
-void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, uint8_t a)
+void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, const SwSurface* surface, uint8_t a)
 {
     if (fill->radial.a < RADIAL_A_THRESHOLD) {
         auto radial = &fill->radial;
@@ -456,7 +455,7 @@ void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
             for (uint32_t i = 0; i < len; ++i, ++dst) {
                 auto x0 = 0.5f * (rx * rx + ry * ry - radial->fr * radial->fr) / (radial->dr * radial->fr + rx * radial->dx + ry * radial->dy);
                 auto tmp = op(_pixel(fill, x0), *dst, 255);
-                *dst = op2(tmp, *dst);
+                *dst = op2(surface, tmp, *dst);
                 rx += radial->a11;
                 ry += radial->a21;
             }
@@ -464,7 +463,7 @@ void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
             for (uint32_t i = 0; i < len; ++i, ++dst) {
                 auto x0 = 0.5f * (rx * rx + ry * ry - radial->fr * radial->fr) / (radial->dr * radial->fr + rx * radial->dx + ry * radial->dy);
                 auto tmp = op(_pixel(fill, x0), *dst, 255);
-                auto tmp2 = op2(tmp, *dst);
+                auto tmp2 = op2(surface, tmp, *dst);
                 *dst = INTERPOLATE(tmp2, *dst, a);
                 rx += radial->a11;
                 ry += radial->a21;
@@ -476,7 +475,7 @@ void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
         if (a == 255) {
             for (uint32_t i = 0 ; i < len ; ++i, ++dst) {
                 auto tmp = op(_pixel(fill, sqrtf(det) - b), *dst, 255);
-                *dst = op2(tmp, *dst);
+                *dst = op2(surface, tmp, *dst);
                 det += deltaDet;
                 deltaDet += deltaDeltaDet;
                 b += deltaB;
@@ -484,7 +483,7 @@ void fillRadial(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
         } else {
             for (uint32_t i = 0 ; i < len ; ++i, ++dst) {
                 auto tmp = op(_pixel(fill, sqrtf(det) - b), *dst, 255);
-                auto tmp2 = op2(tmp, *dst);
+                auto tmp2 = op2(surface, tmp, *dst);
                 *dst = INTERPOLATE(tmp2, *dst, a);
                 det += deltaDet;
                 deltaDet += deltaDeltaDet;
@@ -697,8 +696,7 @@ void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
     }
 }
 
-
-void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, uint8_t a)
+void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, const SwSurface* surface, uint8_t a)
 {
     //Rotation
     float rx = x + 0.5f;
@@ -711,12 +709,12 @@ void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
         if (a == 255) {
             for (uint32_t i = 0; i < len; ++i, ++dst) {
                 auto tmp = op(color, *dst, a);
-                *dst = op2(tmp, *dst);
+                *dst = op2(surface, tmp, *dst);
             }
         } else {
             for (uint32_t i = 0; i < len; ++i, ++dst) {
                 auto tmp = op(color, *dst, a);
-                auto tmp2 = op2(tmp, *dst);
+                auto tmp2 = op2(surface, tmp, *dst);
                 *dst = INTERPOLATE(tmp2, *dst, a);
             }
         }
@@ -734,7 +732,7 @@ void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
             auto inc2 = static_cast<int32_t>(inc * FIXPT_SIZE);
             for (uint32_t j = 0; j < len; ++j, ++dst) {
                 auto tmp = op(_fixedPixel(fill, t2), *dst, 255);
-                *dst = op2(tmp, *dst);
+                *dst = op2(surface, tmp, *dst);
                 t2 += inc2;
             }
         //we have to fallback to float math
@@ -742,7 +740,7 @@ void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
             uint32_t counter = 0;
             while (counter++ < len) {
                 auto tmp = op(_pixel(fill, t / SW_COLOR_TABLE), *dst, 255);
-                *dst = op2(tmp, *dst);
+                *dst = op2(surface, tmp, *dst);
                 ++dst;
                 t += inc;
             }
@@ -754,7 +752,7 @@ void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
             auto inc2 = static_cast<int32_t>(inc * FIXPT_SIZE);
             for (uint32_t j = 0; j < len; ++j, ++dst) {
                 auto tmp = op(_fixedPixel(fill, t2), *dst, 255);
-                auto tmp2 = op2(tmp, *dst);
+                auto tmp2 = op2(surface, tmp, *dst);
                 *dst = INTERPOLATE(tmp2, *dst, a);
                 t2 += inc2;
             }
@@ -763,7 +761,7 @@ void fillLinear(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint3
             uint32_t counter = 0;
             while (counter++ < len) {
                 auto tmp = op(_pixel(fill, t / SW_COLOR_TABLE), *dst, 255);
-                auto tmp2 = op2(tmp, *dst);
+                auto tmp2 = op2(surface, tmp, *dst);
                 *dst = INTERPOLATE(tmp2, *dst, a);
                 ++dst;
                 t += inc;

--- a/src/renderer/cpu_engine/tvgSwRaster.cpp
+++ b/src/renderer/cpu_engine/tvgSwRaster.cpp
@@ -1791,39 +1791,3 @@ void rasterXYFlip(uint32_t* src, uint32_t* dst, int32_t stride, int32_t w, int32
         }
     }
 }
-
-
-//TODO: can be moved in tvgColor
-void rasterRGB2HSL(uint8_t r, uint8_t g, uint8_t b, float* h, float* s, float* l)
-{
-    auto rf = r / 255.0f;
-    auto gf = g / 255.0f;
-    auto bf = b / 255.0f;
-    auto maxVal = std::max(std::max(rf, gf), bf);
-    auto minVal = std::min(std::min(rf, gf), bf);
-    auto delta = maxVal - minVal;
-
-    //lightness
-    float t = 0.0f;
-    if (l || s) {
-        t = (maxVal + minVal) * 0.5f;
-        if (l) *l = t;
-    }
-
-    if (tvg::zero(delta)) {
-        if (h) *h = 0.0f;
-        if (s) *s = 0.0f;
-    } else {
-        //saturation
-        if (s) {
-            *s = (t < 0.5f) ? (delta / (maxVal + minVal)) : (delta / (2.0f - maxVal - minVal));
-        }
-        //hue
-        if (h) {
-            if (maxVal == rf) *h = (gf - bf) / delta + (gf < bf ? 6.0f : 0.0f);
-            else if (maxVal == gf) *h = (bf - rf) / delta + 2.0f;
-            else *h = (rf - gf) / delta + 4.0f;
-            *h *= 60.0f; //directly convert to degrees
-        }
-    }
-}

--- a/src/renderer/cpu_engine/tvgSwRaster.cpp
+++ b/src/renderer/cpu_engine/tvgSwRaster.cpp
@@ -52,9 +52,9 @@ struct FillLinear
         fillLinear(fill, dst, y, x, len, cmp, alpha, csize, opacity);
     }
 
-    void operator()(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, uint8_t a)
+    void operator()(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, const SwSurface* surface, uint8_t a)
     {
-        fillLinear(fill, dst, y, x, len, op, op2, a);
+        fillLinear(fill, dst, y, x, len, op, op2, surface, a);
     }
 
 };
@@ -81,9 +81,9 @@ struct FillRadial
         fillRadial(fill, dst, y, x, len, cmp, alpha, csize, opacity);
     }
 
-    void operator()(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, uint8_t a)
+    void operator()(const SwFill* fill, uint32_t* dst, uint32_t y, uint32_t x, uint32_t len, SwBlenderA op, SwBlender op2, const SwSurface* surface, uint8_t a)
     {
-        fillRadial(fill, dst, y, x, len, op, op2, a);
+        fillRadial(fill, dst, y, x, len, op, op2, surface, a);
     }
 };
 
@@ -135,6 +135,22 @@ static inline uint32_t _abgrJoin(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 static inline uint32_t _argbJoin(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
     return (a << 24 | r << 16 | g << 8 | b);
+}
+
+static inline void _abgrSplit(uint32_t c, uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a)
+{
+    r = C3(c);
+    g = C2(c);
+    b = C1(c);
+    a = A(c);
+}
+
+static inline void _argbSplit(uint32_t c, uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a)
+{
+    r = C1(c);
+    g = C2(c);
+    b = C3(c);
+    a = A(c);
 }
 
 static inline bool _blending(const SwSurface* surface)
@@ -429,7 +445,7 @@ static bool _rasterBlendingRect(SwSurface* surface, const RenderRegion& bbox, co
     for (uint32_t y = 0; y < bbox.h(); ++y) {
         auto dst = &buffer[y * surface->stride];
         for (uint32_t x = 0; x < bbox.w(); ++x, ++dst) {
-            *dst = surface->blender(color, *dst);
+            *dst = surface->blender(surface, color, *dst);
         }
     }
     return true;
@@ -604,11 +620,11 @@ static bool _rasterBlendingRle(SwSurface* surface, const SwRle* rle, const Rende
         auto dst = &surface->buf32[span->y * surface->stride + x];
         if (span->coverage == 255) {
             for (auto x = 0; x < len; ++x, ++dst) {
-                *dst = surface->blender(color, *dst);
+                *dst = surface->blender(surface, color, *dst);
             }
         } else {
             for (auto x = 0; x < len; ++x, ++dst) {
-                *dst = INTERPOLATE(surface->blender(color, *dst), *dst, span->coverage);
+                *dst = INTERPOLATE(surface->blender(surface, color, *dst), *dst, span->coverage);
             }
         }
     }
@@ -749,13 +765,13 @@ static bool _rasterScaledBlendingRleImage(SwSurface* surface, const SwImage& ima
             for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst) {
                 SCALED_IMAGE_RANGE_X
                 auto src = scaleMethod(image.buf32, image.stride, image.w, image.h, sx, sy, miny, maxy, sampleSize);
-                *dst = INTERPOLATE(surface->blender(rasterUnpremultiply(src), *dst), *dst, A(src));
+                *dst = INTERPOLATE(surface->blender(surface, rasterUnpremultiply(src), *dst), *dst, A(src));
             }
         } else {
             for (uint32_t x = static_cast<uint32_t>(span->x); x < static_cast<uint32_t>(span->x) + span->len; ++x, ++dst) {
                 SCALED_IMAGE_RANGE_X
                 auto src = scaleMethod(image.buf32, image.stride, image.w, image.h, sx, sy, miny, maxy, sampleSize);
-                *dst = INTERPOLATE(surface->blender(rasterUnpremultiply(src), *dst), *dst, MULTIPLY(alpha, A(src)));
+                *dst = INTERPOLATE(surface->blender(surface, rasterUnpremultiply(src), *dst), *dst, MULTIPLY(alpha, A(src)));
             }
         }
     }
@@ -832,11 +848,11 @@ static bool _rasterDirectBlendingRleImage(SwSurface* surface, const SwImage& ima
         auto alpha = MULTIPLY(span->coverage, opacity);
         if (alpha == 255) {
             for (auto x = 0; x < len; ++x, ++dst, ++src) {
-                *dst = surface->blender(rasterUnpremultiply(*src), *dst);
+                *dst = surface->blender(surface, rasterUnpremultiply(*src), *dst);
             }
         } else {
             for (auto x = 0; x < len; ++x, ++dst, ++src) {
-                *dst = INTERPOLATE(surface->blender(rasterUnpremultiply(*src), *dst), *dst, MULTIPLY(alpha, A(*src)));
+                *dst = INTERPOLATE(surface->blender(surface, rasterUnpremultiply(*src), *dst), *dst, MULTIPLY(alpha, A(*src)));
             }
         }
     }
@@ -931,7 +947,7 @@ static bool _rasterScaledBlendingImage(SwSurface* surface, const SwImage& image,
         for (auto x = bbox.min.x; x < bbox.max.x; ++x, ++dst) {
             SCALED_IMAGE_RANGE_X
             auto src = scaleMethod(image.buf32, image.stride, image.w, image.h, sx, sy, miny, maxy, sampleSize);
-            *dst = INTERPOLATE(surface->blender(rasterUnpremultiply(src), *dst), *dst, MULTIPLY(opacity, A(src)));
+            *dst = INTERPOLATE(surface->blender(surface, rasterUnpremultiply(src), *dst), *dst, MULTIPLY(opacity, A(src)));
         }
     }
     return true;
@@ -1082,11 +1098,11 @@ static bool _rasterDirectMattedBlendingImage(SwSurface* surface, const SwImage& 
         auto src = sbuffer;
         if (opacity == 255) {
             for (auto dst = dbuffer; dst < dbuffer + w; ++dst, ++src, cmp += csize) {
-                *dst = INTERPOLATE(surface->blender(*src, *dst), *dst, MULTIPLY(A(*src), alpha(cmp)));
+                *dst = INTERPOLATE(surface->blender(surface, *src, *dst), *dst, MULTIPLY(A(*src), alpha(cmp)));
             }
         } else {
             for (auto dst = dbuffer; dst < dbuffer + w; ++dst, ++src, cmp += csize) {
-                *dst = INTERPOLATE(surface->blender(*src, *dst), *dst, MULTIPLY(MULTIPLY(A(*src), alpha(cmp)), opacity));
+                *dst = INTERPOLATE(surface->blender(surface, *src, *dst), *dst, MULTIPLY(MULTIPLY(A(*src), alpha(cmp)), opacity));
             }
         }
         cbuffer += compositor->image.stride * csize;
@@ -1115,11 +1131,11 @@ static bool _rasterDirectBlendingImage(SwSurface* surface, const SwImage& image,
         auto src = sbuffer;
         if (opacity == 255) {
             for (auto dst = dbuffer; dst < dbuffer + w; dst++, src++) {
-                *dst = INTERPOLATE(surface->blender(rasterUnpremultiply(*src), *dst), *dst, A(*src));
+                *dst = INTERPOLATE(surface->blender(surface, rasterUnpremultiply(*src), *dst), *dst, A(*src));
             }
         } else {
             for (auto dst = dbuffer; dst < dbuffer + w; dst++, src++) {
-                *dst = INTERPOLATE(surface->blender(rasterUnpremultiply(*src), *dst), *dst, MULTIPLY(opacity, A(*src)));
+                *dst = INTERPOLATE(surface->blender(surface, rasterUnpremultiply(*src), *dst), *dst, MULTIPLY(opacity, A(*src)));
             }
         }
     }
@@ -1203,11 +1219,11 @@ static bool _rasterBlendingGradientRect(SwSurface* surface, const RenderRegion& 
 
     if (fill->translucent) {
         for (uint32_t y = 0; y < bbox.h(); ++y) {
-            fillMethod()(fill, buffer + y * surface->stride, bbox.min.y + y, bbox.min.x, bbox.w(), opBlendPreNormal, surface->blender, 255);
+            fillMethod()(fill, buffer + y * surface->stride, bbox.min.y + y, bbox.min.x, bbox.w(), opBlendPreNormal, surface->blender, surface, 255);
         }
     } else {
         for (uint32_t y = 0; y < bbox.h(); ++y) {
-            fillMethod()(fill, buffer + y * surface->stride, bbox.min.y + y, bbox.min.x, bbox.w(), opBlendSrcOver, surface->blender, 255);
+            fillMethod()(fill, buffer + y * surface->stride, bbox.min.y + y, bbox.min.x, bbox.w(), opBlendSrcOver, surface->blender, surface, 255);
         }
     }
     return true;
@@ -1364,7 +1380,7 @@ static bool _rasterBlendingGradientRle(SwSurface* surface, const SwRle* rle, con
 
     for (uint32_t i = 0; i < rle->size(); ++i, ++span) {
         auto dst = &surface->buf32[span->y * surface->stride + span->x];
-        fillMethod()(fill, dst, span->y, span->x, span->len, opBlendPreNormal, surface->blender, span->coverage);
+        fillMethod()(fill, dst, span->y, span->x, span->len, opBlendPreNormal, surface->blender, surface, span->coverage);
     }
     return true;
 }
@@ -1498,10 +1514,12 @@ bool rasterCompositor(SwSurface* surface)
 
     if (surface->cs == ColorSpace::ABGR8888 || surface->cs == ColorSpace::ABGR8888S) {
         surface->join = _abgrJoin;
+        surface->split = _abgrSplit;
         surface->alphas[2] = _abgrLuma;
         surface->alphas[3] = _abgrInvLuma;
     } else if (surface->cs == ColorSpace::ARGB8888 || surface->cs == ColorSpace::ARGB8888S) {
         surface->join = _argbJoin;
+        surface->split = _argbSplit;
         surface->alphas[2] = _argbLuma;
         surface->alphas[3] = _argbInvLuma;
     } else {
@@ -1788,42 +1806,6 @@ void rasterXYFlip(uint32_t* src, uint32_t* dst, int32_t stride, int32_t w, int32
                 p += 1 - by * stride;
                 q += stride - by;
             }
-        }
-    }
-}
-
-
-//TODO: can be moved in tvgColor
-void rasterRGB2HSL(uint8_t r, uint8_t g, uint8_t b, float* h, float* s, float* l)
-{
-    auto rf = r / 255.0f;
-    auto gf = g / 255.0f;
-    auto bf = b / 255.0f;
-    auto maxVal = std::max(std::max(rf, gf), bf);
-    auto minVal = std::min(std::min(rf, gf), bf);
-    auto delta = maxVal - minVal;
-
-    //lightness
-    float t = 0.0f;
-    if (l || s) {
-        t = (maxVal + minVal) * 0.5f;
-        if (l) *l = t;
-    }
-
-    if (tvg::zero(delta)) {
-        if (h) *h = 0.0f;
-        if (s) *s = 0.0f;
-    } else {
-        //saturation
-        if (s) {
-            *s = (t < 0.5f) ? (delta / (maxVal + minVal)) : (delta / (2.0f - maxVal - minVal));
-        }
-        //hue
-        if (h) {
-            if (maxVal == rf) *h = (gf - bf) / delta + (gf < bf ? 6.0f : 0.0f);
-            else if (maxVal == gf) *h = (bf - rf) / delta + 2.0f;
-            else *h = (rf - gf) / delta + 4.0f;
-            *h *= 60.0f; //directly convert to degrees
         }
     }
 }

--- a/src/renderer/cpu_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/cpu_engine/tvgSwRasterTexmap.h
@@ -147,7 +147,7 @@ static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage
                     if (feather < 255) px = ALPHA_BLEND(px, feather);
                 }
 
-                *buf = INTERPOLATE(surface->blender(rasterUnpremultiply(px), *buf), *buf, MULTIPLY(opacity, A(px)));
+                *buf = INTERPOLATE(surface->blender(surface, rasterUnpremultiply(px), *buf), *buf, MULTIPLY(opacity, A(px)));
                 ++buf;
 
                 //Step UV horizontally

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -370,4 +370,97 @@ TEST_CASE("Image Rotation", "[tvgSwEngine]")
     REQUIRE(Initializer::term() == Result::Success);
 }
 
+struct Pixel
+{
+    uint8_t r, g, b, a;
+};
+
+static Pixel _decode(uint32_t pixel, ColorSpace cs)
+{
+    if (cs == ColorSpace::ABGR8888 || cs == ColorSpace::ABGR8888S) {
+        return {static_cast<uint8_t>(pixel), static_cast<uint8_t>(pixel >> 8), static_cast<uint8_t>(pixel >> 16), static_cast<uint8_t>(pixel >> 24)};
+    }
+    return {static_cast<uint8_t>(pixel >> 16), static_cast<uint8_t>(pixel >> 8), static_cast<uint8_t>(pixel), static_cast<uint8_t>(pixel >> 24)};
+}
+
+static int _diff(uint8_t a, uint8_t b)
+{
+    return a > b ? a - b : b - a;
+}
+
+static Pixel _renderBlendedPixel(BlendMethod method, ColorSpace cs)
+{
+    constexpr uint32_t Size = 8;
+    uint32_t buffer[Size * Size] = {};
+
+    auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+    REQUIRE(canvas);
+    REQUIRE(canvas->target(buffer, Size, Size, Size, cs) == Result::Success);
+
+    auto dst = Shape::gen();
+    REQUIRE(dst);
+    REQUIRE(dst->appendRect(0, 0, Size, Size) == Result::Success);
+    REQUIRE(dst->fill(20, 80, 210, 255) == Result::Success);
+    REQUIRE(canvas->add(dst) == Result::Success);
+
+    auto src = Shape::gen();
+    REQUIRE(src);
+    REQUIRE(src->appendRect(0, 0, Size, Size) == Result::Success);
+    REQUIRE(src->fill(230, 40, 20, 255) == Result::Success);
+    REQUIRE(src->blend(method) == Result::Success);
+    REQUIRE(canvas->add(src) == Result::Success);
+
+    REQUIRE(canvas->draw(true) == Result::Success);
+    REQUIRE(canvas->sync() == Result::Success);
+
+    return _decode(buffer[(Size / 2) * Size + (Size / 2)], cs);
+}
+
+static void _requirePixelNear(const Pixel& lhs, const Pixel& rhs)
+{
+    REQUIRE(_diff(lhs.r, rhs.r) <= 1);
+    REQUIRE(_diff(lhs.g, rhs.g) <= 1);
+    REQUIRE(_diff(lhs.b, rhs.b) <= 1);
+    REQUIRE(_diff(lhs.a, rhs.a) <= 1);
+}
+
+TEST_CASE("Non-separable blend colorspace parity", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        const BlendMethod methods[] = {
+            BlendMethod::Hue,
+            BlendMethod::Saturation,
+            BlendMethod::Color,
+            BlendMethod::Luminosity};
+
+        for (auto method : methods) {
+            INFO("BlendMethod: " << static_cast<int>(method));
+            auto native = _renderBlendedPixel(method, ColorSpace::ABGR8888);
+            auto web = _renderBlendedPixel(method, ColorSpace::ARGB8888S);
+            INFO("ABGR8888 rgba: " << static_cast<int>(native.r) << ", " << static_cast<int>(native.g) << ", " << static_cast<int>(native.b) << ", " << static_cast<int>(native.a));
+            INFO("ARGB8888S rgba: " << static_cast<int>(web.r) << ", " << static_cast<int>(web.g) << ", " << static_cast<int>(web.b) << ", " << static_cast<int>(web.a));
+            _requirePixelNear(native, web);
+        }
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
+TEST_CASE("Soft-light blend matches compositing spec", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        const ColorSpace colorspaces[] = {
+            ColorSpace::ABGR8888,
+            ColorSpace::ARGB8888S};
+
+        for (auto cs : colorspaces) {
+            INFO("ColorSpace: " << static_cast<int>(cs));
+            auto pixel = _renderBlendedPixel(BlendMethod::SoftLight, cs);
+            _requirePixelNear(pixel, {55, 42, 179, 255});
+        }
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
 #endif


### PR DESCRIPTION
### Summary
This PR aligns the software renderer’s special blend modes with browser-style compositing behavior.

It updates SoftLight and the non-separable blend modes, Hue, Saturation, Color, and Luminosity, to use local raster blend helpers instead of the previous HSL conversion path. It also adds ABGR-specific non-separable blend helpers so ABGR and ARGB targets produce matching logical RGBA results.

### Changes
- Pass the active `SwSurface` into software blend callbacks so blend helpers can use the target color-space channel layout.
- Add surface-specific channel split helpers alongside the existing join helpers.
- Rework Hue, Saturation, Color, and Luminosity blend modes to use luminance/saturation operations instead of RGB/HSL conversion.
- Update SoftLight blending to match the compositing formula.
- Add SW engine coverage for non-separable blend parity between ABGR and ARGB targets, plus a SoftLight reference pixel test.
- The FPS in the Example Lottie maintains a difference of less than 0.2% after 3,000 frames.
### Related Issue
Related to https://github.com/thorvg/thorvg/issues/4190

### Verification
- Added `Non-separable blend colorspace parity` coverage in `test/testSwEngine.cpp`.

<img width="3840" height="1754" alt="image" src="https://github.com/user-attachments/assets/a7e538c8-79db-48af-b22b-6854addc53fd" />