### PR TITLE
lottie: introduce root layer for compact runtime memory

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -35,7 +35,7 @@
 /* Internal Class Implementation                                        */
 /************************************************************************/
 
-static bool _buildComposition(LottieComposition* comp, LottieLayer* parent);
+static bool _buildComposition(LottieComposition* comp, LottieRootLayer* parent);
 static bool _draw(LottieGroup* parent, LottieShape* shape, RenderContext* ctx);
 
 static void _dimension3d(LottieTransform* transform, float frameNo, Matrix& m, float angle, LottieTween& tween, LottieExpressions* exps)
@@ -1611,7 +1611,7 @@ static void _buildReference(LottieComposition* comp, LottieLayer* layer)
     ARRAY_FOREACH(p, comp->assets) {
         if (layer->rid != (*p)->id) continue;
         if (layer->type == LottieLayer::Precomp) {
-            auto asset = static_cast<LottieLayer*>(*p);
+            auto asset = static_cast<LottieRootLayer*>(*p);
             if (_buildComposition(comp, asset)) {
                 layer->children = asset->children;
                 layer->reqFragment = asset->reqFragment;
@@ -1672,7 +1672,7 @@ static void _attachFont(LottieComposition* comp, LottieLayer* parent)
     parent->children.clear();  // make the invalid text layer empty to prevent an access during rendering.
 }
 
-static bool _buildComposition(LottieComposition* comp, LottieLayer* parent)
+static bool _buildComposition(LottieComposition* comp, LottieRootLayer* parent)
 {
     if (parent->children.count == 0) return false;
     if (parent->buildDone) return true;

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -466,8 +466,7 @@ static jerry_value_t _effect(const jerry_call_info_t* info, const jerry_value_t 
     return obj;
 }
 
-
-static void _buildLayer(jerry_value_t context, float frameNo, LottieLayer* layer, LottieLayer* comp, LottieExpression* exp)
+static void _buildLayer(jerry_value_t context, float frameNo, LottieLayer* layer, LottieRootLayer* comp, LottieExpression* exp)
 {
     auto width = jerry_number(layer->w);
     jerry_object_set_sz(context, EXP_WIDTH, width);
@@ -1428,8 +1427,7 @@ void LottieExpressions::buildGlobal(Context& context, float frameNo, LottieExpre
     jerry_value_free(outPoint);
 }
 
-
-void LottieExpressions::buildComp(jerry_value_t context, float frameNo, LottieLayer* comp, LottieExpression* exp)
+void LottieExpressions::buildComp(jerry_value_t context, float frameNo, LottieRootLayer* comp, LottieExpression* exp)
 {
     //layer(index) / layer(name) / layer(otherLayer, reIndex)
     auto layer = jerry_function_external(_layer);
@@ -1527,7 +1525,7 @@ jerry_value_t LottieExpressions::evaluate(float frameNo, LottieExpression* exp)
     buildComp(context, exp->comp, frameNo, exp);
 
     //this composition
-    buildComp(context.thisComp, frameNo, exp->layer->comp, exp);
+    buildComp(context.thisComp, frameNo, exp->layer->precomp, exp);
 
     //update global context values
     _buildProperty(frameNo, context.global, exp);

--- a/src/loaders/lottie/tvgLottieExpressions.h
+++ b/src/loaders/lottie/tvgLottieExpressions.h
@@ -33,7 +33,7 @@
 
 struct LottieExpression;
 struct LottieComposition;
-struct LottieLayer;
+struct LottieRootLayer;
 struct LottieModifier;
 
 #ifdef THORVG_LOTTIE_EXPRESSIONS_SUPPORT
@@ -180,7 +180,7 @@ private:
     jerry_value_t buildGlobal(Context& context);
 
     void buildComp(Context& context, LottieComposition* comp, float frameNo, LottieExpression* exp);
-    void buildComp(jerry_value_t context, float frameNo, LottieLayer* comp, LottieExpression* exp);
+    void buildComp(jerry_value_t context, float frameNo, LottieRootLayer* comp, LottieExpression* exp);
     void buildGlobal(Context& context, float frameNo, LottieExpression* exp);
 
     Point toPoint2d(jerry_value_t obj);

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -27,7 +27,7 @@
 
 
 /************************************************************************/
-/* Internal Class Implementation                                        */
+/* LottieTextFollowPath                                                 */
 /************************************************************************/
 
 Point LottieTextFollowPath::split(float dLen, float lenSearched, float& angle)
@@ -56,10 +56,6 @@ Point LottieTextFollowPath::split(float dLen, float lenSearched, float& angle)
     }
     return {};
 }
-
-/************************************************************************/
-/* External Class Implementation                                        */
-/************************************************************************/
 
 void LottieTextFollowPath::rewind()
 {
@@ -179,6 +175,9 @@ Point LottieTextFollowPath::position(float lenSearched, float& angle)
     return {};
 }
 
+/************************************************************************/
+/* LottieSlot                                                           */
+/************************************************************************/
 
 void LottieSlot::reset()
 {
@@ -206,6 +205,9 @@ void LottieSlot::apply(LottieProperty* prop, bool byDefault)
     if (!byDefault) overridden = true;
 }
 
+/************************************************************************/
+/* LottieTextRange                                                      */
+/************************************************************************/
 
 float LottieTextRange::factor(float frameNo, float totalLen, float idx)
 {
@@ -288,12 +290,9 @@ float LottieTextRange::factor(float frameNo, float totalLen, float idx)
     return f * this->maxAmount(frameNo) * 0.01f;
 }
 
-
-void LottieFont::prepare()
-{
-    if (b64src) Text::load(name, b64src, size, mime, false);
-}
-
+/************************************************************************/
+/* LottieImage                                                          */
+/************************************************************************/
 
 void LottieImage::prepare(bool external)
 {
@@ -307,6 +306,10 @@ void LottieImage::prepare(bool external)
     bitmap.picture = picture;
     picture->ref();
 }
+
+/************************************************************************/
+/* LottieTrimpath                                                       */
+/************************************************************************/
 
 void LottieTrimpath::segment(float frameNo, float& start, float& end, LottieTween& tween, LottieExpressions* exps)
 {
@@ -333,6 +336,9 @@ void LottieTrimpath::segment(float frameNo, float& start, float& end, LottieTwee
     end += o;
 }
 
+/************************************************************************/
+/* LottieGradient                                                       */
+/************************************************************************/
 
 uint32_t LottieGradient::populate(ColorStop& color, size_t count)
 {
@@ -470,6 +476,9 @@ Fill* LottieGradient::fill(float frameNo, uint8_t opacity, LottieTween& tween, L
     return fill;
 }
 
+/************************************************************************/
+/* LottieGroup                                                          */
+/************************************************************************/
 
 LottieGroup::LottieGroup(LottieObject::Type type) : LottieObject(type)
 {
@@ -562,11 +571,44 @@ void LottieGroup::prepare()
     }
 }
 
-LottieLayer::LottieLayer() : LottieGroup(LottieObject::Layer)
+/************************************************************************/
+/* LottieRootLayer                                                      */
+/************************************************************************/
+
+float LottieRootLayer::remap(LottieComposition* comp, float frameNo, LottieExpressions* exp)
+{
+    if (timeRemap.frames || timeRemap.value >= 0.0f) return comp->frameAtTime(timeRemap(frameNo, exp));
+    return (frameNo - startFrame) / timeStretch;
+}
+
+LottieLayer* LottieRootLayer::layerById(unsigned long id)
+{
+    ARRAY_FOREACH(p, children) {
+        if ((*p)->type != LottieObject::Type::Layer) continue;
+        auto layer = static_cast<LottieLayer*>(*p);
+        if (layer->id == id) return layer;
+    }
+    return nullptr;
+}
+
+LottieLayer* LottieRootLayer::layerByIdx(int16_t ix)
+{
+    ARRAY_FOREACH(p, children) {
+        if ((*p)->type != LottieObject::Type::Layer) continue;
+        auto layer = static_cast<LottieLayer*>(*p);
+        if (layer->ix == ix) return layer;
+    }
+    return nullptr;
+}
+
+/************************************************************************/
+/* LottieLayer                                                          */
+/************************************************************************/
+
+LottieLayer::LottieLayer() : LottieRootLayer(LottieObject::Layer)
 {
     autoOrient = false;
     matteSrc = false;
-    effect = false;
 }
 
 LottieLayer::~LottieLayer()
@@ -616,18 +658,15 @@ void LottieLayer::prepare(RGB32* color)
     LottieGroup::prepare();
 }
 
-
-float LottieLayer::remap(LottieComposition* comp, float frameNo, LottieExpressions* exp)
-{
-    if (timeRemap.frames || timeRemap.value >= 0.0f) return comp->frameAtTime(timeRemap(frameNo, exp));
-    return (frameNo - startFrame) / timeStretch;
-}
+/************************************************************************/
+/* LottieComposition                                                    */
+/************************************************************************/
 
 LottieComposition::~LottieComposition()
 {
     if (!initiated && root) Paint::rel(root->scene);
 
-    delete(root);
+    delete (root);
     tvg::free(version);
     tvg::free(name);
 
@@ -636,8 +675,8 @@ LottieComposition::~LottieComposition()
         tvg::free(*p);
     }
 
-    ARRAY_FOREACH(p, assets) delete(*p);
-    ARRAY_FOREACH(p, fonts) delete(*p);
-    ARRAY_FOREACH(p, slots) delete(*p);
-    ARRAY_FOREACH(p, markers) delete(*p);
+    ARRAY_FOREACH(p, assets) delete (*p);
+    ARRAY_FOREACH(p, fonts) delete (*p);
+    ARRAY_FOREACH(p, slots) delete (*p);
+    ARRAY_FOREACH(p, markers) delete (*p);
 }

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -421,7 +421,10 @@ struct LottieFont
     float ascent = 0.0f;
     Origin origin = Local;
 
-    void prepare();
+    void prepare()
+    {
+        if (b64src) Text::load(name, b64src, size, mime, false);
+    }
 };
 
 struct LottieMarker
@@ -941,8 +944,33 @@ struct LottieGroup : LottieObject, LottieRenderPooler<tvg::Shape>
     bool allowMerge : 1;    //if this group is consisted of simple (transformed) shapes.
 };
 
