### PR TITLE
lottie: robustness of embedded data parsing

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -986,13 +986,16 @@ void LottieParser::parseImage(LottieImage* image, const char* data, const char* 
 
     //embedded image resource. should start with "data:"
     //header look like "data:image/png;base64," so need to skip till ','.
-    if (embedded && !strncmp(data, "data:", 5)) {
+    if (embedded && !strncmp(data, "data:image/", 11)) {
         //figure out the mimetype
         auto mimeType = data + 11;
         auto needle = strstr(mimeType, ";");
+        if (!needle) return;
         image->bitmap.mimeType = duplicate(mimeType, needle - mimeType);
         //b64 data
-        auto b64Data = strstr(data, ",") + 1;
+        auto b64Data = strstr(needle, ",");
+        if (!b64Data) return;
+        ++b64Data;
         size_t length = dlen - (b64Data - data);
         image->bitmap.size = b64Decode(b64Data, length, &image->bitmap.data);
     //remote image resource (https:// or http://)
@@ -1068,7 +1071,9 @@ void LottieParser::parseFontData(LottieFont* font, const char* data)
             TVGLOG("LOTTIE", "TODO: Support a new font type!");
             return;
         }
-        data += sizeof(";base64,") - 1;
+        auto b64Data = strstr(data, ",");
+        if (!b64Data) return;
+        data = b64Data + 1;
         font->size = b64Decode(data, strlen(data), &font->b64src);
     //external font resource
     } else {


### PR DESCRIPTION
Prevent crashes when parsing malformed embedded image/font data.

Test file : [test.json](https://github.com/user-attachments/files/27370018/test.json)

<img width="3024" height="1022" alt="CleanShot 2026-05-05 at 02 23 09@2x" src="https://github.com/user-attachments/assets/e5231a22-055a-42ab-bbc7-6a8c7aa23711" />


