### PR TITLE
infra: add pixel perfection CI

### DIFF
--- a/.github/workflows/pixel_test.yml
+++ b/.github/workflows/pixel_test.yml
@@ -1,0 +1,172 @@
+name: Pixel Test
+
+on: pull_request
+
+permissions:
+  contents: read
+
+env:
+  THORVG_PIXEL_REFERENCE_REF: v1.0.6
+  WGPU_NATIVE_VERSION: v27.0.4.0
+
+jobs:
+  pixel_test:
+    name: reference vs PR merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    env:
+      PKG_CONFIG_PATH: /usr/local/lib/pkgconfig:/usr/local/lib/x86_64-linux-gnu/pkgconfig
+      LD_LIBRARY_PATH: /usr/local/lib:/usr/local/lib/x86_64-linux-gnu
+      LIBGL_ALWAYS_SOFTWARE: 1
+
+    steps:
+      - name: Checkout ThorVG PR merge
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          path: thorvg
+          fetch-depth: 0
+
+      - name: Checkout pixel inspector
+        uses: actions/checkout@v4
+        with:
+          repository: thorvg/thorvg.pixel-inspector
+          path: tvg-pixel-inspector
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build pkg-config valgrind curl jq unzip libturbojpeg0-dev libpng-dev libwebp-dev libegl-dev libgl1-mesa-dev
+
+      - name: Install Chrome if missing
+        run: |
+          if ! command -v google-chrome >/dev/null 2>&1; then
+            curl -fsSL -o /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            sudo apt-get install -y /tmp/google-chrome.deb
+          fi
+
+      - name: Install wgpu_native
+        run: bash thorvg/.github/workflows/install_wgpu_native.sh
+
+      - name: Run pixel comparison
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+
+          install_thorvg_source() {
+            local src_dir="$1"
+            local build_dir="$2"
+
+            meson setup "$build_dir" "$src_dir" --wipe -Dengines=all -Dloaders=all -Dsavers=all -Dextra=lottie_exp,openmp
+            ninja -C "$build_dir"
+            sudo ninja -C "$build_dir" install
+            sudo ldconfig
+          }
+
+          cd "$GITHUB_WORKSPACE/thorvg"
+          PR_REF="$(git rev-parse HEAD)"
+          echo "test_ref=PR merge ($PR_REF)"
+
+          # Update reference pngs
+          git checkout "$THORVG_PIXEL_REFERENCE_REF"
+          install_thorvg_source "$GITHUB_WORKSPACE/thorvg" "$GITHUB_WORKSPACE/build-reference"
+          cd "$GITHUB_WORKSPACE/tvg-pixel-inspector"
+          bash ./build_and_run.sh --update-reference
+
+          # Run tests against PR merge
+          cd "$GITHUB_WORKSPACE/thorvg"
+          git checkout "$PR_REF"
+          install_thorvg_source "$GITHUB_WORKSPACE/thorvg" "$GITHUB_WORKSPACE/build-pr"
+          cd "$GITHUB_WORKSPACE/tvg-pixel-inspector"
+          bash ./build_and_run.sh
+
+      - name: Export report tabs to PDFs
+        if: always()
+        run: |
+          set -euo pipefail
+
+          REPORT_HTML="$GITHUB_WORKSPACE/tvg-pixel-inspector/artifacts/reporter.html"
+          if [ -f "$REPORT_HTML" ]; then
+            BACKENDS="$(grep -oE 'data-tab="[a-z]+"' "$REPORT_HTML" | sed -E 's/.*"(.*)".*/\1/' | grep -vx 'all' || true)"
+            if [ -z "$BACKENDS" ]; then
+              echo "No backend tabs found in $REPORT_HTML; skipping PDF export."
+            fi
+
+            for BACKEND in $BACKENDS; do
+              REPORT_PDF="$GITHUB_WORKSPACE/tvg-pixel-inspector/artifacts/reporter.$BACKEND.pdf"
+              google-chrome \
+                --headless \
+                --disable-gpu \
+                --no-sandbox \
+                --print-to-pdf="$REPORT_PDF" \
+                "file://$REPORT_HTML#$BACKEND" \
+                && echo "Wrote $REPORT_PDF" || echo "Failed to print $REPORT_PDF"
+            done
+          else
+            echo "Report HTML not found: $REPORT_HTML"
+          fi
+
+      - name: Upload report PDFs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: thorvg-pixel-report
+          path: tvg-pixel-inspector/artifacts/reporter.*.pdf
+          if-no-files-found: warn
+
+      - name: Write pixel report summary
+        if: always()
+        run: |
+          python3 -u - <<'PY'
+          import html
+          import pathlib
+          import re
+
+          report_html = pathlib.Path("tvg-pixel-inspector/artifacts/reporter.html")
+          report_txt = pathlib.Path("pixel-report.txt")
+
+          if not report_html.exists():
+              report_txt.write_text("status=missing\n")
+              raise SystemExit(0)
+
+          text = report_html.read_text(errors="replace")
+
+          def first(pattern, default="0"):
+              match = re.search(pattern, text, re.S)
+              return html.unescape(match.group(1)).strip() if match else default
+
+          compared = first(r'<span>compared</span><b[^>]*>([^<]+)</b>')
+          different = first(r'<span>different</span><b[^>]*>([^<]+)</b>')
+          failed = first(r'<span>failed</span><b[^>]*>([^<]+)</b>')
+
+          backends = []
+          for match in re.finditer(
+              r'<section class="panel backend" data-backend="([^"]+)">.*?'
+              r'<p class="muted">compared ([0-9]+), stored ([0-9]+), different ([0-9]+), failed ([0-9]+)</p>',
+              text,
+              re.S,
+          ):
+              backends.append(tuple(html.unescape(value) for value in match.groups()))
+
+          lines = [
+              "status=ok",
+              "pr=${{ github.event.pull_request.number }}",
+              f"compared={compared}",
+              f"different={different}",
+              f"failed={failed}",
+          ]
+
+          for backend, backend_compared, _stored, backend_different, backend_failed in backends:
+              lines.append(f"backend={backend},{backend_compared},{backend_different},{backend_failed}")
+
+          report_txt.write_text("\n".join(lines) + "\n")
+          PY
+
+      - name: Upload pixel report summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: thorvg-pixel-summary
+          path: pixel-report.txt
+          if-no-files-found: warn

