### PR TITLE
lottie: ignore empty font glyph

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -300,15 +300,16 @@ struct LottieGlyph
 {
     Array<LottieObject*> children;   //glyph shapes.
     float width;
-    char* code;
+    char* code = nullptr;
     char* family = nullptr;
     char* style = nullptr;
     uint16_t size;
     uint8_t len;
 
-    void prepare()
+    bool prepare()
     {
-        len = strlen(code);
+        len = code ? strlen(code) : 0;
+        return len > 0;
     }
 
     ~LottieGlyph()

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1207,8 +1207,7 @@ void LottieParser::parseChars(Array<LottieGlyph*>& glyphs)
                 }
             } else skip();
         }
-        glyph->prepare();
-        glyphs.push(glyph);
+        if (glyph->prepare()) glyphs.push(glyph);
     }
 }
 


### PR DESCRIPTION
Lottie animation with an empty "ch", it caused infinite loop bug in `_nextWordWidth`.

<img width="1022" height="378" alt="CleanShot 2026-06-05 at 22 13 47@2x" src="https://github.com/user-attachments/assets/cb6da891-4c68-4099-a853-7e1dd0e43e39" />


Such a glyph is unlookupable, so drop it at parse time instead of pushing it into the font's glyph table.

issue: https://github.com/thorvg/thorvg/issues/4432