### PR TITLE
snft: fix a crash on duplicating an unshaped text

### DIFF
--- a/src/loaders/sfnt/tvgSfntLoader.cpp
+++ b/src/loaders/sfnt/tvgSfntLoader.cpp
@@ -595,8 +595,10 @@ void SfntLoader::copy(const FontMetrics& in, FontMetrics& out)
 {
     release(out);
     out = in;
-    if (in.engine) out.engine = tvg::calloc<SfntMetrics>(1, sizeof(SfntMetrics));
-    *static_cast<SfntMetrics*>(out.engine) = *static_cast<SfntMetrics*>(in.engine);
+    if (in.engine) {
+        out.engine = tvg::calloc<SfntMetrics>(1, sizeof(SfntMetrics));
+        *static_cast<SfntMetrics*>(out.engine) = *static_cast<SfntMetrics*>(in.engine);
+    }
 }
 
 void SfntLoader::metrics(const FontMetrics& fm, TextMetrics& out)


### PR DESCRIPTION
Duplicating a text that has a font set but no content yet reaches FontLoader::copy() with a null engine, causing SIGSEGV.

```cpp
auto proto = tvg::Text::gen();
proto->font("PublicSans-Regular");
proto->size(40);
proto->fill(255, 255, 255);

auto text = static_cast<tvg::Text*>(proto->duplicate()); // Crash 
text->text("hello");
text->translate(50, 150 + 70);
canvas->add(text);
```

<img width="1708" height="186" alt="CleanShot 2026-06-11 at 17 19 43@2x" src="https://github.com/user-attachments/assets/fa2eca24-f5d2-423f-8254-ae426a986baa" />
