### PR TITLE
svg_loader: add tspan element support

### DIFF
--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -889,18 +889,17 @@ static char* _processText(const char* text, SvgXmlSpace space)
     return processed;
 }
 
-static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const Box& vBox, const string& svgPath)
+static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const Matrix* transform)
 {
-    auto textNode = &node->node.text;
     if (!textNode->text) return nullptr;
 
     auto text = Text::gen();
 
     Matrix textTransform;
-    if (node->transform) textTransform = *node->transform;
+    if (transform) textTransform = *transform;
     else textTransform = tvg::identity();
 
-    translateR(&textTransform, {node->node.text.x, node->node.text.y - textNode->fontSize});
+    translateR(&textTransform, {textNode->x, textNode->y - textNode->fontSize});
     text->transform(textTransform);
 
     //TODO: handle def values of font and size as used in a system?
@@ -910,22 +909,99 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
     }
     text->size(size);
 
-    // Handle xml:space
-    auto xmlSpace = node->xmlSpace;
-    auto parent = node->parent;
-    while (xmlSpace == SvgXmlSpace::None && parent) {
-        xmlSpace = parent->xmlSpace;
-        parent = parent->parent;
-    }
-    if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
     auto processedText = _processText(textNode->text, xmlSpace);
-    text->align(node->style->textAnchor, 0.0f);
     text->text(processedText);
     tvg::free(processedText);
 
-    _applyTextFill(node->style, text, vBox);
+    return text;
+}
 
-    auto p = _applyFilter(ctx, text, node, vBox, svgPath);
+static bool _hasPositionedTspan(const SvgNode* node, int depth)
+{
+    if (depth > 2192) {
+        TVGERR("SVG", "Infinite recursive call - stopped after %d calls! Svg file may be incorrectly formatted.", depth);
+        return true;
+    }
+    ARRAY_FOREACH(p, node->child)
+    {
+        if ((*p)->type != SvgNodeType::Tspan) continue;
+        auto& textNode = (*p)->node.text;
+        if (textNode.text) return true;
+        if (_hasPositionedTspan(*p, depth + 1)) return true;
+    }
+    return false;
+}
+
+static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* scene, const Box& vBox, const string& svgPath, int depth)
+{
+    if (depth > 2192) {
+        TVGERR("SVG", "Infinite recursive call - stopped after %d calls! Svg file may be incorrectly formatted.", depth);
+        return;
+    }
+    ARRAY_FOREACH(p, node->child)
+    {
+        auto child = *p;
+        if (child->type != SvgNodeType::Tspan) continue;
+
+        auto textNode = child->node.text;
+        if (textNode.text) {
+            auto xmlSpace = child->xmlSpace;
+            for (auto n = child->parent; n; n = n->parent) {
+                if (textNode.x == FLT_MAX) textNode.x = n->node.text.x;
+                if (textNode.y == FLT_MAX) textNode.y = n->node.text.y;
+                if (textNode.fontSize <= 0.0f) textNode.fontSize = n->node.text.fontSize;
+                if (!textNode.fontFamily) textNode.fontFamily = n->node.text.fontFamily;
+                if (xmlSpace == SvgXmlSpace::None) xmlSpace = n->xmlSpace;
+                if (n->type == SvgNodeType::Text) break;
+            }
+            if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
+
+            auto text = _buildText(&textNode, xmlSpace, nullptr);
+            if (text) {
+                text->align(child->style->textAnchor, 0.0f);
+                _applyTextFill(child->style, text, vBox);
+                auto paint = _applyFilter(ctx, text, child, vBox, svgPath);
+                paint = _applyComposition(ctx, paint, child, vBox, svgPath);
+                paint = _applyBlend(paint, child);
+                scene->add(paint);
+            }
+        }
+        _buildTspanScene(ctx, child, scene, vBox, svgPath, depth + 1);
+    }
+}
+
+static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const Box& vBox, const string& svgPath)
+{
+    auto textNode = &node->node.text;
+
+    // Handle xml:space
+    auto xmlSpace = node->xmlSpace;
+    for (auto n = node->parent; xmlSpace == SvgXmlSpace::None && n; n = n->parent)
+        xmlSpace = n->xmlSpace;
+    if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
+
+    if (!_hasPositionedTspan(node, 0)) {
+        auto text = _buildText(textNode, xmlSpace, node->transform);
+        if (!text) return nullptr;
+        text->align(node->style->textAnchor, 0.0f);
+        _applyTextFill(node->style, text, vBox);
+        auto p = _applyFilter(ctx, text, node, vBox, svgPath);
+        p = _applyComposition(ctx, p, node, vBox, svgPath);
+        return _applyBlend(p, node);
+    }
+
+    auto scene = Scene::gen();
+    if (node->transform) scene->transform(*node->transform);
+
+    if (auto text = _buildText(textNode, xmlSpace, nullptr)) {
+        text->align(node->style->textAnchor, 0.0f);
+        _applyTextFill(node->style, text, vBox);
+        scene->add(text);
+    }
+
+    _buildTspanScene(ctx, node, scene, vBox, svgPath, 0);
+
+    auto p = _applyFilter(ctx, scene, node, vBox, svgPath);
     p = _applyComposition(ctx, p, node, vBox, svgPath);
     return _applyBlend(p, node);
 }

