### PR TITLE
svg_loader: fix tspan/text positioning

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -2172,6 +2172,8 @@ struct TVG_API Text : Paint
      *
      * @param[in] ch A pointer to a UTF-8 encoded character.
      * @param[out] metrics A reference to a @ref GlyphMetrics structure to be filled with the resulting values.
+     * @param[out] next An optional pointer that receives the position immediately
+     *                  following the processed UTF-8 character.
      *
      * @return Result::InsufficientCondition if no font or size has been set yet.
      * @return Result::InvalidArguments if the given character is invalid or not supported.
@@ -2180,7 +2182,7 @@ struct TVG_API Text : Paint
      * @note Currently, ThorVG only supports horizontal text layout.
      * @note Experimental API
      */
-    Result metrics(const char* ch, GlyphMetrics& metrics) const noexcept;
+    Result metrics(const char* ch, GlyphMetrics& metrics, const char** next = nullptr) const noexcept;
 
     /**
      * @brief Loads a scalable font data (ttf) from a file.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2603,6 +2603,8 @@ TVG_API Tvg_Result tvg_text_get_text_metrics(const Tvg_Paint text, Tvg_Text_Metr
  * @param[in] text The text object.
  * @param[in] ch A pointer to a UTF-8 encoded character.
  * @param[out] metrics A pointer to a @ref Tvg_Glyph_Metrics structure to be filled with the resulting values.
+ * @param[out] next An optional pointer that receives the position immediately
+ *                  following the processed UTF-8 character.
  *
  * @return TVG_RESULT_INSUFFICIENT_CONDITION if no font or size has been set yet.
  * @return TVG_RESULT_INVALID_ARGUMENT if the given character is invalid or not supported.
@@ -2611,7 +2613,7 @@ TVG_API Tvg_Result tvg_text_get_text_metrics(const Tvg_Paint text, Tvg_Text_Metr
  * @note Currently, ThorVG only supports horizontal text layout.
  * @note Experimental API
  */
