### PR TITLE
cpu: Fix SwSpan uint16_t overflow for large canvases

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,3 +59,4 @@
 - Mattia Basaglia @mbasaglia
 - Jongmin Kim @jmkim
 - Andrew X @LizzaM1net
+- Geordie Jay @ephemer

--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -114,8 +114,8 @@ struct SwOutline
 
 struct SwSpan
 {
-    uint16_t x, y;
-    uint16_t len;
+    int32_t x, y;
+    int32_t len;
     uint8_t coverage;
 
     bool fetch(const RenderRegion& bbox, int32_t& x, int32_t& len) const
@@ -135,7 +135,7 @@ struct SwRle
         return fetch(bbox.min.y, bbox.max.y - 1, end);
     }
 
-    const SwSpan* fetch(int32_t min, uint32_t max, const SwSpan** end) const
+    const SwSpan* fetch(int32_t min, int32_t max, const SwSpan** end) const
     {
         const SwSpan* begin;
 

--- a/src/renderer/cpu_engine/tvgSwRle.cpp
+++ b/src/renderer/cpu_engine/tvgSwRle.cpp
@@ -303,12 +303,6 @@ static void _horizLine(RleWorker& rw, int32_t x, int32_t y, int32_t area, int32_
 
     if (coverage == 0) return;
 
-    //span has ushort coordinates. check limit overflow
-    if (x >= SHRT_MAX || y >= SHRT_MAX) {
-        TVGERR("SW_ENGINE", "XY-coordinate overflow!");
-        return;
-    }
-
     auto rle = rw.rle;
 
     if (!rw.antiAlias) coverage = 255;
@@ -338,7 +332,7 @@ static void _horizLine(RleWorker& rw, int32_t x, int32_t y, int32_t area, int32_
     if (aCount + xOver <= 0) return;
 
     //add a span to the current list
-    rle->spans.next() = {(uint16_t)x, (uint16_t)y, uint16_t(aCount + xOver), (uint8_t)coverage};
+    rle->spans.next() = {x, y,  aCount + xOver, (uint8_t)coverage};
 }
 
 
@@ -847,9 +841,9 @@ SwRle* rleRender(const RenderRegion* bbox)
     rle->spans.count = bbox->h();
 
     //cheaper without push()
-    auto x = uint16_t(bbox->min.x);
-    auto y = uint16_t(bbox->min.y);
-    auto len = uint16_t(bbox->w());
+    auto x = bbox->min.x;
+    auto y = bbox->min.y;
+    auto len = (int32_t)bbox->w();
 
     ARRAY_FOREACH(p, rle->spans) {
         *p = {x, y++, len, 255};
@@ -910,7 +904,7 @@ bool rleClip(SwRle* rle, const SwRle *clip)
             //clip span region
             auto x = std::max(spans->x, temp->x);
             auto len = std::min((spans->x + spans->len), (temp->x + temp->len)) - x;
-            if (len > 0) out.next() = {uint16_t(x), temp->y, uint16_t(len), (uint8_t)(((spans->coverage * temp->coverage) + 0xff) >> 8)};
+            if (len > 0) out.next() = {x, temp->y, len, (uint8_t)(((spans->coverage * temp->coverage) + 0xff) >> 8)};
             ++temp;
         }
         ++spans;
@@ -932,17 +926,17 @@ bool rleClip(SwRle *rle, const RenderRegion* clip)
     out.reserve(rle->spans.count);
     auto data = out.data;
     const SwSpan* end;
-    uint16_t x, len;
+    int32_t x, len;
 
     for (auto p = rle->fetch(*clip, &end); p < end; ++p) {
         if (p->y >= max.y) break;
         if (p->y < min.y || p->x >= max.x || (p->x + p->len) <= min.x) continue;
         if (p->x < min.x) {
             x = min.x;
-            len = std::min(uint16_t(p->len - (x - p->x)), uint16_t(max.x - x));
+            len = std::min(p->len - (x - p->x), (max.x - x));
         } else {
             x = p->x;
-            len = std::min(p->len, uint16_t(max.x - x));
+            len = std::min(p->len, max.x - x);
         }
         if (len > 0) {
             *data = {x, p->y, len, p->coverage};


### PR DESCRIPTION
SwSpan used uint16_t for x, y, and len fields, which overflows at 65535 pixels. At 2x scale on large documents (e.g. sheet music scores), pixel dimensions easily exceed this limit, causing rendering corruption.

Promote SwSpan fields to uint32_t and update all cast sites in tvgSwRle.cpp accordingly.