### PR TITLE
svg_loader: support the <pattern> element

### DIFF
--- a/src/common/tvgMath.cpp
+++ b/src/common/tvgMath.cpp
@@ -354,6 +354,18 @@ void Bezier::bounds(BBox& box, const Point& start, const Point& ctrl1, const Poi
         auto a = -1.0f * start + 3.0f * ctrl1 - 3.0f * ctrl2 + end;
         auto b = start - 2.0f * ctrl1 + ctrl2;
         auto c = -1.0f * start + ctrl1;
+        if (tvg::zero(a)) {
+            if (tvg::zero(b)) return;
+            auto t = -c / (2.0f * b);
+            if (t > 0.0f && t < 1.0f) {
+                auto s = 1.0f - t;
+                auto q = s * s * s * start + 3.0f * s * s * t * ctrl1 + 3.0f * s * t * t * ctrl2 + t * t * t * end;
+                if (q < min) min = q;
+                if (q > max) max = q;
+            }
+            return;
+        }
+
         auto h = b * b - a * c;
         if (h <= 0.0f) return;
         h = sqrtf(h);

--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -37,6 +37,7 @@
 
 static bool _appendClipShape(SvgParserContext& ctx, SvgNode* node, Shape* shape, const Box& vBox, const string& svgPath, const Matrix* transform);
 static Scene* _sceneBuildHelper(SvgParserContext& ctx, const SvgNode* node, const Box& vBox, const string& svgPath, bool mask, int depth);
+static Paint* _applyPatternProperty(SvgParserContext& ctx, Shape* vg, SvgNode* node, SvgNode* patternNode, const Box& vBox, const string& svgPath);
 
 static inline bool _isGroupType(SvgNodeType type)
 {
@@ -57,6 +58,11 @@ static Box _bounds(Paint* paint)
 static Box _objectBoundingBox(const Box& ratio, const Box& bounds)
 {
     return {bounds.x + ratio.x * bounds.w, bounds.y + ratio.y * bounds.h, ratio.w * bounds.w, ratio.h * bounds.h};
+}
+
+static inline bool _validBox(const Box& b)
+{
+    return b.w > 0.0f && b.h > 0.0f;
 }
 
 static void _transformMultiply(const Matrix* mBBox, Matrix* gradTransf)
@@ -395,6 +401,32 @@ static Paint* _applyFilter(SvgParserContext& ctx, Paint* paint, const SvgNode* n
     return scene;
 }
 
+static void _applyStroke(SvgStyleProperty* style, Shape* vg, const Box& vBox, const Box& viewport)
+{
+    vg->strokeWidth(style->stroke.width);
+    vg->strokeCap(style->stroke.cap);
+    vg->strokeJoin(style->stroke.join);
+    vg->strokeMiterlimit(style->stroke.miterlimit);
+    vg->strokeDash(style->stroke.dash.array.data, style->stroke.dash.array.count, style->stroke.dash.offset);
+
+    if (style->stroke.paint.none) {
+        vg->strokeWidth(0.0f);
+    } else if (style->stroke.paint.gradient) {
+        auto bBox = style->stroke.paint.gradient->userSpace ? vBox : _bounds(vg);
+        if (style->stroke.paint.gradient->type == SvgGradientType::Linear) {
+            vg->strokeFill(_applyLinearGradientProperty(style->stroke.paint.gradient, bBox, viewport, style->stroke.opacity));
+        } else if (style->stroke.paint.gradient->type == SvgGradientType::Radial) {
+            vg->strokeFill(_applyRadialGradientProperty(style->stroke.paint.gradient, bBox, viewport, style->stroke.opacity));
+        }
+    } else if (style->stroke.paint.url) {
+        TVGLOG("SVG", "The stroke's url not supported.");
+    } else if (style->stroke.paint.curColor) {
+        vg->strokeFill(style->color.r, style->color.g, style->color.b, style->stroke.opacity);
+    } else {
+        vg->strokeFill(style->stroke.paint.color.r, style->stroke.paint.color.g, style->stroke.paint.color.b, style->stroke.opacity);
+    }
+}
+
 static Paint* _applyProperty(SvgParserContext& ctx, SvgNode* node, Shape* vg, const Box& vBox, const string& svgPath, bool clip)
 {
     SvgStyleProperty* style = node->style;
@@ -411,6 +443,20 @@ static Paint* _applyProperty(SvgParserContext& ctx, SvgNode* node, Shape* vg, co
             vg->fill(_applyLinearGradientProperty(style->fill.paint.gradient, bBox, ctx.parser->global, style->fill.opacity));
         } else if (style->fill.paint.gradient->type == SvgGradientType::Radial) {
             vg->fill(_applyRadialGradientProperty(style->fill.paint.gradient, bBox, ctx.parser->global, style->fill.opacity));
+        }
+    } else if (style->fill.paint.pattern) {
+        if (auto patternPaint = _applyPatternProperty(ctx, vg, node, style->fill.paint.pattern, vBox, svgPath)) {
+            vg->fillRule(style->fill.fillRule);
+            vg->order(!style->paintOrder);
+            _applyStroke(style, vg, vBox, ctx.parser->global);
+            auto patternScene = Scene::gen();
+            patternScene->add(patternPaint);
+            patternScene->add(vg);
+            patternScene->opacity(style->opacity);
+            if (node->transform && !clip) patternScene->transform(*node->transform);
+            auto p = _applyFilter(ctx, patternScene, node, vBox, svgPath);
+            p = _applyComposition(ctx, p, node, vBox, svgPath);
+            return _applyBlend(p, node);
         }
     } else if (style->fill.paint.url) {
         TVGLOG("SVG", "The fill's url not supported.");
@@ -431,33 +477,7 @@ static Paint* _applyProperty(SvgParserContext& ctx, SvgNode* node, Shape* vg, co
         return vg;
     }
 
-    //Apply the stroke style property
-    vg->strokeWidth(style->stroke.width);
-    vg->strokeCap(style->stroke.cap);
-    vg->strokeJoin(style->stroke.join);
-    vg->strokeMiterlimit(style->stroke.miterlimit);
-    vg->strokeDash(style->stroke.dash.array.data, style->stroke.dash.array.count, style->stroke.dash.offset);
-
-    //If stroke property is nullptr then do nothing
-    if (style->stroke.paint.none) {
-        vg->strokeWidth(0.0f);
-    } else if (style->stroke.paint.gradient) {
-        auto bBox = style->stroke.paint.gradient->userSpace ? vBox : _bounds(vg);
-        if (style->stroke.paint.gradient->type == SvgGradientType::Linear) {
-            vg->strokeFill(_applyLinearGradientProperty(style->stroke.paint.gradient, bBox, ctx.parser->global, style->stroke.opacity));
-        } else if (style->stroke.paint.gradient->type == SvgGradientType::Radial) {
-            vg->strokeFill(_applyRadialGradientProperty(style->stroke.paint.gradient, bBox, ctx.parser->global, style->stroke.opacity));
-        }
-    } else if (style->stroke.paint.url) {
-        //TODO: Apply the color pointed by url
-        TVGLOG("SVG", "The stroke's url not supported.");
-    } else if (style->stroke.paint.curColor) {
-        //Apply the current style color
-        vg->strokeFill(style->color.r, style->color.g, style->color.b, style->stroke.opacity);
-    } else {
-        //Apply the stroke color
-        vg->strokeFill(style->stroke.paint.color.r, style->stroke.paint.color.g, style->stroke.paint.color.b, style->stroke.opacity);
-    }
+    _applyStroke(style, vg, vBox, ctx.parser->global);
 
     //apply transform after the local space shape bbox for gradient acquisition
     if (node->transform && !clip) vg->transform(*node->transform);
@@ -1062,7 +1082,7 @@ static Scene* _sceneBuildHelper(SvgParserContext& ctx, const SvgNode* node, cons
     ARRAY_FOREACH(p, node->child) {
         auto child = *p;
         Paint* paint = nullptr;
-        if (child->type == SvgNodeType::ClipPath || child->type == SvgNodeType::Filter) continue;
+        if (child->type == SvgNodeType::ClipPath || child->type == SvgNodeType::Filter || child->type == SvgNodeType::Pattern) continue;
         if (_isGroupType(child->type)) {
             if (child->type == SvgNodeType::Use) paint = _useBuildHelper(ctx, child, vBox, svgPath, depth + 1);
             else if (!(child->type == SvgNodeType::Symbol && node->type != SvgNodeType::Use)) paint = _sceneBuildHelper(ctx, child, vBox, svgPath, false, depth + 1);
@@ -1085,6 +1105,143 @@ static Scene* _sceneBuildHelper(SvgParserContext& ctx, const SvgNode* node, cons
     return (Scene*)_applyBlend(_applyComposition(ctx, _applyFilter(ctx, scene, node, vBox, svgPath), node, vBox, svgPath), node);
 }
 
+static Paint* _buildPatternChild(SvgParserContext& ctx, SvgNode* child, const Box& vBox, const string& svgPath)
+{
+    if (child->type == SvgNodeType::ClipPath || child->type == SvgNodeType::Filter || child->type == SvgNodeType::Pattern) return nullptr;
+    if (_isGroupType(child->type)) {
+        if (child->type == SvgNodeType::Use) return _useBuildHelper(ctx, child, vBox, svgPath, 0);
+        if (child->type != SvgNodeType::Symbol) return _sceneBuildHelper(ctx, child, vBox, svgPath, false, 0);
+        return nullptr;
+    }
+    if (child->type == SvgNodeType::Image) return _imageBuildHelper(ctx, child, vBox, svgPath);
+    if (child->type == SvgNodeType::Text) return _textBuildHelper(ctx, child, vBox, svgPath);
+    if (child->type == SvgNodeType::Mask) return nullptr;
+    return _shapeBuildHelper(ctx, child, vBox, svgPath);
+}
+
+static Paint* _buildBaseTile(SvgParserContext& ctx, SvgNode* patternNode, const Box& vBox, const string& svgPath)
+{
+    Paint* paint = nullptr;
+    Scene* tileScene = nullptr;
+    ARRAY_FOREACH(p, patternNode->child) {
+        auto child = _buildPatternChild(ctx, *p, vBox, svgPath);
+        if (!child) continue;
+        if (!paint && !tileScene) {
+            paint = child;
+            continue;
+        }
+        if (!tileScene) {
+            tileScene = Scene::gen();
+            tileScene->add(paint);
+            paint = nullptr;
+        }
+        tileScene->add(child);
+    }
+    if (tileScene) return tileScene;
+    return paint;
+}
+
+static bool _patternCellRect(const SvgPatternNode& pat, const Box& bbox, Box& cell)
+{
+    if (pat.patternUserSpace) {
+        cell = pat.box;
+    } else {
+        cell.x = bbox.x + pat.box.x * bbox.w;
+        cell.y = bbox.y + pat.box.y * bbox.h;
+        cell.w = pat.box.w * bbox.w;
+        cell.h = pat.box.h * bbox.h;
+    }
+    return _validBox(cell);
+}
+
+static Matrix _patternContentTransform(const SvgPatternNode& pat, const Box& bbox, const Box& cell)
+{
+    if (pat.hasViewBox) {
+        auto sx = cell.w / pat.vbox.w;
+        auto sy = cell.h / pat.vbox.h;
+        return {sx, 0, -pat.vbox.x * sx, 0, sy, -pat.vbox.y * sy, 0, 0, 1};
+    }
+    if (!pat.contentUserSpace) return {bbox.w, 0, 0, 0, bbox.h, 0, 0, 0, 1};
+    return tvg::identity();
+}
+
+static Box _transformBounds(const Box& bounds, const Matrix& matrix)
+{
+    auto lt = Point{bounds.x, bounds.y} * matrix;
+    auto lb = Point{bounds.x, bounds.y + bounds.h} * matrix;
+    auto rt = Point{bounds.x + bounds.w, bounds.y} * matrix;
+    auto rb = Point{bounds.x + bounds.w, bounds.y + bounds.h} * matrix;
+
+    auto min = tvg::min(tvg::min(lt, lb), tvg::min(rt, rb));
+    auto max = tvg::max(tvg::max(lt, lb), tvg::max(rt, rb));
+
+    return {min.x, min.y, max.x - min.x, max.y - min.y};
+}
+
+static void _patternTileGrid(const Box& cell, const Box& bbox, const Matrix* transform, float& startX, float& startY, int& cols, int& rows)
+{
+    auto box = bbox;
+    Matrix inv;
+    if (transform && tvg::inverse(transform, &inv)) box = _transformBounds(bbox, inv);
+
+    startX = cell.x + floorf((box.x - cell.x) / cell.w) * cell.w;
+    startY = cell.y + floorf((box.y - cell.y) / cell.h) * cell.h;
+    cols = (int)ceilf((box.x + box.w - startX) / cell.w);
+    rows = (int)ceilf((box.y + box.h - startY) / cell.h);
+}
+
+static Paint* _applyPatternProperty(SvgParserContext& ctx, Shape* vg, SvgNode* node, SvgNode* patternNode, const Box& vBox, const string& svgPath)
+{
+    if (!patternNode || patternNode->child.empty()) return nullptr;
+    auto& pat = patternNode->node.pattern;
+
+    if (pat.applying) {
+        TVGLOG("SVG", "Circular pattern reference detected; skipped.");
+        return nullptr;
+    }
+
+    auto bbox = _bounds(vg);
+    if (!_validBox(bbox)) return nullptr;
+
+    Box cell;
+    if (!_patternCellRect(pat, bbox, cell)) return nullptr;
+
+    float startX, startY;
+    int cols, rows;
+    _patternTileGrid(cell, bbox, pat.transform, startX, startY, cols, rows);
+
+    auto contentTransform = _patternContentTransform(pat, bbox, cell);
+
+    pat.applying = true;
+
+    auto base = _buildBaseTile(ctx, patternNode, vBox, svgPath);
+    auto tilesScene = Scene::gen();
+    if (base) {
+        for (int r = 0; r < rows; ++r) {
+            for (int c = 0; c < cols; ++c) {
+                auto copy = base->duplicate();
+                if (!copy) continue;
+                Matrix tileTransform = Matrix{1, 0, startX + c * cell.w, 0, 1, startY + r * cell.h, 0, 0, 1} * contentTransform;
+                if (pat.transform) tileTransform = *pat.transform * tileTransform;
+                copy->transform(tileTransform * copy->transform());
+                tilesScene->add(copy);
+            }
+        }
+        Paint::rel(base);
+    }
+
+    auto clipper = Shape::gen();
+    if (!_recognizeShape(node, clipper)) {
+        pat.applying = false;
+        Paint::rel(tilesScene);
+        Paint::rel(clipper);
+        return nullptr;
+    }
+    tilesScene->clip(clipper);
+
+    pat.applying = false;
+    return tilesScene;
+}
 
 static void _updateInvalidViewSize(Scene* scene, Box& vBox, float& w, float& h, SvgViewFlag viewFlag)
 {

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -84,6 +84,7 @@ enum struct SvgNodeType : uint16_t
     Symbol,
     Filter,
     GaussianBlur,
+    Pattern,
     Unknown
 };
 
@@ -422,6 +423,18 @@ struct SvgFilterNode
     bool primitiveUserSpace;
 };
 
+struct SvgPatternNode
+{
+    Box box;
+    Box vbox;
+    Matrix* transform;
+    bool isPercentage[4];
+    bool patternUserSpace;
+    bool contentUserSpace;
+    bool hasViewBox;
+    bool applying;
+};
+
 struct SvgLinearGradient
 {
     float x1, y1, x2, y2;
@@ -452,6 +465,7 @@ struct SvgComposite
 struct SvgPaint
 {
     SvgStyleGradient* gradient;
+    SvgNode* pattern;
     char *url;
     SvgColor color;
     bool none;
@@ -563,6 +577,7 @@ struct SvgNode
         SvgTextNode text;
         SvgFilterNode filter;
         SvgGaussianBlurNode gaussianBlur;
+        SvgPatternNode pattern;
     } node;
     SvgXmlSpace xmlSpace = SvgXmlSpace::None;
     ~SvgNode();

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1540,6 +1540,45 @@ static SvgNode* _createFilterNode(SvgParserContext* ctx, SvgNode* parent, const 
     return ctx->parser->node;
 }
 
+static bool _attrParsePatternNode(void* data, const char* key, const char* value)
+{
+    auto ctx = (SvgParserContext*)data;
+    auto node = ctx->parser->node;
+    auto pattern = &node->node.pattern;
+
+    if (_parseBox(key, value, &pattern->box, pattern->isPercentage)) return true;
+
+    if (STR_AS(key, "id")) _copyId(&node->id, value);
+    else if (STR_AS(key, "patternUnits")) {
+        if (STR_AS(value, "userSpaceOnUse")) pattern->patternUserSpace = true;
+    } else if (STR_AS(key, "patternContentUnits")) {
+        if (STR_AS(value, "objectBoundingBox")) pattern->contentUserSpace = false;
+    } else if (STR_AS(key, "viewBox")) {
+        if (!_parseNumber(&value, nullptr, &pattern->vbox.x) || !_parseNumber(&value, nullptr, &pattern->vbox.y)) return false;
+        if (!_parseNumber(&value, nullptr, &pattern->vbox.w) || !_parseNumber(&value, nullptr, &pattern->vbox.h)) return false;
+        if (pattern->vbox.w > 0.0f && pattern->vbox.h > 0.0f) pattern->hasViewBox = true;
+    } else if (STR_AS(key, "patternTransform")) {
+        pattern->transform = _parseTransformationMatrix(value);
+    }
+    return true;
+}
+
+static SvgNode* _createPatternNode(SvgParserContext* ctx, SvgNode* parent, const char* buf, unsigned bufLength, parseAttributes func)
+{
+    ctx->parser->node = _createNode(parent, SvgNodeType::Pattern);
+    if (!ctx->parser->node) return nullptr;
+    SvgPatternNode& pattern = ctx->parser->node->node.pattern;
+
+    ctx->parser->node->style->display = false;
+    pattern.patternUserSpace = false;
+    pattern.contentUserSpace = true;
+
+    func(buf, bufLength, _attrParsePatternNode, ctx);
+
+    if (pattern.patternUserSpace) _recalcBox(ctx, &pattern.box, pattern.isPercentage);
+
+    return ctx->parser->node;
+}
 
 static bool _attrParsePathNode(void* data, const char* key, const char* value)
 {
@@ -2204,9 +2243,8 @@ static constexpr struct
     {"clipPath", sizeof("clipPath"), _createClipPathNode},
     {"style", sizeof("style"), _createCssStyleNode},
     {"symbol", sizeof("symbol"), _createSymbolNode},
-    {"filter", sizeof("filter"), _createFilterNode}
-};
-
+    {"filter", sizeof("filter"), _createFilterNode},
+    {"pattern", sizeof("pattern"), _createPatternNode}};
 
 #define FIND_FACTORY(Short_Name, Tags_Array)                                           \
     static FactoryMethod                                                               \
@@ -3043,6 +3081,15 @@ static void _copyAttr(SvgNode* to, const SvgNode* from)
             to->node.use = from->node.use;
             break;
         }
+        case SvgNodeType::Pattern: {
+            to->node.pattern = from->node.pattern;
+            to->node.pattern.applying = false;
+            if (from->node.pattern.transform) {
+                to->node.pattern.transform = tvg::malloc<Matrix>(sizeof(Matrix));
+                *to->node.pattern.transform = *from->node.pattern.transform;
+            }
+            break;
+        }
         case SvgNodeType::Tspan:
         case SvgNodeType::Text: {
             to->node.text.x = from->node.text.x;
@@ -3458,6 +3505,10 @@ static void _free(SvgNode* node)
              tvg::free(node->node.text.fontFamily);
              break;
          }
+         case SvgNodeType::Pattern: {
+             tvg::free(node->node.pattern.transform);
+             break;
+         }
          default: {
              break;
          }
@@ -3681,6 +3732,24 @@ static void _updateGradient(SvgParserContext* ctx, SvgNode* node, Array<SvgStyle
     }
 }
 
+static void _updatePattern(SvgNode* node, SvgNode* root, SvgNode* defs)
+{
+    auto lookup = [&](const char* url) -> SvgNode* {
+        SvgNode* p = nullptr;
+        if (defs) p = _findNodeById(defs, url);
+        if (!p) p = _findNodeById(root, url);
+        if (p && p->type != SvgNodeType::Pattern) return nullptr;
+        return p;
+    };
+
+    if (node->style) {
+        auto& fill = node->style->fill.paint;
+        if (fill.url && !fill.gradient && !fill.pattern) fill.pattern = lookup(fill.url);
+    }
+    ARRAY_FOREACH(c, node->child) {
+        _updatePattern(*c, root, defs);
+    }
+}
 
 static void _updateComposite(SvgNode* node, SvgNode* root)
 {
@@ -3800,15 +3869,22 @@ void SvgLoader::run(unsigned tid)
 
                 _updateComposite(ctx.doc, ctx.doc);
                 if (defs) _updateComposite(ctx.doc, defs);
+                if (defs) _updateComposite(defs, defs);
 
                 _updateFilter(ctx.doc, ctx.doc);
                 if (defs) _updateFilter(ctx.doc, defs);
+                if (defs) _updateFilter(defs, defs);
 
                 _updateStyle(ctx.doc, nullptr);
                 if (defs) _updateStyle(defs, nullptr);
 
                 if (ctx.gradients.count > 0) _updateGradient(&ctx, ctx.doc, &ctx.gradients);
                 if (defs) _updateGradient(&ctx, ctx.doc, &defs->node.defs.gradients);
+                if (defs && ctx.gradients.count > 0) _updateGradient(&ctx, defs, &ctx.gradients);
+                if (defs) _updateGradient(&ctx, defs, &defs->node.defs.gradients);
+
+                _updatePattern(ctx.doc, ctx.doc, defs);
+                if (defs) _updatePattern(defs, ctx.doc, defs);
 
                 root = svgSceneBuild(ctx, vbox, w, h, align, meetOrSlice, svgPath, viewFlag);
 

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -240,6 +240,7 @@ const char* xmlNodeTypeToString(TVG_UNUSED SvgNodeType type)
         "Symbol",
         "Filter",
         "GaussianBlur",
+        "Pattern",
         "Unknown",
     };
     return TYPE_NAMES[(int) type];


### PR DESCRIPTION
Add SVG `<pattern>` support. Pattern children are tiled across the shape's bounding box and clipped by the shape itself, which also fixes images embedded inside a pattern. Tile build follows the lottie Repeater pattern: the pattern body is walked once into a base paint, then every tile is produced by Paint::duplicate() with a per-cell transform composed onto its own.

- Supported attributes

| attribute | values | notes |
| --- | --- | --- |
| `patternUnits` | `objectBoundingBox` (default), `userSpaceOnUse` | |
| `patternContentUnits` | `userSpaceOnUse` (default), `objectBoundingBox` | |
| `x` / `y` / `width` / `height` | length / percentage | |
| `viewBox` | `x y w h` | stretched into the tile cell | 
| `patternTransform` | matrix / translate / scale / rotate / skew | applied on top of cell placement |

- Not supported (intentional, future work)

| attribute / feature | notes |
| --- | --- |
| `preserveAspectRatio` | viewBox always stretches |
| `href` / `xlink:href` | pattern attribute inheritance |
| `stroke="url(#pattern)"` | only fill is wired up |


issue : https://github.com/thorvg/thorvg/issues/4369 https://github.com/thorvg/thorvg/issues/1319 https://github.com/thorvg/thorvg/issues/1816