### PR TITLE
lottie: fix stale curSlot after slot del()

### DIFF
--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -327,6 +327,7 @@ bool LottieLoader::del(uint32_t slotcode, bool byDefault)
         }
         this->slots.remove(slot);
         delete(slot);
+        if (curSlot == slotcode) curSlot = 0;
         break;
     }
     return true;


### PR DESCRIPTION
Commit 8af22a30 added an early-return in `apply()` guarded by `curSlot == slotcode`, but `del()` does not invalidate `curSlot`. If `gen()` is later called with byte-identical JSON, djb2 returns the same code and the next `apply()` short-circuits without applying the slot.

Reset `curSlot` in `del()` when it matches the slot being removed.