### PR TITLE
lottie: copy embedded font data to avoid use-after-free

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -301,7 +301,7 @@ void LottieFont::prepare()
 {
     if (!b64src) return;
 
-    Text::load(name, b64src, size, mime, false);
+    Text::load(name, b64src, size, mime, true);
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -301,7 +301,10 @@ void LottieFont::prepare()
 {
     if (!b64src) return;
 
-    Text::load(name, b64src, size, mime, true);
+    if (Text::load(name, b64src, size, mime, true) == Result::Success) {
+        tvg::free(b64src);
+        b64src = nullptr;
+    }
 }
 
 

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -75,7 +75,9 @@ Result Text::load(const char* name, const char* data, uint32_t size, const char*
     }
 
     LoaderOps ops = {Type::Text};
-    if (!LoaderMgr::loader(name, data, size, mimeType, &ops, copy)) return Result::NonSupport;
+    auto loader = LoaderMgr::loader(name, data, size, mimeType, &ops, copy);
+    if (!loader) return Result::NonSupport;
+    if (loader->sharing > 0) --loader->sharing;
     return Result::Success;
 }
 


### PR DESCRIPTION
When a Lottie embeds a font, `LottieFont::prepare()` loads it with `copy=false`, so the font loader only keeps a pointer to the `LottieFont`'s `b64src` buffer instead of owning a copy.

That loader is cached globally and shared by font name across animations, so it can outlive the `LottieFont` that owns the data. Once that animation is destroyed, `b64src` is freed and the cached loader is left pointing at freed memory — any other animation still using the same font then renders missing or garbled glyphs.

Passing `copy=true` lets the loader own its own copy of the font data, so it no longer depends on the animation's lifetime.

The in-memory `Text::load(name, data, ...)` overload also leaked the cached loader's `sharing` count on repeated loads of the same font name — the file-path overload already compensates for this, but this one did not. With `copy=true` that would keep the copied font data pinned and stop `term()`/unload from ever freeing the loader, so the second commit drops the extra reference when an existing cached loader is reused.

Reproducible with multiple players sharing an embedded font: LottieFiles/dotlottie-web#877