--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -889,18 +889,17 @@ static char* _processText(const char* text, SvgXmlSpace space)
     return processed;
 }
 
-static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const Box& vBox, const string& svgPath)
+static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const Matrix* transform)
 {
-    auto textNode = &node->node.text;
     if (!textNode->text) return nullptr;
 
     auto text = Text::gen();
 
     Matrix textTransform;
-    if (node->transform) textTransform = *node->transform;
+    if (transform) textTransform = *transform;
     else textTransform = tvg::identity();
 
-    translateR(&textTransform, {node->node.text.x, node->node.text.y - textNode->fontSize});
+    translateR(&textTransform, {textNode->x, textNode->y - textNode->fontSize});
     text->transform(textTransform);
 
     //TODO: handle def values of font and size as used in a system?
@@ -910,21 +909,96 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
     }
     text->size(size);
 
-    // Handle xml:space
-    auto xmlSpace = node->xmlSpace;
-    auto parent = node->parent;
-    while (xmlSpace == SvgXmlSpace::None && parent) {
-        xmlSpace = parent->xmlSpace;
-        parent = parent->parent;
-    }
-    if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
     auto processedText = _processText(textNode->text, xmlSpace);
     text->text(processedText);
     tvg::free(processedText);
 
-    _applyTextFill(node->style, text, vBox);
+    return text;
+}
 
