### PR TITLE
lottie: support per-dimension easing

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -349,12 +349,26 @@ bool LottieParser::getValue(RGB32& color)
 }
 
 
-void LottieParser::getInterpolatorPoint(Point& pt)
+void LottieParser::getInterpolatorPoint(Point pt[DimCnt])
 {
+    auto getField = [&](float& x, float& y) {
+        if (peekType() != kArrayType) {
+            x = y = getFloat();
+            return;
+        }
+        enterArray();
+        if (!nextArrayValue()) return;
+        x = getFloat();
+        if (nextArrayValue()) {
+            y = getFloat();
+            while (nextArrayValue()) getFloat();
+        } else y = x;
+    };
+
     enterObject();
     while (auto key = nextObjectKey()) {
-        if (KEY_AS("x")) getValue(pt.x);
-        else if (KEY_AS("y")) getValue(pt.y);
+        if (KEY_AS("x")) getField(pt[DimX].x, pt[DimY].x);
+        else if (KEY_AS("y")) getField(pt[DimX].y, pt[DimY].y);
     }
 }
 
@@ -418,7 +432,7 @@ LottieInterpolator* LottieParser::getInterpolator(const char* key, Point& in, Po
 template<typename T>
 void LottieParser::parseKeyFrame(T& prop)
 {
-    Point inTangent, outTangent;
+    Point inTangent[DimCnt], outTangent[DimCnt];
     const char* interpolatorKey = nullptr;
     auto& frame = prop.newFrame();
     auto interpolator = false;
@@ -458,7 +472,10 @@ void LottieParser::parseKeyFrame(T& prop)
     }
 
     if (interpolator) {
-        frame.interpolator = getInterpolator(interpolatorKey, inTangent, outTangent);
+        frame.setInterpolator(getInterpolator(interpolatorKey, inTangent[DimX], outTangent[DimX]), DimX);
+        if (inTangent[DimY] != inTangent[DimX] || outTangent[DimY] != outTangent[DimX]) {
+            frame.setInterpolator(getInterpolator(nullptr, inTangent[DimY], outTangent[DimY]), DimY);
+        }
     }
 }
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -348,12 +348,26 @@ bool LottieParser::getValue(RGB32& color)
 }
 
 
-void LottieParser::getInterpolatorPoint(Point& pt)
+void LottieParser::getInterpolatorPoint(Point pt[DimCnt])
 {
+    auto getField = [&](float& x, float& y) {
+        if (peekType() != kArrayType) {
+            x = y = getFloat();
+            return;
+        }
+        enterArray();
+        if (!nextArrayValue()) return;
+        x = getFloat();
+        if (nextArrayValue()) {
+            y = getFloat();
+            while (nextArrayValue()) getFloat();
+        } else y = x;
+    };
+
     enterObject();
     while (auto key = nextObjectKey()) {
-        if (KEY_AS("x")) getValue(pt.x);
-        else if (KEY_AS("y")) getValue(pt.y);
+        if (KEY_AS("x")) getField(pt[DimX].x, pt[DimY].x);
+        else if (KEY_AS("y")) getField(pt[DimX].y, pt[DimY].y);
     }
 }
 
@@ -417,7 +431,7 @@ LottieInterpolator* LottieParser::getInterpolator(const char* key, Point& in, Po
 template<typename T>
 void LottieParser::parseKeyFrame(T& prop)
 {
-    Point inTangent, outTangent;
+    Point inTangent[DimCnt], outTangent[DimCnt];
     const char* interpolatorKey = nullptr;
     auto& frame = prop.newFrame();
     auto interpolator = false;
@@ -457,7 +471,10 @@ void LottieParser::parseKeyFrame(T& prop)
     }
 
     if (interpolator) {
-        frame.interpolator = getInterpolator(interpolatorKey, inTangent, outTangent);
+        frame.setInterpolator(getInterpolator(interpolatorKey, inTangent[DimX], outTangent[DimX]), DimX);
+        if (inTangent[DimY] != inTangent[DimX] || outTangent[DimY] != outTangent[DimX]) {
+            frame.setInterpolator(getInterpolator(nullptr, inTangent[DimY], outTangent[DimY]), DimY);
+        }
     }
 }
 

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -53,7 +53,7 @@ private:
     LottieEffect* getEffect(int type);
 
     void getExpression(char* code, LottieComposition* comp, LottieLayer* layer, LottieObject* object, LottieProperty* property);
