### PR TITLE
loader: update loader functions to accept `LoaderOps` parameter

### DIFF
--- a/src/renderer/tvgLoader.cpp
+++ b/src/renderer/tvgLoader.cpp
@@ -266,7 +266,7 @@ bool LoaderMgr::retrieve(Loader* loader)
     return true;
 }
 
-tvg::Loader* LoaderMgr::loader(const char* filename, bool* invalid)
+tvg::Loader* LoaderMgr::loader(const char* filename, const LoaderOps* ops, bool* invalid)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     *invalid = false;
@@ -281,7 +281,7 @@ tvg::Loader* LoaderMgr::loader(const char* filename, bool* invalid)
     }
 
     if (auto loader = _findByPath(filename)) {
-        if (loader->open(filename)) {
+        if (loader->open(filename, ops)) {
             if (allowCache) {
                 loader->cache(duplicate(filename));
                 {
@@ -296,7 +296,7 @@ tvg::Loader* LoaderMgr::loader(const char* filename, bool* invalid)
     //Unknown MimeType. Try with the candidates in the order
     for (int i = 0; i < static_cast<int>(FileType::Raw); i++) {
         if (auto loader = _find(static_cast<FileType>(i))) {
-            if (loader->open(filename)) {
+            if (loader->open(filename, ops)) {
                 if (allowCache) {
                     loader->cache(duplicate(filename));
                     {
@@ -320,7 +320,7 @@ bool LoaderMgr::retrieve(const char* filename)
     return retrieve(_findFromCache(filename));
 }
 
-tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mimeType, const char* rpath, bool copy)
+tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy)
 {
     //Note that users could use the same data pointer with the different content.
     //Thus caching is only valid for shareable.
@@ -339,7 +339,7 @@ tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mime
     //Try with the given MimeType
     if (mimeType) {
         if (auto loader = _findByType(mimeType)) {
-            if (loader->open(data, size, rpath, copy)) {
+            if (loader->open(data, size, ops, copy)) {
                 if (allowCache) {
                     loader->cache(HASH_KEY(data));
                     ScopedLock lock(_key);
@@ -356,7 +356,7 @@ tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mime
     for (int i = 0; i < static_cast<int>(FileType::Raw); i++) {
         auto loader = _find(static_cast<FileType>(i));
         if (loader) {
-            if (loader->open(data, size, rpath, copy)) {
+            if (loader->open(data, size, ops, copy)) {
                 if (allowCache) {
                     loader->cache(HASH_KEY(data));
                     ScopedLock lock(_key);
@@ -395,7 +395,7 @@ tvg::Loader* LoaderMgr::loader(const uint32_t* data, uint32_t w, uint32_t h, Col
 
 
 //loads fonts from memory - loader is cached (regardless of copy value) in order to access it while setting font
-tvg::Loader* LoaderMgr::loader(const char* name, const char* data, uint32_t size, TVG_UNUSED const char* mimeType, bool copy)
+tvg::Loader* LoaderMgr::loader(const char* name, const char* data, uint32_t size, TVG_UNUSED const char* mimeType, const LoaderOps* ops, bool copy)
 {
 #ifdef THORVG_TTF_LOADER_SUPPORT
     //TODO: add check for mimetype ?
@@ -403,7 +403,7 @@ tvg::Loader* LoaderMgr::loader(const char* name, const char* data, uint32_t size
 
     //function is dedicated for ttf loader (the only supported font loader)
     auto loader = new TtfLoader;
-    if (loader->open(data, size, "", copy)) {
+    if (loader->open(data, size, ops, copy)) {
         loader->name = duplicate(name);
         loader->cached = true;  //force it.
         ScopedLock lock(_key);


### PR DESCRIPTION
When [updating ThorVG to version 1.0.4](https://github.com/godotengine/godot/pull/118784), I came across a compilation error - it seemed like there was an API mismatch between `.cpp` and `.h` files; indeed, adding the new `LoaderOps` parameter solves the issue.

I'm not sure what the reason for this issue is. Was it simply overlooked in the commit https://github.com/thorvg/thorvg/commit/06b0c19eead79c3e1c66b1738ac5bf6bb10f60cc?
