### PR TITLE
gl_engine: clamp Gaussian blur sampling to valid region

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
@@ -77,7 +77,7 @@ GlRenderTask* GlEffect::render(RenderEffectGaussianBlur* effect, GlRenderTarget*
     auto dstCopyFbo1 = blendPool[1]->getRenderTarget(vp);
 
     // add uniform data
-    float viewport[4] {(float)vp.min.x, (float)vp.min.y, (float)vp.max.x, (float)vp.max.y};
+    float viewport[4]{0.0f, 0.0f, (float)vp.sw(), (float)vp.sh()};
     auto blurOffset = gpuBuffer->push((GlGaussianBlur*)(effect->rd), sizeof(GlGaussianBlur), true);
     auto viewportOffset = gpuBuffer->push(viewport, sizeof(viewport), true);
 
@@ -157,7 +157,7 @@ GlRenderTask* GlEffect::render(RenderEffectDropShadow* effect, GlRenderTarget* d
     auto dstCopyFbo1 = blendPool[1]->getRenderTarget(vp);
 
     // add uniform data
-    float viewport[4] {(float)vp.min.x, (float)vp.min.y, (float)vp.max.x, (float)vp.max.y};
+    float viewport[4]{0.0f, 0.0f, (float)vp.sw(), (float)vp.sh()};
     GlDropShadow* params = (GlDropShadow*)(effect->rd);
     auto paramsOffset = gpuBuffer->push(params, sizeof(GlDropShadow), true);
     auto viewportOffset = gpuBuffer->push(viewport, sizeof(viewport), true);

--- a/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
@@ -1113,17 +1113,19 @@ void main()
     float sigma = uGaussian.sigma * uGaussian.scale;
     float weightSum = 0.0;
     int radius = int(uGaussian.extend);
-    
-    for (int y = -radius; y <= radius; ++y) {
-        vec2 offset = vec2(0.0, float(y) * texelSize.y);
-        vec2 coord = vUV + offset;
-        float pixCoord = uViewport.vp.y - coord.y / texelSize.y;
-        float weight = pixCoord < uViewport.vp.w ? gaussian(float(y), sigma) : 0.0;
+    vec2 texelStep = vec2(0.0, texelSize.y);
+
+    // Clamp the kernel range once so edge pixels skip taps outside the valid viewport.
+    int first = max(-radius, int(ceil(uViewport.vp.y - gl_FragCoord.y)));
+    int last = min(radius, int(ceil(uViewport.vp.w - gl_FragCoord.y)) - 1);
+    vec2 coord = vUV + texelStep * float(first);
+    for (int y = first; y <= last; ++y) {
+        float weight = gaussian(float(y), sigma);
         colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
+        coord += texelStep;
     }
-    
-    FragColor = colorSum / weightSum;
+    FragColor = weightSum > 0.0 ? colorSum / weightSum : texture(uSrcTexture, vUV);
 } 
 )";
 
@@ -1155,17 +1157,19 @@ void main()
     float sigma = uGaussian.sigma * uGaussian.scale;
     float weightSum = 0.0;
     int radius = int(uGaussian.extend);
-    
-    for (int y = -radius; y <= radius; ++y) {
-        vec2 offset = vec2(float(y) * texelSize.x, 0.0);
-        vec2 coord = vUV + offset;
-        float pixCoord = uViewport.vp.x + coord.x / texelSize.x;
-        float weight = pixCoord < uViewport.vp.z ? gaussian(float(y), sigma) : 0.0;
+    vec2 texelStep = vec2(texelSize.x, 0.0);
+
+    // Clamp the kernel range once so edge pixels skip taps outside the valid viewport.
+    int first = max(-radius, int(ceil(uViewport.vp.x - gl_FragCoord.x)));
+    int last = min(radius, int(ceil(uViewport.vp.z - gl_FragCoord.x)) - 1);
+    vec2 coord = vUV + texelStep * float(first);
+    for (int x = first; x <= last; ++x) {
+        float weight = gaussian(float(x), sigma);
         colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
+        coord += texelStep;
     }
-    
-    FragColor = colorSum / weightSum;
+    FragColor = weightSum > 0.0 ? colorSum / weightSum : texture(uSrcTexture, vUV);
 } 
 )";
 


### PR DESCRIPTION
## Summary

Fix GL Gaussian blur sampling at region edges when using pooled intermediate render targets.

The blur source texture can be larger than the valid rendered region because pooled FBOs are power-of-two aligned. This updates Gaussian blur and drop shadow blur to pass texture-local viewport bounds, then clamps the shader kernel range so samples outside the valid region are skipped and the remaining weights are renormalized.
<img width="370" height="323" alt="image" src="https://github.com/user-attachments/assets/e931d596-af9a-4c47-b1f4-177aad991d5a" />
<img width="333" height="338" alt="image" src="https://github.com/user-attachments/assets/f251d4df-6f52-4a02-983f-98e88dc17b5d" />

## Details

- Use `{0, 0, vp.sw(), vp.sh()}` as the blur viewport bounds for pooled intermediate textures.
- Clamp vertical and horizontal Gaussian kernel ranges against `gl_FragCoord`.
- Fall back to the current texel if no valid blur samples are available.
- No render-task or FBO flow changes.

## Testing

- Rendering verification is left for manual visual testing. No observable regression during all.sh execution.
- Maintain FPS consistency.

Related issue: https://github.com/thorvg/thorvg/issues/4407