### PR TITLE
chore: fix valgrind report and uninitialized value noise

### DIFF
--- a/.github/workflows/memcheck_asan.sh
+++ b/.github/workflows/memcheck_asan.sh
@@ -29,7 +29,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
         OUTPUT+=$'\n```\n' 
 
         (
-            echo '<details><summary>ASAN output</sumary>'
+            echo '<details><summary>ASAN output</summary>'
             echo
             echo "$OUTPUT"
             echo

--- a/.github/workflows/memcheck_valgrind.sh
+++ b/.github/workflows/memcheck_valgrind.sh
@@ -18,7 +18,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
 
     echo $COMMENTS_URL
     echo "MEMCHECK errors:"
-    echo $PAYLOAD_MEMCHECK
+    echo "$PAYLOAD_MEMCHECK"
 
     DEFINITELY_LOST_NUMBER=$(echo "$PAYLOAD_MEMCHECK" | grep -oP 'definitely lost:\s*\K[0-9]+(?=\s*bytes in)')
     ERROR_NUMBER=$(echo "$PAYLOAD_MEMCHECK" | grep -oP 'ERROR SUMMARY:\s*\K[0-9]+(?=\s*errors)')
@@ -30,7 +30,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
         OUTPUT+=$'\n```\n' 
 
         (
-            echo '<details><summary>Valgrind output</sumary>'
+            echo '<details><summary>Valgrind output</summary>'
             echo
             echo "$OUTPUT"
             echo

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -197,8 +197,8 @@ struct LottieProperty
 
     LottieExpression* exp = nullptr;
     Type type;
-    uint8_t ix;  //property index
-    unsigned long sid; //property sid for slot
+    uint8_t ix = 0;  //property index
+    unsigned long sid = 0; //property sid for slot
 
     LottieProperty(Type type = Type::Invalid) : type(type) {}
     virtual ~LottieProperty() {}

--- a/test/testAccessor.cpp
+++ b/test/testAccessor.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Set", "[tvgAccessor]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         auto picture = Picture::gen();

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -301,7 +301,7 @@ TEST_CASE("Intersection", "[tvgPaint]")
     {
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
 
-        uint32_t buffer[200 * 200];
+        uint32_t buffer[200 * 200] = {};
         canvas->target(buffer, 200, 200, 200, ColorSpace::ARGB8888);
 
         auto shape = Shape::gen();

--- a/test/testPicture.cpp
+++ b/test/testPicture.cpp
@@ -297,7 +297,7 @@ TEST_CASE("Load PNG file and render", "[tvgPicture]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         auto picture = Picture::gen();
@@ -372,7 +372,7 @@ TEST_CASE("Load JPG file and render", "[tvgPicture]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         auto picture = Picture::gen();
@@ -441,7 +441,7 @@ TEST_CASE("Load WEBP file and render", "[tvgPicture]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         auto picture = Picture::gen();

--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -101,7 +101,7 @@ TEST_CASE("Scene Clear And Reuse Shape", "[tvgScene]")
     REQUIRE(Initializer::init() == Result::Success);
     {
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888);
 
         auto scene = Scene::gen();
@@ -132,7 +132,7 @@ TEST_CASE("Scene Effects", "[tvgScene]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         auto shape = Shape::gen();

--- a/test/testSwCanvas.cpp
+++ b/test/testSwCanvas.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Target Buffer", "[tvgSwCanvas]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
@@ -81,7 +81,7 @@ TEST_CASE("Pushing Paints", "[tvgSwCanvas]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         //Try all types of paints.
@@ -128,7 +128,7 @@ TEST_CASE("Update", "[tvgSwCanvas]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         REQUIRE(canvas->update() == Result::Success);
@@ -160,7 +160,7 @@ TEST_CASE("Synchronized Drawing", "[tvgSwCanvas]")
         REQUIRE(canvas->sync() == Result::Success);
         REQUIRE(canvas->draw() == Result::InsufficientCondition);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         REQUIRE(canvas->draw() == Result::Success);
@@ -194,7 +194,7 @@ TEST_CASE("Asynchronous Drawing", "[tvgSwCanvas]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         for (int i = 0; i < 3; ++i) {
@@ -220,7 +220,7 @@ TEST_CASE("Viewport", "[tvgSwCanvas]")
 
         REQUIRE(canvas->viewport(25, 25, 100, 100) == Result::Success);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         REQUIRE(canvas->viewport(25, 25, 50, 50) == Result::Success);

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Basic draw", "[tvgSwEngine]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888S) == Result::Success);
 
         std::vector<MaskMethod> masks;
@@ -143,7 +143,7 @@ TEST_CASE("Image Draw", "[tvgSwEngine]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         //raw image
@@ -249,7 +249,7 @@ TEST_CASE("Filling Draw", "[tvgSwEngine]")
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
         REQUIRE(canvas);
 
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         REQUIRE(canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
 
         std::vector<MaskMethod> masks;

--- a/test/testText.cpp
+++ b/test/testText.cpp
@@ -127,7 +127,7 @@ TEST_CASE("Text Basic", "[tvgText]")
     Initializer::init();
     {
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888);
 
         auto text = Text::gen();
@@ -153,7 +153,7 @@ TEST_CASE("Text with composite glyphs", "[tvgText]")
     Initializer::init();
     {
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888);
 
         auto text = Text::gen();
@@ -176,7 +176,7 @@ TEST_CASE("Text Styles", "[tvgText]")
     Initializer::init();
     {
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888);
 
         auto text = Text::gen();
@@ -210,7 +210,7 @@ TEST_CASE("Text Layout", "[tvgText]")
     Initializer::init();
     {
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888);
 
         auto text = Text::gen();
@@ -244,7 +244,7 @@ TEST_CASE("Text Wrap Mode", "[tvgText]")
     Initializer::init();
     {
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888);
 
         auto text = Text::gen();
@@ -283,7 +283,7 @@ TEST_CASE("Text Spacing", "[tvgText]")
     Initializer::init();
     {
         auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
-        uint32_t buffer[100*100];
+        uint32_t buffer[100*100] = {};
         canvas->target(buffer, 100, 100, 100, ColorSpace::ARGB8888);
 
         auto text = Text::gen();


### PR DESCRIPTION
https://github.com/thorvg/thorvg/actions/runs/24756890394

Currently, Valgrind reports a very large number of Conditional jump or move depends on uninitialised value(s) errors. The issue is not isolated to a single occurrence; it appears repeatedly across the test run and produces a substantial amount of log noise.


|before | after|
|-|-|
| 6133963 errors from 500 contexts | 0 errors from 0 contexts |





