### PR TITLE
gl_engine: fix stencil cover rendering

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlCommon.h
+++ b/src/renderer/gpu_engine/gl/tvgGlCommon.h
@@ -74,7 +74,6 @@ struct GlGeometryBuffer {
         vertex.clear();
         index.clear();
     }
-
 };
 
 struct GlGeometry
@@ -94,7 +93,13 @@ struct GlGeometry
     bool tesselateStroke(const RenderShape& rshape);
     bool tesselateThinPath(const RenderPath& path);
     void tesselateImage(const RenderSurface* image);
-    bool draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag);
+    bool drawable(RenderUpdateFlag flag) const
+    {
+        if (flag == RenderUpdateFlag::None) return false;
+        auto buffer = ((flag & RenderUpdateFlag::Stroke) || (flag & RenderUpdateFlag::GradientStroke)) ? &stroke : &fill;
+        return !buffer->index.empty();
+    }
+    void draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag) const;
     GlStencilMode getStencilMode(RenderUpdateFlag flag);
     RenderRegion getBounds() const;
 

--- a/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
@@ -288,14 +288,9 @@ void GlGeometry::tesselateImage(const RenderSurface* image)
     fillBounds = _transformBounds(RenderRegion{{0, 0}, {int32_t(image->w), int32_t(image->h)}}, matrix);
 }
 
-
-bool GlGeometry::draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag)
+void GlGeometry::draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag) const
 {
-    if (flag == RenderUpdateFlag::None) return false;
-
     auto buffer = ((flag & RenderUpdateFlag::Stroke) || (flag & RenderUpdateFlag::GradientStroke)) ? &stroke : &fill;
-    if (buffer->index.empty()) return false;
-
     auto vertexOffset = gpuBuffer->push(buffer->vertex.data, buffer->vertex.count * sizeof(float));
     auto indexOffset = gpuBuffer->pushIndex(buffer->index.data, buffer->index.count * sizeof(uint32_t));
 
@@ -307,9 +302,7 @@ bool GlGeometry::draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdate
         task->addVertexLayout(GlVertexLayout{0, 2, 2 * sizeof(float), vertexOffset});
     }
     task->setDrawRange(indexOffset, buffer->index.count);
-    return true;
 }
