### PR TITLE
infra: create or update binary size report comment

### DIFF
--- a/.github/workflows/binary_size_report.yml
+++ b/.github/workflows/binary_size_report.yml
@@ -82,11 +82,12 @@ jobs:
         pathlib.Path("report.md").write_text("\n".join(lines) + "\n")
         PY
 
-    - name: Post comment
+    - name: Create or update comment
       uses: actions/github-script@v7
       with:
         script: |
           const fs = require('fs');
+          const reportHeader = '## Binary Size Report';
           const body = fs.readFileSync('report.md', 'utf8');
 
           // Resolve the PR number from workflow metadata, with a head
@@ -137,9 +138,39 @@ jobs:
             return;
           }
 
-          await github.rest.issues.createComment({
+          core.info(`Resolved PR number: #${prNumber}`);
+
+          const comments = await github.paginate(github.rest.issues.listComments, {
             issue_number: prNumber,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body
+            per_page: 100,
           });
+
+          const existingComments = comments.filter(comment =>
+            comment.user?.login === 'github-actions[bot]' &&
+            comment.user?.type === 'Bot' &&
+            comment.body?.includes(reportHeader)
+          );
+
+          const existingComment = existingComments.at(-1);
+          core.info(`Found ${existingComments.length} matching binary size comment(s).`);
+          core.info(`Selected comment id: ${existingComment?.id ?? 'none'}`);
+
+          if (existingComment) {
+            await github.rest.issues.updateComment({
+              comment_id: existingComment.id,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+            core.info(`Updated binary size comment: ${existingComment.html_url}`);
+          } else {
+            const response = await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+            core.info(`Created binary size comment: ${response.data.html_url}`);
+          }


### PR DESCRIPTION
### Summary

- Run build, test, regression, and binary size workflows only when relevant paths change.

- Binary size reporting now uses create-or-update comments instead of creating a new PR comment on each run.


### ex) Binary Size Report

The binary size report is updated in place:

https://github.com/Nor-s/sizecheck-action-test/pull/23#issuecomment-4439449963

<img width="1118" height="463" alt="image" src="https://github.com/user-attachments/assets/9bbe474b-7004-45ff-95ab-b7f8b0ef7933" />


### ex) When Updating Only `.gitignore`

The workflows are skipped when a PR changes only unrelated files.


<img width="1118" height="463" alt="image" src="https://github.com/user-attachments/assets/94d2600e-7358-4fb4-870f-fea1671e9ebf" />
