### PR TITLE
svg_loader: support text-anchor on tspan

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3160,7 +3160,7 @@ static void _spliceTspanClose(SvgParserContext* ctx)
 
     auto& t = cur->node.text;
     bool unpositioned = (t.x == FLT_MAX && t.y == FLT_MAX);
-    bool noOverride = (t.fontSize <= 0.0f && !t.fontFamily && cur->xmlSpace == SvgXmlSpace::None);
+    bool noOverride = (t.fontSize <= 0.0f && !t.fontFamily && cur->xmlSpace == SvgXmlSpace::None && !(cur->style->flags & SvgStyleFlags::TextAnchor));
 
     if (t.text && unpositioned && noOverride && cur->parent) {
         auto& parentText = cur->parent->node.text;


### PR DESCRIPTION
A tspan with its own text-anchor is no longer merged into the parent chunk and is rendered with its own anchor at the parent's position. Tspans without an explicit text-anchor still merge as before, so the existing chunk behavior for plain mixed text + tspan content is kept.

+https://github.com/thorvg/thorvg/pull/4357#issuecomment-4296667095