-
 
 GlStencilMode GlGeometry::getStencilMode(RenderUpdateFlag flag)
 {

--- a/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
@@ -37,17 +37,6 @@ static void clearColorTarget(uint32_t width, uint32_t height)
 /* GlRenderTask Class Implementation                                    */
 /************************************************************************/
 
-GlRenderTask::GlRenderTask(GlProgram* program, GlRenderTask* other): mProgram(program)
-{
-    mVertexLayout.push(other->mVertexLayout);
-    mViewport = other->mViewport;
-    mIndexOffset = other->mIndexOffset;
-    mIndexCount = other->mIndexCount;
-    mViewMatrix = other->mViewMatrix;
-    mUseViewMatrix = other->mUseViewMatrix;
-}
-
-
 void GlRenderTask::run()
 {
     // bind shader

--- a/src/renderer/gpu_engine/gl/tvgGlRenderTask.h
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTask.h
@@ -77,7 +77,6 @@ class GlRenderTask
 {
 public:
     GlRenderTask(GlProgram* program): mProgram(program) {}
-    GlRenderTask(GlProgram* program, GlRenderTask* other);
 
     virtual ~GlRenderTask() = default;
 

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -38,6 +38,10 @@
 static int32_t _rendererCnt = -1;
 static mutex _rendererMtx;
 
+static constexpr float IDENTITY_VERTEX[] = {-1.f, 1.f, -1.f, -1.f, 1.f, 1.f, 1.f, -1.f};
+static constexpr uint32_t RECT_INDEX[] = {0, 1, 2, 2, 1, 3};
+static constexpr uint32_t RECT_INDEX_COUNT = sizeof(RECT_INDEX) / sizeof(RECT_INDEX[0]);
+
 void GlRenderer::disposeTexture(GLuint texId)
 {
     if (!texId) return;
@@ -184,6 +188,46 @@ RenderRegion GlRenderer::viewportRegion(const RenderRegion& vp, const RenderRegi
     return {{x, yGl}, {x + w, yGl + h}};
 }
 
+static GlRenderTask* drawStencilCover(GlProgram* stencilProgram, GlRenderTask* coverTask, const GlGeometry& geometry,
+                                      GlStageBuffer* gpuBuffer, RenderUpdateFlag flag, int32_t depth,
+                                      const Matrix& viewMatrix, const RenderRegion& viewRegion)
+{
+    auto stencilTask = new GlRenderTask(stencilProgram);
+    stencilTask->setViewMatrix(viewMatrix);
+    stencilTask->setDrawDepth(depth);
+    stencilTask->setViewport(viewRegion);
+    geometry.draw(stencilTask, gpuBuffer, flag);
+
+    auto bbox = ((flag & RenderUpdateFlag::Stroke) || (flag & RenderUpdateFlag::GradientStroke)) ? geometry.strokeBounds : geometry.fillBounds;
+
+    float vertex[] = {
+        float(bbox.min.x), float(bbox.min.y),
+        float(bbox.min.x), float(bbox.max.y),
+        float(bbox.max.x), float(bbox.min.y),
+        float(bbox.max.x), float(bbox.max.y)};
+    coverTask->addVertexLayout(GlVertexLayout{0, 2, 2 * sizeof(float), gpuBuffer->push(vertex, sizeof(vertex))});
+    coverTask->setDrawRange(gpuBuffer->pushIndex((void*)RECT_INDEX, sizeof(RECT_INDEX)), RECT_INDEX_COUNT);
+    return stencilTask;
+}
+
+static GlRenderTask* drawPrimitiveGeometry(GlProgram* stencilProgram, GlRenderTask* task, const GlGeometry& geometry,
+                                           GlStageBuffer* gpuBuffer, RenderUpdateFlag flag, GlStencilMode stencilMode,
+                                           int32_t depth, const Matrix& viewMatrix, const RenderRegion& viewRegion)
+{
+    if (stencilMode == GlStencilMode::None) {
+        geometry.draw(task, gpuBuffer, flag);
+        return nullptr;
+    }
+
+    return drawStencilCover(stencilProgram, task, geometry, gpuBuffer, flag, depth, viewMatrix, viewRegion);
+}
+
+static void addPrimitiveTask(GlRenderPass* pass, GlRenderTask* task, GlRenderTask* stencilTask, GlStencilMode stencilMode)
+{
+    if (stencilTask) pass->addRenderTask(new GlStencilCoverTask(stencilTask, task, stencilMode));
+    else pass->addRenderTask(task);
+}
+
 GlRenderTask* GlRenderer::createPrimitiveTask(RenderTypes type, BlendSource source, const RenderRegion& viewRegion, GlRenderTarget*& dstCopyFbo)
 {
     dstCopyFbo = nullptr;
@@ -199,16 +243,6 @@ GlRenderTask* GlRenderer::createPrimitiveTask(RenderTypes type, BlendSource sour
 
     auto program = getBlendProgram(mBlendMethod, source);
     return new GlDirectBlendTask(program, currentPass()->getFbo(), dstCopyFbo, viewRegion);
-}
-
-GlRenderTask* GlRenderer::createStencilTask(GlRenderTask* task, GlStencilMode stencilMode, int32_t depth)
-{
-    if (stencilMode == GlStencilMode::None) return nullptr;
-
-    auto stencilTask = new GlRenderTask(mPrograms[RT_Stencil], task);
-    stencilTask->setDrawDepth(depth);
-
-    return stencilTask;
 }
 
 void GlRenderer::bindBlendTarget(GlRenderTask* task, const GlRenderTarget* dstCopyFbo, const RenderRegion& viewRegion, uint32_t binding)
@@ -232,6 +266,8 @@ void GlRenderer::bindBlendTarget(GlRenderTask* task, const GlRenderTarget* dstCo
 
 void GlRenderer::drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdateFlag flag, int32_t depth)
 {
+    if (!sdata.geometry.drawable(flag)) return;
+
     auto blendShape = (mBlendMethod != BlendMethod::Normal);
     auto vp = currentPass()->getViewport();
     auto bbox = blendShape ? sdata.geometry.getBounds() : sdata.geometry.viewport;
@@ -255,11 +291,6 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdat
     task->setViewMatrix(currentPass()->getViewMatrix());
     task->setDrawDepth(depth);
 
-    if (!sdata.geometry.draw(task, &mGpuBuffer, flag)) {
-        delete task;
-        return;
-    }
-
     auto a = MULTIPLY(c.a, sdata.opacity);
     if (flag & RenderUpdateFlag::Stroke) {
         auto strokeWidth = sdata.geometry.strokeRenderWidth;
@@ -271,16 +302,17 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdat
     task->setVertexColor(c.r / 255.f, c.g / 255.f, c.b / 255.f, a / 255.f);
     task->setViewport(viewRegion);
 
-    auto stencilTask = createStencilTask(task, stencilMode, depth);
+    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, &mGpuBuffer, flag, stencilMode, depth, currentPass()->getViewMatrix(), viewRegion);
     // Keep BlendRegion on the existing solid-shape blend UBO slot.
     bindBlendTarget(task, dstCopyFbo, viewRegion, 2);
 
-    if (stencilTask) currentPass()->addRenderTask(new GlStencilCoverTask(stencilTask, task, stencilMode));
-    else currentPass()->addRenderTask(task);
+    addPrimitiveTask(currentPass(), task, stencilTask, stencilMode);
 }
 
 void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFlag flag, int32_t depth)
 {
+    if (!sdata.geometry.drawable(flag)) return;
+
     auto blendShape = (mBlendMethod != BlendMethod::Normal);
     auto vp = currentPass()->getViewport();
     auto bbox = blendShape ? sdata.geometry.getBounds() : sdata.geometry.viewport;
@@ -310,15 +342,10 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
     task->setViewMatrix(currentPass()->getViewMatrix());
     task->setDrawDepth(depth);
 
-    if (!sdata.geometry.draw(task, &mGpuBuffer, flag)) {
-        delete task;
-        return;
-    }
-
     task->setViewport(viewRegion);
 
     GlStencilMode stencilMode = sdata.geometry.getStencilMode(flag);
-    auto stencilTask = createStencilTask(task, stencilMode, depth);
+    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, &mGpuBuffer, flag, stencilMode, depth, currentPass()->getViewMatrix(), viewRegion);
 
     // transform buffer (inverse fill-space transform)
     float invMat3[GL_MAT3_STD140_SIZE];
@@ -435,41 +462,15 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
     // TransformInfo uses slot 0 and GradientInfo uses slot 2, so BlendRegion moves to 3.
     bindBlendTarget(task, dstCopyFbo, viewRegion, 3);
 
-    if (stencilTask) {
-        currentPass()->addRenderTask(new GlStencilCoverTask(stencilTask, task, stencilMode));
-    } else {
-        currentPass()->addRenderTask(task);
-    }
+    addPrimitiveTask(currentPass(), task, stencilTask, stencilMode);
 }
 
 
 void GlRenderer::drawClip(Array<RenderData>& clips)
 {
-    Array<float> identityVertex(4 * 2);
-    float left = -1.f;
-    float top = 1.f;
-    float right = 1.f;
-    float bottom = -1.f;
-
-    identityVertex.push(left);
-    identityVertex.push(top);
-    identityVertex.push(left);
-    identityVertex.push(bottom);
-    identityVertex.push(right);
-    identityVertex.push(top);
-    identityVertex.push(right);
-    identityVertex.push(bottom);
-
-    Array<uint32_t> identityIndex(6);
-    identityIndex.push(0);
-    identityIndex.push(1);
-    identityIndex.push(2);
-    identityIndex.push(2);
-    identityIndex.push(1);
-    identityIndex.push(3);
-
-    auto identityVertexOffset = mGpuBuffer.push(identityVertex.data, 8 * sizeof(float));
-    auto identityIndexOffset = mGpuBuffer.pushIndex(identityIndex.data, 6 * sizeof(uint32_t));
+    uint32_t identityVertexOffset = 0;
+    uint32_t identityIndexOffset = 0;
+    auto identityReady = false;
 
     Array<int32_t> clipDepths(clips.count);
     clipDepths.count = clips.count;
@@ -483,11 +484,18 @@ void GlRenderer::drawClip(Array<RenderData>& clips)
 
     for (uint32_t i = 0; i < clips.count; ++i) {
         auto sdata = static_cast<GlShape*>(clips[i]);
+        auto flag = (sdata->geometry.stroke.vertex.count > 0) ? RenderUpdateFlag::Stroke : RenderUpdateFlag::Path;
+        if (!sdata->geometry.drawable(flag)) continue;
+
+        if (!identityReady) {
+            identityVertexOffset = mGpuBuffer.push((void*)IDENTITY_VERTEX, sizeof(IDENTITY_VERTEX));
+            identityIndexOffset = mGpuBuffer.pushIndex((void*)RECT_INDEX, sizeof(RECT_INDEX));
+            identityReady = true;
+        }
+
         auto clipTask = new GlRenderTask(mPrograms[RT_Stencil]);
         clipTask->setDrawDepth(clipDepths[i]);
         clipTask->setViewMatrix(viewMatrix);
-
-        auto flag = (sdata->geometry.stroke.vertex.count > 0) ? RenderUpdateFlag::Stroke : RenderUpdateFlag::Path;
         sdata->geometry.draw(clipTask, &mGpuBuffer, flag);
 
         auto bbox = sdata->geometry.viewport;
@@ -501,7 +509,7 @@ void GlRenderer::drawClip(Array<RenderData>& clips)
 
         maskTask->setDrawDepth(clipDepths[i]);
         maskTask->addVertexLayout(GlVertexLayout{0, 2, 2 * sizeof(float), identityVertexOffset});
-        maskTask->setDrawRange(identityIndexOffset, 6);
+        maskTask->setDrawRange(identityIndexOffset, RECT_INDEX_COUNT);
         maskTask->setViewport({{0, 0}, {vp.sw(), vp.sh()}});
 
         currentPass()->addRenderTask(new GlClipTask(clipTask, maskTask));
@@ -721,13 +729,12 @@ void GlRenderer::prepareCmpTask(GlRenderTask* task, const RenderRegion& vp, uint
         right, top,    uw, uh,   // right top point
         right, bottom, uw, 0.f   // right bottom point
     };
-    uint32_t indices[6]{0, 1, 2, 2, 1, 3};
     uint32_t vertexOffset = mGpuBuffer.push(vertices, sizeof(vertices));
-    uint32_t indexOffset = mGpuBuffer.pushIndex(indices, sizeof(indices));
+    uint32_t indexOffset = mGpuBuffer.pushIndex((void*)RECT_INDEX, sizeof(RECT_INDEX));
 
     task->addVertexLayout(GlVertexLayout{0, 2, 4 * sizeof(float), vertexOffset});
     task->addVertexLayout(GlVertexLayout{1, 2, 4 * sizeof(float), vertexOffset + 2 * sizeof(float)});
-    task->setDrawRange(indexOffset, 6);
+    task->setDrawRange(indexOffset, RECT_INDEX_COUNT);
     y = (passVp.sh() - y - h);
     task->setViewport({{x, y}, {x + w, y + h}});
 }
@@ -1126,6 +1133,7 @@ bool GlRenderer::renderImage(void* data)
     auto bbox = sdata->geometry.viewport;
     bbox.intersect(vp);
     if (bbox.invalid()) return true;
+    if (!sdata->geometry.drawable(RenderUpdateFlag::Image)) return true;
 
     auto x = bbox.sx() - vp.sx();
     auto y = bbox.sy() - vp.sy();
@@ -1135,11 +1143,7 @@ bool GlRenderer::renderImage(void* data)
 
     auto task = new GlRenderTask(mPrograms[RT_Image]);
     task->setDrawDepth(drawDepth);
-
-    if (!sdata->geometry.draw(task, &mGpuBuffer, RenderUpdateFlag::Image)) {
-        delete task;
-        return true;
-    }
+    sdata->geometry.draw(task, &mGpuBuffer, RenderUpdateFlag::Image);
 
     bool complexBlend = beginComplexBlending(bbox, sdata->geometry.getBounds());
     if (complexBlend) vp = currentPass()->getViewport();

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.h
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.h
@@ -194,7 +194,6 @@ private:
     void initShaders();
     static RenderRegion viewportRegion(const RenderRegion& vp, const RenderRegion& bbox);
     GlRenderTask* createPrimitiveTask(RenderTypes type, BlendSource source, const RenderRegion& viewRegion, GlRenderTarget*& dstCopyFbo);
-    GlRenderTask* createStencilTask(GlRenderTask* task, GlStencilMode stencilMode, int32_t depth);
     void bindBlendTarget(GlRenderTask* task, const GlRenderTarget* dstCopyFbo, const RenderRegion& viewRegion, uint32_t binding);
     void drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdateFlag flag, int32_t depth);
     void drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFlag flag, int32_t depth);

--- a/src/renderer/gpu_engine/gl/tvgGlSolidBatch.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlSolidBatch.cpp
@@ -81,12 +81,7 @@ void GlSolidBatch::emitSingle(GlRenderer& renderer, GlRenderPass* pass, GlShape&
     auto drawTask = new GlRenderTask(renderer.mPrograms[GlRenderer::RT_Color]);
     drawTask->setViewMatrix(pass->getViewMatrix());
     drawTask->setDrawDepth(depth);
-
-    if (!sdata.geometry.draw(drawTask, &renderer.mGpuBuffer, RenderUpdateFlag::Color)) {
-        delete drawTask;
-        clear();
-        return;
-    }
+    sdata.geometry.draw(drawTask, &renderer.mGpuBuffer, RenderUpdateFlag::Color);
 
     auto taskColor = GlSolidBatch::solidColor(sdata, color, RenderUpdateFlag::Color);
     drawTask->setVertexColor(taskColor.r / 255.f, taskColor.g / 255.f, taskColor.b / 255.f, taskColor.a / 255.f);


### PR DESCRIPTION
This PR updates GL stencil cover rendering to draw the original geometry only into the stencil pass, then render the color/gradient pass with a bounding-box cover quad.

This avoids cloning the primitive render task state for stencil rendering and removes the unused task-copy constructor path.

Related issue: https://github.com/thorvg/thorvg/issues/4260
## FPS Changes in Lottie Example
- Maintain consistent FPS on a better GPU device (NV RTX5080 Laptop)
- Increase FPS by 1% on Mac M1
## Binary Size Report

| Config | main text | main data | PR text | PR data | Delta |
|--------|----------:|----------:|--------:|--------:|------:|
| arm64-clang | 848,961 | 23,616 | 848,897 | 23,616 | -64 (-0.01%) |
| x86-gcc | 879,822 | 11,488 | 879,676 | 11,488 | -146 (-0.02%) |
| x86_64-clang | 853,244 | 22,120 | 853,132 | 22,120 | -112 (-0.01%) |
| x86_64-gcc | 858,493 | 21,880 | 858,399 | 21,880 | -94 (-0.01%) |