### PR TITLE
loaders, wg_engine: optimize colorspace handling

### DIFF
--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -32,15 +32,27 @@
 
 void WebpLoader::run(unsigned tid)
 {
-    //TODO: acquire the current colorspace format & pre-multiplied alpha image.
-    surface.buf8 = WebPDecodeBGRA(data, size, nullptr, nullptr);
+    WebPDecoderConfig config;
+    if (!WebPInitDecoderConfig(&config)) return;
+
+    // request premultiplied image data
+    if (ImageLoader::cs == ColorSpace::ARGB8888 || ImageLoader::cs == ColorSpace::ARGB8888S) {
+        config.output.colorspace = MODE_bgrA;
+        if (WebPDecode(data, size, &config) != VP8_STATUS_OK) return;
+        surface.buf8 = config.output.u.RGBA.rgba;
+        surface.cs = ColorSpace::ARGB8888;
+    } else {
+        config.output.colorspace = MODE_rgbA;
+        if (WebPDecode(data, size, &config) != VP8_STATUS_OK) return;
+        surface.buf8 = config.output.u.RGBA.rgba;
+        surface.cs = ColorSpace::ABGR8888;
+    }
+
     surface.stride = (uint32_t)w;
     surface.w = (uint32_t)w;
     surface.h = (uint32_t)h;
     surface.channelSize = sizeof(uint32_t);
-    surface.cs = ColorSpace::ARGB8888;
-    surface.premultiplied = false;
-
+    surface.premultiplied = true;
 }
 
 
@@ -69,10 +81,10 @@ bool WebpLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 #ifdef THORVG_FILE_IO_SUPPORT
     if (!(data = (unsigned char*)Loader::open(path, size))) return false;
 
-    int width, height;
-    if (!WebPGetInfo(data, size, &width, &height)) return false;
-    w = static_cast<float>(width);
-    h = static_cast<float>(height);
+    WebPBitstreamFeatures features;
+    if (WebPGetFeatures(data, size, &features)) return false;
+    w = static_cast<float>(features.width);
+    h = static_cast<float>(features.height);
     freeData = true;
     return true;
 #else
@@ -92,12 +104,10 @@ bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOp
         freeData = false;
     }
 
-    int width, height;
-    if (!WebPGetInfo(this->data, size, &width, &height)) return false;
-
-    w = static_cast<float>(width);
-    h = static_cast<float>(height);
-    surface.cs = ColorSpace::ARGB8888;
+    WebPBitstreamFeatures features;
+    if (WebPGetFeatures(this->data, size, &features)) return false;
+    w = static_cast<float>(features.width);
+    h = static_cast<float>(features.height);
     this->size = size;
     return true;
 }

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -38,8 +38,8 @@ void JpgLoader::clear()
 
 void JpgLoader::run(unsigned tid)
 {
-    surface.cs = ImageLoader::cs;
-    surface.buf8 = jpgdDecompress(decoder, surface.cs);
+    surface.cs = ColorSpace::ABGR8888;
+    surface.buf8 = jpgdDecompress(decoder);
     surface.stride = static_cast<uint32_t>(w);
     surface.w = static_cast<uint32_t>(w);
     surface.h = static_cast<uint32_t>(h);

--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -2482,12 +2482,10 @@ void jpgdDelete(jpeg_decoder* decoder)
     delete(decoder);
 }
 