-TVG_API Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics);
+TVG_API Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics, const char** next);
 
 /**
  * @brief Loads a scalable font data from a file.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -999,10 +999,9 @@ TVG_API Tvg_Result tvg_text_get_text_metrics(const Tvg_Paint text, Tvg_Text_Metr
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
-
-TVG_API Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics)
+TVG_API Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics, const char** next)
 {
-    if (text && metrics) return (Tvg_Result) reinterpret_cast<Text*>(text)->metrics(ch, *reinterpret_cast<GlyphMetrics*>(metrics));
+    if (text && metrics) return (Tvg_Result) reinterpret_cast<Text*>(text)->metrics(ch, *reinterpret_cast<GlyphMetrics*>(metrics), next);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 

--- a/src/loaders/sfnt/tvgSfntLoader.cpp
+++ b/src/loaders/sfnt/tvgSfntLoader.cpp
@@ -608,7 +608,7 @@ void SfntLoader::metrics(const FontMetrics& fm, TextMetrics& out)
     out.linegap = reader->metrics.hhea.linegap * scale;
 }
 
-bool SfntLoader::metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out)
+bool SfntLoader::metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out, const char** next)
 {
     auto code = _codepoints(&ch, ch + strlen(ch));
     auto glyph = request(code);
@@ -629,5 +629,7 @@ bool SfntLoader::metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& ou
     }
     out.min = glyph->bbox.min * scale;
     out.max = glyph->bbox.max * scale;
+
+    if (next) *next = ch;
     return true;
 }

--- a/src/loaders/sfnt/tvgSfntLoader.h
+++ b/src/loaders/sfnt/tvgSfntLoader.h
@@ -58,7 +58,7 @@ struct SfntLoader : public FontLoader
     void copy(const FontMetrics& in, FontMetrics& out) override;
     void release(FontMetrics& fm) override;
     void metrics(const FontMetrics& fm, TextMetrics& out) override;
-    bool metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out) override;
+    bool metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out, const char** next) override;
 
     static SfntReader* gen(uint8_t* data, uint32_t size);
 

--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -922,6 +922,21 @@ static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const
     return text;
 }
 
+static void _updatePos(Text* text, const SvgTextNode& textNode, float anchor, Point& textPos)
+{
+    auto advance = _bounds(text).w;
+    if (auto utf8 = text->text()) {
+        GlyphMetrics gm;
+        if (text->metrics(utf8, gm) == Result::Success) advance += gm.min.x;
+        while (utf8) {
+            if (text->metrics(utf8, gm, &utf8) == Result::Success) advance += gm.advance - gm.max.x;
+            else break;
+        }
+    }
+    textPos.x = textNode.x + textNode.dx + (1.0f - anchor) * advance;
+    textPos.y = textNode.y + textNode.dy;
+}
+
 static bool _hasPositionedTspan(const SvgNode* node, int depth)
 {
     if (depth > 2192) {
@@ -938,7 +953,7 @@ static bool _hasPositionedTspan(const SvgNode* node, int depth)
     return false;
 }
 
-static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* scene, const Box& vBox, const string& svgPath, int depth)
+static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* scene, const Box& vBox, const string& svgPath, int depth, Point& textPos)
 {
     if (depth > 2192) {
         TVGERR("SVG", "Infinite recursive call - stopped after %d calls! Svg file may be incorrectly formatted.", depth);
@@ -953,8 +968,6 @@ static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* 
         if (textNode.text) {
             auto xmlSpace = child->xmlSpace;
             for (auto n = child->parent; n; n = n->parent) {
-                if (textNode.x == FLT_MAX) textNode.x = n->node.text.x;
-                if (textNode.y == FLT_MAX) textNode.y = n->node.text.y;
                 if (textNode.fontSize <= 0.0f) textNode.fontSize = n->node.text.fontSize;
                 if (!textNode.fontFamily) textNode.fontFamily = n->node.text.fontFamily;
                 if (xmlSpace == SvgXmlSpace::None) xmlSpace = n->xmlSpace;
@@ -962,9 +975,13 @@ static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* 
             }
             if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
 
+            if (textNode.x == FLT_MAX) textNode.x = textPos.x;
+            if (textNode.y == FLT_MAX) textNode.y = textPos.y;
+
             auto text = _buildText(&textNode, xmlSpace, nullptr);
             if (text) {
                 text->align(child->style->textAnchor, 0.0f);
+                _updatePos(text, textNode, child->style->textAnchor, textPos);
                 _applyTextFill(child->style, text, vBox, ctx.parser->global);
                 auto paint = _applyFilter(ctx, text, child, vBox, svgPath);
                 paint = _applyComposition(ctx, paint, child, vBox, svgPath);
@@ -972,7 +989,7 @@ static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* 
                 scene->add(paint);
             }
         }
-        _buildTspanScene(ctx, child, scene, vBox, svgPath, depth + 1);
+        _buildTspanScene(ctx, child, scene, vBox, svgPath, depth + 1, textPos);
     }
 }
 
@@ -999,13 +1016,16 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
     auto scene = Scene::gen();
     if (node->transform) scene->transform(*node->transform);
 
+    Point textPos = {textNode->x, textNode->y};
+
     if (auto text = _buildText(textNode, xmlSpace, nullptr)) {
         text->align(node->style->textAnchor, 0.0f);
+        _updatePos(text, *textNode, node->style->textAnchor, textPos);
         _applyTextFill(node->style, text, vBox, ctx.parser->global);
         scene->add(text);
     }
 
-    _buildTspanScene(ctx, node, scene, vBox, svgPath, 0);
+    _buildTspanScene(ctx, node, scene, vBox, svgPath, 0, textPos);
 
     auto p = _applyFilter(ctx, scene, node, vBox, svgPath);
     p = _applyComposition(ctx, p, node, vBox, svgPath);

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -89,6 +89,7 @@ enum struct SvgNodeType : uint16_t
 
 enum struct SvgFillFlags : uint8_t
 {
+    None = 0x0,
     Paint = 0x01,
     Opacity = 0x02,
     Gradient = 0x04,
@@ -148,6 +149,7 @@ enum struct SvgGradientType : uint8_t
 
 enum struct SvgStyleFlags
 {
+    None = 0x0,
     Color = 0x01,
     Fill = 0x02,
     FillRule = 0x04,

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3157,6 +3157,16 @@ static int _svgLoaderParserXmlTagName(const char* content, char* tagName, unsign
     return sz;
 }
 
+static bool _hasTspanChild(const SvgNode* node, const SvgNode* exclude = nullptr)
+{
+    ARRAY_FOREACH(p, node->child) {
+        if (*p == exclude) continue;
+        if ((*p)->type == SvgNodeType::Tspan && ((*p)->node.text.text || !(*p)->child.empty())) return true;
+    }
+    return false;
+}
+
+
 static void _spliceTspanClose(SvgParserContext* ctx)
 {
     auto cur = ctx->parser->node;
@@ -3164,9 +3174,11 @@ static void _spliceTspanClose(SvgParserContext* ctx)
 
     auto& t = cur->node.text;
     bool unpositioned = (t.x == FLT_MAX && t.y == FLT_MAX && t.dx == 0.0f && t.dy == 0.0f);
-    bool noOverride = (t.fontSize <= 0.0f && !t.fontFamily && cur->xmlSpace == SvgXmlSpace::None && !(cur->style->flags & SvgStyleFlags::TextAnchor));
+    bool noOverride = (t.fontSize <= 0.0f && !t.fontFamily && cur->xmlSpace == SvgXmlSpace::None && cur->style->flags == SvgStyleFlags::None && cur->style->fill.flags == SvgFillFlags::None);
 
-    if (t.text && unpositioned && noOverride && cur->parent) {
+    auto splice = t.text && unpositioned && noOverride && cur->parent && cur->child.empty() && !_hasTspanChild(cur->parent, cur);
+
+    if (splice) {
         auto& parentText = cur->parent->node.text;
         parentText.text = append(parentText.text, t.text, strlen(t.text));
         tvg::free(t.text);
@@ -3339,7 +3351,17 @@ static void _svgLoaderParserXmlOpen(SvgParserContext* ctx, const char* content, 
 
 static void _svgLoaderParserText(SvgParserContext* ctx, const char* content, unsigned int length)
 {
-    auto& text = ctx->parser->node->node.text;
+    auto node = ctx->parser->node;
+
+    if (_hasTspanChild(node)) {
+        auto run = _createNode(node, SvgNodeType::Tspan);
+        run->node.text.x = FLT_MAX;
+        run->node.text.y = FLT_MAX;
+        run->node.text.text = append(run->node.text.text, content, length);
+        return;
+    }
+
+    auto& text = node->node.text;
     text.text = append(text.text, content, length);
 }
 

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -219,7 +219,7 @@ struct FontLoader : Loader
     virtual void transform(Paint* paint, FontMetrics& fm, float italicShear) = 0;
     virtual void release(FontMetrics& fm) = 0;
     virtual void metrics(const FontMetrics& fm, TextMetrics& out) = 0;
-    virtual bool metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out) = 0;
+    virtual bool metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out, const char** next) = 0;
     virtual void copy(const FontMetrics& in, FontMetrics& out) = 0;
 };
 }

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -163,10 +163,9 @@ Result Text::metrics(TextMetrics& metrics) const noexcept
     return to<TextImpl>(this)->metrics(metrics);
 }
 
-
-Result Text::metrics(const char* ch, GlyphMetrics& metrics) const noexcept
+Result Text::metrics(const char* ch, GlyphMetrics& metrics, const char** next) const noexcept
 {
-    return to<TextImpl>(this)->metrics(ch, metrics);
+    return to<TextImpl>(this)->metrics(ch, metrics, next);
 }
 
 

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -133,10 +133,10 @@ struct TextImpl : Text
         return Result::Success;
     }
 
-    Result metrics(const char* ch, GlyphMetrics& metrics)
+    Result metrics(const char* ch, GlyphMetrics& metrics, const char** next)
     {
         if (!loader || fm.fontSize <= 0.0f) return Result::InsufficientCondition;
-        if (ch && loader->metrics(fm, ch, metrics)) return Result::Success;
+        if (ch && loader->metrics(fm, ch, metrics, next)) return Result::Success;
         return Result::InvalidArguments;
     }
 


### PR DESCRIPTION
Track a running text position so a run with unset x/y continues from the previous run's end and dx/dy apply as deltas on top. Apply text-anchor before measuring so the anchor takes effect.

issue : #4421