### PR TITLE
lottie: added zigzag support

### DIFF
--- a/src/common/tvgMath.cpp
+++ b/src/common/tvgMath.cpp
@@ -402,10 +402,8 @@ Point Bezier::at(float t) const
 }
 
 
-float Bezier::angle(float t) const
+Point Bezier::tangent(float t) const
 {
-    if (t < 0 || t > 1) return 0;
-
     //derivate
     // p'(t) = 3 * (-(1-2t+t^2) * p0 + (1 - 4 * t + 3 * t^2) * p1 + (2 * t - 3 *
     // t^2) * p2 + t^2 * p3)
@@ -419,7 +417,14 @@ float Bezier::angle(float t) const
     pt.x *= 3;
     pt.y *= 3;
 
-    return rad2deg(tvg::atan(pt));
+    return pt;
+}
+
+
+float Bezier::angle(float t) const
+{
+    if (t < 0 || t > 1) return 0;
+    return rad2deg(tvg::atan(tangent(t)));
 }
 
 

--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -489,6 +489,7 @@ struct Bezier
     float at(float at, float length) const;
     float atApprox(float at, float length) const;
     Point at(float t) const;
+    Point tangent(float t) const;
     float angle(float t) const;
     bool flatten(float tolerance) const;
     uint32_t segments(float scale = 1.0f) const;

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -788,6 +788,16 @@ void LottieBuilder::updatePuckerBloat(TVG_UNUSED LottieGroup* parent, LottieObje
     ctx->update(new LottiePuckerBloatModifier(puckerBloat->amount(frameNo, tween, exps)));
 }
 
+void LottieBuilder::updateZigZag(TVG_UNUSED LottieGroup* parent, LottieObject** child, float frameNo, TVG_UNUSED Inlist<RenderContext>& contexts, RenderContext* ctx)
+{
+    auto zigzag = static_cast<LottieZigZag*>(*child);
+    auto amplitude = zigzag->amplitude(frameNo, tween, exps);
+    if (tvg::zero(amplitude)) return;
+    auto frequency = zigzag->frequency(frameNo, tween, exps);
+    auto point = (LottieZigZagModifier::PointType)zigzag->point(frameNo, tween, exps);
+    ctx->update(new LottieZigZagModifier(amplitude, frequency, point));
+}
+
 void LottieBuilder::updateRepeater(TVG_UNUSED LottieGroup* parent, LottieObject** child, float frameNo, TVG_UNUSED Inlist<RenderContext>& contexts, RenderContext* ctx)
 {
     auto repeater = static_cast<LottieRepeater*>(*child);
@@ -897,6 +907,10 @@ void LottieBuilder::updateChildren(LottieGroup* parent, float frameNo, Inlist<Re
                 }
                 case LottieObject::PuckerBloat: {
                     updatePuckerBloat(parent, child, frameNo, contexts, ctx);
+                    break;
+                }
+                case LottieObject::ZigZag: {
+                    updateZigZag(parent, child, frameNo, contexts, ctx);
                     break;
                 }
                 default: break;

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -125,6 +125,11 @@ struct RenderContext
                     update(new LottiePuckerBloatModifier(pucker->amount));
                     break;
                 }
+                case LottieModifier::Type::ZigZag: {
+                    auto zigzag = static_cast<LottieZigZagModifier*>(m);
+                    update(new LottieZigZagModifier(zigzag->amp, zigzag->freq, zigzag->point));
+                    break;
+                }
             }
             m = m->next;
         }
