### PR TITLE
lottie: removed experimental apis

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -3139,23 +3139,6 @@ TVG_API Tvg_Result tvg_lottie_animation_get_marker_info(Tvg_Animation animation,
 TVG_API Tvg_Result tvg_lottie_animation_tween(Tvg_Animation animation, float from, float to, float progress);
 
 /**
- * @brief Updates the value of an expression variable for a specific layer.
- *
- * @param[in] animation The Lottie animation object.
- * @param[in] layer The name of the layer containing the variable to be updated.
- * @param[in] ix The property index of the variable within the layer.
- * @param[in] var The name of the variable to be updated.
- * @param[in] val The new value to assign to the variable.
- *
- * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the animation is not loaded.
- * @retval TVG_RESULT_INVALID_ARGUMENT When the given parameter is invalid.
- * @retval TVG_RESULT_NOT_SUPPORTED When neither the layer nor the property is found in the current animation.
- *
- * @note Experimental API
- */
-TVG_API Tvg_Result tvg_lottie_animation_assign(Tvg_Animation animation, const char* layer, uint32_t ix, const char* var, float val);
-
-/**
  * @brief Sets the quality level for Lottie effects.
  *
  * This function controls the rendering quality of effects like blur, shadows, etc.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -1284,17 +1284,6 @@ TVG_API Tvg_Result tvg_lottie_animation_tween(Tvg_Animation animation, float fro
     return TVG_RESULT_NOT_SUPPORTED;
 }
 
-
-TVG_API Tvg_Result tvg_lottie_animation_assign(Tvg_Animation animation, const char* layer, uint32_t ix, const char* var, float val)
-{
-#ifdef THORVG_LOTTIE_LOADER_SUPPORT
-    if (animation) return (Tvg_Result) reinterpret_cast<LottieAnimation*>(animation)->assign(layer, ix, var, val);
-    return TVG_RESULT_INVALID_ARGUMENT;
-#endif
-    return TVG_RESULT_NOT_SUPPORTED;
-}
-
-
 TVG_API Tvg_Result tvg_lottie_animation_set_quality(Tvg_Animation animation, uint8_t value)
 {
 #ifdef THORVG_LOTTIE_LOADER_SUPPORT

--- a/src/loaders/lottie/thorvg_lottie.h
+++ b/src/loaders/lottie/thorvg_lottie.h
@@ -97,25 +97,6 @@ public:
     const char* marker(uint32_t idx, float* begin, float* end) noexcept;
 
     /**
-     * @brief Updates the value of an expression variable for a specific layer.
-     *
-     * This function sets the value of a specified expression variable within a particular layer.
-     * It is useful for dynamically changing the properties of a layer at runtime.
-     *
-     * @param[in] layer The name of the layer containing the variable to be updated.
-     * @param[in] ix The property index of the variable within the layer.
-     * @param[in] var The name of the variable to be updated.
-     * @param[in] val The new value to assign to the variable.
-     *
-     * @retval Result::InsufficientCondition If the animation is not loaded.
-     * @retval Result::InvalidArguments When the given parameter is invalid.
-     * @retval Result::NonSupport When neither the layer nor the property is found in the current animation.
-     *
-     * @note Experimental API
-     */
-    Result assign(const char* layer, uint32_t ix, const char* var, float val);
-
-    /**
      * @brief Creates a new slot based on the given Lottie slot data.
      *
      * This function parses the provided JSON-formatted slot data and generates

--- a/src/loaders/lottie/tvgLottieAnimation.cpp
+++ b/src/loaders/lottie/tvgLottieAnimation.cpp
@@ -113,21 +113,6 @@ const char* LottieAnimation::marker(uint32_t idx, float* begin, float* end) noex
     return static_cast<LottieLoader*>(loader)->markers(idx, begin, end);
 }
 
-Result LottieAnimation::assign(const char* layer, uint32_t ix, const char* var, float val)
-{
-    if (!layer || !var) return Result::InvalidArguments;
-
-    auto loader = to<PictureImpl>(pImpl->picture)->loader;
-    if (!loader) return Result::InsufficientCondition;
-    if (static_cast<LottieLoader*>(loader)->assign(layer, ix, var, val)) {
-        PAINT(pImpl->picture)->mark(RenderUpdateFlag::All);
-        return Result::Success;
-    }
-
-    return Result::NonSupport;
-}
-
-
 Result LottieAnimation::quality(uint8_t value) noexcept
 {
     if (value > 100) return Result::InvalidArguments;

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -1462,21 +1462,9 @@ jerry_value_t LottieExpressions::buildGlobal(Context& context)
     return context.global;
 }
 
-
-void LottieExpressions::buildWritables(Context& context, LottieExpression* exp)
-{
-    if (exp->writables.empty()) return;
-    ARRAY_FOREACH(p, exp->writables) {
-        auto writable = jerry_number(p->val);
-        jerry_object_set_sz(context.global, p->var, writable);
-        jerry_value_free(writable);
-    }
-}
-
-
 jerry_value_t LottieExpressions::evaluate(float frameNo, LottieExpression* exp)
 {
-    if (exp->disabled && exp->writables.empty()) return jerry_undefined();
+    if (exp->disabled) return jerry_undefined();
 
     auto& context = this->context();
 
@@ -1501,9 +1489,6 @@ jerry_value_t LottieExpressions::evaluate(float frameNo, LottieExpression* exp)
 
     //expansions per object type
     if (exp->object->type == LottieObject::Transform) _buildTransform(context.global, frameNo, static_cast<LottieTransform*>(exp->object));
-
-    //update writable values
-    buildWritables(context, exp);
 
     //evaluate the code
     auto eval = jerry_eval((jerry_char_t *) exp->code, strlen(exp->code), JERRY_PARSE_NO_OPTS);

--- a/src/loaders/lottie/tvgLottieExpressions.h
+++ b/src/loaders/lottie/tvgLottieExpressions.h
@@ -183,7 +183,6 @@ private:
     void buildComp(Context& context, LottieComposition* comp, float frameNo, LottieExpression* exp);
     void buildComp(jerry_value_t context, float frameNo, LottieLayer* comp, LottieExpression* exp);
     void buildGlobal(Context& context, float frameNo, LottieExpression* exp);
-    void buildWritables(Context& context, LottieExpression* exp);
 
     Point toPoint2d(jerry_value_t obj);
     RGB32 toColor(jerry_value_t obj);

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -511,16 +511,6 @@ bool LottieLoader::tween(float from, float to, float progress)
     return true;
 }
 
-
-bool LottieLoader::assign(const char* layer, uint32_t ix, const char* var, float val)
-{
-    if (!ready() || !comp->expressions) return false;
-    comp->root->assign(layer, ix, var, val);
-
-    return true;
-}
-
-
 bool LottieLoader::quality(uint8_t value)
 {
     if (!ready()) return false;

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -99,7 +99,6 @@ public:
 
     float shorten(float frameNo);  //Reduce the accuracy for performance
     bool tween(float from, float to, float progress);
-    bool assign(const char* layer, uint32_t ix, const char* var, float val);
     bool quality(uint8_t value);
 
 private:

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -638,21 +638,6 @@ float LottieLayer::remap(LottieComposition* comp, float frameNo, LottieExpressio
     return (frameNo - startFrame) / timeStretch;
 }
 
-
-bool LottieLayer::assign(const char* layer, uint32_t ix, const char* var, float val)
-{
-    //find the target layer by name
-    auto target = layerById(djb2Encode(layer));
-    if (!target) return false;
-
-    //find the target property by ix
-    auto property = target->property(ix);
-    if (property && property->exp) return property->exp->assign(var, val);
-
-    return false;
-}
-
-
 LottieComposition::~LottieComposition()
 {
     if (!initiated && root) Paint::rel(root->scene);

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -1064,7 +1064,6 @@ struct LottieLayer : LottieGroup
     void prepare(RGB32* color = nullptr);
     float remap(LottieComposition* comp, float frameNo, LottieExpressions* exp);
     LottieProperty* property(uint16_t ix) override;
-    bool assign(const char* layer, uint32_t ix, const char* var, float val);
 
     char* name = nullptr;
     LottieLayer* parent = nullptr;

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -126,18 +126,11 @@ struct LottieVectorFrame
 
 struct LottieExpression
 {
-    //writable expressions variable name and value.
-    struct Writable {
-        char* var;
-        float val;
-    };
-
     char* code;
     LottieComposition* comp;
     LottieLayer* layer;
     LottieObject* object;
     LottieProperty* property;
-    Array<Writable> writables;
     bool disabled = false;
 
     LottieExpression() {}
@@ -154,23 +147,7 @@ struct LottieExpression
 
     ~LottieExpression()
     {
-        ARRAY_FOREACH(p, writables) {
-            tvg::free(p->var);
-        }
         tvg::free(code);
-    }
-
-    bool assign(const char* var, float val)
-    {
-        //overwrite the existing value
-        ARRAY_FOREACH(p, writables) {
-            if (tvg::equal(var, p->var)) {
-                p->val = val;
-                return true;
-            }
-        }
-        writables.push({tvg::duplicate(var), val});
-        return true;
     }
 };
 


### PR DESCRIPTION
Clean up experimental APIs which are not practically used anywhere
- Clean up experimental APIs which are not practically used anywhere
- You can also use lottie slot overriding features (See LottieInteraction)

C++:
 - Result LottieAnimation::assign(const char* layer, uint32_t ix, const char* var, float val)

CAPI:
 - Tvg_Result tvg_lottie_animation_assign(Tvg_Animation animation, const char* layer, uint32_t ix, const char* var, float val)