-    void getInterpolatorPoint(Point& pt);
+    void getInterpolatorPoint(Point pt[DimCnt]);
     void getPathSet(LottiePath* obj, LottiePathSet& path);
     void getLayerSize(float& val);
     bool getValue(TextDocument& doc);

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -42,6 +42,9 @@ struct LottieProperty;
 #define DEFAULT_COND (!tween.active || !frames || (frames->count == 1))
 
 
+enum Dim : uint8_t { DimX = 0, DimY = 1, DimCnt = 2 };
+
+
 template<typename T>
 struct LottieScalarFrame
 {
@@ -70,6 +73,8 @@ struct LottieScalarFrame
     void prepare(TVG_UNUSED LottieScalarFrame* next)
     {
     }
+
+    void setInterpolator(LottieInterpolator* ip, TVG_UNUSED Dim dim) { interpolator = ip; }
 };
 
 
@@ -78,42 +83,58 @@ struct LottieVectorFrame
 {
     T value;                    //keyframe value
     float no;                   //frame number
-    LottieInterpolator* interpolator;
+    LottieInterpolator* interpolator[DimCnt] = {};
     T outTangent, inTangent;
     float length;
     bool hasTangent = false;
     bool hold = false;
 
+    Point progress(float t)
+    {
+        auto tx = interpolator[DimX] ? interpolator[DimX]->progress(t) : t;
+        auto ty = interpolator[DimY] ? interpolator[DimY]->progress(t) : tx;
+        return {tx, ty};
+    }
+
     T interpolate(LottieVectorFrame* next, float frameNo)
     {
         auto t = (frameNo - no) / (next->no - no);
-        if (interpolator) t = interpolator->progress(t);
+        auto p = progress(t);
 
         if (hold) {
-            if (t < 1.0f) return value;
-            else return next->value;
+            if (p.x < 1.0f) return value;
+            return next->value;
         }
 
         if (hasTangent) {
             Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
-            return bz.at(bz.atApprox(t * length, length));
-        } else {
-            return tvg::lerp(value, next->value, t);
+            return bz.at(bz.atApprox(p.x * length, length));
         }
+
+        return {tvg::lerp(value.x, next->value.x, p.x), tvg::lerp(value.y, next->value.y, p.y)};
     }
 
     float angle(LottieVectorFrame* next, float frameNo)
     {
-        if (!hasTangent) {
-            Point dp = next->value - value;
+        auto t = (frameNo - no) / (next->no - no);
+
+        //spatial bezier
+        if (hasTangent) {
+            if (interpolator[DimX]) t = interpolator[DimX]->progress(t);
+            Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
+            t = bz.atApprox(t * length, length);
+            return bz.angle(t >= 1.0f ? 0.99f : (t <= 0.0f ? 0.01f : t));
+        }
+
+        //per-dimension easing
+        if (interpolator[DimY]) {
+            auto p1 = progress(t);
+            auto p2 = progress(tvg::clamp(t + 0.001f, 0.0f, 1.0f));
+            Point dp = {(next->value.x - value.x) * (p2.x - p1.x), (next->value.y - value.y) * (p2.y - p1.y)};
             return rad2deg(tvg::atan(dp));
         }
 
-        auto t = (frameNo - no) / (next->no - no);
-        if (interpolator) t = interpolator->progress(t);
-        Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
-        t = bz.atApprox(t * length, length);
-        return bz.angle(t >= 1.0f ? 0.99f : (t <= 0.0f ? 0.01f : t));
+        return rad2deg(tvg::atan(next->value - value));
     }
 
     void prepare(LottieVectorFrame* next)
@@ -121,6 +142,8 @@ struct LottieVectorFrame
         Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
         length = bz.lengthApprox();
     }
+
+    void setInterpolator(LottieInterpolator* ip, Dim dim) { interpolator[dim] = ip; }
 };
 
 

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -37,6 +37,8 @@ struct LottieProperty;
 //default keyframe updates condition (no tweening)
 #define DEFAULT_COND (!tween.active || !frames || (frames->count == 1))
 
+enum Dim : uint8_t { DimX = 0, DimY = 1, DimCnt = 2 };
+
 template<typename T>
 struct LottieScalarFrame
 {
@@ -59,6 +61,7 @@ struct LottieScalarFrame
 
     float angle(LottieScalarFrame* next, float frameNo) { return 0.0f; }
     void prepare(TVG_UNUSED LottieScalarFrame* next) {}
+    void setInterpolator(LottieInterpolator* ip, TVG_UNUSED Dim dim) { interpolator = ip; }
 };
 
 template<typename T>
