### PR TITLE
cpu_engine: restore rounding accuracy

### DIFF
--- a/src/renderer/cpu_engine/tvgSwUtil.cpp
+++ b/src/renderer/cpu_engine/tvgSwUtil.cpp
@@ -46,8 +46,8 @@ void utilExport(SwOutline* outline, const Matrix& transform, BBox& bbox)
 bool utilBBox(const BBox& bbox, const RenderRegion& clipBox, RenderRegion& renderBox, bool fastTrack)
 {
     if (fastTrack) {
-        renderBox.min = {(int32_t)nearbyint(bbox.min.x), (int32_t)nearbyint(bbox.min.y)};
-        renderBox.max = {(int32_t)nearbyint(bbox.max.x), (int32_t)nearbyint(bbox.max.y)};
+        renderBox.min = {(int32_t)round(bbox.min.x), (int32_t)round(bbox.min.y)};
+        renderBox.max = {(int32_t)round(bbox.max.x), (int32_t)round(bbox.max.y)};
     } else {
         renderBox.min = {(int32_t)floorf(bbox.min.x), (int32_t)floorf(bbox.min.y)};
         renderBox.max = {(int32_t)ceilf(bbox.max.x), (int32_t)ceilf(bbox.max.y)};


### PR DESCRIPTION
Revert the use of `nearbyint()` back to `round()` for backward compatibility.

`nearbyint()` does not always round values with a fractional part of 0.5 upward, as it follows the current floating-point rounding mode.

This behavior introduced inconsistencies in bounding box calculations, resulting in occasional one-pixel errors.

In the future, the ThorVG CPU engine could be revised to support sub-pixel rendering for non-transformed rectangles positioned on fractional pixel coordinates, this problem will be resolved consequently.

issue: #4420