### PR TITLE
lottie/expressions: widen content() shape coverage

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -65,6 +65,8 @@ static const char* EXP_TIME = "time";
 static const char* EXP_VALUE = "value";
 static const char* EXP_INDEX = "index";
 static const char* EXP_EFFECT= "effect";
+static const char* EXP_SIZE = "size";
+static const char* EXP_POSITION = "position";
 
 static LottieExpressions* _exps = nullptr;
 static uint32_t _refCnt = 0;
@@ -356,6 +358,37 @@ static jerry_value_t _buildPolystar(LottiePolyStar* polystar, float frameNo)
     auto ptsCnt = jerry_number(polystar->ptsCnt(frameNo));
     jerry_object_set_sz(obj, "points", ptsCnt);
     jerry_value_free(ptsCnt);
+
+    return obj;
+}
+
+
+static jerry_value_t _buildRect(LottieRect* rect, float frameNo)
+{
+    auto obj = jerry_object();
+    auto size = _buildValue(frameNo, &rect->size);
+    jerry_object_set_sz(obj, EXP_SIZE, size);
+    jerry_value_free(size);
+    auto position = _buildValue(frameNo, &rect->position);
+    jerry_object_set_sz(obj, EXP_POSITION, position);
+    jerry_value_free(position);
+    auto roundness = jerry_number(rect->radius(frameNo));
+    jerry_object_set_sz(obj, "roundness", roundness);
+    jerry_value_free(roundness);
+
+    return obj;
+}
+
+
+static jerry_value_t _buildEllipse(LottieEllipse* ellipse, float frameNo)
+{
+    auto obj = jerry_object();
+    auto size = _buildValue(frameNo, &ellipse->size);
+    jerry_object_set_sz(obj, EXP_SIZE, size);
+    jerry_value_free(size);
+    auto position = _buildValue(frameNo, &ellipse->position);
+    jerry_object_set_sz(obj, EXP_POSITION, position);
+    jerry_value_free(position);
 
     return obj;
 }
@@ -718,6 +751,8 @@ static jerry_value_t _content(const jerry_call_info_t* info, const jerry_value_t
             jerry_object_set_sz(obj, "path", obj);
             return obj;
         }
+        case LottieObject::Rect: return _buildRect(static_cast<LottieRect*>(target), data->frameNo);
+        case LottieObject::Ellipse: return _buildEllipse(static_cast<LottieEllipse*>(target), data->frameNo);
         case LottieObject::Polystar: return _buildPolystar(static_cast<LottiePolyStar*>(target), data->frameNo);
         case LottieObject::Trimpath: return _buildTrimpath(static_cast<LottieTrimpath*>(target), data->frameNo);
         default: break;


### PR DESCRIPTION
Rect and ellipse fell through to undefined in content(), so expressions couldn't read their size/position/roundness.

related: https://github.com/thorvg/thorvg/issues/4394

test files:
- [content_ellipse_test.json](https://github.com/user-attachments/files/28662091/content_ellipse_test.json)
- [content_rect_test.json](https://github.com/user-attachments/files/28662092/content_rect_test.json)


| Before | After | Expectation |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-06 at 17 45 35@2x" src="https://github.com/user-attachments/assets/18c7514d-e248-4438-bb32-761e8f5c8d9b" /> | <img height="500" alt="CleanShot 2026-06-06 at 17 44 15" src="https://github.com/user-attachments/assets/16ebeb19-221a-4425-8215-ba4de98d3d62" /> | <img height="500" alt="CleanShot 2026-06-06 at 17 45 26" src="https://github.com/user-attachments/assets/5294d679-3cd0-4775-8280-a444bbb81543" /> |

| Before | After | Expectation |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-06 at 17 45 45@2x" src="https://github.com/user-attachments/assets/465adcfe-3fcc-4947-a1e1-26904e8d056c" /> | <img height="500" alt="CleanShot 2026-06-06 at 17 44 52" src="https://github.com/user-attachments/assets/d2bcae90-217b-4795-8dd6-cde858a7e9d2" /> | <img height="500" alt="CleanShot 2026-06-06 at 17 45 15" src="https://github.com/user-attachments/assets/77e9b967-64ca-4ed8-b591-3a2a5fca5a19" /> |