@@ -228,6 +233,7 @@ private:
     void updateRoundedCorner(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updateOffsetPath(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updatePuckerBloat(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
+    void updateZigZag(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
 
     LottieExpressions* exps;
     Tween tween;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -273,6 +273,7 @@ struct LottieObject
         RoundedCorner,
         OffsetPath,
         PuckerBloat,
+        ZigZag,
         TextRange,
         Audio
     };
@@ -1034,6 +1035,18 @@ struct LottiePuckerBloat : LottieObject
     }
 
     LottieFloat amount = 0.0f;
+};
+
+struct LottieZigZag : LottieObject
+{
+    LottieZigZag()
+    {
+        LottieObject::type = LottieObject::ZigZag;
+    }
+
+    LottieFloat amplitude = 0.0f;
+    LottieInteger frequency = 0;
+    LottieInteger point = 1; //1: corner, 2: smooth
 };
 
 struct LottieGroup : LottieObject, LottieRenderPooler<tvg::Shape>

--- a/src/loaders/lottie/tvgLottieModifier.cpp
+++ b/src/loaders/lottie/tvgLottieModifier.cpp
@@ -596,3 +596,162 @@ void LottiePuckerBloatModifier::ellipse(const RenderPath& in, RenderPath& out, T
 {
     path(in, out, nullptr);
 }
+
+/************************************************************************/
+/* LottieZigZagModifier                                                 */
+/************************************************************************/
+
+LottieZigZagModifier::Vertex LottieZigZagModifier::ridge(const Point& at, const Point& dir, float sign, float inAmp, float outAmp) const
+{
+    auto len = tvg::length(dir);
+    if (len < FLT_EPSILON) return {at, at, at};
+    auto pos = at + tvg::normal({}, dir) * (sign * amp);
+    auto unit = dir / len;
+    return {pos, pos - unit * inAmp, pos + unit * outAmp};
+}
+
+void LottieZigZagModifier::corner(uint32_t cur, float sign, const Array<Point>& verts, Array<Vertex>& ridges) const
+{
+    auto curIdx = cur % verts.count;
+    auto prevIdx = (curIdx == 0) ? verts.count - 1 : curIdx - 1;
+    auto nextIdx = (curIdx + 1) % verts.count;
+    auto dir = verts[nextIdx] - verts[prevIdx];
+    auto outAmp = 0.0f, inAmp = 0.0f;
+    if (point == Smooth) {
+        outAmp = tvg::length(verts[nextIdx] - verts[curIdx]) / ((freq + 1) * 2);
+        inAmp = tvg::length(verts[prevIdx] - verts[curIdx]) / ((freq + 1) * 2);
+    }
+    ridges.push(ridge(verts[curIdx], dir, sign, inAmp, outAmp));
+}
+
+
+float LottieZigZagModifier::segment(uint32_t idx, float sign, const Array<Point>& verts, const Array<Point>& ins, const Array<Point>& outs, Array<Vertex>& ridges) const
+{
+    if (freq == 0) return sign;
+    auto i0 = idx;
+    auto i1 = (idx + 1) % verts.count;
+    Point p0 = verts[i0], p1 = outs[i0], p2 = ins[i1], p3 = verts[i1];
+    auto sAmp = (point == Smooth) ? tvg::length(p3 - p0) / ((freq + 1) * 2) : 0.0f;
+    Bezier bz{p0, p1, p2, p3};
+    for (int k = 0; k < freq; ++k) {
+        auto t = float(k + 1) / float(freq + 1);
+        ridges.push(ridge(bz.at(t), bz.tangent(t), sign, sAmp, sAmp));
+        sign = -sign;
+    }
+    return sign;
+}
+
+
+void LottieZigZagModifier::flush(bool closed, Array<Point>& verts, Array<Point>& ins, Array<Point>& outs, Array<Vertex>& ridges, RenderPath& dst) const
+{
+    if (verts.count == 0) return;
+
+    //collapse closing duplicate vertex
+    if (closed && verts.count > 1 && tvg::zero(verts.last() - verts[0])) {
+        ins[0] = ins.last();
+        verts.pop();
+        ins.pop();
+        outs.pop();
+    }
+    if (verts.count < 2) return;
+
+    auto segCount = closed ? verts.count : verts.count - 1;
+
+    ridges.clear();
+    ridges.reserve((segCount + 1) * (freq + 1));
+
+    auto sign = 1.0f;
+    corner(0, sign, verts, ridges);
+    for (uint32_t i = 0; i < segCount; ++i) {
+        sign = segment(i, -sign, verts, ins, outs, ridges);
+        corner(i + 1, sign, verts, ridges);
+    }
+
+    if (ridges.count == 0) return;
+    dst.moveTo(ridges[0].v);
+    for (uint32_t i = 1; i < ridges.count; ++i) {
+        dst.cubicTo(ridges[i - 1].out, ridges[i].in, ridges[i].v);
+    }
+    if (closed) dst.close();
+}
+
+
+RenderPath& LottieZigZagModifier::modify(const RenderPath& in, RenderPath& out, Matrix* transform)
+{
+    auto& path = (next) ? RenderPath::scratch() : out;
+    auto pivot = path.pts.count;
+    path.cmds.reserve(path.cmds.count + in.cmds.count * (freq + 2));
+    path.pts.reserve(path.pts.count + in.pts.count * (freq + 2));
+
+    Array<Point> verts, ins, outs;
+    Array<Vertex> ridges;
+    auto closed = false;
+
+    for (uint32_t iCmd = 0, iPt = 0; iCmd < in.cmds.count; ++iCmd) {
+        switch (in.cmds[iCmd]) {
+            case PathCommand::MoveTo: {
+                flush(closed, verts, ins, outs, ridges, path);
+                verts.clear();
+                ins.clear();
+                outs.clear();
+                closed = false;
+                auto first = in.pts[iPt++];
+                verts.push(first);
+                ins.push(first);
+                outs.push(first);
+                break;
+            }
+            case PathCommand::CubicTo: {
+                outs.last() = in.pts[iPt];
+                ins.push(in.pts[iPt + 1]);
+                verts.push(in.pts[iPt + 2]);
+                outs.push(in.pts[iPt + 2]);
+                iPt += 3;
+                break;
+            }
+            case PathCommand::LineTo: {
+                outs.last() = verts.last();
+                ins.push(in.pts[iPt]);
+                verts.push(in.pts[iPt]);
+                outs.push(in.pts[iPt]);
+                ++iPt;
+                break;
+            }
+            case PathCommand::Close: {
+                closed = true;
+                break;
+            }
+            default: break;
+        }
+    }
+    flush(closed, verts, ins, outs, ridges, path);
+
+    if (transform) {
+        for (auto i = pivot; i < path.pts.count; ++i) {
+            path.pts[i] *= *transform;
+        }
+    }
+
+    return path;
+}
+
+void LottieZigZagModifier::path(const RenderPath& in, RenderPath& out, Matrix* transform)
+{
+    auto& result = modify(in, out, transform);
+    if (next) next->path(result, out, nullptr);
+}
+
+void LottieZigZagModifier::polystar(const RenderPath& in, RenderPath& out, TVG_UNUSED float, TVG_UNUSED bool)
+{
+    path(in, out, nullptr);
+}
+
+void LottieZigZagModifier::rect(const RenderPath& in, RenderPath& out, TVG_UNUSED const Point&, TVG_UNUSED const Point&, TVG_UNUSED float, TVG_UNUSED bool)
+{
+    path(in, out, nullptr);
+}
+
+void LottieZigZagModifier::ellipse(const RenderPath& in, RenderPath& out, TVG_UNUSED const Point&, TVG_UNUSED const Point&, TVG_UNUSED bool)
+{
+    path(in, out, nullptr);
+}

--- a/src/loaders/lottie/tvgLottieModifier.h
+++ b/src/loaders/lottie/tvgLottieModifier.h
@@ -34,7 +34,8 @@ struct LottieModifier
     {
         Roundness = 0,
         Offset,
-        PuckerBloat
+        PuckerBloat,
+        ZigZag
     };
 
     LottieModifier* next = nullptr;
@@ -121,6 +122,37 @@ struct LottiePuckerBloatModifier : LottieModifier
 
 private:
     Point center(const PathCommand* cmds, uint32_t cmdsCnt, const Point* pts);
+};
+
+struct LottieZigZagModifier : LottieModifier
+{
+    enum PointType : uint8_t { Corner = 1, Smooth = 2 };
+
+    struct Vertex
+    {
+        Point v;
+        Point in;
+        Point out;
+    };
+
+    float amp;
+    int freq;
+    PointType point;
+
+    LottieZigZagModifier(float amp, int freq, PointType point) :
+        LottieModifier(ZigZag), amp(amp), freq(freq), point(point) {}
+
+    void path(const RenderPath& in, RenderPath& out, Matrix* transform) override;
+    void polystar(const RenderPath& in, RenderPath& out, float outerRoundness, bool hasRoundness) override;
+    void rect(const RenderPath& in, RenderPath& out, const Point& pos, const Point& size, float r, bool clockwise) override;
+    void ellipse(const RenderPath& in, RenderPath& out, const Point& center, const Point& radius, bool clockwise) override;
+
+private:
+    RenderPath& modify(const RenderPath& in, RenderPath& out, Matrix* transform);
+    Vertex ridge(const Point& at, const Point& dir, float sign, float inAmp, float outAmp) const;
+    void corner(uint32_t cur, float sign, const Array<Point>& verts, Array<Vertex>& ridges) const;
+    float segment(uint32_t idx, float sign, const Array<Point>& verts, const Array<Point>& ins, const Array<Point>& outs, Array<Vertex>& ridges) const;
+    void flush(bool closed, Array<Point>& verts, Array<Point>& ins, Array<Point>& outs, Array<Vertex>& ridges, RenderPath& out) const;
 };
 
 #endif

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -898,6 +898,22 @@ LottiePuckerBloat* LottieParser::parsePuckerBloat()
     return puckerBloat;
 }
 
