### PR TITLE
svg_loader: support dx/dy on text and tspan

### DIFF
--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -899,7 +899,7 @@ static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const
     if (transform) textTransform = *transform;
     else textTransform = tvg::identity();
 
-    translateR(&textTransform, {textNode->x, textNode->y - textNode->fontSize});
+    translateR(&textTransform, {textNode->x + textNode->dx, textNode->y + textNode->dy - textNode->fontSize});
     text->transform(textTransform);
 
     //TODO: handle def values of font and size as used in a system?

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -396,6 +396,7 @@ struct SvgTextNode
     char* text;
     char* fontFamily;
     float x, y;
+    float dx, dy;
     float fontSize;
 };
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -2109,7 +2109,9 @@ static constexpr struct
     size_t offset;
 } textTags[] = {
     {"x", SvgParserLengthType::Horizontal, sizeof("x"), offsetof(SvgTextNode, x)},
-    {"y", SvgParserLengthType::Vertical, sizeof("y"), offsetof(SvgTextNode, y)}};
+    {"y", SvgParserLengthType::Vertical, sizeof("y"), offsetof(SvgTextNode, y)},
+    {"dx", SvgParserLengthType::Horizontal, sizeof("dx"), offsetof(SvgTextNode, dx)},
+    {"dy", SvgParserLengthType::Vertical, sizeof("dy"), offsetof(SvgTextNode, dy)}};
 
 static bool _attrPrescanTextFontSize(void* data, const char* key, const char* value)
 {
@@ -3050,6 +3052,8 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
         case SvgNodeType::Text: {
             to->node.text.x = from->node.text.x;
             to->node.text.y = from->node.text.y;
+            to->node.text.dx = from->node.text.dx;
+            to->node.text.dy = from->node.text.dy;
             to->node.text.fontSize = from->node.text.fontSize;
             svgUtilReplace(&to->node.text.text, from->node.text.text);
             svgUtilReplace(&to->node.text.fontFamily, from->node.text.fontFamily);
@@ -3159,7 +3163,7 @@ static void _spliceTspanClose(SvgParserContext* ctx)
     if (!cur || cur->type != SvgNodeType::Tspan) return;
 
     auto& t = cur->node.text;
-    bool unpositioned = (t.x == FLT_MAX && t.y == FLT_MAX);
+    bool unpositioned = (t.x == FLT_MAX && t.y == FLT_MAX && t.dx == 0.0f && t.dy == 0.0f);
     bool noOverride = (t.fontSize <= 0.0f && !t.fontFamily && cur->xmlSpace == SvgXmlSpace::None && !(cur->style->flags & SvgStyleFlags::TextAnchor));
 
     if (t.text && unpositioned && noOverride && cur->parent) {


### PR DESCRIPTION
Add dx/dy positional shift attributes to text and tspan elements.

https://github.com/thorvg/thorvg/issues/4107