### PR TITLE
lottie: accept image data mime case variants

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1062,7 +1062,7 @@ void LottieParser::parseFontData(LottieFont* font, const char* data)
     //handle base64 font data
     if (!strncmp(data, "data:font/", sizeof("data:font/") - 1)) {
         data += sizeof("data:font/") - 1;
-        if (!strncmp(data, "ttf", 3)) {
+        if (!strncasecmp(data, "ttf", 3)) {
             data += 3;
         } else {
             TVGLOG("LOTTIE", "TODO: Support a new font type!");


### PR DESCRIPTION
related: https://github.com/thorvg/thorvg/pull/4371

Test file : [test_font_ttf_case.json](https://github.com/user-attachments/files/27273601/test_font_ttf_case.json)

> Uppercase `data:font/TTF` -> The font couldn't be loaded

| Before  | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/e5f7ce4b-7f35-411c-ac5c-fe4aba9aa342" width="100%"> | <img src="https://github.com/user-attachments/assets/bbe54d7f-4187-4a0a-85be-2dd939395436" width="100%"> |