### PR TITLE
gpu_engine: draw strokes in local coordinates

### DIFF
--- a/src/common/tvgMath.cpp
+++ b/src/common/tvgMath.cpp
@@ -458,7 +458,7 @@ void Bezier::bounds(BBox& box, const Point& start, const Point& ctrl1, const Poi
 }
 
 
-bool Bezier::flatten() const
+bool Bezier::flatten(float tolerance) const
 {
     float diff1_x = fabsf((ctrl1.x * 3.f) - (start.x * 2.f) - end.x);
     float diff1_y = fabsf((ctrl1.y * 3.f) - (start.y * 2.f) - end.y);
@@ -466,13 +466,14 @@ bool Bezier::flatten() const
     float diff2_y = fabsf((ctrl2.y * 3.f) - (end.y * 2.f) - start.y);
     if (diff1_x < diff2_x) diff1_x = diff2_x;
     if (diff1_y < diff2_y) diff1_y = diff2_y;
-    return (diff1_x + diff1_y <= 0.5f);
+    return (diff1_x + diff1_y <= tolerance);
 }
 
 
-uint32_t Bezier::segments() const
+uint32_t Bezier::segments(float scale) const
 {
     static constexpr uint32_t MaxSegments = 1u << 10; // 2^10 segments cap keeps runtime bounded
+    auto tolerance = 0.5f / scale;
     uint32_t count = 0;
     Array<Bezier> stack;
     stack.push(*this);
@@ -480,7 +481,7 @@ uint32_t Bezier::segments() const
 
     while (!stack.empty()) {
         auto current = stack.pick();
-        if (current.flatten()) {
+        if (current.flatten(tolerance)) {
             ++count;
             continue;
         }

--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -135,7 +135,9 @@ static inline constexpr const Matrix identity()
 
 static inline float scaling(const Matrix& m)
 {
-    return sqrtf(m.e11 * m.e11 + m.e21 * m.e21);
+    auto sx = m.e11 * m.e11 + m.e21 * m.e21;
+    auto sy = m.e12 * m.e12 + m.e22 * m.e22;
+    return sqrtf((sx > sy) ? sx : sy);
 }
 
 
@@ -488,8 +490,8 @@ struct Bezier
     float atApprox(float at, float length) const;
     Point at(float t) const;
     float angle(float t) const;
-    bool flatten() const;
-    uint32_t segments() const;
+    bool flatten(float tolerance) const;
+    uint32_t segments(float scale = 1.0f) const;
 
     Bezier operator*(const Matrix& m);
 

--- a/src/renderer/gpu_engine/gl/tvgGlCommon.h
+++ b/src/renderer/gpu_engine/gl/tvgGlCommon.h
@@ -78,7 +78,7 @@ struct GlGeometryBuffer {
 
 struct GlGeometry
 {
-    const Matrix* inverseMatrix()
+    const Matrix* inverseMatrix() const
     {
         if (!inverseMatrixDirty) return &cachedInverseMatrix;
         inverse(&matrix, &cachedInverseMatrix);
@@ -91,7 +91,7 @@ struct GlGeometry
     void prepare(const RenderShape& rshape);
     bool tesselateShape(const RenderShape& rshape, float* opacityMultiplier = nullptr);
     bool tesselateStroke(const RenderShape& rshape);
-    bool tesselateThinPath(const RenderPath& path);
+    bool tesselateThinFill(const RenderPath& path);
     void tesselateImage(const RenderSurface* image);
     bool drawable(RenderUpdateFlag flag) const
     {
@@ -109,10 +109,11 @@ struct GlGeometry
     RenderRegion fillBounds = {};
     RenderRegion strokeBounds = {};
     FillRule fillRule = FillRule::NonZero;
-    RenderPath optPath;  //optimal path
+    RenderPath optPath;        // optimal transformed path
+    RenderPath optStrokePath;  // matching local path using transformed-space tolerance
     float strokeRenderWidth = 0.0f;
-    Matrix cachedInverseMatrix = {};
-    bool inverseMatrixDirty = true;
+    mutable Matrix cachedInverseMatrix = {};
+    mutable bool inverseMatrixDirty = true;
     bool fillWorld = false;
     bool optPathThin = false;
     bool optPathSkipFill = false;
@@ -140,9 +141,8 @@ struct GlShape
 
 struct GlIntersector
 {
-    bool isPointInTriangle(const Point& p, const Point& a, const Point& b, const Point& c);
     bool isPointInImage(const Point& p, const GlGeometryBuffer& mesh, const Matrix& tr);
-    bool isPointInTris(const Point& p, const GlGeometryBuffer& mesh, const Matrix& tr);
+    bool isPointInTris(const Point& p, const GlGeometryBuffer& mesh);
     bool isPointInMesh(const Point& p, const GlGeometryBuffer& mesh, const Matrix& tr);
     bool intersectClips(const Point& pt, const tvg::Array<tvg::RenderData>& clips);
     bool intersectShape(const RenderRegion region, const GlShape* shape);

--- a/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
@@ -25,54 +25,26 @@
 #include "tvgGlRenderTask.h"
 #include "tvgGlTessellator.h"
 
-static RenderRegion _transformBounds(const RenderRegion& bounds, const Matrix& matrix)
-{
-    if (bounds.invalid()) return bounds;
-
-    auto lt = Point{float(bounds.min.x), float(bounds.min.y)} * matrix;
-    auto lb = Point{float(bounds.min.x), float(bounds.max.y)} * matrix;
-    auto rt = Point{float(bounds.max.x), float(bounds.min.y)} * matrix;
-    auto rb = Point{float(bounds.max.x), float(bounds.max.y)} * matrix;
-
-    auto left = min(min(lt.x, lb.x), min(rt.x, rb.x));
-    auto top = min(min(lt.y, lb.y), min(rt.y, rb.y));
-    auto right = max(max(lt.x, lb.x), max(rt.x, rb.x));
-    auto bottom = max(max(lt.y, lb.y), max(rt.y, rb.y));
-
-    return RenderRegion{{int32_t(floor(left)), int32_t(floor(top))}, {int32_t(ceil(right)), int32_t(ceil(bottom))}};
-}
-
-
-bool GlIntersector::isPointInTriangle(const Point& p, const Point& a, const Point& b, const Point& c)
-{
-    auto d1 = tvg::cross(p - a, p - b);
-    auto d2 = tvg::cross(p - b, p - c);
-    auto d3 = tvg::cross(p - c, p - a);
-    auto has_neg = (d1 < 0) || (d2 < 0) || (d3 < 0);
-    auto has_pos = (d1 > 0) || (d2 > 0) || (d3 > 0);
-    return !(has_neg && has_pos);
-}
-
 bool GlIntersector::isPointInImage(const Point& p, const GlGeometryBuffer& mesh, const Matrix& tr)
 {
     for (uint32_t i = 0; i < mesh.index.count; i += 3) {
         auto p0 = Point{mesh.vertex[mesh.index[i+0]*4+0], mesh.vertex[mesh.index[i+0]*4+1]} * tr;
         auto p1 = Point{mesh.vertex[mesh.index[i+1]*4+0], mesh.vertex[mesh.index[i+1]*4+1]} * tr;
         auto p2 = Point{mesh.vertex[mesh.index[i+2]*4+0], mesh.vertex[mesh.index[i+2]*4+1]} * tr;
-        if (isPointInTriangle(p, p0, p1, p2)) return true;
+        if (gpuPointInTriangle(p, p0, p1, p2)) return true;
     }
     return false;
 }
 
 
 // triangle list
-bool GlIntersector::isPointInTris(const Point& p, const GlGeometryBuffer& mesh, const Matrix& tr)
+bool GlIntersector::isPointInTris(const Point& p, const GlGeometryBuffer& mesh)
 {
     for (uint32_t i = 0; i < mesh.index.count; i += 3) {
-        auto p0 = Point{mesh.vertex[mesh.index[i+0]*2+0], mesh.vertex[mesh.index[i+0]*2+1]} * tr;
-        auto p1 = Point{mesh.vertex[mesh.index[i+1]*2+0], mesh.vertex[mesh.index[i+1]*2+1]} * tr;
-        auto p2 = Point{mesh.vertex[mesh.index[i+2]*2+0], mesh.vertex[mesh.index[i+2]*2+1]} * tr;
-        if (isPointInTriangle(p, p0, p1, p2)) return true;
+        auto p0 = Point{mesh.vertex[mesh.index[i + 0] * 2 + 0], mesh.vertex[mesh.index[i + 0] * 2 + 1]};
+        auto p1 = Point{mesh.vertex[mesh.index[i + 1] * 2 + 0], mesh.vertex[mesh.index[i + 1] * 2 + 1]};
+        auto p2 = Point{mesh.vertex[mesh.index[i + 2] * 2 + 0], mesh.vertex[mesh.index[i + 2] * 2 + 1]};
+        if (gpuPointInTriangle(p, p0, p1, p2)) return true;
     }
     return false;
 }
@@ -102,16 +74,18 @@ bool GlIntersector::isPointInMesh(const Point& p, const GlGeometryBuffer& mesh, 
     return (crossings % 2) == 1;
 }
 
-
 bool GlIntersector::intersectClips(const Point& pt, const tvg::Array<tvg::RenderData>& clips)
 {
     for (uint32_t i = 0; i < clips.count; i++) {
-        auto clip = (GlShape*)clips[i];
-        if (!isPointInMesh(pt, clip->geometry.fill, clip->geometry.fillWorld ? tvg::identity() : clip->geometry.matrix)) return false;
+        auto clip = (const GlShape*)clips[i];
+        if (clip->validFill) {
+            if (!isPointInMesh(pt, clip->geometry.fill, clip->geometry.fillWorld ? tvg::identity() : clip->geometry.matrix)) return false;
+        } else if (clip->validStroke) {
+            if (!isPointInTris(pt * *clip->geometry.inverseMatrix(), clip->geometry.stroke)) return false;
+        }
     }
     return true;
 }
-
 
 bool GlIntersector::intersectShape(const RenderRegion region, const GlShape* shape)
 {
@@ -125,7 +99,7 @@ bool GlIntersector::intersectShape(const RenderRegion region, const GlShape* sha
             if (y % 2 == 1) pt.y = (float)sizeY - y - sizeY % 2 + region.min.y;
             if (intersectClips(pt, shape->clips)) {
                 if (shape->validFill && isPointInMesh(pt, shape->geometry.fill, shape->geometry.fillWorld ? tvg::identity() : shape->geometry.matrix)) return true;
-                if (shape->validStroke && isPointInTris(pt, shape->geometry.stroke, tvg::identity())) return true;
+                if (shape->validStroke && isPointInTris(pt * *shape->geometry.inverseMatrix(), shape->geometry.stroke)) return true;
             }
         }
     }
@@ -154,16 +128,26 @@ void GlGeometry::prepare(const RenderShape& rshape)
 {
     optPathThin = false;
     optPathSkipFill = false;
+    optStrokePath.clear();
+
+    auto strokeWidth = rshape.strokeWidth();
+    auto localOut = (std::isfinite(strokeWidth) && !tvg::zero(strokeWidth)) ? &optStrokePath : nullptr;
+    auto path = &rshape.path;
+    RenderPath trimmedPath;
+
     if (rshape.trimpath()) {
-        RenderPath trimmedPath;
         if (rshape.stroke->trim.trim(rshape.path, trimmedPath)) {
-            gpuOptimize(trimmedPath, optPath, matrix, optPathThin, optPathSkipFill);
+            path = &trimmedPath;
         } else {
             optPath.clear();
+            return;
         }
-    } else {
-        gpuOptimize(rshape.path, optPath, matrix, optPathThin, optPathSkipFill);
     }
+
+    GpuOptimizeResult result{&optPath, localOut};
+    gpuOptimize(*path, result, matrix);
+    optPathThin = result.thin;
+    optPathSkipFill = result.skipFill;
 }
 
 
@@ -182,13 +166,7 @@ bool GlGeometry::tesselateShape(const RenderShape& rshape, float* opacityMultipl
     // After CTM:  [.]        // thinner than 1 px in device space
     // Visible thin fills use stroke tessellation; sub-quantum fills are skipped earlier.
     if (optPathThin && tvg::zero(rshape.strokeWidth())) {
-        if (tesselateThinPath(optPath)) {
-            // The time spent is similar to substituting buffers in tessellation, so we just move the buffers to keep the code simple.
-            stroke.index.move(fill.index);
-            stroke.vertex.move(fill.vertex);
-            fillBounds = strokeBounds;
-            strokeBounds = {};
-            strokeRenderWidth = 0.0f;
+        if (tesselateThinFill(optPath)) {
             if (opacityMultiplier) *opacityMultiplier = MIN_GL_STROKE_ALPHA;
             fillRule = rshape.rule;
             return true;
@@ -207,15 +185,21 @@ bool GlGeometry::tesselateShape(const RenderShape& rshape, float* opacityMultipl
 }
 
 
-bool GlGeometry::tesselateThinPath(const RenderPath& path)
+bool GlGeometry::tesselateThinFill(const RenderPath& path)
 {
     stroke.clear();
     strokeBounds = {};
-    strokeRenderWidth = MIN_GL_STROKE_WIDTH;
     if (path.pts.count < 2) return false;
+
+    // Thin fills borrow stroke tessellation, but the generated stroke buffer is
+    // temporary. It must be moved into fill before this function returns.
     Stroker stroker(&stroke, MIN_GL_STROKE_WIDTH, StrokeCap::Butt, StrokeJoin::Bevel);
-    stroker.run(path);
-    strokeBounds = stroker.bounds();
+    stroker.run(path); // path is already in world space.
+    stroke.index.move(fill.index);
+    stroke.vertex.move(fill.vertex);
+    fillBounds = stroker.bounds();
+    strokeBounds = {};
+    strokeRenderWidth = 0.0f;
     return true;
 }
 
@@ -226,28 +210,23 @@ bool GlGeometry::tesselateStroke(const RenderShape& rshape)
     strokeBounds = {};
     strokeRenderWidth = 0.0f;
 
-    auto strokeWidth = 0.0f;
-    if (isinf(matrix.e11)) {
-        strokeWidth = rshape.strokeWidth() * scaling(matrix);
-        if (strokeWidth <= MIN_GL_STROKE_WIDTH) strokeWidth = MIN_GL_STROKE_WIDTH;
-        strokeWidth = strokeWidth / matrix.e11;
-    } else {
-        strokeWidth = rshape.strokeWidth();
-    }
-    auto strokeWidthWorld = strokeWidth * scaling(matrix);
-    if (!std::isfinite(strokeWidthWorld)) strokeWidthWorld = strokeWidth;
+    auto strokeWidth = rshape.strokeWidth();
+    if (!std::isfinite(strokeWidth)) return false;
+    if (tvg::zero(strokeWidth)) return false;
 
-    //run stroking only if it's valid
-    if (!tvg::zero(strokeWidthWorld)) {
-        Stroker stroker(&stroke, strokeWidthWorld, rshape.strokeCap(), rshape.strokeJoin(), rshape.strokeMiterlimit());
-        auto& dashed = RenderPath::scratch();
-        if (gpuStrokeDash(rshape, dashed, &matrix)) stroker.run(dashed);
-        else stroker.run(optPath);
-        strokeBounds = stroker.bounds();
-        strokeRenderWidth = strokeWidthWorld;
-        return true;
-    }
-    return false;
+    auto qualityScale = scaling(matrix);
+    if (!std::isfinite(qualityScale)) return false;
+    if (tvg::zero(qualityScale)) return false;
+    strokeRenderWidth = strokeWidth * qualityScale;
+    if (!std::isfinite(strokeRenderWidth)) return false; // Invalid stroke render width when width and quality scale are finite but their product is not finite.
+
+    // Keep stroke vertices local; GL applies model later through uViewMatrix.
+    Stroker stroker(&stroke, strokeWidth, rshape.strokeCap(), rshape.strokeJoin(), rshape.strokeMiterlimit(), qualityScale);
+    auto& dashed = RenderPath::scratch();
+    if (gpuStrokeDash(rshape, dashed, nullptr)) stroker.run(dashed);
+    else stroker.run(optStrokePath);
+    strokeBounds = stroker.bounds();
+    return true;
 }
 
 
@@ -285,7 +264,7 @@ void GlGeometry::tesselateImage(const RenderSurface* image)
     fill.index.push(1);
     fill.index.push(3);
 
-    fillBounds = _transformBounds(RenderRegion{{0, 0}, {int32_t(image->w), int32_t(image->h)}}, matrix);
+    fillBounds = gpuTransformBounds(RenderRegion{{0, 0}, {int32_t(image->w), int32_t(image->h)}}, matrix);
 }
 
 void GlGeometry::draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag) const
@@ -324,7 +303,7 @@ RenderRegion GlGeometry::getBounds() const
     auto hasBounds = false;
 
     if (!fill.index.empty()) {
-        auto fill = fillWorld ? fillBounds : _transformBounds(fillBounds, matrix);
+        auto fill = fillWorld ? fillBounds : gpuTransformBounds(fillBounds, matrix);
         if (fill.valid()) {
             bounds = fill;
             hasBounds = true;
@@ -332,7 +311,7 @@ RenderRegion GlGeometry::getBounds() const
     }
 
     if (!stroke.index.empty()) {
-        auto stroke = strokeBounds;
+        auto stroke = gpuTransformBounds(strokeBounds, matrix);
         if (stroke.valid()) {
             if (hasBounds) bounds.add(stroke);
             else {

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -295,8 +295,9 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdat
 
     GlRenderTarget* dstCopyFbo = nullptr;
     auto task = createPrimitiveTask(RT_Color, BlendSource::Solid, viewRegion, dstCopyFbo);
+    auto viewMatrix = _viewMatrix(sdata.geometry, currentPass()->getViewMatrix(), flag);
 
-    task->setViewMatrix(_viewMatrix(sdata.geometry, currentPass()->getViewMatrix(), flag));
+    task->setViewMatrix(viewMatrix);
     task->setDrawDepth(depth);
 
     auto a = MULTIPLY(c.a, sdata.opacity);
@@ -310,7 +311,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdat
     task->setVertexColor(c.r / 255.f, c.g / 255.f, c.b / 255.f, a / 255.f);
     task->setViewport(viewRegion);
 
-    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, &mGpuBuffer, flag, stencilMode, depth, currentPass()->getViewMatrix(), viewRegion);
+    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, &mGpuBuffer, flag, stencilMode, depth, viewMatrix, viewRegion);
     // Keep BlendRegion on the existing solid-shape blend UBO slot.
     bindBlendTarget(task, dstCopyFbo, viewRegion, 2);
 
@@ -346,14 +347,15 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
     } else return;
 
     auto task = createPrimitiveTask(taskType, blendSource, viewRegion, dstCopyFbo);
+    auto viewMatrix = _viewMatrix(sdata.geometry, currentPass()->getViewMatrix(), flag);
 
-    task->setViewMatrix(_viewMatrix(sdata.geometry, currentPass()->getViewMatrix(), flag));
+    task->setViewMatrix(viewMatrix);
     task->setDrawDepth(depth);
 
     task->setViewport(viewRegion);
 
     GlStencilMode stencilMode = sdata.geometry.getStencilMode(flag);
-    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, &mGpuBuffer, flag, stencilMode, depth, currentPass()->getViewMatrix(), viewRegion);
+    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, &mGpuBuffer, flag, stencilMode, depth, viewMatrix, viewRegion);
 
     // transform buffer (inverse fill-space transform)
     float invMat3[GL_MAT3_STD140_SIZE];
@@ -507,7 +509,7 @@ void GlRenderer::drawClip(Array<RenderData>& clips)
 
         auto clipTask = new GlRenderTask(mPrograms[RT_Stencil]);
         clipTask->setDrawDepth(clipDepths[i]);
-        clipTask->setViewMatrix(viewMatrix);
+        clipTask->setViewMatrix(_viewMatrix(sdata->geometry, viewMatrix, flag));
         sdata->geometry.draw(clipTask, &mGpuBuffer, flag);
 
         auto bbox = sdata->geometry.viewport;

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -228,6 +228,14 @@ static void addPrimitiveTask(GlRenderPass* pass, GlRenderTask* task, GlRenderTas
     else pass->addRenderTask(task);
 }
 
+static Matrix _viewMatrix(const GlGeometry& geometry, const Matrix& viewMatrix, RenderUpdateFlag flag)
+{
+    // Most GL meshes are already in world space; local strokes fold model into
+    // the shader's view matrix so the draw path can stay shared.
+    if ((flag & RenderUpdateFlag::Stroke) || (flag & RenderUpdateFlag::GradientStroke)) return viewMatrix * geometry.matrix;
+    return viewMatrix;
+}
+
 GlRenderTask* GlRenderer::createPrimitiveTask(RenderTypes type, BlendSource source, const RenderRegion& viewRegion, GlRenderTarget*& dstCopyFbo)
 {
     dstCopyFbo = nullptr;
@@ -288,7 +296,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdat
     GlRenderTarget* dstCopyFbo = nullptr;
     auto task = createPrimitiveTask(RT_Color, BlendSource::Solid, viewRegion, dstCopyFbo);
 
-    task->setViewMatrix(currentPass()->getViewMatrix());
+    task->setViewMatrix(_viewMatrix(sdata.geometry, currentPass()->getViewMatrix(), flag));
     task->setDrawDepth(depth);
 
     auto a = MULTIPLY(c.a, sdata.opacity);
@@ -339,7 +347,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
 
     auto task = createPrimitiveTask(taskType, blendSource, viewRegion, dstCopyFbo);
 
-    task->setViewMatrix(currentPass()->getViewMatrix());
+    task->setViewMatrix(_viewMatrix(sdata.geometry, currentPass()->getViewMatrix(), flag));
     task->setDrawDepth(depth);
 
     task->setViewport(viewRegion);
@@ -351,9 +359,13 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
     float invMat3[GL_MAT3_STD140_SIZE];
     Matrix inv;
     inverse(&fill->transform(), &inv);
-    Matrix invShape;
-    inverse(&sdata.geometry.matrix, &invShape);
-    inv = inv * invShape;
+    if (!(flag & RenderUpdateFlag::GradientStroke)) {
+        // World-space meshes need inverse model before gradient lookup. Local
+        // gradient strokes already pass local positions to TransformInfo.
+        Matrix invShape;
+        inverse(&sdata.geometry.matrix, &invShape);
+        inv = inv * invShape;
+    }
     getMatrix3Std140(inv, invMat3);
 
     float transformInfo[GL_MAT3_STD140_SIZE];
@@ -965,38 +977,25 @@ bool GlRenderer::sync()
 
 bool GlRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
 {
-    if (data) {
-        auto sdata = static_cast<GlShape*>(data);
-        if (sdata->validStroke) {
-            tvg::BBox bbox;
-            bbox.init();
-            auto& vertexes = sdata->geometry.stroke.vertex;
-            if (m == sdata->geometry.matrix) {
-                // Common AABB path: stroke vertices are already in world space.
-                for (uint32_t i = 0; i < vertexes.count / 2; i++) {
-                    Point vert = {vertexes[i * 2 + 0], vertexes[i * 2 + 1]};
-                    bbox = { min(bbox.min, vert), max(bbox.max, vert)};
-                }
-            } else {
-                // GL stroke vertices are generated in world space.
-                // Normalize to local space first, then remap to the caller-requested space.
-                // - OBB path passes m = identity -> result becomes local (caller applies model later).
-                const auto inverseModel = sdata->geometry.inverseMatrix();
+    if (!data) return false;
 
-                for (uint32_t i = 0; i < vertexes.count / 2; i++) {
-                    Point vert = {vertexes[i * 2 + 0], vertexes[i * 2 + 1]};
-                    vert *= (*inverseModel) * m;
-                    bbox = { min(bbox.min, vert), max(bbox.max, vert)};
-                }
-            }
-            pt4[0] = bbox.min;
-            pt4[1] = {bbox.max.x, bbox.min.y};
-            pt4[2] = bbox.max;
-            pt4[3] = {bbox.min.x, bbox.max.y};
-            return true;
-        }
+    auto sdata = static_cast<GlShape*>(data);
+    if (!sdata->validStroke) return false;
+
+    tvg::BBox bbox;
+    bbox.init();
+    auto& vertexes = sdata->geometry.stroke.vertex;
+    for (uint32_t i = 0; i < vertexes.count / 2; i++) {
+        Point vert = {vertexes[i * 2 + 0], vertexes[i * 2 + 1]};
+        vert *= m;
+        bbox = {min(bbox.min, vert), max(bbox.max, vert)};
     }
-    return false;
+
+    pt4[0] = bbox.min;
+    pt4[1] = {bbox.max.x, bbox.min.y};
+    pt4[2] = bbox.max;
+    pt4[3] = {bbox.min.x, bbox.max.y};
+    return true;
 }
 
 
@@ -1299,8 +1298,9 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
     sdata->geometry.setMatrix(transform);
     sdata->geometry.viewport = vport;
-    if (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform)) sdata->geometry.prepare(rshape);
-    
+    auto strokePathMissing = (flags & RenderUpdateFlag::Stroke) && rshape.stroke && std::isfinite(rshape.strokeWidth()) && !tvg::zero(rshape.strokeWidth()) && sdata->geometry.optStrokePath.empty();
+    if ((flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform)) || strokePathMissing) sdata->geometry.prepare(rshape);
+
     //TODO: Please precisely update tessellation not to update only if the color is changed.
     if (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
         sdata->validFill = false;

--- a/src/renderer/gpu_engine/gl/tvgGlTessellator.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlTessellator.cpp
@@ -32,7 +32,7 @@ static uint32_t _pushVertex(Array<float>& array, float x, float y)
     return (array.count - 2) / 2;
 }
 
-Stroker::Stroker(GlGeometryBuffer* buffer, float width, StrokeCap cap, StrokeJoin join, float miterLimit) : mBuffer(buffer), mWidth(width), mMiterLimit(miterLimit), mCap(cap), mJoin(join)
+Stroker::Stroker(GlGeometryBuffer* buffer, float width, StrokeCap cap, StrokeJoin join, float miterLimit, float qualityScale) : mBuffer(buffer), mWidth(width), mMiterLimit(miterLimit), mQualityScale(qualityScale), mCap(cap), mJoin(join)
 {
 }
 
@@ -167,7 +167,7 @@ void Stroker::cubicTo(const Point& cnt1, const Point& cnt2, const Point& end)
 {
     Bezier curve{ mState.prevPt, cnt1, cnt2, end };
 
-    auto count = curve.segments();
+    auto count = curve.segments(mQualityScale);
     auto step = 1.f / count;
 
     for (uint32_t i = 0; i <= count; i++) {
@@ -243,7 +243,7 @@ void Stroker::round(const Point &prev, const Point& curr, const Point& center)
     }
 
     auto arcAngle = endAngle - startAngle;
-    auto count = arcSegmentsCnt(arcAngle, radius());
+    auto count = arcSegmentsCnt(arcAngle, radius() * mQualityScale);
 
     auto c = _pushVertex(mBuffer->vertex, center.x, center.y);
     auto pi = _pushVertex(mBuffer->vertex, prev.x, prev.y);
@@ -270,7 +270,7 @@ void Stroker::round(const Point &prev, const Point& curr, const Point& center)
 
 void Stroker::roundPoint(const Point &p)
 {
-    auto count = arcSegmentsCnt(2.0f * MATH_PI, radius());
+    auto count = arcSegmentsCnt(2.0f * MATH_PI, radius() * mQualityScale);
     auto c = _pushVertex(mBuffer->vertex, p.x, p.y);
     auto step = 2.0f * MATH_PI / (count - 1);
 

--- a/src/renderer/gpu_engine/gl/tvgGlTessellator.h
+++ b/src/renderer/gpu_engine/gl/tvgGlTessellator.h
@@ -38,7 +38,7 @@ class Stroker
         Point prevPtDir;
     };
 public:
-    Stroker(GlGeometryBuffer* buffer, float strokeWidth, StrokeCap cap, StrokeJoin join, float miterLimit = 4.0f);
+    Stroker(GlGeometryBuffer* buffer, float strokeWidth, StrokeCap cap, StrokeJoin join, float miterLimit = 4.0f, float qualityScale = 1.0f);
     void run(const RenderPath& path);
     RenderRegion bounds() const;
 
@@ -65,6 +65,7 @@ private:
     GlGeometryBuffer* mBuffer;
     float mWidth = 0.0f;
     float mMiterLimit = 4.f;
+    float mQualityScale = 1.0f;
     StrokeCap mCap = StrokeCap::Square;
     StrokeJoin mJoin = StrokeJoin::Bevel;
     State mState = {};

--- a/src/renderer/gpu_engine/tvgGpuCommon.cpp
+++ b/src/renderer/gpu_engine/tvgGpuCommon.cpp
@@ -56,12 +56,10 @@ RenderRegion gpuTransformBounds(const RenderRegion& bounds, const Matrix& matrix
     auto rt = Point{float(bounds.max.x), float(bounds.min.y)} * matrix;
     auto rb = Point{float(bounds.max.x), float(bounds.max.y)} * matrix;
 
-    auto left = std::min(std::min(lt.x, lb.x), std::min(rt.x, rb.x));
-    auto top = std::min(std::min(lt.y, lb.y), std::min(rt.y, rb.y));
-    auto right = std::max(std::max(lt.x, lb.x), std::max(rt.x, rb.x));
-    auto bottom = std::max(std::max(lt.y, lb.y), std::max(rt.y, rb.y));
+    auto min = tvg::min(tvg::min(lt, lb), tvg::min(rt, rb));
+    auto max = tvg::max(tvg::max(lt, lb), tvg::max(rt, rb));
 
-    return RenderRegion{{int32_t(floor(left)), int32_t(floor(top))}, {int32_t(ceil(right)), int32_t(ceil(bottom))}};
+    return RenderRegion{{int32_t(floor(min.x)), int32_t(floor(min.y))}, {int32_t(ceil(max.x)), int32_t(ceil(max.y))}};
 }
 
 struct ThinPathTracker

--- a/src/renderer/gpu_engine/tvgGpuCommon.cpp
+++ b/src/renderer/gpu_engine/tvgGpuCommon.cpp
@@ -37,6 +37,33 @@ constexpr uint32_t SW_AA_COVERAGE_BITS = 8;
 constexpr auto AA_COVERAGE_QUANTUM = 1.0f / static_cast<float>(1u << SW_AA_COVERAGE_BITS);
 constexpr auto MAX_PIXEL_SPAN = 1.41421356237f;
 
+bool gpuPointInTriangle(const Point& p, const Point& a, const Point& b, const Point& c)
+{
+    auto d1 = tvg::cross(p - a, p - b);
+    auto d2 = tvg::cross(p - b, p - c);
+    auto d3 = tvg::cross(p - c, p - a);
+    auto hasNeg = (d1 < 0) || (d2 < 0) || (d3 < 0);
+    auto hasPos = (d1 > 0) || (d2 > 0) || (d3 > 0);
+    return !(hasNeg && hasPos);
+}
+
+RenderRegion gpuTransformBounds(const RenderRegion& bounds, const Matrix& matrix)
+{
+    if (bounds.invalid()) return bounds;
+
+    auto lt = Point{float(bounds.min.x), float(bounds.min.y)} * matrix;
+    auto lb = Point{float(bounds.min.x), float(bounds.max.y)} * matrix;
+    auto rt = Point{float(bounds.max.x), float(bounds.min.y)} * matrix;
+    auto rb = Point{float(bounds.max.x), float(bounds.max.y)} * matrix;
+
+    auto left = std::min(std::min(lt.x, lb.x), std::min(rt.x, rb.x));
+    auto top = std::min(std::min(lt.y, lb.y), std::min(rt.y, rb.y));
+    auto right = std::max(std::max(lt.x, lb.x), std::max(rt.x, rb.x));
+    auto bottom = std::max(std::max(lt.y, lb.y), std::max(rt.y, rb.y));
+
+    return RenderRegion{{int32_t(floor(left)), int32_t(floor(top))}, {int32_t(ceil(right)), int32_t(ceil(bottom))}};
+}
+
 struct ThinPathTracker
 {
     enum
@@ -185,17 +212,31 @@ struct ThinPathTracker
     }
 };
 
-// Simplify the transformed path and classify thin-fill fallback / skip-fill cases.
-void gpuOptimize(const RenderPath& in, RenderPath& out, const Matrix& matrix, bool& thin, bool& skipFill)
+// Simplify in transformed space and optionally mirror the same decisions into a
+// local-coordinate path for stroke tessellation.
+void gpuOptimize(const RenderPath& in, GpuOptimizeResult& result, const Matrix& matrix)
 {
-    thin = false;
-    skipFill = false;
-    if (in.empty()) return;
+    result.thin = false;
+    result.skipFill = false;
+    if (!result.transformed) return;
+
+    auto& out = *result.transformed;
+    auto localOut = result.local;
 
     out.cmds.clear();
     out.pts.clear();
+    if (localOut) {
+        localOut->cmds.clear();
+        localOut->pts.clear();
+    }
+    if (in.empty()) return;
+
     out.cmds.reserve(in.cmds.count);
     out.pts.reserve(in.pts.count);
+    if (localOut) {
+        localOut->cmds.reserve(in.cmds.count);
+        localOut->pts.reserve(in.pts.count);
+    }
 
     auto cmds = in.cmds.data;
     auto cmdCnt = in.cmds.count;
@@ -236,10 +277,14 @@ void gpuOptimize(const RenderPath& in, RenderPath& out, const Matrix& matrix, bo
         point2Line(ctrl2, start, vec, vecLen, maxDist, minT, maxT);
     };
 
-    auto addLineCmd = [&](const Point& ptT) {
+    auto addLineCmd = [&](const Point& local, const Point& transformed) {
         out.cmds.push(PathCommand::LineTo);
-        out.pts.push(ptT);
-        lastOutT = ptT;
+        out.pts.push(transformed);
+        if (localOut) {
+            localOut->cmds.push(PathCommand::LineTo);
+            localOut->pts.push(local);
+        }
+        lastOutT = transformed;
     };
 
     auto processCubicTo = [&](const Point* cubicPts, const Point& startOutT, const Point& startInT, Point& endT) {
@@ -274,12 +319,18 @@ void gpuOptimize(const RenderPath& in, RenderPath& out, const Matrix& matrix, bo
         auto inSpan = (minT >= -tEps) && (maxT <= 1.0f + tEps);
         if (flat && inSpan) {
             subpathHasSegment = true;
-            addLineCmd(endT);
+            addLineCmd(cubicPts[2], endT);
         } else {
             out.cmds.push(PathCommand::CubicTo);
             out.pts.push(ctrl1T);
             out.pts.push(ctrl2T);
             out.pts.push(endT);
+            if (localOut) {
+                localOut->cmds.push(PathCommand::CubicTo);
+                localOut->pts.push(cubicPts[0]);
+                localOut->pts.push(cubicPts[1]);
+                localOut->pts.push(cubicPts[2]);
+            }
             lastOutT = endT;
             subpathHasSegment = true;
             thinTracker.disable();
@@ -290,9 +341,14 @@ void gpuOptimize(const RenderPath& in, RenderPath& out, const Matrix& matrix, bo
         switch (cmds[i]) {
             case PathCommand::MoveTo: {
                 finalizeSubpath();
-                auto ptT = (*pts) * matrix;
+                auto pt = *pts;
+                auto ptT = pt * matrix;
                 out.cmds.push(PathCommand::MoveTo);
                 out.pts.push(ptT);
+                if (localOut) {
+                    localOut->cmds.push(PathCommand::MoveTo);
+                    localOut->pts.push(pt);
+                }
                 lastOutT = ptT;
                 lastInT = ptT;
                 subpathStartT = ptT;
@@ -302,7 +358,8 @@ void gpuOptimize(const RenderPath& in, RenderPath& out, const Matrix& matrix, bo
             }
             case PathCommand::LineTo: {
                 auto startInT = lastInT;
-                auto ptT = (*pts) * matrix;
+                auto pt = *pts;
+                auto ptT = pt * matrix;
                 auto closedIn = tvg::closed(startInT, ptT, PATH_OPT_PX_TOLERANCE);
                 if (!closedIn) subpathHasSegment = true;
                 thinTracker.trackLine(startInT, ptT, closedIn);
@@ -311,7 +368,7 @@ void gpuOptimize(const RenderPath& in, RenderPath& out, const Matrix& matrix, bo
                     pts++;
                     break;
                 }
-                addLineCmd(ptT);
+                addLineCmd(pt, ptT);
                 pts++;
                 break;
             }
@@ -329,6 +386,7 @@ void gpuOptimize(const RenderPath& in, RenderPath& out, const Matrix& matrix, bo
                     thinTracker.trackClose(lastInT, subpathStartT, closedIn);
                 }
                 out.cmds.push(PathCommand::Close);
+                if (localOut) localOut->cmds.push(PathCommand::Close);
                 lastOutT = subpathStartT;
                 lastInT = subpathStartT;
                 break;
@@ -338,11 +396,11 @@ void gpuOptimize(const RenderPath& in, RenderPath& out, const Matrix& matrix, bo
     }
     finalizeSubpath();
     // thin means "use thin fill fallback", not just "the geometry is narrow".
-    thin = thinTracker.candidate && thinTracker.ready && (drawableSubpathCnt == 1);
-    if (thin && thinTracker.tooThin()) {
+    result.thin = thinTracker.candidate && thinTracker.ready && (drawableSubpathCnt == 1);
+    if (result.thin && thinTracker.tooThin()) {
         // Too thin for fallback: keep the path for strokes, but skip the fill.
-        thin = false;
-        skipFill = true;
+        result.thin = false;
+        result.skipFill = true;
     }
 }
 

--- a/src/renderer/gpu_engine/tvgGpuCommon.h
+++ b/src/renderer/gpu_engine/tvgGpuCommon.h
@@ -29,7 +29,17 @@
 namespace tvg
 {
 
-void gpuOptimize(const RenderPath& in, RenderPath& out, const Matrix& matrix, bool& thin, bool& skipFill);
+struct GpuOptimizeResult
+{
+    RenderPath* transformed = nullptr;
+    RenderPath* local = nullptr;
+    bool thin = false;
+    bool skipFill = false;
+};
+
+void gpuOptimize(const RenderPath& in, GpuOptimizeResult& result, const Matrix& matrix);
+bool gpuPointInTriangle(const Point& p, const Point& a, const Point& b, const Point& c);
+RenderRegion gpuTransformBounds(const RenderRegion& bounds, const Matrix& matrix);
 bool gpuEdgesCross(const Point& p0, const Point& p1, const Point& p2, const Point& p3);
 bool gpuStrokeDash(const RenderShape& rs, RenderPath& out, const Matrix* transform);
 

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -83,6 +83,7 @@ void WgCompositor::release(WgContext& context)
     // release stage buffer
     stageBufferSolidColor.release(context);
     stageBufferPaint.release(context);
+    stageBufferViewMat.release(context);
     stageBufferGeometry.release(context);
     // release pipelines
     pipelines.release(context);
@@ -236,6 +237,7 @@ void WgCompositor::reset(WgContext& context)
     stageBufferGeometry.clear();
     stageBufferSolidColor.clear();
     stageBufferPaint.clear();
+    stageBufferViewMat.clear();
 }
 
 
@@ -245,6 +247,7 @@ void WgCompositor::flush(WgContext& context)
     stageBufferGeometry.flush(context);
     stageBufferSolidColor.flush(context);
     stageBufferPaint.flush(context);
+    stageBufferViewMat.flush(context);
     context.submit();
 }
 
@@ -256,6 +259,12 @@ void WgCompositor::requestShape(WgRenderDataShape* renderData)
     auto& shapeSettings = renderData->renderSettingsShape;
     if (shapeSettings.fillType == WgRenderSettingsType::Solid) shapeSettings.solidColorInd = stageBufferSolidColor.append(shapeSettings.settings.color);
     else shapeSettings.bindGroupInd = stageBufferPaint.append(shapeSettings.settings);
+
+    if (renderData->meshStrokes.vbuffer.count > 0) {
+        Matrix viewMatrix{2.0f / width, 0.0f, -1.0f, 0.0f, -2.0f / height, 1.0f, 0.0f, 0.0f, 1.0f};
+        WgShaderTypeMat4x4fBlock strokeViewMat{{viewMatrix * renderData->transform}, {}};
+        renderData->strokeViewMatInd = stageBufferViewMat.append(strokeViewMat);
+    }
 
     if (!renderData->renderSettingsStroke.skip && renderData->meshStrokes.vbuffer.count > 0) {
         auto& strokeSettings = renderData->renderSettingsStroke;
@@ -559,17 +568,18 @@ void WgCompositor::drawStrokes(WgContext& context, WgRenderDataShape* renderData
     assert(renderPassEncoder);
     if (renderData->renderSettingsStroke.skip || renderData->meshStrokes.vbuffer.count == 0 || renderData->viewport.invalid()) return;
     WgRenderSettings& settings = renderData->renderSettingsStroke;
+    auto strokeView = stageBufferViewMat[renderData->strokeViewMatInd];
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
     // draw strokes to stencil (first pass)
     // setup stencil rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
     // draw to stencil (first pass)
     drawMesh(context, &renderData->meshStrokes);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
         drawMeshSolid(context, &renderData->meshStrokesBBox, settings.solidColorInd);
@@ -593,6 +603,7 @@ void WgCompositor::blendStrokes(WgContext& context, WgRenderDataShape* renderDat
     assert(renderPassEncoder);
     if (renderData->renderSettingsStroke.skip || renderData->meshStrokes.vbuffer.count == 0 || renderData->viewport.invalid()) return;
     WgRenderSettings& settings = renderData->renderSettingsStroke;
+    auto strokeView = stageBufferViewMat[renderData->strokeViewMatInd];
     // copy current render target data to dst target
     WgRenderTarget *target = currentTarget;
     endRenderPass();
@@ -602,13 +613,13 @@ void WgCompositor::blendStrokes(WgContext& context, WgRenderDataShape* renderDat
     // draw strokes to stencil (first pass)
     // setup stencil rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
     // draw to stencil (first pass)
     drawMesh(context, &renderData->meshStrokes);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     uint32_t blendMethodInd = (uint32_t)blendMethod;
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
@@ -636,22 +647,24 @@ void WgCompositor::clipStrokes(WgContext& context, WgRenderDataShape* renderData
     assert(renderPassEncoder);
     if (renderData->renderSettingsStroke.skip || renderData->meshStrokes.vbuffer.count == 0 || renderData->viewport.invalid()) return;
     WgRenderSettings& settings = renderData->renderSettingsStroke;
+    auto strokeView = stageBufferViewMat[renderData->strokeViewMatInd];
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
     // draw strokes to stencil (first pass)
     // setup stencil rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
     // draw to stencil (first pass)
     drawMesh(context, &renderData->meshStrokes);
     // merge depth and stencil buffer
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.merge_depth_stencil);
     drawMesh(context, &renderData->meshBBox);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
         drawMeshSolid(context, &renderData->meshStrokesBBox, settings.solidColorInd);
@@ -789,13 +802,14 @@ void WgCompositor::blendScene(WgContext& context, WgRenderTarget* scene, WgCompo
 void WgCompositor::markupClipPath(WgContext& context, WgRenderDataShape* renderData)
 {
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     // markup stencil
     if (renderData->meshStrokes.vbuffer.count > 0) {
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, stageBufferViewMat[renderData->strokeViewMatInd], 0, nullptr);
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
         drawMesh(context, &renderData->meshStrokes);
     } else if (renderData->meshShape.vbuffer.count > 0) {
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
         WGPURenderPipeline stencilPipeline = (renderData->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, stencilPipeline);
@@ -829,6 +843,7 @@ void WgCompositor::renderClipPath(WgContext& context, WgRenderDataPaint* paint)
         markupClipPath(context, renderData);
         // copy stencil to depth (clear stencil)
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[190], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.copy_stencil_to_depth_interm);
         drawMesh(context, &renderData->meshBBox);

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.h
@@ -43,6 +43,7 @@ private:
     WgStageBufferGeometry stageBufferGeometry{};
     WgStageBufferSolidColor stageBufferSolidColor{};
     WgStageBufferUniform<WgShaderTypePaintSettings> stageBufferPaint;
+    WgStageBufferUniform<WgShaderTypeMat4x4fBlock> stageBufferViewMat;
     // global stencil/depth buffer handles
     WGPUTexture texDepthStencil{};
     WGPUTextureView texViewDepthStencil{};

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -187,10 +187,18 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
     bool optPathSkipFill = false;
     if (rshape.trimpath()) {
         auto& trimmed = RenderPath::scratch();
-        if (rshape.stroke->trim.trim(rshape.path, trimmed)) gpuOptimize(trimmed, optPath, matrix, optPathThin, optPathSkipFill);
+        if (rshape.stroke->trim.trim(rshape.path, trimmed)) {
+            GpuOptimizeResult result{&optPath};
+            gpuOptimize(trimmed, result, matrix);
+            optPathThin = result.thin;
+            optPathSkipFill = result.skipFill;
+        }
         else optPath.clear();
     } else {
-        gpuOptimize(rshape.path, optPath, matrix, optPathThin, optPathSkipFill);
+        GpuOptimizeResult result{&optPath};
+        gpuOptimize(rshape.path, result, matrix);
+        optPathThin = result.thin;
+        optPathSkipFill = result.skipFill;
     }
 
     auto updatePath = flag & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path);

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -183,19 +183,22 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
 
     // optimize path
     auto& optPath = RenderPath::scratch();
+    RenderPath optStrokePath;
     bool optPathThin = false;
     bool optPathSkipFill = false;
+    auto strokeWidth = rshape.strokeWidth();
+    auto localOut = (std::isfinite(strokeWidth) && !tvg::zero(strokeWidth)) ? &optStrokePath : nullptr;
     if (rshape.trimpath()) {
         auto& trimmed = RenderPath::scratch();
         if (rshape.stroke->trim.trim(rshape.path, trimmed)) {
-            GpuOptimizeResult result{&optPath};
+            GpuOptimizeResult result{&optPath, localOut};
             gpuOptimize(trimmed, result, matrix);
             optPathThin = result.thin;
             optPathSkipFill = result.skipFill;
         }
         else optPath.clear();
     } else {
-        GpuOptimizeResult result{&optPath};
+        GpuOptimizeResult result{&optPath, localOut};
         gpuOptimize(rshape.path, result, matrix);
         optPathThin = result.thin;
         optPathSkipFill = result.skipFill;
@@ -232,24 +235,26 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
     }
     // update strokes shapes
     if (rshape.stroke && (updatePath || (flag & (RenderUpdateFlag::Stroke | RenderUpdateFlag::GradientStroke)))) {
-        auto strokeWidth = rshape.strokeWidth();
-        auto strokeWidthWorld = strokeWidth * scaling(matrix);
+        auto qualityScale = scaling(matrix);
+        auto strokeWidthWorld = strokeWidth * qualityScale;
         if (!std::isfinite(strokeWidthWorld)) strokeWidthWorld = strokeWidth;
         if (!std::isfinite(strokeWidthWorld)) strokeWidthWorld = 0.0f;
+        if (!std::isfinite(qualityScale) || tvg::zero(qualityScale)) qualityScale = 1.0f;
 
         //run stroking only if it's valid
         if (!tvg::zero(strokeWidthWorld)) {
-            WgStroker stroker(&meshStrokes, strokeWidthWorld, rshape.strokeCap(), rshape.strokeJoin(), rshape.strokeMiterlimit());
+            WgStroker stroker(&meshStrokes, strokeWidth, rshape.strokeCap(), rshape.strokeJoin(), rshape.strokeMiterlimit(), qualityScale);
             auto& dashed = RenderPath::scratch();
-            if (gpuStrokeDash(rshape, dashed, &matrix)) stroker.run(dashed);
-            else stroker.run(optPath);
+            if (gpuStrokeDash(rshape, dashed, nullptr)) stroker.run(dashed);
+            else stroker.run(optStrokePath);
             renderSettingsStroke.opacityMultiplier = 1.0f;
             if (meshStrokes.ibuffer.empty()) {
                 meshStrokes.clear();
             } else {
                 auto bbox = stroker.getBBox();
                 meshStrokesBBox.bbox(bbox.min, bbox.max);
-                updateBBox(bbox);
+                auto strokeBounds = gpuTransformBounds(stroker.bounds(), matrix);
+                updateBBox({{(float)strokeBounds.min.x, (float)strokeBounds.min.y}, {(float)strokeBounds.max.x, (float)strokeBounds.max.y}});
             }
         }
     }
@@ -638,7 +643,6 @@ bool WgIntersector::isPointInMesh(const Point& p, const WgMeshData& mesh)
     return (crossings % 2) == 1;
 }
 
-
 bool WgIntersector::intersectClips(const Point& pt, const Array<WgRenderDataPaint*>& clips)
 {
     for (uint32_t i = 0; i < clips.count; i++) {
@@ -652,6 +656,8 @@ bool WgIntersector::intersectClips(const Point& pt, const Array<WgRenderDataPain
 bool WgIntersector::intersectShape(const RenderRegion region, const WgRenderDataShape* shape)
 {
     if (!shape || ((shape->meshShape.ibuffer.count == 0) && (shape->meshStrokes.ibuffer.count == 0))) return false;
+    Matrix inverseModel;
+    auto testStroke = !shape->renderSettingsStroke.skip && inverse(&shape->transform, &inverseModel);
     auto sizeX = region.sw();
     auto sizeY = region.sh();
     for (int32_t y = 0; y <= sizeY; y++) {
@@ -660,7 +666,7 @@ bool WgIntersector::intersectShape(const RenderRegion region, const WgRenderData
             if (y % 2 == 1) pt.y = (float) sizeY - y - sizeY % 2 + region.min.y;
             if (intersectClips(pt, shape->clips)) {
                 if (!shape->renderSettingsShape.skip && isPointInMesh(pt, shape->meshShape)) return true;
-                if (!shape->renderSettingsStroke.skip && isPointInTris(pt, shape->meshStrokes)) return true;
+                if (testStroke && isPointInTris(pt * inverseModel, shape->meshStrokes)) return true;
             }
         }
     }

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.h
@@ -90,6 +90,7 @@ struct WgRenderDataShape: public WgRenderDataPaint
     FillRule fillRule{};
     bool convex{};
     BBox bbox;
+    uint32_t strokeViewMatInd{};
 
     void updateBBox(BBox bb);
     void updateAABB() { aabb = bbox; }

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -166,7 +166,7 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
     if (rshape.stroke && !renderDataShape->renderSettingsStroke.skip) {
         if (rshape.stroke->fill && (!data || (flags & (RenderUpdateFlag::GradientStroke | RenderUpdateFlag::Transform)))) {
             bool updateColorRamp = !data || ((flags & RenderUpdateFlag::GradientStroke) != RenderUpdateFlag::None);
-            renderDataShape->renderSettingsStroke.update(mContext, rshape.stroke->fill, &transform, updateColorRamp);
+            renderDataShape->renderSettingsStroke.update(mContext, rshape.stroke->fill, nullptr, updateColorRamp);
         } else if (!data || (flags & RenderUpdateFlag::Stroke)) {
             renderDataShape->renderSettingsStroke.update(mContext, rshape.stroke->color);
         }
@@ -302,22 +302,10 @@ bool WgRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
                 bbox.init();
                 auto& vertexes = renderData->meshStrokes.vbuffer;
 
-                if (m == renderData->transform) {
-                    for (uint32_t i = 0; i < vertexes.count; i++) {
-                        Point vert = vertexes[i];
-                        bbox.min = min(bbox.min, vert);
-                        bbox.max = max(bbox.max, vert);
-                    }
-                } else {
-                    Matrix inverseModel;
-                    inverse(&renderData->transform, &inverseModel);
-                    inverseModel *= m;
-                    for (uint32_t i = 0; i < vertexes.count; i++) {
-                        Point vert = vertexes[i];
-                        vert *= inverseModel;
-                        bbox.min = min(bbox.min, vert);
-                        bbox.max = max(bbox.max, vert);
-                    }
+                for (uint32_t i = 0; i < vertexes.count; i++) {
+                    Point vert = vertexes[i] * m;
+                    bbox.min = min(bbox.min, vert);
+                    bbox.max = max(bbox.max, vert);
                 }
 
                 pt4[0] = bbox.min;

--- a/src/renderer/gpu_engine/wg/tvgWgShaderTypes.h
+++ b/src/renderer/gpu_engine/wg/tvgWgShaderTypes.h
@@ -42,6 +42,12 @@ struct WgShaderTypeMat4x4f
     void update(size_t w, size_t h);
 };
 
+struct WgShaderTypeMat4x4fBlock
+{
+    WgShaderTypeMat4x4f matrix;
+    uint8_t _padding[256 - sizeof(WgShaderTypeMat4x4f)]{};
+};
+
 // vec4f
 struct WgShaderTypeVec4f
 {

--- a/src/renderer/gpu_engine/wg/tvgWgTessellator.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgTessellator.cpp
@@ -25,8 +25,8 @@
 #include "tvgMath.h"
 
 
-WgStroker::WgStroker(WgMeshData* buffer, float width, StrokeCap cap, StrokeJoin join, float miterLimit)
-    : mBuffer(buffer), mWidth(width), mMiterLimit(miterLimit), mCap(cap), mJoin(join)
+WgStroker::WgStroker(WgMeshData* buffer, float width, StrokeCap cap, StrokeJoin join, float miterLimit, float qualityScale)
+    : mBuffer(buffer), mWidth(width), mMiterLimit(miterLimit), mQualityScale(qualityScale), mCap(cap), mJoin(join)
 {
 }
 
@@ -165,7 +165,7 @@ void WgStroker::lineTo(const Point& curr)
 void WgStroker::cubicTo(const Point& cnt1, const Point& cnt2, const Point& end)
 {
     Bezier curve {mState.prevPt, cnt1, cnt2, end};
-    auto count = curve.segments();
+    auto count = curve.segments(mQualityScale);
     auto step = 1.f / count;
 
     for (uint32_t i = 0; i <= count; i++) {
@@ -241,7 +241,7 @@ void WgStroker::round(const Point &prev, const Point& curr, const Point& center)
     }
 
     auto arcAngle = endAngle - startAngle;
-    auto count = tvg::arcSegmentsCnt(arcAngle, radius());
+    auto count = tvg::arcSegmentsCnt(arcAngle, radius() * mQualityScale);
 
     auto c = mBuffer->vbuffer.count;  mBuffer->vbuffer.push(center);
     auto pi = mBuffer->vbuffer.count; mBuffer->vbuffer.push(prev);
@@ -268,7 +268,7 @@ void WgStroker::round(const Point &prev, const Point& curr, const Point& center)
 
 void WgStroker::roundPoint(const Point &p)
 {
-    auto count = tvg::arcSegmentsCnt(2.0f * MATH_PI, radius());
+    auto count = tvg::arcSegmentsCnt(2.0f * MATH_PI, radius() * mQualityScale);
     auto c = mBuffer->vbuffer.count; mBuffer->vbuffer.push(p);
     auto step = 2.0f * MATH_PI / (count - 1);
 

--- a/src/renderer/gpu_engine/wg/tvgWgTessellator.h
+++ b/src/renderer/gpu_engine/wg/tvgWgTessellator.h
@@ -39,7 +39,7 @@ class WgStroker
         Point prevPtDir;
     };
 public:
-    WgStroker(WgMeshData* buffer, float width, StrokeCap cap, StrokeJoin join = StrokeJoin::Bevel, float miterLimit = 4.0f);
+    WgStroker(WgMeshData* buffer, float width, StrokeCap cap, StrokeJoin join = StrokeJoin::Bevel, float miterLimit = 4.0f, float qualityScale = 1.0f);
     void run(const RenderPath& path);
     RenderRegion bounds() const;
     BBox getBBox() const;
@@ -65,6 +65,7 @@ private:
     WgMeshData* mBuffer;
     float mWidth = 0.0f;
     float mMiterLimit = 4.f;
+    float mQualityScale = 1.0f;
     StrokeCap mCap = StrokeCap::Square;
     StrokeJoin mJoin = StrokeJoin::Bevel;
     State mState = {};


### PR DESCRIPTION
## Summary
- Tessellate GL and WebGPU stroke meshes in shape-local coordinates.
- Apply the model/view transform at draw time for stroke rendering paths.
- Keep tessellation quality based on device-space scale for curves, caps, and joins.
- Share GPU helper logic for transform bounds, quality scale, and triangle hit testing.
- Keep stroke gradients, bounds, blend paths, clip paths, and hit tests consistent with local stroke geometry.

## Why
World-space stroke tessellation could make transformed strokes diverge from the original path geometry. Keeping stroke meshes in local coordinates preserves shape-space stroke behavior while still using transform scale for tessellation quality.

## Testing
- Manually checked rendering with `thorvg.example`.
- Observed no FPS difference after 2000 frames.

<img width="1136" height="1080" alt="Screenshot 2026-05-04 at 6 38 51 AM" src="https://github.com/user-attachments/assets/483ad8aa-6934-4190-b3d8-b087a2c6137e" />
<img width="1136" height="1168" alt="image" src="https://github.com/user-attachments/assets/115ce163-0f9b-4383-9d7f-26d13eae99ca" />

## Binary Size Report

| Config | main text | main data | PR text | PR data | Delta |
|--------|----------:|----------:|--------:|--------:|------:|
| arm64-clang | 848,897 | 23,616 | 849,265 | 23,616 | +368 (+0.04%) |
| x86-gcc | 879,676 | 11,488 | 880,550 | 11,488 | +874 (+0.10%) |
| x86_64-clang | 853,132 | 22,120 | 853,600 | 22,120 | +468 (+0.05%) |
| x86_64-gcc | 858,399 | 21,880 | 859,209 | 21,880 | +810 (+0.09%) |

issue: 
https://github.com/thorvg/thorvg/issues/4354
https://github.com/thorvg/thorvg/issues/4408
