### PR TITLE
lottie/expressions: support sourceRectAtTime()

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1580,6 +1580,9 @@ void LottieBuilder::updateLayer(LottieComposition* comp, Scene* scene, LottieLay
         }
     }
 
+    //cache the source bounding box
+    if (exps && comp->expressions) exps->bounds(layer);
+
     updateMasks(layer, frameNo);
 
     updateEffect(layer, frameNo, comp->quality);

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -23,6 +23,8 @@
 
 #include "tvgMath.h"
 #include "tvgCompressor.h"
+#include "tvgPaint.h"
+#include "tvgScene.h"
 #include "tvgLottieModel.h"
 #include "tvgLottieExpressions.h"
 #include "tvgLock.h"
@@ -467,6 +469,33 @@ static jerry_value_t _effect(const jerry_call_info_t* info, const jerry_value_t 
 }
 
 
+static jerry_value_t _sourceRectAtTime(const jerry_call_info_t* info, const jerry_value_t args[], const jerry_length_t argsCnt)
+{
+    auto data = static_cast<ExpContent*>(jerry_object_get_native_ptr(info->function, &freeCb));
+    auto rect = static_cast<LottieLayer*>(data->data)->srcRect;
+
+    auto x = rect ? rect->min.x : 0.0f;
+    auto y = rect ? rect->min.y : 0.0f;
+    auto w = rect ? rect->max.x - rect->min.x : 0.0f;
+    auto h = rect ? rect->max.y - rect->min.y : 0.0f;
+
+    auto obj = jerry_object();
+    auto top = jerry_number(y);
+    auto left = jerry_number(x);
+    auto width = jerry_number(w);
+    auto height = jerry_number(h);
+    jerry_object_set_sz(obj, "top", top);
+    jerry_object_set_sz(obj, "left", left);
+    jerry_object_set_sz(obj, EXP_WIDTH, width);
+    jerry_object_set_sz(obj, EXP_HEIGHT, height);
+    jerry_value_free(top);
+    jerry_value_free(left);
+    jerry_value_free(width);
+    jerry_value_free(height);
+    return obj;
+}
+
+
 static void _buildLayer(jerry_value_t context, float frameNo, LottieLayer* layer, LottieLayer* comp, LottieExpression* exp)
 {
     auto width = jerry_number(layer->w);
@@ -550,6 +579,11 @@ static void _buildLayer(jerry_value_t context, float frameNo, LottieLayer* layer
     jerry_object_set_sz(context, "toComp", toComp);
     jerry_object_set_native_ptr(toComp, nullptr, layer);
     jerry_value_free(toComp);
+
+    auto sourceRect = jerry_function_external(_sourceRectAtTime);
+    jerry_object_set_sz(context, "sourceRectAtTime", sourceRect);
+    jerry_object_set_native_ptr(sourceRect, &freeCb, _expcontent(exp, frameNo, layer));
+    jerry_value_free(sourceRect);
 
     //content("name"), #look for the named property from a layer
     auto data = _expcontent(exp, frameNo, layer, 2);
@@ -1666,6 +1700,29 @@ void LottieExpressions::update(float curTime)
     auto time = jerry_number(curTime);
     jerry_object_set_sz(context.global, EXP_TIME, time);
     jerry_value_free(time);
+}
+
+
+void LottieExpressions::bounds(LottieLayer* layer)
+{
+    BBox box;
+    box.init();
+    auto ret = false;
+    auto identity = tvg::identity();
+    Point pt4[4];
+
+    for (auto child : to<SceneImpl>(layer->scene)->paints) {
+        if (!PAINT(child)->bounds(pt4, &identity, false)) continue;
+        for (int i = 0; i < 4; ++i) {
+            box.min = {std::min(box.min.x, pt4[i].x), std::min(box.min.y, pt4[i].y)};
+            box.max = {std::max(box.max.x, pt4[i].x), std::max(box.max.y, pt4[i].y)};
+        }
+        ret = true;
+    }
+    if (ret) {
+        if (!layer->srcRect) layer->srcRect = new BBox;
+        *layer->srcRect = box;
+    }
 }
 
 Point LottieExpressions::toPoint2d(jerry_value_t obj)

--- a/src/loaders/lottie/tvgLottieExpressions.h
+++ b/src/loaders/lottie/tvgLottieExpressions.h
@@ -153,6 +153,7 @@ struct LottieExpressions
     }
 
     void update(float curTime);
+    void bounds(LottieLayer* layer);
 
 private:
     LottieExpressions();
@@ -204,6 +205,7 @@ struct LottieExpressions
     template<typename Property> bool result(TVG_UNUSED float, TVG_UNUSED RenderPath&, TVG_UNUSED Matrix*, TVG_UNUSED LottieModifier*, TVG_UNUSED LottieExpression*) { return false; }
     bool result(TVG_UNUSED float, TVG_UNUSED TextDocument& doc, TVG_UNUSED LottieExpression*) { return false; }
     void update(TVG_UNUSED float) {}
+    void bounds(TVG_UNUSED LottieLayer*) {}
 };
 
 #endif //THORVG_LOTTIE_EXPRESSIONS_SUPPORT

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -585,6 +585,7 @@ LottieLayer::~LottieLayer()
 
     delete(transform);
     delete(audioCtrl);
+    delete(srcRect);
     tvg::free(name);
 }
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -1095,6 +1095,7 @@ struct LottieLayer : LottieGroup
     Array<LottieMask*> masks;
     Array<LottieEffect*> effects;
     LottieLayer* matteTarget = nullptr;
+    BBox* srcRect = nullptr;  // used by expressions (sourceRectAtTime)
 
     LottieRenderPooler<tvg::Shape> statical;  //static pooler for solid fill and clipper
 


### PR DESCRIPTION
Layer.sourceRectAtTime() returns the source bounding box {top, left, width, height}.

see: https://lottiefiles.github.io/lottie-docs/expressions/#layersourcerectattime

related: https://github.com/thorvg/thorvg/issues/4394

test file: 
[21. Source Rectangle.json](https://github.com/user-attachments/files/28659452/21.Source.Rectangle.json)


| Current | Patched| Expectation |
|---------|---------|---------|
| <img width="2060" height="1896" alt="texidddddisdidd" src="https://github.com/user-attachments/assets/23d0c429-13c3-450b-a560-303a170a2499" /> | <img width="2058" height="1900" alt="• • • Thervo Example (Botware)" src="https://github.com/user-attachments/assets/daecf2c0-876e-4a52-9ba2-8f229aabc216" /> | <img width="2060"  alt="CleanShot 2026-06-06 at 13 35 55@2x" src="https://github.com/user-attachments/assets/893fb97a-1ae8-4d5b-9bff-312a87d4052a" /> |