-
-unsigned char* jpgdDecompress(jpeg_decoder* decoder, ColorSpace cs)
+unsigned char* jpgdDecompress(jpeg_decoder* decoder)
 {
     if (!decoder || decoder->begin_decoding() != JPGD_SUCCESS) return nullptr;
 
-    auto bgra = (cs == ColorSpace::ABGR8888S || cs == ColorSpace::ABGR8888);
     auto channel = 4; //OPTIMIZE: jpg is 3 channel format, not really need 4 channel components.
     auto width = decoder->get_width();
     auto height = decoder->get_height();
@@ -2503,17 +2501,8 @@ unsigned char* jpgdDecompress(jpeg_decoder* decoder, ColorSpace cs)
             return nullptr;
         }
         if (decoder->get_num_components() == 3) {
-            if (bgra) {
-                memcpy(dst, src, stride);
-                dst += stride;
-            } else {
-                for (int x = 0; x < width; x++, src += 4, dst += 4) {
-                    dst[0] = src[2];
-                    dst[1] = src[1];
-                    dst[2] = src[0];
-                    dst[3] = 255;
-                }
-            }
+            memcpy(dst, src, stride);
+            dst += stride;
         } else if (decoder->get_num_components() == 1) {
             for (int x = 0; x < width; x++, src++, dst += 4) {
                 dst[0] = *src;

--- a/src/loaders/jpg/tvgJpgd.h
+++ b/src/loaders/jpg/tvgJpgd.h
@@ -27,7 +27,7 @@ class jpeg_decoder;
 
 jpeg_decoder* jpgdHeader(const char* data, int size, int* width, int* height);
 jpeg_decoder* jpgdHeader(const char* filename, int* width, int* height);
-unsigned char* jpgdDecompress(jpeg_decoder* decoder, ColorSpace cs);
+unsigned char* jpgdDecompress(jpeg_decoder* decoder);
 void jpgdDelete(jpeg_decoder* decoder);
 
 #endif //_TVG_JPGD_H_

--- a/src/loaders/webp/dec/webp.cpp
+++ b/src/loaders/webp/dec/webp.cpp
@@ -569,20 +569,6 @@ static void DefaultFeatures(WebPBitstreamFeatures* const features) {
   memset(features, 0, sizeof(*features));
 }
 
-static VP8StatusCode GetFeatures(const uint8_t* const data, size_t data_size,
-                                 WebPBitstreamFeatures* const features) {
-  if (features == NULL || data == NULL) {
-    return VP8_STATUS_INVALID_PARAM;
-  }
-  DefaultFeatures(features);
-
-  // Only parse enough of the data to retrieve the features.
-  return ParseHeadersInternal(data, data_size,
-                              &features->width, &features->height,
-                              &features->has_alpha, &features->has_animation,
-                              &features->format, NULL);
-}
-
 //------------------------------------------------------------------------------
 // Cropping and rescaling.
 
@@ -648,7 +634,6 @@ int WebPIoInitFromOptions(const WebPDecoderOptions* const options,
 /* External Class Implementation                                        */
 /************************************************************************/
 
-
 uint8_t* WebPDecodeBGRA(const uint8_t* data, size_t data_size,
                         int* width, int* height) {
   return Decode(MODE_bgrA, data, data_size, width, height, NULL);
@@ -663,8 +648,8 @@ int WebPGetInfo(const uint8_t* data, size_t data_size,
                 int* width, int* height) {
   WebPBitstreamFeatures features;
 
-  if (GetFeatures(data, data_size, &features) != VP8_STATUS_OK) {
-    return 0;
+  if (WebPGetFeatures(data, data_size, &features) != VP8_STATUS_OK) {
+      return 0;
   }
 
   if (width != NULL) {
@@ -675,4 +660,16 @@ int WebPGetInfo(const uint8_t* data, size_t data_size,
   }
 
   return 1;
+}
+
+VP8StatusCode WebPGetFeatures(const uint8_t* data, size_t data_size,
+                              WebPBitstreamFeatures* features)
+{
+    DefaultFeatures(features);
+
+    // Only parse enough of the data to retrieve the features.
+    return ParseHeadersInternal(data, data_size,
+                                &features->width, &features->height,
+                                &features->has_alpha, &features->has_animation,
+                                &features->format, NULL);
 }

--- a/src/loaders/webp/tvgWebpLoader.cpp
+++ b/src/loaders/webp/tvgWebpLoader.cpp
@@ -35,6 +35,7 @@ void WebpLoader::clear()
 
 void WebpLoader::run(unsigned tid)
 {
+    // static loader WebPDecodeRGBA/WebPDecodeBGRA returns a premultiplied version.
     if (surface.cs == ColorSpace::ARGB8888 || surface.cs == ColorSpace::ARGB8888S) {
         surface.buf8 = WebPDecodeBGRA(data, size, nullptr, nullptr);
         surface.cs = ColorSpace::ARGB8888;
@@ -74,10 +75,10 @@ bool WebpLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 #ifdef THORVG_FILE_IO_SUPPORT
     if (!(data = (uint8_t*)Loader::open(path, size))) return false;
 
-    int width, height;
-    if (!WebPGetInfo(data, size, &width, &height)) return false;
-    w = static_cast<float>(width);
-    h = static_cast<float>(height);
+    WebPBitstreamFeatures features;
+    if (WebPGetFeatures(data, size, &features)) return false;
+    w = static_cast<float>(features.width);
+    h = static_cast<float>(features.height);
     freeData = true;
     return true;
 #else
@@ -97,11 +98,10 @@ bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOp
         freeData = false;
     }
 
-    int width, height;
-    if (!WebPGetInfo(this->data, size, &width, &height)) return false;
-
-    w = static_cast<float>(width);
-    h = static_cast<float>(height);
+    WebPBitstreamFeatures features;
+    if (WebPGetFeatures(this->data, size, &features)) return false;
+    w = static_cast<float>(features.width);
+    h = static_cast<float>(features.height);
     this->size = size;
 
     return true;

--- a/src/loaders/webp/webp/decode.h
+++ b/src/loaders/webp/webp/decode.h
@@ -215,6 +215,13 @@ struct WebPBitstreamFeatures {
   uint32_t pad[2];              // padding for later use
 };
 
+// Retrieve features from the bitstream. The *features structure is filled
+// with information gathered from the bitstream.
+// Returns VP8_STATUS_OK when the features are successfully retrieved. Returns
+// VP8_STATUS_NOT_ENOUGH_DATA when more data is needed to retrieve the
+// features from headers. Returns error in other cases.
+WEBP_EXTERN(VP8StatusCode) WebPGetFeatures(const uint8_t*, size_t, WebPBitstreamFeatures*);
+
 // Decoding options
 struct WebPDecoderOptions {
   int bypass_filtering;               // if true, skip the in-loop filtering
@@ -235,8 +242,6 @@ struct WebPDecoderOptions {
   int no_enhancement;                 // if true, discard enhancement layer
   uint32_t pad[3];                    // padding for later use
 };
-
-
 
 #ifdef __cplusplus
 }    // extern "C"

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -35,18 +35,10 @@
 
 void WgImageData::update(WgContext& context, const RenderSurface* surface, FilterMethod filter)
 {
-    // get appropriate texture format from color space
-    WGPUTextureFormat texFormat = WGPUTextureFormat_BGRA8Unorm;
-    if (surface->cs == ColorSpace::ABGR8888S)
-        texFormat = WGPUTextureFormat_RGBA8Unorm;
-    if (surface->cs == ColorSpace::Grayscale8)
-        texFormat = WGPUTextureFormat_R8Unorm;
     auto bytesPerRow = surface->stride * CHANNEL_SIZE(surface->cs);
     auto dataSize = static_cast<uint64_t>(bytesPerRow) * surface->h;
     // allocate new texture handle
-    bool texHandleChanged = context.allocateTexture(texture, surface->w, surface->h, texFormat, surface->data, bytesPerRow, dataSize);
-    // update texture view of texture handle was changed
-    if (texHandleChanged) {
+    if (context.allocateTexture(texture, surface->w, surface->h, WgTextureMgr::textureFormat(surface), surface->data, bytesPerRow, dataSize)) {
         context.releaseTextureView(textureView);
         textureView = context.createTextureView(texture);
         // update bind group

--- a/src/renderer/gpu_engine/wg/tvgWgTextureMgr.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgTextureMgr.cpp
@@ -52,17 +52,16 @@ WgTextureMgr::SurfaceEntry* WgTextureMgr::find(const RenderSurface* surface)
 
 WGPUTextureFormat WgTextureMgr::textureFormat(const RenderSurface* surface)
 {
-    if (surface->cs == ColorSpace::ABGR8888S) return WGPUTextureFormat_RGBA8Unorm;
-    if (surface->cs == ColorSpace::Grayscale8) return WGPUTextureFormat_R8Unorm;
-    return WGPUTextureFormat_BGRA8Unorm;
+    if (surface->cs == ColorSpace::ABGR8888 || surface->cs == ColorSpace::ABGR8888S) return WGPUTextureFormat_RGBA8Unorm;
+    if (surface->cs == ColorSpace::ARGB8888 || surface->cs == ColorSpace::ARGB8888S) return WGPUTextureFormat_BGRA8Unorm;
+    return WGPUTextureFormat_R8Unorm;  // must be
 }
 
 void WgTextureMgr::upload(WgContext& context, WgTextureEntry& entry, const RenderSurface* surface, FilterMethod filter)
 {
     auto bytesPerRow = surface->stride * CHANNEL_SIZE(surface->cs);
     auto dataSize = static_cast<uint64_t>(bytesPerRow) * surface->h;
-    auto texHandleChanged = context.allocateTexture(entry.texture, surface->w, surface->h, textureFormat(surface), surface->data, bytesPerRow, dataSize);
-    if (!texHandleChanged) return;
+    if (!context.allocateTexture(entry.texture, surface->w, surface->h, textureFormat(surface), surface->data, bytesPerRow, dataSize)) return;
 
     context.releaseTextureView(entry.textureView);
     entry.textureView = context.createTextureView(entry.texture);

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -67,6 +67,10 @@ struct PictureImpl : Picture
         auto pivot = Point{-origin.x * float(w), -origin.y * float(h)};
 
         if (bitmap) {
+            if (bitmap->cs == ColorSpace::Unknown) {
+                TVGERR("RENDERER", "Unknown colorspace picture data");
+                return false;
+            }
             //Overriding Transformation by the desired image size
             auto sx = w / loader->w;
             auto sy = h / loader->h;


### PR DESCRIPTION
This optimization streamlines the image data decoding workflow.

- external webp: decode directly into BGRA/RGBA colorspaces
- webp: properly address premultiplied value with decoding has_alpha property
- static webp: recover the WebPGetFeatures() for accesing has alpha property
- static jpg: skip manual conversion and let the engine handle it
- wg_engine: properly handle ABGR8888 colorspace in texture format decision