+struct LottieRootLayer : LottieGroup
+{
+    LottieFloat timeRemap = -1.0f;
 
-struct LottieLayer : LottieGroup
+    float timeStretch = 1.0f;
+    float w = 0.0f, h = 0.0f;
+    float inFrame = 0.0f;
+    float outFrame = 0.0f;
+    float startFrame = 0.0f;
+
+    bool effect = false;  // true if any effect is activated in its tree
+
+    LottieRootLayer(LottieObject::Type type = LottieObject::Composition) : LottieGroup(type) {}
+
+    float remap(LottieComposition* comp, float frameNo, LottieExpressions* exp);
+    LottieLayer* layerById(unsigned long id);
+    LottieLayer* layerByIdx(int16_t ix);
+
+    LottieProperty* override(LottieProperty* prop, bool release) override
+    {
+        LottieProperty* backup = nullptr;
+        OVERRIDE(timeRemap);
+        return backup;
+    }
+};
+
+struct LottieLayer : LottieRootLayer
 {
     enum Type : uint8_t {Precomp = 0, Solid, Image, Null, Shape, Text, Audio};
 
@@ -951,32 +979,17 @@ struct LottieLayer : LottieGroup
 
     bool mergeable() override { return false; }
     void prepare(RGB32* color = nullptr);
-    float remap(LottieComposition* comp, float frameNo, LottieExpressions* exp);
     LottieProperty* property(uint16_t ix) override;
-
-    LottieProperty* override(LottieProperty* prop, bool release) override
-    {
-        LottieProperty* backup = nullptr;
-        OVERRIDE(timeRemap);
-        return backup;
-    }
 
     char* name = nullptr;
     LottieLayer* parent = nullptr;
-    LottieFloat timeRemap = -1.0f;
-    LottieLayer* comp = nullptr;  //Precompositor, current layer is belonges.
+    LottieRootLayer* precomp = nullptr;  // precompositor, the current layer is belonges.
     LottieTransform* transform = nullptr;
     Array<LottieMask*> masks;
     Array<LottieEffect*> effects;
     LottieLayer* matteTarget = nullptr;
 
     LottieRenderPooler<tvg::Shape> statical;  //static pooler for solid fill and clipper
-
-    float timeStretch = 1.0f;
-    float w = 0.0f, h = 0.0f;
-    float inFrame = 0.0f;
-    float outFrame = 0.0f;
-    float startFrame = 0.0f;
 
     struct AudioControl {
         LottieFloat volume = 100.0f;
@@ -997,7 +1010,6 @@ struct LottieLayer : LottieGroup
 
     MaskMethod matteType = MaskMethod::None;
     Type type = Null;
-    bool effect : 1;        // true if any effect is activated in its tree
     bool autoOrient : 1;
     bool matteSrc : 1;
 
@@ -1019,26 +1031,6 @@ struct LottieLayer : LottieGroup
     {
         ARRAY_FOREACH(p, effects) {
             if (ix == (*p)->ix) return *p;
-        }
-        return nullptr;
-    }
-
-    LottieLayer* layerById(unsigned long id)
-    {
-        ARRAY_FOREACH(p, children) {
-            if ((*p)->type != LottieObject::Type::Layer) continue;
-            auto layer = static_cast<LottieLayer*>(*p);
-            if (layer->id == id) return layer;
-        }
-        return nullptr;
-    }
-
-    LottieLayer* layerByIdx(int16_t ix)
-    {
-        ARRAY_FOREACH(p, children) {
-            if ((*p)->type != LottieObject::Type::Layer) continue;
-            auto layer = static_cast<LottieLayer*>(*p);
-            if (layer->ix == ix) return layer;
         }
         return nullptr;
     }
@@ -1129,7 +1121,7 @@ struct LottieComposition
         if (frameNo >= root->outFrame) frameNo = root->outFrame - 1;
     }
 
-    LottieLayer* root = nullptr;
+    LottieRootLayer* root = nullptr;
     char* version = nullptr;
     char* name = nullptr;
     float w, h;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1062,7 +1062,7 @@ LottieObject* LottieParser::parseAsset()
                 id = _int2str(getInt());
             }
         }
