### PR TITLE
engine: add Aliased option for SW (Experimental APIs)

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -133,9 +133,10 @@ enum struct ColorSpace : uint8_t
  */
 enum struct EngineOption : uint8_t
 {
-    None = 0,                   /**< No engine options are enabled. This may be used to explicitly disable all optional behaviors. */
-    Default = 1 << 0,           /**< Uses the default rendering mode. */
-    SmartRender = 1 << 1        /**< Enables automatic partial (smart) rendering optimizations. */
+    None = 0,                    /**< No engine options are enabled. This may be used to explicitly disable all optional behaviors. */
+    Default = 1 << 0,            /**< Uses the default rendering mode. */
+    SmartRender = 1 << 1,        /**< Enables automatic partial (smart) rendering optimizations. */
+    Aliased = 1 << 2             /**< Disables anti-aliased rendering. @note Experimental API */
 };
 
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -162,9 +162,10 @@ typedef enum
  */
 typedef enum
 {
-    TVG_ENGINE_OPTION_NONE = 0,                   /**< No engine options are enabled. This may be used to explicitly disable all optional behaviors. */
-    TVG_ENGINE_OPTION_DEFAULT = 1 << 0,           /**< Uses the default rendering mode. */
-    TVG_ENGINE_OPTION_SMART_RENDER = 1 << 1       /**< Enables automatic partial (smart) rendering optimizations. */
+    TVG_ENGINE_OPTION_NONE = 0,                      /**< No engine options are enabled. This may be used to explicitly disable all optional behaviors. */
+    TVG_ENGINE_OPTION_DEFAULT = 1 << 0,              /**< Uses the default rendering mode. */
+    TVG_ENGINE_OPTION_SMART_RENDER = 1 << 1,         /**< Enables automatic partial (smart) rendering optimizations. */
+    TVG_ENGINE_OPTION_ALIASED = 1 << 2               /**< Disables anti-aliased rendering from the default rendering mode. @note Experimental API */
 } Tvg_Engine_Option;
 
 /**

--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -690,7 +690,7 @@ bool shapePrepare(SwShape& shape, const RenderShape* rshape, const Matrix& trans
 bool shapeGenRle(SwShape& shape, const RenderRegion& bbox, SwMpool* mpool, unsigned tid, bool antiAlias);
 void shapeDelOutline(SwShape& shape, SwMpool* mpool, uint32_t tid);
 void shapeResetStroke(SwShape& shape, const RenderShape* rshape, const Matrix& transform, SwMpool* mpool, unsigned tid);
-bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid);
+bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool antiAlias);
 void shapeFree(SwShape& shape);
 void shapeDelStroke(SwShape& shape);
 bool shapeGenFillColors(SwShape& shape, const Fill* fill, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable);

--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -101,7 +101,7 @@ struct SwShapeTask : SwTask
        Additionally, the stroke style should not be dashed. */
     bool antialiasing(float strokeWidth)
     {
-        return strokeWidth < 2.0f || rshape->stroke->dash.count > 0 || rshape->stroke->first || rshape->trimpath() || rshape->stroke->color.a < 255;
+        return renderer->antiAlias && (strokeWidth < 2.0f || rshape->stroke->dash.count > 0 || rshape->stroke->first || rshape->trimpath() || rshape->stroke->color.a < 255);
     }
 
     float validStrokeWidth(bool clipper)