@@ -66,42 +69,58 @@ struct LottieVectorFrame
 {
     T value;                    //keyframe value
     float no;                   //frame number
-    LottieInterpolator* interpolator;
+    LottieInterpolator* interpolator[DimCnt] = {};
     T outTangent, inTangent;
     float length;
     bool hasTangent = false;
     bool hold = false;
 
+    Point progress(float t)
+    {
+        auto tx = interpolator[DimX] ? interpolator[DimX]->progress(t) : t;
+        auto ty = interpolator[DimY] ? interpolator[DimY]->progress(t) : tx;
+        return {tx, ty};
+    }
+
     T interpolate(LottieVectorFrame* next, float frameNo)
     {
         auto t = (frameNo - no) / (next->no - no);
-        if (interpolator) t = interpolator->progress(t);
+        auto p = progress(t);
 
         if (hold) {
-            if (t < 1.0f) return value;
-            else return next->value;
+            if (p.x < 1.0f) return value;
+            return next->value;
         }
 
         if (hasTangent) {
             Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
-            return bz.at(bz.atApprox(t * length, length));
-        } else {
-            return tvg::lerp(value, next->value, t);
+            return bz.at(bz.atApprox(p.x * length, length));
         }
+
+        return {tvg::lerp(value.x, next->value.x, p.x), tvg::lerp(value.y, next->value.y, p.y)};
     }
 
     float angle(LottieVectorFrame* next, float frameNo)
     {
-        if (!hasTangent) {
-            Point dp = next->value - value;
+        auto t = (frameNo - no) / (next->no - no);
+
+        //spatial bezier
+        if (hasTangent) {
+            if (interpolator[DimX]) t = interpolator[DimX]->progress(t);
+            Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
+            t = bz.atApprox(t * length, length);
+            return bz.angle(t >= 1.0f ? 0.99f : (t <= 0.0f ? 0.01f : t));
+        }
+
+        //per-dimension easing
+        if (interpolator[DimY]) {
+            auto p1 = progress(t);
+            auto p2 = progress(tvg::clamp(t + 0.001f, 0.0f, 1.0f));
+            Point dp = {(next->value.x - value.x) * (p2.x - p1.x), (next->value.y - value.y) * (p2.y - p1.y)};
             return rad2deg(tvg::atan(dp));
         }
 
-        auto t = (frameNo - no) / (next->no - no);
-        if (interpolator) t = interpolator->progress(t);
-        Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
-        t = bz.atApprox(t * length, length);
-        return bz.angle(t >= 1.0f ? 0.99f : (t <= 0.0f ? 0.01f : t));
+        return rad2deg(tvg::atan(next->value - value));
     }
 
     void prepare(LottieVectorFrame* next)
@@ -109,6 +128,8 @@ struct LottieVectorFrame
         Bezier bz = {value, value + outTangent, next->value + inTangent, next->value};
         length = bz.lengthApprox();
     }
+
+    void setInterpolator(LottieInterpolator* ip, Dim dim) { interpolator[dim] = ip; }
 };
 
 struct LottieExpression


### PR DESCRIPTION
When keyframe easing (i/o) is split into per-dimension arrays, parse a separate bezier interpolator per dimension.

Previously, applied a single curve to all dimensions.

```js
// supported
 {
    "t": 0,
    "s": [100, 100],
    "i": { "x": 0.10, "y": 1.00 },
    "o": { "x": 0.90, "y": 0.00 }
  }

// not supported ([1] value ignored)
{
    "t": 0,
    "s": [100, 100],
    "i": { "x": [0.10, 0.90], "y": [1.00, 0.05] },
    "o": { "x": [0.90, 0.10], "y": [0.00, 0.95] }
},
```



issue: https://github.com/thorvg/thorvg/issues/4071, https://github.com/thorvg/thorvg/issues/3839

test file:  [INTRO_LETTER_SOUP_DSKTP (4).json](https://github.com/user-attachments/files/28678978/INTRO_LETTER_SOUP_DSKTP.4.json)

| Before | After |
|---------|---------|
| <img height="500" alt="CleanShot 2026-06-07 at 18 47 52" src="https://github.com/user-attachments/assets/7cbccc11-689a-4b98-b70a-2ccf435abf0b" /> | <img height="500" alt="CleanShot 2026-06-07 at 18 47 16" src="https://github.com/user-attachments/assets/c4219239-4fe2-4de9-b0d4-56d3fea0ed37" /> |

