### PR TITLE
lottie/text: support perpendicular rotation in text follow path

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1188,6 +1188,7 @@ static void _commit(LottieGlyph* glyph, Shape* shape, const RenderText& ctx)
         auto width = glyph->width * 0.5f;
         auto pos = ctx.follow->position(ctx.cursor.x + width + ctx.firstMargin, angle);
         matrix.e11 = matrix.e22 = ctx.capScale;
+        if (ctx.perpToPath) rotate(&matrix, rad2deg(angle));
         matrix.e13 = pos.x - width * matrix.e11;
         matrix.e23 = pos.y - width * matrix.e21;
     } else {
@@ -1242,6 +1243,7 @@ void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieTex
     RenderText ctx(text, doc);
     ctx.follow = (text->follow && ((uint32_t)text->follow->maskIdx < layer->masks.count)) ? text->follow : nullptr;
     ctx.firstMargin = ctx.follow ? ctx.follow->prepare(layer->masks[ctx.follow->maskIdx], frameNo, ctx.scale, tween, exps) : 0.0f;
+    ctx.perpToPath = ctx.follow && ctx.follow->perpendicular(frameNo, tween, exps);
     auto lineWrapped = false;
 
     //text string

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1197,6 +1197,7 @@ static void _commit(LottieGlyph* glyph, Shape* shape, const RenderText& ctx)
         auto width = glyph->width * 0.5f;
         auto pos = ctx.follow->position(ctx.cursor.x + width + ctx.firstMargin, angle);
         matrix.e11 = matrix.e22 = ctx.capScale;
+        if (ctx.perpToPath) rotate(&matrix, rad2deg(angle));
         matrix.e13 = pos.x - width * matrix.e11;
         matrix.e23 = pos.y - width * matrix.e21;
     } else {
@@ -1251,6 +1252,7 @@ void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieTex
     RenderText ctx(text, doc);
     ctx.follow = (text->follow && ((uint32_t)text->follow->maskIdx < layer->masks.count)) ? text->follow : nullptr;
     ctx.firstMargin = ctx.follow ? ctx.follow->prepare(layer->masks[ctx.follow->maskIdx], frameNo, ctx.scale, tween, exps) : 0.0f;
+    ctx.perpToPath = ctx.follow && ctx.follow->perpendicular(frameNo, tween, exps);
     auto lineWrapped = false;
 
     //text string

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -51,6 +51,7 @@ struct RenderText
     Point cursor{};
     int line = 0, space = 0, idx = 0;
     float lineSpace = 0.0f, totalLineSpace = 0.0f;
+    bool perpToPath = false;
     char *p;  //current processing character
     int nChars;
     float scale;

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -52,6 +52,7 @@ struct RenderText
     Point cursor{};
     int line = 0, space = 0, idx = 0;
     float lineSpace = 0.0f, totalLineSpace = 0.0f;
+    bool perpToPath = false;
     char *p;  //current processing character
     int nChars;
     float scale;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -504,6 +504,7 @@ private:
 
 public:
     LottieFloat firstMargin = 0.0f;
+    LottieInteger perpendicular = 0;
     LottieMask* mask;
     int8_t maskIdx = -1;
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -464,6 +464,7 @@ private:
 
 public:
     LottieFloat firstMargin = 0.0f;
+    LottieInteger perpendicular = 0;
     LottieMask* mask;
     int8_t maskIdx = -1;
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1344,6 +1344,7 @@ void LottieParser::parseTextFollowPath(LottieText* text)
     do {
         if (KEY_AS("m")) text->follow->maskIdx = getInt();
         else if (KEY_AS("f")) parseProperty(text->follow->firstMargin);
+        else if (KEY_AS("p")) parseProperty(text->follow->perpendicular);
         else skip();
     } while ((key = nextObjectKey()));
 }

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1328,6 +1328,7 @@ void LottieParser::parseTextFollowPath(LottieText* text)
     do {
         if (KEY_AS("m")) text->follow->maskIdx = getInt();
         else if (KEY_AS("f")) parseProperty(text->follow->firstMargin);
+        else if (KEY_AS("p")) parseProperty(text->follow->perpendicular);
         else skip();
     } while ((key = nextObjectKey()));
 }


### PR DESCRIPTION
Added missing spec, perpendicular option in the text follow path.

see : https://lottiefiles.github.io/lottie-docs/text/#text-follow-path

<img width="1998" height="800" alt="CleanShot 2026-06-10 at 19 02 04@2x" src="https://github.com/user-attachments/assets/b5a14035-7f96-4015-ace7-05f903547d39" />

test file :  [embedded_text_on_path_sample.json](https://github.com/user-attachments/files/28790324/embedded_text_on_path_sample.json)


| Before | After | Expected |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-10 at 19 05 10@2x" src="https://github.com/user-attachments/assets/a6d958b4-eb13-47cb-b40e-721281d447d6" /> | <img height="500" alt="CleanShot 2026-06-10 at 19 03 57@2x" src="https://github.com/user-attachments/assets/b812bb64-975d-408d-899d-92a25d3893aa" /> | <img height="500" alt="Notion 2026-06-10 19 03 31" src="https://github.com/user-attachments/assets/d0aeede1-17b6-4f8c-abc2-557f1a918596" /> |