--- a/.github/workflows/pixel_test_report.yml
+++ b/.github/workflows/pixel_test_report.yml
@@ -1,0 +1,205 @@
+name: Pixel Test Comment
+
+on:
+  workflow_run:
+    workflows: ["Pixel Test"]
+    types: [completed]
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download pixel summary
+        uses: actions/download-artifact@v4
+        with:
+          path: ci-report
+          pattern: thorvg-pixel-summary
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create or update comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const reportHeader = '## Pixel Test Report';
+            const workflowRun = context.payload.workflow_run;
+            const summaryPath = path.join('ci-report', 'pixel-report.txt');
+
+            function parseSummary(filename) {
+              const summary = {
+                exists: fs.existsSync(filename),
+                status: 'missing-artifact',
+                prNumber: null,
+                compared: '0',
+                different: '0',
+                failed: '0',
+                backends: [],
+              };
+
+              if (!summary.exists) return summary;
+
+              for (const line of fs.readFileSync(filename, 'utf8').split(/\r?\n/)) {
+                if (!line) continue;
+                const index = line.indexOf('=');
+                if (index < 0) continue;
+
+                const key = line.slice(0, index);
+                const value = line.slice(index + 1);
+
+                if (key === 'status') summary.status = value;
+                else if (key === 'pr') {
+                  const prNumber = Number(value);
+                  if (Number.isInteger(prNumber) && prNumber > 0) summary.prNumber = prNumber;
+                }
+                else if (key === 'compared') summary.compared = value;
+                else if (key === 'different') summary.different = value;
+                else if (key === 'failed') summary.failed = value;
+                else if (key === 'backend') {
+                  const [name, compared, different, failed] = value.split(',');
+                  if (name && compared && different && failed) {
+                    summary.backends.push({name, compared, different, failed});
+                  }
+                }
+              }
+
+              return summary;
+            }
+
+            function renderSummary(summary) {
+              if (!summary.exists) {
+                return `${reportHeader}\n\nPixel report summary artifact was not generated.\n\n`;
+              }
+
+              if (summary.status !== 'ok') {
+                return `${reportHeader}\n\nPixel report HTML was not generated.\n\n`;
+              }
+
+              let body = `${reportHeader}\n\n`;
+              body += '| Backend | Compared | Diff | Failed |\n';
+              body += '| --- | ---: | ---: | ---: |\n';
+
+              if (summary.backends.length > 0) {
+                for (const backend of summary.backends) {
+                  body += `| \`${backend.name}\` | ${backend.compared} | ${backend.different} | ${backend.failed} |\n`;
+                }
+              } else {
+                body += `| \`all\` | ${summary.compared} | ${summary.different} | ${summary.failed} |\n`;
+              }
+
+              body += '\n';
+              return body;
+            }
+
+            const summary = parseSummary(summaryPath);
+            let body = renderSummary(summary);
+
+            // Return the PR number from workflow_run.pull_requests when it is uniquely present.
+            function extractPayloadPrNumber() {
+              const prs = Array.isArray(workflowRun.pull_requests) ? workflowRun.pull_requests : [];
+              const numbers = prs
+                .map(pr => Number(pr.number))
+                .filter(n => Number.isInteger(n) && n > 0);
+              return numbers.length === 1 ? numbers[0] : null;
+            }
+
+            // Look up the open PR number by matching the workflow run's head owner and branch.
+            async function lookupPrNumberByHeadBranch() {
+              const headOwner = workflowRun.head_repository?.owner?.login;
+              const headBranch = workflowRun.head_branch;
+
+              if (!headOwner || !headBranch) {
+                return null;
+              }
+
+              const response = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                head: `${headOwner}:${headBranch}`,
+                per_page: 10,
+              });
+
+              const prs = response.data;
+              if (prs.length === 1) return prs[0].number;
+              return null;
+            }
+
+            let prNumber = summary.prNumber;
+            if (!prNumber) {
+              prNumber = extractPayloadPrNumber();
+            }
+            if (!prNumber) {
+              prNumber = await lookupPrNumberByHeadBranch();
+            }
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(
+                `Could not resolve a unique PR number for workflow run ${workflowRun.id} ` +
+                `(head=${workflowRun.head_repository?.full_name || 'unknown'}:${workflowRun.head_branch || 'unknown'})`
+              );
+              return;
+            }
+
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: workflowRun.id,
+              per_page: 100,
+            });
+
+            const pdfArtifact = artifacts.find(artifact =>
+              artifact.name === 'thorvg-pixel-report' && !artifact.expired
+            );
+
+            if (pdfArtifact) {
+              const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${workflowRun.id}/artifacts/${pdfArtifact.id}`;
+              body += `- [Download PDF report](${url})\n`;
+            } else {
+              body += '- PDF report was not generated.\n';
+            }
+
+            core.info(`Resolved PR number: #${prNumber}`);
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+
+            const existingComments = comments.filter(comment =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.user?.type === 'Bot' &&
+              comment.body?.includes(reportHeader)
+            );
+
+            const existingComment = existingComments.at(-1);
+            core.info(`Found ${existingComments.length} matching pixel report comment(s).`);
+            core.info(`Selected comment id: ${existingComment?.id ?? 'none'}`);
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+              core.info(`Updated pixel report comment: ${existingComment.html_url}`);
+            } else {
+              const response = await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+              core.info(`Created pixel report comment: ${response.data.html_url}`);
+            }


### PR DESCRIPTION
Add a Pixel Test CI that renders against a reference commit using thorvg.pixel-inspector and compares it with the PR merge result.

- pixel_test.yml: build reference & PR, run pixel comparison per backend, export per-backend PDF reports, upload report/summary artifacts
- pixel_test_report.yml: post or update a PR comment with the per-backend compared/diff/failed table and a link to the PDF report

issue: #4232


## Screenshot

- https://github.com/Nor-s/thorvg/pull/1#issuecomment-4621323701

The screenshot below shows an example of applying the recent commit 8af2027491253b14e9a303aa1d464a13ce98ea50 — (a regression fix → confirm that 2 alpha-value changes were corrected).

| comment | report |
|-|-|
|<img width="828" height="537" alt="image" src="https://github.com/user-attachments/assets/92694987-5f6e-47e6-855b-3038a6ad126e" />|<img width="1433" height="800" alt="image" src="https://github.com/user-attachments/assets/3f47bc79-00e6-4ddf-99cd-312c325ea054" />|

The reporting mechanism is similar to binary_size. It updates the (existing) comment.

A link is provided where the PDF report can be downloaded.