-    auto p = _applyFilter(ctx, text, node, vBox, svgPath);
+static bool _hasPositionedTspan(const SvgNode* node, int depth)
+{
+    if (depth > 2192) {
+        TVGERR("SVG", "Infinite recursive call - stopped after %d calls! Svg file may be incorrectly formatted.", depth);
+        return true;
+    }
+    ARRAY_FOREACH(p, node->child)
+    {
+        if ((*p)->type != SvgNodeType::Tspan) continue;
+        auto& textNode = (*p)->node.text;
+        if (textNode.text) return true;
+        if (_hasPositionedTspan(*p, depth + 1)) return true;
+    }
+    return false;
+}
+
+static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* scene, const Box& vBox, const string& svgPath, int depth)
+{
+    if (depth > 2192) {
+        TVGERR("SVG", "Infinite recursive call - stopped after %d calls! Svg file may be incorrectly formatted.", depth);
+        return;
+    }
+    ARRAY_FOREACH(p, node->child)
+    {
+        auto child = *p;
+        if (child->type != SvgNodeType::Tspan) continue;
+
+        auto textNode = child->node.text;
+        if (textNode.text) {
+            auto xmlSpace = child->xmlSpace;
+            for (auto n = child->parent; n; n = n->parent) {
+                if (textNode.x == FLT_MAX) textNode.x = n->node.text.x;
+                if (textNode.y == FLT_MAX) textNode.y = n->node.text.y;
+                if (textNode.fontSize <= 0.0f) textNode.fontSize = n->node.text.fontSize;
+                if (!textNode.fontFamily) textNode.fontFamily = n->node.text.fontFamily;
+                if (xmlSpace == SvgXmlSpace::None) xmlSpace = n->xmlSpace;
+                if (n->type == SvgNodeType::Text) break;
+            }
+            if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
+
+            auto text = _buildText(&textNode, xmlSpace, nullptr);
+            if (text) {
+                _applyTextFill(child->style, text, vBox);
+                auto paint = _applyFilter(ctx, text, child, vBox, svgPath);
+                paint = _applyComposition(ctx, paint, child, vBox, svgPath);
+                paint = _applyBlend(paint, child);
+                scene->add(paint);
+            }
+        }
+        _buildTspanScene(ctx, child, scene, vBox, svgPath, depth + 1);
+    }
+}
+
+static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const Box& vBox, const string& svgPath)
+{
+    auto textNode = &node->node.text;
+
+    // Handle xml:space
+    auto xmlSpace = node->xmlSpace;
+    for (auto n = node->parent; xmlSpace == SvgXmlSpace::None && n; n = n->parent)
+        xmlSpace = n->xmlSpace;
+    if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
+
+    if (!_hasPositionedTspan(node, 0)) {
+        auto text = _buildText(textNode, xmlSpace, node->transform);
+        if (!text) return nullptr;
+        _applyTextFill(node->style, text, vBox);
+        auto p = _applyFilter(ctx, text, node, vBox, svgPath);
+        p = _applyComposition(ctx, p, node, vBox, svgPath);
+        return _applyBlend(p, node);
+    }
+
+    auto scene = Scene::gen();
+    if (node->transform) scene->transform(*node->transform);
+
+    if (auto text = _buildText(textNode, xmlSpace, nullptr)) {
+        _applyTextFill(node->style, text, vBox);
+        scene->add(text);
+    }
+
+    _buildTspanScene(ctx, node, scene, vBox, svgPath, 0);
+
+    auto p = _applyFilter(ctx, scene, node, vBox, svgPath);
     p = _applyComposition(ctx, p, node, vBox, svgPath);
     return _applyBlend(p, node);
 }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -125,7 +125,7 @@ static void _parseAspectRatio(const char** content, AspectRatioAlign* align, Asp
 static float _findEmBaseFontSize(const SvgNode* from)
 {
     for (auto n = from; n; n = n->parent) {
-        if (n->type == SvgNodeType::Text && n->node.text.fontSize > 0.0f) return n->node.text.fontSize;
+        if ((n->type == SvgNodeType::Text || n->type == SvgNodeType::Tspan) && n->node.text.fontSize > 0.0f) return n->node.text.fontSize;
     }
     return DEFAULT_FONT_SIZE;
 }
@@ -2162,6 +2162,19 @@ static SvgNode* _createTextNode(SvgParserContext* ctx, SvgNode* parent, const ch
     return ctx->parser->node;
 }
 
+static SvgNode* _createTspanNode(SvgParserContext* ctx, SvgNode* parent, const char* buf, unsigned bufLength, parseAttributes func)
+{
+    ctx->parser->node = _createNode(parent, SvgNodeType::Tspan);
+    if (!ctx->parser->node) return nullptr;
+
+    ctx->parser->node->node.text.x = FLT_MAX;
+    ctx->parser->node->node.text.y = FLT_MAX;
+
+    func(buf, bufLength, _attrPrescanTextFontSize, ctx);
+    func(buf, bufLength, _attrParseTextNode, ctx);
+
+    return ctx->parser->node;
+}
 
 static constexpr struct
 {
@@ -2179,9 +2192,7 @@ static constexpr struct
     {"line", sizeof("line"), _createLineNode},
     {"image", sizeof("image"), _createImageNode},
     {"text", sizeof("text"), _createTextNode},
-    {"feGaussianBlur", sizeof("feGaussianBlur"), _createGaussianBlurNode}
-};
-
+    {"feGaussianBlur", sizeof("feGaussianBlur"), _createGaussianBlurNode}};
 
 static constexpr struct
 {
@@ -3035,6 +3046,7 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             to->node.use = from->node.use;
             break;
         }
