### PR TITLE
svg_loader: add text-anchor attribute support

### DIFF
--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -919,6 +919,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
     }
     if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
     auto processedText = _processText(textNode->text, xmlSpace);
+    text->align(node->style->textAnchor, 0.0f);
     text->text(processedText);
     tvg::free(processedText);
 

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -168,7 +168,8 @@ enum struct SvgStyleFlags
     StrokeMiterlimit = 0x20000,
     StrokeDashOffset = 0x40000,
     Filter = 0x80000,
-    BlendMode = 0x100000
+    BlendMode = 0x100000,
+    TextAnchor = 0x200000
 };
 
 constexpr bool operator&(SvgStyleFlags a, SvgStyleFlags b)
@@ -519,6 +520,7 @@ struct SvgStyleProperty
     int opacity;
     SvgColor color;
     char* cssClass;
+    float textAnchor;  // 0=start, 0.5=middle, 1=end
     SvgStyleFlags flags;
     SvgStyleFlags flagsImportance; //indicates the importance of the flag - if set, higher priority is applied (https://drafts.csswg.org/css-cascade-4/#importance)
     bool curColorSet;

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -145,6 +145,11 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from, bool 
         to->flags |= SvgStyleFlags::BlendMode;
         if (from->flagsImportance & SvgStyleFlags::BlendMode) to->flagsImportance |= SvgStyleFlags::BlendMode;
     }
+    if (((from->flags & SvgStyleFlags::TextAnchor) && (overwrite || !(to->flags & SvgStyleFlags::TextAnchor))) || _isImportanceApplicable(to->flagsImportance, from->flagsImportance, SvgStyleFlags::TextAnchor)) {
+        to->textAnchor = from->textAnchor;
+        to->flags |= SvgStyleFlags::TextAnchor;
+        if (from->flagsImportance & SvgStyleFlags::TextAnchor) to->flagsImportance |= SvgStyleFlags::TextAnchor;
+    }
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1078,6 +1078,14 @@ static void _handleMixBlendModeAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* n
     node->style->flags |= SvgStyleFlags::BlendMode;
 }
 
+static void _handleTextAnchorAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* node, const char* value)
+{
+    node->style->flags |= SvgStyleFlags::TextAnchor;
+    if (STR_AS(value, "middle")) node->style->textAnchor = 0.5f;
+    else if (STR_AS(value, "end")) node->style->textAnchor = 1.0f;
+    else node->style->textAnchor = 0.0f;
+}
+
 static void _handleCssClassAttr(SvgParserContext* ctx, SvgNode* node, const char* value)
 {
     auto cssClass = &node->style->cssClass;
@@ -1121,9 +1129,8 @@ static constexpr struct
     STYLE_DEF(display, Display, SvgStyleFlags::Display),
     STYLE_DEF(paint-order, PaintOrder, SvgStyleFlags::PaintOrder),
     STYLE_DEF(filter, Filter, SvgStyleFlags::Filter),
-    STYLE_DEF(mix-blend-mode, MixBlendMode, SvgStyleFlags::BlendMode)
-};
-
+    STYLE_DEF(mix-blend-mode, MixBlendMode, SvgStyleFlags::BlendMode),
+    STYLE_DEF(text-anchor, TextAnchor, SvgStyleFlags::TextAnchor)};
 
 static SvgXmlSpace _toXmlSpace(const char* str)
 {
@@ -2912,6 +2919,7 @@ static void _styleInherit(SvgStyleProperty* child, const SvgStyleProperty* paren
     if (!(child->stroke.flags & SvgStrokeFlags::Cap)) child->stroke.cap = parent->stroke.cap;
     if (!(child->stroke.flags & SvgStrokeFlags::Join)) child->stroke.join = parent->stroke.join;
     if (!(child->stroke.flags & SvgStrokeFlags::Miterlimit)) child->stroke.miterlimit = parent->stroke.miterlimit;
+    if (!(child->flags & SvgStyleFlags::TextAnchor)) child->textAnchor = parent->textAnchor;
 }
 
 
@@ -2928,6 +2936,7 @@ static void _styleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
     if (from->flags & SvgStyleFlags::PaintOrder) to->paintOrder = from->paintOrder;
     if (from->flags & SvgStyleFlags::Display) to->display = from->display;
     if (from->flags & SvgStyleFlags::BlendMode) to->blendMode = from->blendMode;
+    if (from->flags & SvgStyleFlags::TextAnchor) to->textAnchor = from->textAnchor;
 
     //Fill
     to->fill.flags = (to->fill.flags | from->fill.flags);


### PR DESCRIPTION
Parse the text-anchor attribute and apply it using the Text::align()
The anchor value is stored on SvgStyleProperty as a float (0=start, 0.5=middle, 1=end).

https://github.com/thorvg/thorvg/issues/4107