### PR TITLE
lottie/expressions: free jerry_value_t on eval exception path

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -1494,6 +1494,7 @@ jerry_value_t LottieExpressions::evaluate(float frameNo, LottieExpression* exp)
 
     if (jerry_value_is_exception(eval)) {
         TVGERR("LOTTIE", "Failed to dispatch the expressions!");
+        jerry_value_free(eval);
         exp->disabled = true;
         return jerry_undefined();
     }


### PR DESCRIPTION
jerry_eval() returns a jerry_value_t that must be freed by the caller regardless of whether it is an exception. The exception path was missing jerry_value_free(eval), leaking the value on every failed expression evaluation.