+        case SvgNodeType::Tspan:
         case SvgNodeType::Text: {
             to->node.text.x = from->node.text.x;
             to->node.text.y = from->node.text.y;
@@ -3141,6 +3153,23 @@ static int _svgLoaderParserXmlTagName(const char* content, char* tagName, unsign
     return sz;
 }
 
+static void _spliceTspanClose(SvgParserContext* ctx)
+{
+    auto cur = ctx->parser->node;
+    if (!cur || cur->type != SvgNodeType::Tspan) return;
+
+    auto& t = cur->node.text;
+    bool unpositioned = (t.x == FLT_MAX && t.y == FLT_MAX);
+    bool noOverride = (t.fontSize <= 0.0f && !t.fontFamily && cur->xmlSpace == SvgXmlSpace::None);
+
+    if (t.text && unpositioned && noOverride && cur->parent) {
+        auto& parentText = cur->parent->node.text;
+        parentText.text = append(parentText.text, t.text, strlen(t.text));
+        tvg::free(t.text);
+        t.text = nullptr;
+    }
+    ctx->parser->node = cur->parent;
+}
 
 static void _svgLoaderParserXmlClose(SvgParserContext* ctx, const char* content, unsigned int length)
 {
@@ -3165,6 +3194,11 @@ static void _svgLoaderParserXmlClose(SvgParserContext* ctx, const char* content,
             ctx->gradientStack.pop();
             break;
         }
+    }
+
+    if (ctx->openedTag == OpenedTagType::Text && STR_AS(tagName, "tspan")) {
+        _spliceTspanClose(ctx);
+        return;
     }
 
     for (unsigned int i = 0; i < sizeof(graphicsTags) / sizeof(graphicsTags[0]); i++) {
@@ -3262,6 +3296,10 @@ static void _svgLoaderParserXmlOpen(SvgParserContext* ctx, const char* content, 
         if (node->type != SvgNodeType::Defs || !empty) {
             ctx->stack.push(node);
         }
+    } else if (ctx->openedTag == OpenedTagType::Text && STR_AS(tagName, "tspan")) {
+        parent = ctx->parser->node;
+        node = _createTspanNode(ctx, parent, attrs, attrsLength, xmlParseAttributes);
+        if (empty) ctx->parser->node = parent;
     } else if ((method = _findGraphicsFactory(tagName))) {
         if (ctx->stack.count > 0) parent = ctx->stack.last();
         else parent = ctx->doc;
@@ -3393,6 +3431,7 @@ static void _free(SvgNode* node)
              tvg::free(node->node.image.href);
              break;
          }
+         case SvgNodeType::Tspan:
          case SvgNodeType::Text: {
              tvg::free(node->node.text.text);
              tvg::free(node->node.text.fontFamily);

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -125,7 +125,7 @@ static void _parseAspectRatio(const char** content, AspectRatioAlign* align, Asp
 static float _findEmBaseFontSize(const SvgNode* from)
 {
     for (auto n = from; n; n = n->parent) {
-        if (n->type == SvgNodeType::Text && n->node.text.fontSize > 0.0f) return n->node.text.fontSize;
+        if ((n->type == SvgNodeType::Text || n->type == SvgNodeType::Tspan) && n->node.text.fontSize > 0.0f) return n->node.text.fontSize;
     }
     return DEFAULT_FONT_SIZE;
 }
@@ -2155,6 +2155,19 @@ static SvgNode* _createTextNode(SvgParserContext* ctx, SvgNode* parent, const ch
     return ctx->parser->node;
 }
 
+static SvgNode* _createTspanNode(SvgParserContext* ctx, SvgNode* parent, const char* buf, unsigned bufLength, parseAttributes func)
+{
+    ctx->parser->node = _createNode(parent, SvgNodeType::Tspan);
+    if (!ctx->parser->node) return nullptr;
+
+    ctx->parser->node->node.text.x = FLT_MAX;
+    ctx->parser->node->node.text.y = FLT_MAX;
+
+    func(buf, bufLength, _attrPrescanTextFontSize, ctx);
+    func(buf, bufLength, _attrParseTextNode, ctx);
+
+    return ctx->parser->node;
+}
 
 static constexpr struct
 {
@@ -2172,9 +2185,7 @@ static constexpr struct
     {"line", sizeof("line"), _createLineNode},
     {"image", sizeof("image"), _createImageNode},
     {"text", sizeof("text"), _createTextNode},
-    {"feGaussianBlur", sizeof("feGaussianBlur"), _createGaussianBlurNode}
-};
-
+    {"feGaussianBlur", sizeof("feGaussianBlur"), _createGaussianBlurNode}};
 
 static constexpr struct
 {
@@ -3026,6 +3037,7 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             to->node.use = from->node.use;
             break;
         }
+        case SvgNodeType::Tspan:
         case SvgNodeType::Text: {
             to->node.text.x = from->node.text.x;
             to->node.text.y = from->node.text.y;
@@ -3132,6 +3144,23 @@ static int _svgLoaderParserXmlTagName(const char* content, char* tagName, unsign
     return sz;
 }
 
+static void _spliceTspanClose(SvgParserContext* ctx)
+{
+    auto cur = ctx->parser->node;
+    if (!cur || cur->type != SvgNodeType::Tspan) return;
+
+    auto& t = cur->node.text;
+    bool unpositioned = (t.x == FLT_MAX && t.y == FLT_MAX);
+    bool noOverride = (t.fontSize <= 0.0f && !t.fontFamily && cur->xmlSpace == SvgXmlSpace::None);
+
+    if (t.text && unpositioned && noOverride && cur->parent) {
+        auto& parentText = cur->parent->node.text;
+        parentText.text = append(parentText.text, t.text, strlen(t.text));
+        tvg::free(t.text);
+        t.text = nullptr;
+    }
+    ctx->parser->node = cur->parent;
+}
 
 static void _svgLoaderParserXmlClose(SvgParserContext* ctx, const char* content, unsigned int length)
 {
@@ -3156,6 +3185,11 @@ static void _svgLoaderParserXmlClose(SvgParserContext* ctx, const char* content,
             ctx->gradientStack.pop();
             break;
         }
+    }
+
+    if (ctx->openedTag == OpenedTagType::Text && STR_AS(tagName, "tspan")) {
+        _spliceTspanClose(ctx);
+        return;
     }
 
     for (unsigned int i = 0; i < sizeof(graphicsTags) / sizeof(graphicsTags[0]); i++) {
@@ -3253,6 +3287,10 @@ static void _svgLoaderParserXmlOpen(SvgParserContext* ctx, const char* content, 
         if (node->type != SvgNodeType::Defs || !empty) {
             ctx->stack.push(node);
         }
+    } else if (ctx->openedTag == OpenedTagType::Text && STR_AS(tagName, "tspan")) {
+        parent = ctx->parser->node;
+        node = _createTspanNode(ctx, parent, attrs, attrsLength, xmlParseAttributes);
+        if (empty) ctx->parser->node = parent;
     } else if ((method = _findGraphicsFactory(tagName))) {
         if (ctx->stack.count > 0) parent = ctx->stack.last();
         else parent = ctx->doc;
@@ -3384,6 +3422,7 @@ static void _free(SvgNode* node)
              tvg::free(node->node.image.href);
              break;
          }
+         case SvgNodeType::Tspan:
          case SvgNodeType::Text: {
              tvg::free(node->node.text.text);
              tvg::free(node->node.text.fontFamily);


### PR DESCRIPTION
Support `<tspan>` as a child of `<text>`. Positioned tspan (with explicit x or y) renders as a separate Text in a Scene. unpositioned tspan text is spliced into the parent at close time to preserve document order. Inherits x/y, font-size, font-family, and xml:space from the ancestor chain.

x,y use `FLT_MAX` as the "unset" to distinguish an explicit 0 from "inherit from ancestor".

https://github.com/thorvg/thorvg/issues/4107