### PR TITLE
lottie/text: allow tracking with negative values

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1029,7 +1029,7 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     paint->align(doc.justify, metrics.ascent / (metrics.ascent - metrics.descent));
 
     //apply spacing
-    auto hspacing = (doc.tracking > 0.0f) ? (1.0f + doc.tracking * doc.size / metrics.ascent) : 1.0f;
+    auto hspacing = 1.0f + doc.tracking * doc.size / metrics.ascent;
     auto vspacing = (doc.height > 0.0f && paint->lines() > 1) ? (doc.height / metrics.advance) : 1.0f;
     paint->spacing(hspacing, vspacing);
 


### PR DESCRIPTION
The font(url) text path guarded tracking with `tracking > 0`, so negative tracking was silently ignored and fell back to no spacing.

test file: [font-negative-tracking.json](https://github.com/user-attachments/files/28741041/font-negative-tracking.json)



| tr = -200 (newly supported) | tr = 0 | tr = 200 |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-09 at 14 56 37@2x" src="https://github.com/user-attachments/assets/37ba5139-f8c3-4c93-9244-10c90dd34396" /> | <img height="500" alt="CleanShot 2026-06-09 at 14 56 24@2x" src="https://github.com/user-attachments/assets/f3cb32e0-4569-45bc-84b1-763e0a45498b" /> | <img height="500" alt="CleanShot 2026-06-09 at 14 56 10@2x" src="https://github.com/user-attachments/assets/a2634ce2-009f-45b8-855a-593600bfacfd" /> |