### PR TITLE
lottie: Parse "shapes" property only for Shape layers

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1558,7 +1558,10 @@ LottieLayer* LottieParser::parseLayer(LottieLayer* precomp)
             layer->transform = parseTransform(ddd);
         }
         else if (KEY_AS("ao")) layer->autoOrient = getInt();
-        else if (KEY_AS("shapes")) parseShapes(layer->children);
+        else if (KEY_AS("shapes")) {
+            if (layer->type == LottieLayer::Shape)
+                parseShapes(layer->children);
+        }
         else if (KEY_AS("ip")) layer->inFrame = getFloat();
         else if (KEY_AS("op")) layer->outFrame = getFloat();
         else if (KEY_AS("st")) layer->startFrame = getFloat();


### PR DESCRIPTION
LottieFiles spec says only Shape layer has "shape" property.
https://lottiefiles.github.io/lottie-docs/layers/#shape-layer

It could lead to crashes because e.g. Image layer could get children other than LottieImage, which will lead to crash because of static_cast
https://github.com/thorvg/thorvg/blob/9ab446ccbeb2066fc51eed24c82957270f39e1c6/src/loaders/lottie/tvgLottieBuilder.cpp#L951