+LottieZigZag* LottieParser::parseZigZag()
+{
+    auto zigzag = new LottieZigZag;
+
+    context.parent = zigzag;
+
+    while (auto key = nextObjectKey()) {
+        if (parseCommon(zigzag, key)) continue;
+        else if (KEY_AS("s")) parseProperty(zigzag->amplitude);
+        else if (KEY_AS("r")) parseProperty(zigzag->frequency);
+        else if (KEY_AS("pt")) parseProperty(zigzag->point);
+        else skip();
+    }
+    return zigzag;
+}
+
 LottieObject* LottieParser::parseObject(const char* type)
 {
     if (!strcmp(type, "gr")) return parseGroup();
@@ -915,9 +931,9 @@ LottieObject* LottieParser::parseObject(const char* type)
     else if (!strcmp(type, "rp")) return parseRepeater();
     else if (!strcmp(type, "pb")) return parsePuckerBloat();
     else if (!strcmp(type, "op")) return parseOffsetPath();
+    else if (!strcmp(type, "zz")) return parseZigZag();
     else if (!strcmp(type, "mm")) TVGLOG("LOTTIE", "MergePath(mm) is not supported yet");
     else if (!strcmp(type, "tw")) TVGLOG("LOTTIE", "Twist(tw) is not supported yet");
-    else if (!strcmp(type, "zz")) TVGLOG("LOTTIE", "ZigZag(zz) is not supported yet");
     return nullptr;
 }
 

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -97,6 +97,7 @@ private:
     LottieRepeater* parseRepeater();
     LottieOffsetPath* parseOffsetPath();
     LottiePuckerBloat* parsePuckerBloat();
+    LottieZigZag* parseZigZag();
     LottieFont* parseFont();
     void parseFontData(LottieFont* font, const char* data);
     LottieMarker* parseMarker();


### PR DESCRIPTION
| Before | After |
|---|---|
| <img width="2404" height="1668" alt="Before" src="https://github.com/user-attachments/assets/941bfacf-5d59-44ab-bd98-0a6a93c22f55" /> | <img width="2408" height="1670" alt="After" src="https://github.com/user-attachments/assets/315ec07e-da36-4fb8-a954-d933f629ab42" /> |

Test files:
- [zigzag-smooth.json](https://github.com/user-attachments/files/28275838/zigzag-smooth.json)
- [zigzag-corner.json](https://github.com/user-attachments/files/28275841/zigzag-corner.json)

spec: https://lottiefiles.github.io/lottie-docs/shapes/#zig-zag
issue: https://github.com/thorvg/thorvg/issues/2681