@@ -150,7 +150,7 @@ struct SwShapeTask : SwTask
         if (updateShape || flags[0] & RenderUpdateFlag::Stroke) {
             if (strokeWidth > 0.0f) {
                 shapeResetStroke(shape, rshape, transform, renderer->mpool, tid);
-                if (!shapeGenStrokeRle(shape, rshape, transform, clipBox, curBox, renderer->mpool, tid)) goto err;
+                if (!shapeGenStrokeRle(shape, rshape, transform, clipBox, curBox, renderer->mpool, tid, renderer->antiAlias)) goto err;
                 if (auto fill = rshape->strokeFill()) {
                     auto ctable = (flags[0] & RenderUpdateFlag::GradientStroke) ? true : false;
                     if (ctable) shapeResetStrokeFill(shape);
@@ -925,5 +925,7 @@ SwRenderer::SwRenderer(uint32_t threads, EngineOption op)
 
     mpool = mpoolReq();
 
-    if (op == EngineOption::None) dirtyRegion.support = false;
+    auto byDefault = (op == EngineOption::Default);
+    dirtyRegion.support = (byDefault || (op & EngineOption::SmartRender));
+    antiAlias = (byDefault || !(op & EngineOption::Aliased));
 }

--- a/src/renderer/cpu_engine/tvgSwRenderer.h
+++ b/src/renderer/cpu_engine/tvgSwRenderer.h
@@ -77,13 +77,14 @@ struct SwRenderer : RenderMethod
     static bool term();
 
     SwSurface*           surface = nullptr;           // active surface
-    SwMpool* mpool;                                   // designated memory pool
+    SwMpool*             mpool;                       // designated memory pool
+    bool                 antiAlias;                   // anti-aliasing support
 
 private:
+    bool                 fulldraw = true;             //buffer is cleared (need to redraw full screen)
     Array<SwTask*>       tasks;                       //async task list
     Array<SwSurface*>    compositors;                 //render targets cache list
     RenderDirtyRegion    dirtyRegion;                 //partial rendering support
-    bool                 fulldraw = true;             //buffer is cleared (need to redraw full screen)
 
     ~SwRenderer();
 

--- a/src/renderer/cpu_engine/tvgSwShape.cpp
+++ b/src/renderer/cpu_engine/tvgSwShape.cpp
@@ -507,7 +507,7 @@ void shapeResetStroke(SwShape& shape, const RenderShape* rshape, const Matrix& t
 }
 
 
-bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid)
+bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool antiAlias)
 {
     SwOutline* shapeOutline = nullptr;
 
@@ -525,7 +525,7 @@ bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& 
 
     auto strokeOutline = strokeExportOutline(shape.stroke, mpool, tid);
     auto ret = mathUpdateOutlineBBox(strokeOutline, clipBox, renderBox, false);
-    if (ret) shape.strokeRle = rleRender(shape.strokeRle, strokeOutline, renderBox, mpool, tid, true);
+    if (ret) shape.strokeRle = rleRender(shape.strokeRle, strokeOutline, renderBox, mpool, tid, antiAlias);
 
     return ret;
 }

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -207,7 +207,8 @@ GlCanvas* GlCanvas::gen(EngineOption op) noexcept
 {
 #ifdef THORVG_GL_ENGINE_SUPPORT
     if (engineInit > 0) {
-        if (op == EngineOption::SmartRender) TVGLOG("RENDERER", "GlCanvas doesn't support Smart Rendering");
+        if (op & EngineOption::SmartRender) TVGLOG("RENDERER", "GlCanvas doesn't support Smart Rendering");
+        if (op & EngineOption::Aliased) TVGLOG("RENDERER", "GlCanvas doesn't support Aliased");
         auto renderer = GlRenderer::gen(TaskScheduler::threads(), op);
         if (!renderer) return nullptr;
         renderer->ref();
@@ -268,7 +269,8 @@ WgCanvas* WgCanvas::gen(EngineOption op) noexcept
 {
 #ifdef THORVG_WG_ENGINE_SUPPORT
     if (engineInit > 0) {
-        if (op == EngineOption::SmartRender) TVGLOG("RENDERER", "WgCanvas doesn't support Smart Rendering");
+        if (op & EngineOption::SmartRender) TVGLOG("RENDERER", "WgCanvas doesn't support Smart Rendering");
+        if (op & EngineOption::Aliased) TVGLOG("RENDERER", "WgCanvas doesn't support Aliased");
         auto renderer = new WgRenderer(TaskScheduler::threads(), op);
         renderer->ref();
         auto ret = new WgCanvas;

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -54,6 +54,11 @@ static inline RenderUpdateFlag operator|(const RenderUpdateFlag a, const RenderU
     return RenderUpdateFlag(uint16_t(a) | uint16_t(b));
 }
 
+static inline bool operator&(const EngineOption a, const EngineOption b)
+{
+    return (uint8_t(a) & uint8_t(b));
+}
+
 struct RenderSurface
 {
     union {


### PR DESCRIPTION
issue: #4381

### Summary

```cpp
enum struct EngineOption : uint8_t
{
    None = 0,                    /**< No engine options are enabled. This may be used to explicitly disable all optional behaviors. */
    Default = 1 << 0,            /**< Uses the default rendering mode. */
    SmartRender = 1 << 1,        /**< Enables automatic partial (smart) rendering optimizations. */
    Aliased = 1 << 2     /**< Disables anti-aliased rendering @note Experimental API */
};
```
- Introduce a Aliased option for the software renderer

```
C++ API
 + enum struct EngineOption:: Aliased

C API
 + TVG_ENGINE_OPTION_ALIASED
```


| AA Off | AA On |
|-|-|
|<img width="794" height="812" alt="image" src="https://github.com/user-attachments/assets/b99a231f-71e3-47ae-b00e-07569a50b1aa" />|<img width="794" height="825" alt="image" src="https://github.com/user-attachments/assets/69166d25-4681-41f4-923d-e1a0cc5ab9b9" />|
