### PR TITLE
sfnt: hotfix kern table memory corruption

### DIFF
--- a/src/loaders/sfnt/tvgTtfReader.cpp
+++ b/src/loaders/sfnt/tvgTtfReader.cpp
@@ -300,6 +300,7 @@ bool TtfReader::positioning(uint32_t lglyph, uint32_t rglyph, Point& out)
     #define MINIMUM_KERNING 0x02
     #define CROSS_STREAM_KERNING 0x04
 
+    auto kern = this->kern;
     if (!kern) return false;
 
     // kern tables


### PR DESCRIPTION
kern must be retained within member variable
a regression during a main dev of otf support.