### PR TITLE
lottie/expressions: scale uint8_t type correctly

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.h
+++ b/src/loaders/lottie/tvgLottieExpressions.h
@@ -54,6 +54,20 @@ struct LottieExpressions
     }
 
     template<typename Property>
+    bool result(float frameNo, uint8_t& out, LottieExpression* exp) {
+        auto bm_rt = evaluate(frameNo, exp);
+        if (jerry_value_is_undefined(bm_rt)) return false;
+
+        if (auto prop = static_cast<Property*>(jerry_object_get_native_ptr(bm_rt, nullptr))) {
+            out = (*prop)(frameNo);
+        } else {
+            out = (uint8_t)(toFloat(bm_rt) * 2.55f);
+        }
+        jerry_value_free(bm_rt);
+        return true;
+    }
+
+    template<typename Property>
     bool result(float frameNo, Point& out, LottieExpression* exp)
     {
         auto bm_rt = evaluate(frameNo, exp);


### PR DESCRIPTION
The Lottie parser converts uint8_t property values (e.g. opacity) from 0-100 to 0-255 range via *2.55f scaling, but the expression engine returned results in the original 0-100 range without this conversion.

This caused visual discrepancies such as opacity capping differently.

Apply the same `2.55f` scaling to uint8_t expression results, matching the parser's behavior.


Test file : [auto_fade.json](https://github.com/user-attachments/files/26918133/auto_fade.json)


| Expectation | ThorVG(Main) | ThorVG(Patched) |
|--------|--------|--------|
| <img src="https://github.com/user-attachments/assets/6fb95f1b-d44a-4c54-8212-9cc484f37a84" width="100%"> | <img src="https://github.com/user-attachments/assets/ea4d52d7-6d5e-4f63-8b94-bccf4734cca7" width="100%"> | <img src="https://github.com/user-attachments/assets/8d076686-2c21-4d15-92fc-c16b2c3e82c7" width="100%"> |
