### PR TITLE
lottie: minor optimization

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -922,9 +922,8 @@ void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp,
     }
 
     //clip the layer viewport
-    auto clipper = precomp->statical.pooling(true);
-    clipper->transform(precomp->cache.matrix);
-    precomp->scene->clip(clipper);
+    precomp->statical->transform(precomp->cache.matrix);
+    precomp->scene->clip(precomp->statical);
 }
 
 
@@ -942,9 +941,8 @@ void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp,
 
 void LottieBuilder::updateSolid(LottieLayer* layer)
 {
-    auto solidFill = layer->statical.pooling(true);
-    solidFill->opacity(layer->cache.opacity);
-    layer->scene->add(solidFill);
+    layer->statical->opacity(layer->cache.opacity);
+    layer->scene->add(layer->statical);
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -590,6 +590,8 @@ LottieLayer::~LottieLayer()
     //No need to free assets children because the Composition owns them.
     if (rid) children.clear();
 
+    if (statical) statical->unref();
+
     ARRAY_FOREACH(p, masks) delete(*p);
     ARRAY_FOREACH(p, effects) delete(*p);
 
@@ -619,19 +621,12 @@ void LottieLayer::prepare(RGB32* color)
         return;
     }
 
-    //prepare the viewport clipper
-    if (type == LottieLayer::Precomp) {
-        auto clipper = Shape::gen();
-        clipper->appendRect(0.0f, 0.0f, w, h);
-        clipper->ref();
-        statical.pooler.push(clipper);
-    //prepare solid fill in advance if it is a layer type.
-    } else if (color && type == LottieLayer::Solid) {
-        auto solidFill = Shape::gen();
-        solidFill->appendRect(0, 0, static_cast<float>(w), static_cast<float>(h));
-        solidFill->fill(color->r, color->g, color->b);
-        solidFill->ref();
-        statical.pooler.push(solidFill);
+    // prepare the viewport clipper or a solid fill in advance if it is a layer type.
+    if (type == LottieLayer::Precomp || (color && type == LottieLayer::Solid)) {
+        statical = Shape::gen();
+        statical->appendRect(0.0f, 0.0f, w, h);
+        statical->ref();
+        if (color && type == LottieLayer::Solid) statical->fill(color->r, color->g, color->b);
     }
 
     LottieGroup::prepare(LottieObject::Layer);

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -1049,7 +1049,6 @@ struct LottieGroup : LottieObject, LottieRenderPooler<tvg::Shape>
     bool allowMerge : 1;    //if this group is consisted of simple (transformed) shapes.
 };
 
-
 struct LottieLayer : LottieGroup
 {
     enum Type : uint8_t {Precomp = 0, Solid, Image, Null, Shape, Text};
@@ -1071,8 +1070,7 @@ struct LottieLayer : LottieGroup
     Array<LottieMask*> masks;
     Array<LottieEffect*> effects;
     LottieLayer* matteTarget = nullptr;
-
-    LottieRenderPooler<tvg::Shape> statical;  //static pooler for solid fill and clipper
+    tvg::Shape* statical = nullptr;  // a static solid fill (used by SolidLayer) or a static clipper (used by precomp)
 
     float timeStretch = 1.0f;
     float w = 0.0f, h = 0.0f;


### PR DESCRIPTION
- Replaced the shape pooler with a static TVG shape.
- The shape pooler is not quite necessary for this use case.