### PR TITLE
lottie/expressions: expose inPoint/outPoint to global scope

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -1359,6 +1359,14 @@ void LottieExpressions::buildGlobal(float frameNo, LottieExpression* exp)
     auto index = jerry_number(exp->layer->ix);
     jerry_object_set_sz(global, EXP_INDEX, index);
     jerry_value_free(index);
+
+    auto inPoint = jerry_number(exp->layer->inFrame / exp->comp->frameRate);
+    jerry_object_set_sz(global, "inPoint", inPoint);
+    jerry_value_free(inPoint);
+
+    auto outPoint = jerry_number(exp->layer->outFrame / exp->comp->frameRate);
+    jerry_object_set_sz(global, "outPoint", outPoint);
+    jerry_value_free(outPoint);
 }
 
 

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -431,11 +431,11 @@ static void _buildLayer(jerry_value_t context, float frameNo, LottieLayer* layer
     jerry_object_set_sz(context, "hasParent", hasParent);
     jerry_value_free(hasParent);
 
-    auto inPoint = jerry_number(layer->inFrame);
+    auto inPoint = jerry_number(layer->inFrame / exp->comp->frameRate);
     jerry_object_set_sz(context, "inPoint", inPoint);
     jerry_value_free(inPoint);
 
-    auto outPoint = jerry_number(layer->outFrame);
+    auto outPoint = jerry_number(layer->outFrame / exp->comp->frameRate);
     jerry_object_set_sz(context, "outPoint", outPoint);
     jerry_value_free(outPoint);
 
@@ -1359,6 +1359,14 @@ void LottieExpressions::buildGlobal(float frameNo, LottieExpression* exp)
     auto index = jerry_number(exp->layer->ix);
     jerry_object_set_sz(global, EXP_INDEX, index);
     jerry_value_free(index);
+
+    auto inPoint = jerry_number(exp->layer->inFrame / exp->comp->frameRate);
+    jerry_object_set_sz(global, "inPoint", inPoint);
+    jerry_value_free(inPoint);
+
+    auto outPoint = jerry_number(exp->layer->outFrame / exp->comp->frameRate);
+    jerry_object_set_sz(global, "outPoint", outPoint);
+    jerry_value_free(outPoint);
 }
 
 


### PR DESCRIPTION
## Test files
[32. Auto fade in & out.json](https://github.com/user-attachments/files/26895357/32.Auto.fade.in.out.json)

Expressions could access to inPoint/outPoint as global property which previously wasn't handled in ThorVG exp global scope, so the animation looked static.

<img width="3024" height="1524" alt="CleanShot 2026-04-20 at 19 12 36@2x" src="https://github.com/user-attachments/assets/2944227e-7ecf-44a2-9a0e-1b730c287499" />


| Expectation | ThorVG(Main) | ThorVG(Patched) |
|---|---|---|
| ![](https://github.com/user-attachments/assets/411ff09e-2d63-48a2-865a-8cb3cb795f77) | ![](https://github.com/user-attachments/assets/38de67ca-fac1-4074-b368-70d97125ed03) | ![](https://github.com/user-attachments/assets/44fc2b9d-5680-4e7d-b137-a8c5c4c73526) |