### PR TITLE
gl_engine: accept single-stop gradients

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -289,7 +289,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
 
     const Fill::ColorStop* stops = nullptr;
     auto stopCnt = min(fill->colorStops(&stops), static_cast<uint32_t>(MAX_GRADIENT_STOPS));
-    if (stopCnt < 2) return;
+    if (stopCnt < 1) return;
 
     GlRenderTarget* dstCopyFbo = nullptr;
     auto radial = fill->type() == Type::RadialGradient;


### PR DESCRIPTION
Only reject empty gradient stop lists so single-stop fills are rendered instead of skipped.

## NOTE
Tracing further back, the guard first appears in af190033 from September 4, 2020, gl_engine: gradient implementation, when the GL gradient path was introduced in the first place. So this early return is part of the original GL gradient design, not a later workaround.
The CPU path only rejects cnt == 0 in tvgSwFill.cpp (line 129), and the WGPU path does the same in tvgWgShaderTypes.cpp (line 159). It's safe to change until we have an implementation for 1-stop gradients to degrade to a solid color.

I haven't found any obserable regression.

related issue: https://github.com/thorvg/thorvg/issues/4344