### PR TITLE
lottie/expressions: handle 1d wrapper objects as scalars correctly

### DIFF
--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -176,7 +176,29 @@ static jerry_value_t _color(RGB32 rgb)
     return value;
 }
 
+// return true if the number is 1d otherwise 2d, return false
+static bool _number(jerry_value_t obj, Point& out)
+{
+    if (jerry_value_is_number(obj)) {
+        out.x = jerry_value_as_number(obj);
+        return true;
+    }
 
+    // 1d or 2d object
+    auto v1 = jerry_object_get_index(obj, 0);
+    auto v2 = jerry_object_get_index(obj, 1);
+
+    out.x = jerry_value_as_number(v1);
+    jerry_value_free(v1);
+
+    if (jerry_value_is_undefined(v2)) return true;
+    out.y = jerry_value_as_number(v2);
+    jerry_value_free(v2);
+
+    return false;
+}
+
+// TODO: may need to replace with _number(jerry_value_t obj, Point& out)
 static float _number(jerry_value_t obj)
 {
     if (jerry_value_is_number(obj)) return jerry_value_as_number(obj);
@@ -558,37 +580,35 @@ static jerry_value_t _addsub(const jerry_value_t args[], float addsub)
         return val;
     }
 
-    //number + number
-    auto n1 = jerry_value_is_number(args[0]);
-    auto n2 = jerry_value_is_number(args[1]);
+    Point v1{}, v2{};
+    auto n1 = _number(args[0], v1);
+    auto n2 = _number(args[1], v2);
 
     //1d + 1d
-    if (n1 && n2) return jerry_number(_number(args[0]) + addsub * _number(args[1]));
+    if (n1 && n2) return jerry_number(v1.x + (addsub * v2.x));
 
-    auto pt = _point2d(args[n1 ? 1 : 0]);
-
-    //2d + 1d
-    if (n1 || n2) {
-        auto secondary = n1 ? 0 : 1;
-        auto val3 = _number(args[secondary]);
-        if (secondary == 0) pt.x = (pt.x * addsub) + val3;
-        else pt.x += (addsub * val3);
     //2d + 2d
+    if (!n1 && !n2) return _point2d(v1 + (addsub * v2));
+
+    // 2d + 1d?
+    if (n1) {
+        v2.x = v1.x + (addsub * v2.x);
+        return _point2d(v2);
     } else {
-        pt += _point2d(args[1]) * addsub;
+        v1.x = v1.x + (addsub * v2.x);
+        return _point2d(v1);
     }
-
-    return _point2d(pt);
 }
-
 
 static jerry_value_t _muldiv(const jerry_value_t arg1, float arg2)
 {
     //1d
-    if (jerry_value_is_number(arg1)) return jerry_number(_number(arg1) * arg2);
+    Point v1;
+    auto n1 = _number(arg1, v1);
+    if (n1) return jerry_number(v1.x * arg2);
 
     //2d
-    return _point2d(_point2d(arg1) * arg2);
+    return _point2d(v1 * arg2);
 }
 
 


### PR DESCRIPTION
Scalar values exposed to JS are wrapped in an object to support the .value accessor.
In `jerry_value_t _number(float value)`

But `_addsub()`, `_muldiv()` classified only a primitive numbe as 1d, so a wrapped scalar fell into the 2d-point path and read a non-existent index as NaN.

issue: https://github.com/thorvg/thorvg/issues/4393

### Regression Overview
- since: `v1.0.2`
- culprit: https://github.com/thorvg/thorvg/commit/e458d6823
- test file:  [16729.json](https://github.com/user-attachments/files/28677248/16729.json)


| 1.0.1 | Current | Patched |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-07 at 16 03 52" src="https://github.com/user-attachments/assets/997f34b5-6c64-4820-b17b-bbe36eb709ed" /> | <img height="500" alt="CleanShot 2026-06-07 at 16 02 15" src="https://github.com/user-attachments/assets/f7af6ed3-f50c-477c-81c7-0d2d62c65943" /> | <img height="500" alt="CleanShot 2026-06-07 at 16 01 53" src="https://github.com/user-attachments/assets/0165ad44-c61b-45b5-81d7-f7f321e179bf" /> |

In the GL/WG Engine, they show `Bezier segments count exceeded the maximum limit` error in tessellation.
This log is also revolved by this patch.

<img width="1546" height="532" alt="CleanShot 2026-06-07 at 16 05 20@2x" src="https://github.com/user-attachments/assets/afc2c9d7-8338-47c0-b281-cfaf72ea2f36" />

### Regression Verification

Original commit adjusted numeric access for expressions using the .value accessor, and that behavior is still retained.

test file: [circle-blob-icon-lottie-json-animation (5).json](https://github.com/user-attachments/files/28677343/circle-blob-icon-lottie-json-animation.5.json)

| Expressions | Single |
|---------|---------|
| <img height="500" alt="CleanShot 2026-06-07 at 16 15 13" src="https://github.com/user-attachments/assets/ca4c77dc-8367-4c52-be35-9cfeb201484d" /> | <img height="500" alt="CleanShot 2026-06-07 at 16 14 07" src="https://github.com/user-attachments/assets/7f04b37a-4d87-44b1-98d6-754c73f03668" /> |


