### PR TITLE
lottie/expressions: fix uint8_t expression results

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -272,7 +272,7 @@ static jerry_value_t _buildValue(float frameNo, LottieProperty* property)
             return obj;
         }
         case LottieProperty::Type::Color: return _color((*static_cast<LottieColor*>(property))(frameNo));
-        case LottieProperty::Type::Opacity: return jerry_number((*static_cast<LottieOpacity*>(property))(frameNo));
+        case LottieProperty::Type::Opacity: return jerry_number((*static_cast<LottieOpacity*>(property))(frameNo) / 2.55f);
         case LottieProperty::Type::TextDoc: {
             const auto& doc = (*static_cast<LottieTextDoc*>(property))(frameNo);
             return doc.text ? jerry_string_sz(doc.text) : jerry_string_sz("");
@@ -306,7 +306,7 @@ static void _buildTransform(jerry_value_t context, float frameNo, LottieTransfor
     jerry_object_set_sz(obj, "rotation", rotation);
     jerry_value_free(rotation);
 
-    auto opacity = jerry_number(transform->opacity(frameNo));
+    auto opacity = jerry_number(transform->opacity(frameNo) / 2.55f);
     jerry_object_set_sz(obj, "opacity", opacity);
     jerry_value_free(opacity);
 


### PR DESCRIPTION
Opacity is stored as 0-255 internally, but result() (since https://github.com/thorvg/thorvg/commit/9ab446ccbeb2066fc51eed24c82957270f39e1c6)
scales uint8_t results by *2.55f, expecting the 0-100 document range.

Opacity exposed to JS was still raw 0-255 (_buildValue() and
transform.opacity in _buildTransform()), so expressions returning it
got double-scaled and overflowed.

Expose opacity in document units (0-100) at both points.

| before | fetch |
|-|-|
|<img width="1322" height="795" alt="image" src="https://github.com/user-attachments/assets/865ffcf4-ceee-433c-90b8-9e7ce14ffeff" />|<img width="1166" height="671" alt="image" src="https://github.com/user-attachments/assets/7d70dda9-b6d1-431a-a00b-822a575fcafa" />|


issue: https://github.com/thorvg/thorvg/issues/4421