-        else if (KEY_AS("layers")) obj = parseLayers(comp->root);
+        else if (KEY_AS("layers")) obj = parseLayers();
         else if (KEY_AS("u")) subPath = getString();
         else if (KEY_AS("p")) data = getString();
         else if (KEY_AS("w")) width = getFloat();
@@ -1570,12 +1570,11 @@ void LottieParser::parseEffects(LottieLayer* layer)
     }
 }
 
-
-LottieLayer* LottieParser::parseLayer(LottieLayer* precomp)
+LottieLayer* LottieParser::parseLayer(LottieRootLayer* precomp)
 {
     auto layer = new LottieLayer;
 
-    layer->comp = precomp;
+    layer->precomp = precomp;
     context.layer = layer;
 
     auto ddd = false;
@@ -1629,13 +1628,9 @@ LottieLayer* LottieParser::parseLayer(LottieLayer* precomp)
     return layer;
 }
 
-
-LottieLayer* LottieParser::parseLayers(LottieLayer* root)
+LottieRootLayer* LottieParser::parseLayers()
 {
-    auto precomp = new LottieLayer;
-
-    precomp->type = LottieLayer::Precomp;
-    precomp->comp = root;
+    auto precomp = new LottieRootLayer;
 
     enterArray();
     while (nextArrayValue()) {
@@ -1645,7 +1640,6 @@ LottieLayer* LottieParser::parseLayers(LottieLayer* root)
     precomp->prepare();
     return precomp;
 }
-
 
 void LottieParser::postProcess(Array<LottieGlyph*>& glyphs)
 {
@@ -1814,7 +1808,7 @@ bool LottieParser::parse()
         else if (KEY_AS("h")) comp->h = getFloat();
         else if (KEY_AS("nm")) comp->name = getStringCopy();
         else if (KEY_AS("assets")) parseAssets();
-        else if (KEY_AS("layers")) comp->root = parseLayers(comp->root);
+        else if (KEY_AS("layers")) comp->root = parseLayers();
         else if (KEY_AS("fonts")) parseFonts();
         else if (KEY_AS("chars")) parseChars(glyphs);
         else if (KEY_AS("markers")) parseMarkers();

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -80,7 +80,7 @@ private:
     void parseImage(LottieImage* image, const char* data, const char* subPath, bool embedded, float width, float height);
     void parseAudio(LottieAudio* audio, const char* data, const char* subPath, bool embedded);
     void parseVolume(LottieLayer* layer);
-    LottieLayer* parseLayer(LottieLayer* precomp);
+    LottieLayer* parseLayer(LottieRootLayer* precomp);
     LottieObject* parseGroup();
     LottieRect* parseRect();
     LottieEllipse* parseEllipse();
@@ -92,7 +92,7 @@ private:
     LottiePolyStar* parsePolyStar();
     LottieRoundedCorner* parseRoundedCorner();
     LottieGradientFill* parseGradientFill();
-    LottieLayer* parseLayers(LottieLayer* root);
+    LottieRootLayer* parseLayers();
     LottieMask* parseMask();
     LottieTrimpath* parseTrimpath();
     LottieRepeater* parseRepeater();


### PR DESCRIPTION
The precomposited root layer ("layers") does not require full layer properties; it only maintains a minimal list of children. This root layer separates those elements to clarify the purpose of the classes and reduce runtime memory usage.