### PR TITLE
lottie: robustness++

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,3 +58,4 @@
 - Shiny Chang @ShinyChang
 - Mattia Basaglia @mbasaglia
 - Jongmin Kim @jmkim
+- Andrew X @LizzaM1net

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -953,6 +953,11 @@ void LottieBuilder::updateImage(LottieGroup* layer)
     if (layer->children.empty()) return;
 
     auto image = static_cast<LottieImage*>(layer->children.first());
+    if (image->type != LottieObject::Type::Image) {
+        TVGERR("LOTTIE", "Expected image data.");
+        return;
+    }
+
     auto picture = image->bitmap.picture;
     if (!picture) return;
 


### PR DESCRIPTION
- Added a safeguard for cases where an image layer contains mixed object types

Just note that the best is to separte the ImageLayer from the CommonLayer...