### PR TITLE
loaders/webp: fix heap OOB write in VP8L Huffman table build (CVE-2023-4863)

### DIFF
--- a/src/loaders/webp/dec/vp8l.cpp
+++ b/src/loaders/webp/dec/vp8l.cpp
@@ -202,11 +202,11 @@ static int ReadHuffmanCodeLengths(
   int symbol;
   int max_symbol;
   int prev_code_len = DEFAULT_CODE_LENGTH;
-  HuffmanCode table[1 << LENGTHS_TABLE_BITS];
+  HuffmanTables tables;
 
-  if (!VP8LBuildHuffmanTable(table, LENGTHS_TABLE_BITS,
-                             code_length_code_lengths,
-                             NUM_CODE_LENGTH_CODES)) {
+  if (!VP8LHuffmanTablesAllocate(1 << LENGTHS_TABLE_BITS, &tables) ||
+      !VP8LBuildHuffmanTable(&tables, LENGTHS_TABLE_BITS,
+                             code_length_code_lengths, NUM_CODE_LENGTH_CODES)) {
     goto End;
   }
 
@@ -226,7 +226,7 @@ static int ReadHuffmanCodeLengths(
     int code_len;
     if (max_symbol-- == 0) break;
     VP8LFillBitWindow(br);
-    p = &table[VP8LPrefetchBits(br) & LENGTHS_TABLE_MASK];
+    p = &tables.curr_segment->start[VP8LPrefetchBits(br) & LENGTHS_TABLE_MASK];
     VP8LSetBitPos(br, br->bit_pos_ + p->bits);
     code_len = p->value;
     if (code_len < kCodeLengthLiterals) {
@@ -249,6 +249,7 @@ static int ReadHuffmanCodeLengths(
   ok = 1;
 
  End:
+  VP8LHuffmanTablesDeallocate(&tables);
   if (!ok) dec->status_ = VP8_STATUS_BITSTREAM_ERROR;
   return ok;
 }
@@ -256,7 +257,8 @@ static int ReadHuffmanCodeLengths(
 // 'code_lengths' is pre-allocated temporary buffer, used for creating Huffman
 // tree.
 static int ReadHuffmanCode(int alphabet_size, VP8LDecoder* const dec,
-                           int* const code_lengths, HuffmanCode* const table) {
+                           int* const code_lengths,
+                           HuffmanTables* const table) {
   int ok = 0;
   int size = 0;
   VP8LBitReader* const br = &dec->br_;
@@ -311,12 +313,15 @@ static int ReadHuffmanCodes(VP8LDecoder* const dec, int xsize, int ysize,
   VP8LMetadata* const hdr = &dec->hdr_;
   uint32_t* huffman_image = NULL;
   HTreeGroup* htree_groups = NULL;
-  HuffmanCode* huffman_tables = NULL;
-  HuffmanCode* next = NULL;
+  HuffmanTables* huffman_tables = &hdr->huffman_tables_;
   int num_htree_groups = 1;
   int max_alphabet_size = 0;
   int* code_lengths = NULL;
   const int table_size = kTableSize[color_cache_bits];
+
+  // Check the table has been 0 initialized (through InitMetadata).
+  assert(huffman_tables->root.start == NULL);
+  assert(huffman_tables->curr_segment == NULL);
 
   if (allow_recursion && VP8LReadBits(br, 1)) {
     // use meta Huffman codes.
@@ -352,16 +357,16 @@ static int ReadHuffmanCodes(VP8LDecoder* const dec, int xsize, int ysize,
     }
   }
 
-  huffman_tables = tvg::malloc<HuffmanCode>(num_htree_groups * table_size * sizeof(*huffman_tables));
-  htree_groups = VP8LHtreeGroupsNew(num_htree_groups);
   code_lengths = tvg::calloc<int>((uint64_t)max_alphabet_size, sizeof(*code_lengths));
+  htree_groups = VP8LHtreeGroupsNew(num_htree_groups);
 
-  if (htree_groups == NULL || code_lengths == NULL || huffman_tables == NULL) {
+  if (htree_groups == NULL || code_lengths == NULL ||
+      !VP8LHuffmanTablesAllocate(num_htree_groups * table_size,
+                                 huffman_tables)) {
     dec->status_ = VP8_STATUS_OUT_OF_MEMORY;
     goto Error;
   }
 
-  next = huffman_tables;
   for (i = 0; i < num_htree_groups; ++i) {
     HTreeGroup* const htree_group = &htree_groups[i];
     HuffmanCode** const htrees = htree_group->htrees;
@@ -369,18 +374,18 @@ static int ReadHuffmanCodes(VP8LDecoder* const dec, int xsize, int ysize,
     int is_trivial_literal = 1;
     for (j = 0; j < HUFFMAN_CODES_PER_META_CODE; ++j) {
       int alphabet_size = kAlphabetSize[j];
-      htrees[j] = next;
       if (j == 0 && color_cache_bits > 0) {
         alphabet_size += 1 << color_cache_bits;
       }
-      size = ReadHuffmanCode(alphabet_size, dec, code_lengths, next);
-      if (is_trivial_literal && kLiteralMap[j] == 1) {
-        is_trivial_literal = (next->bits == 0);
-      }
-      next += size;
+      size = ReadHuffmanCode(alphabet_size, dec, code_lengths, huffman_tables);
+      htrees[j] = huffman_tables->curr_segment->curr_table;
       if (size == 0) {
         goto Error;
       }
+      if (is_trivial_literal && kLiteralMap[j] == 1) {
+        is_trivial_literal = (htrees[j]->bits == 0);
+      }
+      huffman_tables->curr_segment->curr_table += size;
     }
     htree_group->is_trivial_literal = is_trivial_literal;
     if (is_trivial_literal) {
@@ -397,13 +402,12 @@ static int ReadHuffmanCodes(VP8LDecoder* const dec, int xsize, int ysize,
   hdr->huffman_image_ = huffman_image;
   hdr->num_htree_groups_ = num_htree_groups;
   hdr->htree_groups_ = htree_groups;
-  hdr->huffman_tables_ = huffman_tables;
   return 1;
 
  Error:
   tvg::free(code_lengths);
   tvg::free(huffman_image);
-  tvg::free(huffman_tables);
+  VP8LHuffmanTablesDeallocate(huffman_tables);
   VP8LHtreeGroupsFree(htree_groups);
   return 0;
 }
@@ -1212,7 +1216,7 @@ static void ClearMetadata(VP8LMetadata* const hdr) {
   assert(hdr != NULL);
 
   tvg::free(hdr->huffman_image_);
-  tvg::free(hdr->huffman_tables_);
+  VP8LHuffmanTablesDeallocate(&hdr->huffman_tables_);
   VP8LHtreeGroupsFree(hdr->htree_groups_);
   VP8LColorCacheClear(&hdr->color_cache_);
   VP8LColorCacheClear(&hdr->saved_color_cache_);
@@ -1522,7 +1526,7 @@ int VP8LDecodeImage(VP8LDecoder* const dec) {
   // Sanity checks.
   if (dec == NULL) return 0;
 
-  assert(dec->hdr_.huffman_tables_ != NULL);
+  assert(dec->hdr_.huffman_tables_.root.start != NULL);
   assert(dec->hdr_.htree_groups_ != NULL);
   assert(dec->hdr_.num_htree_groups_ > 0);
 

--- a/src/loaders/webp/dec/vp8li.h
+++ b/src/loaders/webp/dec/vp8li.h
@@ -51,7 +51,7 @@ typedef struct {
   uint32_t       *huffman_image_;
   int             num_htree_groups_;
   HTreeGroup     *htree_groups_;
-  HuffmanCode    *huffman_tables_;
+  HuffmanTables   huffman_tables_;
 } VP8LMetadata;
 
 typedef struct VP8LDecoder VP8LDecoder;

--- a/src/loaders/webp/utils/huffman.cpp
+++ b/src/loaders/webp/utils/huffman.cpp
@@ -73,11 +73,13 @@ static WEBP_INLINE int NextTableBitSize(const int* const count,
   return len - root_bits;
 }
 
-int VP8LBuildHuffmanTable(HuffmanCode* const root_table, int root_bits,
-                          const int code_lengths[], int code_lengths_size) {
+// sorted[code_lengths_size] is a pre-allocated array for sorting symbols
+// by code length.
+static int BuildHuffmanTable(HuffmanCode* const root_table, int root_bits,
+                             const int code_lengths[], int code_lengths_size,
+                             uint16_t sorted[]) {
   HuffmanCode* table = root_table;  // next available space in table
   int total_size = 1 << root_bits;  // total size root table + 2nd level table
-  int* sorted = NULL;               // symbols sorted by code length
   int len;                          // current code length
   int symbol;                       // symbol index in original or sorted table
   // number of codes of each length:
@@ -87,7 +89,8 @@ int VP8LBuildHuffmanTable(HuffmanCode* const root_table, int root_bits,
 
   assert(code_lengths_size != 0);
   assert(code_lengths != NULL);
-  assert(root_table != NULL);
+  assert((root_table != NULL && sorted != NULL) ||
+         (root_table == NULL && sorted == NULL));
   assert(root_bits > 0);
 
   // Build histogram of code lengths.
@@ -112,32 +115,32 @@ int VP8LBuildHuffmanTable(HuffmanCode* const root_table, int root_bits,
     offset[len + 1] = offset[len] + count[len];
   }
 
-  sorted = tvg::malloc<int>(code_lengths_size * sizeof(*sorted));
-  if (sorted == NULL) {
-    return 0;
-  }
-
   // Sort symbols by length, by symbol order within each length.
   for (symbol = 0; symbol < code_lengths_size; ++symbol) {
     const int symbol_code_length = code_lengths[symbol];
     if (code_lengths[symbol] > 0) {
-      sorted[offset[symbol_code_length]++] = symbol;
+      if (sorted != NULL) {
+        sorted[offset[symbol_code_length]++] = symbol;
+      } else {
+        offset[symbol_code_length]++;
+      }
     }
   }
 
   // Special case code with only one value.
   if (offset[MAX_ALLOWED_CODE_LENGTH] == 1) {
-    HuffmanCode code;
-    code.bits = 0;
-    code.value = (uint16_t)sorted[0];
-    ReplicateValue(table, 1, total_size, code);
-    tvg::free(sorted);
+    if (sorted != NULL) {
+      HuffmanCode code;
+      code.bits = 0;
+      code.value = (uint16_t)sorted[0];
+      ReplicateValue(table, 1, total_size, code);
+    }
     return total_size;
   }
 
   {
     int step;              // step size to replicate values in current table
-    uint32_t low = -1;     // low bits for current root entry
+    uint32_t low = 0xffffffffu;        // low bits for current root entry
     uint32_t mask = total_size - 1;    // mask for low bits
     uint32_t key = 0;      // reversed prefix code
     int num_nodes = 1;     // number of Huffman tree nodes
@@ -151,9 +154,9 @@ int VP8LBuildHuffmanTable(HuffmanCode* const root_table, int root_bits,
       num_nodes += num_open;
       num_open -= count[len];
       if (num_open < 0) {
-        tvg::free(sorted);
         return 0;
       }
+      if (root_table == NULL) continue;
       for (; count[len] > 0; --count[len]) {
         HuffmanCode code;
         code.bits = (uint8_t)len;
@@ -170,34 +173,121 @@ int VP8LBuildHuffmanTable(HuffmanCode* const root_table, int root_bits,
       num_nodes += num_open;
       num_open -= count[len];
       if (num_open < 0) {
-        tvg::free(sorted);
         return 0;
       }
       for (; count[len] > 0; --count[len]) {
         HuffmanCode code;
         if ((key & mask) != low) {
-          table += table_size;
+          if (root_table != NULL) table += table_size;
           table_bits = NextTableBitSize(count, len, root_bits);
           table_size = 1 << table_bits;
           total_size += table_size;
           low = key & mask;
-          root_table[low].bits = (uint8_t)(table_bits + root_bits);
-          root_table[low].value = (uint16_t)((table - root_table) - low);
+          if (root_table != NULL) {
+            root_table[low].bits = (uint8_t)(table_bits + root_bits);
+            root_table[low].value = (uint16_t)((table - root_table) - low);
+          }
         }
-        code.bits = (uint8_t)(len - root_bits);
-        code.value = (uint16_t)sorted[symbol++];
-        ReplicateValue(&table[key >> root_bits], step, table_size, code);
+        if (root_table != NULL) {
+          code.bits = (uint8_t)(len - root_bits);
+          code.value = (uint16_t)sorted[symbol++];
+          ReplicateValue(&table[key >> root_bits], step, table_size, code);
+        }
         key = GetNextKey(key, len);
       }
     }
 
     // Check if tree is full.
     if (num_nodes != 2 * offset[MAX_ALLOWED_CODE_LENGTH] - 1) {
-      tvg::free(sorted);
       return 0;
     }
   }
 
-  tvg::free(sorted);
   return total_size;
+}
+
+// Maximum code_lengths_size is 2328 (reached for 11-bit color_cache_bits).
+// More commonly, the value is around ~280.
+#define MAX_CODE_LENGTHS_SIZE \
+  ((1 << MAX_CACHE_BITS) + NUM_LITERAL_CODES + NUM_LENGTH_CODES)
+// Cut-off value for switching between heap and stack allocation.
+#define SORTED_SIZE_CUTOFF 512
+int VP8LBuildHuffmanTable(HuffmanTables* const root_table, int root_bits,
+                          const int code_lengths[], int code_lengths_size) {
+  const int total_size =
+      BuildHuffmanTable(NULL, root_bits, code_lengths, code_lengths_size, NULL);
+  assert(code_lengths_size <= MAX_CODE_LENGTHS_SIZE);
+  if (total_size == 0 || root_table == NULL) return total_size;
+
+  if (root_table->curr_segment->curr_table + total_size >=
+      root_table->curr_segment->start + root_table->curr_segment->size) {
+    // If 'root_table' does not have enough memory, allocate a new segment.
+    // The available part of root_table->curr_segment is left unused because we
+    // need a contiguous buffer.
+    const int segment_size = root_table->curr_segment->size;
+    struct HuffmanTablesSegment* next =
+        tvg::malloc<HuffmanTablesSegment>(sizeof(*next));
+    if (next == NULL) return 0;
+    // Fill the new segment.
+    // We need at least 'total_size' but if that value is small, it is better to
+    // allocate a big chunk to prevent more allocations later. 'segment_size' is
+    // therefore chosen (any other arbitrary value could be chosen).
+    next->size = total_size > segment_size ? total_size : segment_size;
+    next->start = tvg::malloc<HuffmanCode>(next->size * sizeof(*next->start));
+    if (next->start == NULL) {
+      tvg::free(next);
+      return 0;
+    }
+    next->curr_table = next->start;
+    next->next = NULL;
+    // Point to the new segment.
+    root_table->curr_segment->next = next;
+    root_table->curr_segment = next;
+  }
+  if (code_lengths_size <= SORTED_SIZE_CUTOFF) {
+    // use local stack-allocated array.
+    uint16_t sorted[SORTED_SIZE_CUTOFF];
+    BuildHuffmanTable(root_table->curr_segment->curr_table, root_bits,
+                      code_lengths, code_lengths_size, sorted);
+  } else {  // rare case. Use heap allocation.
+    uint16_t* const sorted =
+        tvg::malloc<uint16_t>(code_lengths_size * sizeof(*sorted));
+    if (sorted == NULL) return 0;
+    BuildHuffmanTable(root_table->curr_segment->curr_table, root_bits,
+                      code_lengths, code_lengths_size, sorted);
+    tvg::free(sorted);
+  }
+  return total_size;
+}
+
+int VP8LHuffmanTablesAllocate(int size, HuffmanTables* huffman_tables) {
+  // Have 'segment' point to the first segment for now, 'root'.
+  HuffmanTablesSegment* const root = &huffman_tables->root;
+  huffman_tables->curr_segment = root;
+  // Allocate root.
+  root->start = tvg::malloc<HuffmanCode>(size * sizeof(*root->start));
+  if (root->start == NULL) return 0;
+  root->curr_table = root->start;
+  root->next = NULL;
+  root->size = size;
+  return 1;
+}
+
+void VP8LHuffmanTablesDeallocate(HuffmanTables* const huffman_tables) {
+  HuffmanTablesSegment *current, *next;
+  if (huffman_tables == NULL) return;
+  // Free the root node.
+  current = &huffman_tables->root;
+  next = current->next;
+  tvg::free(current->start);
+  current->start = NULL;
+  current->next = NULL;
+  current = next;
+  // Free the following nodes.
+  while (current != NULL) {
+    next = current->next;
+    tvg::free(current->start);
+    tvg::free(current);
+    current = next;
+  }
 }

--- a/src/loaders/webp/utils/huffman.h
+++ b/src/loaders/webp/utils/huffman.h
@@ -35,6 +35,29 @@ typedef struct {
   uint16_t value;   // symbol value or table offset
 } HuffmanCode;
 
+// Contiguous memory segment of HuffmanCodes.
+typedef struct HuffmanTablesSegment {
+  HuffmanCode* start;
+  // Pointer to where we are writing into the segment. Starts at 'start' and
+  // cannot go beyond 'start' + 'size'.
+  HuffmanCode* curr_table;
+  // Pointer to the next segment in the chain.
+  struct HuffmanTablesSegment* next;
+  int size;
+} HuffmanTablesSegment;
+
+// Chained memory segments of HuffmanCodes.
+typedef struct HuffmanTables {
+  HuffmanTablesSegment root;
+  // Currently processed segment. At first, this is 'root'.
+  HuffmanTablesSegment* curr_segment;
+} HuffmanTables;
+
+// Allocates a HuffmanTables with 'size' contiguous HuffmanCodes. Returns 0 on
+// memory allocation error, 1 otherwise.
+int VP8LHuffmanTablesAllocate(int size, HuffmanTables* huffman_tables);
+void VP8LHuffmanTablesDeallocate(HuffmanTables* const huffman_tables);
+
 // Huffman table group.
 typedef struct HTreeGroup HTreeGroup;
 struct HTreeGroup {
@@ -57,7 +80,7 @@ void VP8LHtreeGroupsFree(HTreeGroup* const htree_groups);
 // the huffman table.
 // Returns built table size or 0 in case of error (invalid tree or
 // memory error).
-int VP8LBuildHuffmanTable(HuffmanCode* const root_table, int root_bits,
+int VP8LBuildHuffmanTable(HuffmanTables* const root_table, int root_bits,
                           const int code_lengths[], int code_lengths_size);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

The vendored WebP decoder in `src/loaders/webp/` is a pre-1.3.2 copy of libwebp and is affected by **CVE-2023-4863** (the in-the-wild "libwebp" heap overflow). When ThorVG is built with the `webp` loader and uses this bundled copy (static builds always use it; shared builds fall back to it when system libwebp is absent), a crafted lossless (VP8L) WebP triggers a heap-buffer-overflow **write**.

This can be reached through the public API (`Picture::load("x.webp")` / `Picture::load(data, size, "webp")`) and, more interestingly, through untrusted SVG `<image>` data URIs: `tvgSvgBuilder.cpp` registers `webp` as a base64 image mime and calls `picture->load(decoded, size, "webp")`.

## Root cause

`ReadHuffmanCodes()` in `dec/vp8l.cpp` allocates a single fixed-size buffer for all Huffman tables:

```cpp
huffman_tables = tvg::malloc<HuffmanCode>(num_htree_groups * table_size * sizeof(*huffman_tables));
```

where `table_size = kTableSize[color_cache_bits]`. `VP8LBuildHuffmanTable()` (`utils/huffman.cpp`) then fills second-level tables into that buffer, advanced only by `next += size`, **without ever checking that the actually built table size stays within the allocation**. A malicious bitstream makes the real table grow past the bound, so `ReplicateValue()` writes out of bounds.

ASan stack (vendored sources, before fix):

```
WRITE of size 4 ... 0 bytes to the right of an 11816-byte region
  #0 ReplicateValue           src/loaders/webp/utils/huffman.cpp:57
  #1 VP8LBuildHuffmanTable     src/loaders/webp/utils/huffman.cpp:189
  #2 ReadHuffmanCode           src/loaders/webp/dec/vp8l.cpp:297
  #3 ReadHuffmanCodes          src/loaders/webp/dec/vp8l.cpp:376
  #4 DecodeImageStream         src/loaders/webp/dec/vp8l.cpp:1302
  #5 VP8LDecodeHeader          src/loaders/webp/dec/vp8l.cpp:1509
  #6 WebPDecodeRGBA            src/loaders/webp/dec/webp.cpp:644
allocated by:
  tvg::malloc<HuffmanCode> ... ReadHuffmanCodes  src/loaders/webp/dec/vp8l.cpp:355
```

## Fix

This ports the **official upstream libwebp fix, commit `902bc91`** (released in libwebp 1.3.2), to the vendored copy. The single fixed-width `HuffmanCode*` table is replaced by the segmented `HuffmanTables` API:

- `utils/huffman.h` — add `HuffmanTablesSegment` / `HuffmanTables`, declare `VP8LHuffmanTablesAllocate` / `VP8LHuffmanTablesDeallocate`, and change `VP8LBuildHuffmanTable()` to take `HuffmanTables*`.
- `utils/huffman.cpp` — split `BuildHuffmanTable()` (which now supports a `NULL` dry-run that only computes the required size) from the `VP8LBuildHuffmanTable()` wrapper. The wrapper first sizes the table, then allocates a fresh segment whenever the current one cannot hold it, and only then fills it — so the buffer can never be overrun. Adds allocate/deallocate.
- `dec/vp8li.h` — `huffman_tables_` becomes an in-place `HuffmanTables`.
- `dec/vp8l.cpp` — allocate via `VP8LHuffmanTablesAllocate()`, advance `curr_segment->curr_table`, and free via `VP8LHuffmanTablesDeallocate()`.

The algorithm matches upstream 1.3.2; the only adaptation is using ThorVG's `tvg::malloc` / `tvg::free` wrappers in place of `WebPSafeMalloc` / `WebPSafeFree`. To keep the change minimal and reviewable, only the CVE-2023-4863 fix (`902bc91`) is ported — the unrelated packed-table / htree-index-mapping changes that also landed in 1.3.2 are intentionally **not** included.

## Verification (ASan)

Built the vendored `dec/*.cpp dsp/*.cpp utils/*.cpp` with `clang++ -fsanitize=address`, decoding via the same `WebPDecodeRGBA` entry that `WebpLoader::run()` uses.

| input | before fix | after fix |
|---|---|---|
| public CVE-2023-4863 reproducer (`bad.webp`) | heap-buffer-overflow WRITE (ASan abort) | returns `NULL`, no crash, exit 0 |
| in-the-wild-style reproducer (`nso.webp`) | heap-buffer-overflow WRITE (ASan abort) | returns `NULL`, no crash, exit 0 |
| valid **lossless** WebP (VP8L) | decodes 2048x396 | decodes 2048x396, **pixel-identical** to upstream libwebp 1.3.2 (same SHA-256) |
| valid **lossy** WebP (VP8) | decodes 128x128 | decodes 128x128 |

So the malformed inputs are now rejected cleanly while normal decoding (including the lossless Huffman path that was changed) is unaffected.

## Disclosure note

CVE-2023-4863 is a long-public 2023 CVE, so this is submitted directly as a fix PR. (Private vulnerability reporting is enabled on the repo, but its REST report endpoint currently returns HTTP 500 for external reporters, so a coordinated private report was not possible.)
