### PR TITLE
infra: use gcc 15 for arm64 binary size check

### DIFF
--- a/.github/workflows/binary_size.yml
+++ b/.github/workflows/binary_size.yml
@@ -55,9 +55,9 @@ jobs:
           - label: arm64 gcc
             key: arm64-gcc
             runs_on: ubuntu-24.04-arm
-            extra_packages: 'libturbojpeg0-dev libpng-dev libwebp-dev libgles-dev'
-            cc: gcc
-            cxx: g++
+            extra_packages: 'gcc-15 g++-15 libturbojpeg0-dev libpng-dev libwebp-dev libgles-dev'
+            cc: gcc-15
+            cxx: g++-15
             c_args: ''
             cpp_args: ''
             c_link_args: ''
@@ -114,6 +114,10 @@ jobs:
 
         mkdir -p "$APT_CACHE_DIR/archives/partial"
         echo "Installing missing packages: ${missing_packages[*]}"
+
+        if echo " ${missing_packages[*]} " | grep -Eq ' (gcc-15|g\+\+-15) '; then
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        fi
 
         sudo apt-get update -o Acquire::Retries=3
         sudo apt-get install -y --no-install-recommends \


### PR DESCRIPTION
| before | after|
|-|-|
|<img width="945" height="425" alt="image" src="https://github.com/user-attachments/assets/02acb48a-5c4c-42f3-be89-cdde95f1e976" />| <img width="945" height="425" alt="image" src="https://github.com/user-attachments/assets/178f2a1b-d1d5-457f-9022-425e65d16ee1" />|

upgrade GCC15 in CI