### PR TITLE
lottie/text: implement text follow path in url font 

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -994,6 +994,14 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
         if (free) tvg::free(src);
     }
 
+    //text on the path
+    if (text->follow && ((uint32_t)text->follow->maskIdx < layer->masks.count)) {
+        auto path = text->pooling();
+        path->reset();
+        layer->masks[text->follow->maskIdx]->pathset(frameNo, to<ShapeImpl>(path)->rs.path, nullptr, tween, exps);
+        to<TextImpl>(paint)->layout(to<ShapeImpl>(path)->rs.path, text->follow->firstMargin(frameNo, tween, exps));
+    }
+
     //text build
     auto len = strlen(doc.text);
     auto buf = tvg::malloc<char>(len + 1);

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -27,47 +27,8 @@
 
 
 /************************************************************************/
-/* Internal Class Implementation                                        */
-/************************************************************************/
-
-Point LottieTextFollowPath::split(float dLen, float lenSearched, float& angle)
-{
-    switch (*cmds) {
-        case PathCommand::MoveTo: {
-            angle = 0.0f;
-            break;
-        }
-        case PathCommand::LineTo: {
-            auto dp = *pts - *(pts - 1);
-            angle = tvg::atan(dp);
-            break;
-        }
-        case PathCommand::CubicTo: {
-            auto bz = Bezier{*(pts - 1), *pts, *(pts + 1), *(pts + 2)};
-            float t = bz.at(lenSearched - currentLen, dLen);
-            angle = deg2rad(bz.angle(t));
-            return bz.at(t);
-        }
-        case PathCommand::Close: {
-            auto dp = *start - *(pts - 1);
-            angle = tvg::atan(dp);
-            break;
-        }
-    }
-    return {};
-}
-
-/************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
-
-void LottieTextFollowPath::rewind()
-{
-    pts = path.pts.data;
-    cmds = path.cmds.data;
-    cmdsCnt = path.cmds.count;
-    currentLen = 0.0f;
-}
 
 float LottieTextFollowPath::prepare(LottieMask* mask, float frameNo, float scale, Tween& tween, LottieExpressions* exps)
 {
@@ -75,108 +36,19 @@ float LottieTextFollowPath::prepare(LottieMask* mask, float frameNo, float scale
     Matrix m{1.0f / scale, 0.0f, 0.0f, 0.0f, 1.0f / scale, 0.0f, 0.0f, 0.0f, 1.0f};
     path.clear();
     mask->pathset(frameNo, path, &m, tween, exps);
-
-    rewind();
-    totalLen = tvg::length(cmds, cmdsCnt, pts, path.pts.count);
-    start = pts;
+    totalLen = tvg::length(path.cmds.data, path.cmds.count, path.pts.data, path.pts.count);
 
     return firstMargin(frameNo, tween, exps) / scale;
 }
 
 Point LottieTextFollowPath::position(float lenSearched, float& angle)
 {
-    //position before the start of the curve
-    if (lenSearched <= 0.0f) {
-        //shape is closed -> wrapping
-        if (path.cmds.last() == PathCommand::Close) {
-            while (lenSearched < 0.0f) lenSearched += totalLen;
-        //linear interpolation
-        } else {
-            if (cmds >= path.cmds.data + path.cmds.count - 1) return *start;
-            switch (*(cmds + 1)) {
-                case PathCommand::LineTo: {
-                    auto dp = *(pts + 1) - *pts;
-                    angle = tvg::atan(dp);
-                    return {pts->x + lenSearched * cos(angle), pts->y + lenSearched * sin(angle)};
-                }
-                case PathCommand::CubicTo: {
-                    angle = deg2rad(Bezier{*pts, *(pts + 1), *(pts + 2), *(pts + 3)}.angle(0.0001f));
-                    return {pts->x + lenSearched * cos(angle), pts->y + lenSearched * sin(angle)};
-                }
-                default:
-                    angle = 0.0f;
-                return *start;
-            }
-        }
+    //text wraps around a closed path
+    if (path.cmds.count > 0 && path.cmds.last() == PathCommand::Close && !tvg::zero(totalLen)) {
+        lenSearched = fmodf(lenSearched, totalLen);
+        if (lenSearched < 0.0f) lenSearched += totalLen;
     }
-
-    auto shift = [&]() -> void {
-        switch (*cmds) {
-            case PathCommand::MoveTo: start = pts; ++pts; break;
-            case PathCommand::LineTo: ++pts; break;
-            case PathCommand::CubicTo: pts += 3; break;
-            case PathCommand::Close: break;
-        }
-        ++cmds;
-        --cmdsCnt;
-    };
-
-    //position beyond the end of the curve
-    if (lenSearched >= totalLen) {
-        //shape is closed -> wrapping
-        if (path.cmds.last() == PathCommand::Close) {
-            while (lenSearched > totalLen) lenSearched -= totalLen;
-        //linear interpolation
-        } else {
-            while (cmdsCnt > 1) shift();
-            switch (*cmds) {
-                case PathCommand::MoveTo:
-                    angle = 0.0f;
-                    return *pts;
-                case PathCommand::LineTo: {
-                    auto len = lenSearched - totalLen;
-                    auto dp = *pts - *(pts - 1);
-                    angle = tvg::atan(dp);
-                    return {pts->x + len * cos(angle), pts->y + len * sin(angle)};
-                }
-                case PathCommand::CubicTo: {
-                    auto len = lenSearched - totalLen;
-                    angle = deg2rad(Bezier{*(pts - 1), *pts, *(pts + 1), *(pts + 2)}.angle(0.999f));
-                    return {(pts + 2)->x + len * cos(angle), (pts + 2)->y + len * sin(angle)};
-                }
-                case PathCommand::Close: {
-                    auto len = lenSearched - totalLen;
-                    auto dp = *start - *(pts - 1);
-                    angle = tvg::atan(dp);
-                    return {(pts - 1)->x + len * cos(angle), (pts - 1)->y + len * sin(angle)};
-                }
-            }
-        }
-    }
-
-    //reset required if text partially crosses curve start
-    if (lenSearched < currentLen) rewind();
-
-    auto length = [&]() -> float {
-        switch (*cmds) {
-            case PathCommand::MoveTo: return 0.0f;
-            case PathCommand::LineTo: return tvg::length(*(pts - 1), *pts);
-            case PathCommand::CubicTo: return Bezier{*(pts - 1), *pts, *(pts + 1), *(pts + 2)}.length();
-            case PathCommand::Close: return tvg::length(*(pts - 1), *start);
-            default: return 0.0f;
-        }
-    };
-
-    while (cmdsCnt > 0) {
-        auto dLen = length();
-        if (currentLen + dLen < lenSearched) {
-            shift();
-            currentLen += dLen;
-            continue;
-        }
-        return split(dLen, lenSearched, angle);
-    }
-    return {};
+    return path.pointAt(lenSearched, angle);
 }
 
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -494,14 +494,7 @@ struct LottieTextFollowPath
 {
 private:
     RenderPath path;
-    PathCommand* cmds;
-    uint32_t cmdsCnt;
-    Point* pts;
-    Point* start;
     float totalLen;
-    float currentLen;
-    Point split(float dLen, float lenSearched, float& angle);
-    void rewind();
 
 public:
     LottieFloat firstMargin = 0.0f;

--- a/src/loaders/sfnt/tvgSfntLoader.cpp
+++ b/src/loaders/sfnt/tvgSfntLoader.cpp
@@ -484,6 +484,50 @@ void SfntLoader::wrapEllipsis(FontMetrics& fm, const Point& box, const char* utf
     _align(fm.align, box, {cursor.x, fm.size.y}, line, out.pts.count, out);  //last line
 }
 
+void SfntLoader::wrapOnPath(FontMetrics& fm, const char* utf8, const char* end, const RenderPath& path, float offset, RenderPath& out)
+{
+    SfntGlyphMetrics* ltgm = nullptr;  // left side glyph between the two adjacent glyphs
+    auto ascent = reader->metrics.hhea.ascent;
+    auto cursor = offset;
+
+    while (utf8 < end) {
+        auto code = _codepoints(&utf8, end);
+        if (code == LINE_FEED_GLYPH_IDX) {
+            cursor = offset;
+            ++fm.lines;
+            ltgm = nullptr;
+            continue;
+        }
+        auto rtgm = request(code);
+        if (!rtgm) continue;
+
+        Point offset{};
+        if (ltgm) reader->positioning(ltgm->idx, rtgm->idx, offset);
+
+        auto advance = (rtgm->advance + offset.x) * fm.spacing.x;
+        auto half = advance * 0.5f;
+
+        //sample the path at the center of the glyph
+        auto angle = 0.0f;
+        auto pos = path.pointAt(cursor + half / fm.scale, angle) * fm.scale;
+
+        //place the glyph along the path
+        auto cosA = cosf(angle);
+        auto sinA = sinf(angle);
+        out.cmds.push(rtgm->path.cmds);
+        out.pts.grow(rtgm->path.pts.count);
+        ARRAY_FOREACH(p, rtgm->path.pts) {
+            auto x = p->x - half;
+            out.pts.push({x * cosA - p->y * sinA + pos.x, x * sinA + p->y * cosA + pos.y - ascent});
+        }
+        cursor += advance / fm.scale;
+
+        //store the base glyph width for italic transform
+        if (!ltgm) static_cast<SfntMetrics*>(fm.engine)->baseGlyph = rtgm;
+        ltgm = rtgm;
+    }
+}
+
 SfntReader* SfntLoader::gen(uint8_t* data, uint32_t size)
 {
     // type checking
@@ -581,6 +625,23 @@ bool SfntLoader::get(FontMetrics& fm, char* text, uint32_t len, RenderPath& out)
     else if (fm.wrap == TextWrap::Smart) wrapWord(fm, box, text, end, out, true);
     else if (fm.wrap == TextWrap::Ellipsis) wrapEllipsis(fm, box, text, end, out);
     else return false;
+
+    return true;
+}
+
+bool SfntLoader::get(FontMetrics& fm, char* text, uint32_t len, const RenderPath& path, float offset, RenderPath& out)
+{
+    out.clear();
+
+    fm.lines = 1;
+
+    if (!text || fm.fontSize == 0.0f) return false;
+
+    fm.scale = reader->metrics.unitsPerEm / (fm.fontSize * FontLoader::DPI);
+    fm.size = {};
+    if (!fm.engine) fm.engine = tvg::calloc<SfntMetrics>(1, sizeof(SfntMetrics));
+
+    wrapOnPath(fm, text, text + len, path, offset, out);
 
     return true;
 }

--- a/src/loaders/sfnt/tvgSfntLoader.h
+++ b/src/loaders/sfnt/tvgSfntLoader.h
@@ -55,6 +55,7 @@ struct SfntLoader : public FontLoader
     bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) override;
     void transform(Paint* paint, FontMetrics& fm, float italicShear) override;
     bool get(FontMetrics& fm, char* text, uint32_t len, RenderPath& out) override;
+    bool get(FontMetrics& fm, char* text, uint32_t len, const RenderPath& path, float offset, RenderPath& out) override;
     void copy(const FontMetrics& in, FontMetrics& out) override;
     void release(FontMetrics& fm) override;
     void metrics(const FontMetrics& fm, TextMetrics& out) override;
@@ -73,6 +74,7 @@ private:
     void wrapChar(FontMetrics& fm, const Point& box, const char* utf8, const char* end, RenderPath& out);
     void wrapWord(FontMetrics& fm, const Point& box, const char* utf8, const char* end, RenderPath& out, bool smart);
     void wrapEllipsis(FontMetrics& fm, const Point& box, const char* utf8, const char* end, RenderPath& out);
+    void wrapOnPath(FontMetrics& fm, const char* utf8, const char* end, const RenderPath& path, float offset, RenderPath& out);
     SfntGlyphMetrics* request(uint32_t code);
     void clear();
 };

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -216,6 +216,7 @@ struct FontLoader : Loader
     using Loader::read;
 
     virtual bool get(FontMetrics& fm, char* text, uint32_t len, RenderPath& out) = 0;
+    virtual bool get(FontMetrics& fm, char* text, uint32_t len, const RenderPath& path, float offset, RenderPath& out) = 0;
     virtual void transform(Paint* paint, FontMetrics& fm, float italicShear) = 0;
     virtual void release(FontMetrics& fm) = 0;
     virtual void metrics(const FontMetrics& fm, TextMetrics& out) = 0;

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -647,6 +647,66 @@ static void _get(float& begin, float& end)
 }
 
 
+Point RenderPath::pointAt(float at, float& angle) const
+{
+    auto cleng = 0.0f;
+    auto p = pts.data;
+    auto c = cmds.data;
+    Bezier bz{};
+    Point pos{}, start{};
+    auto line = true;
+
+    for (uint32_t i = 0; i < cmds.count; ++i, ++c) {
+        switch (*c) {
+            case PathCommand::MoveTo: {
+                pos = start = *p++;
+                continue;
+            }
+            case PathCommand::LineTo: {
+                bz.start = *(p - 1);
+                bz.end = *p++;
+                line = true;
+                break;
+            }
+            case PathCommand::CubicTo: {
+                bz = {*(p - 1), *p, *(p + 1), *(p + 2)};
+                p += 3;
+                line = false;
+                break;
+            }
+            case PathCommand::Close: {
+                bz.start = *(p - 1);
+                bz.end = start;
+                line = true;
+                break;
+            }
+        }
+        auto len = line ? length(bz.start, bz.end) : bz.length();
+        if (tvg::zero(len)) continue;
+
+        //the target lies on this segment
+        if (at <= cleng + len) {
+            if (line) {
+                angle = tvg::atan(bz.end - bz.start);
+                return bz.start + (bz.end - bz.start) * ((at - cleng) / len);
+            }
+            if (at < cleng) {  //ahead of the path
+                angle = deg2rad(bz.angle(0.0001f));
+                return bz.start + Point{cosf(angle), sinf(angle)} * (at - cleng);
+            }
+            auto t = bz.at(at - cleng, len);
+            angle = deg2rad(bz.angle(t));
+            return bz.at(t);
+        }
+        cleng += len;
+        angle = line ? tvg::atan(bz.end - bz.start) : deg2rad(bz.angle(0.999f));
+        pos = bz.end;
+    }
+    //beyond the end of the path
+    return pos + Point{cosf(angle), sinf(angle)} * (at - cleng);
+}
+
+
 bool RenderTrimPath::trim(const RenderPath& in, RenderPath& out) const
 {
     if (in.pts.count < 2 || tvg::zero(begin - end)) return false;

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -322,6 +322,7 @@ struct RenderPath
         return curr;
     }
 
+    Point pointAt(float at, float& angle) const;
     bool bounds(const Matrix* m, BBox& box);
     void addCircle(float cx, float cy, float rx, float ry, bool cw);
     void addRect(float x, float y, float w, float h, float rx, float ry, bool cw);

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -35,13 +35,15 @@ namespace tvg
 struct TextImpl : Text
 {
     Paint::Impl impl;
-    Shape* shape;   //text shape
+    Shape* shape;        //text shape
     FontLoader* loader = nullptr;
     FontMetrics fm;
+    RenderPath path;     //text path
     char* utf8 = nullptr;
     uint32_t utf8len = 0;
     float outlineWidth = 0.0f;
     float italicShear = 0.0f;
+    float offset = 0.0f;
     bool updated = false;
 
     TextImpl() : impl(Paint::Impl(this)), shape(Shape::gen())
@@ -118,9 +120,9 @@ struct TextImpl : Text
     {
         if (!loader) return false;
         if (updated) {
-            if (loader->get(fm, utf8, utf8len, to<ShapeImpl>(shape)->rs.path)) {
-                loader->transform(shape, fm, italicShear);
-            }
+            auto& out = to<ShapeImpl>(shape)->rs.path;
+            auto ret = path.empty() ? loader->get(fm, utf8, utf8len, out) : loader->get(fm, utf8, utf8len, path, offset, out);
+            if (ret) loader->transform(shape, fm, italicShear);
             updated = false;
         }
         return true;
@@ -164,6 +166,16 @@ struct TextImpl : Text
     {
         fm.box = {w, h};
         updated = true;
+    }
+
+    void layout(const RenderPath& path, float offset)
+    {
+        this->path.clear();
+        this->path.cmds.push(path.cmds);
+        this->path.pts.push(path.pts);
+        this->offset = offset;
+        updated = true;
+        impl.mark(RenderUpdateFlag::Path);
     }
 
     Result spacing(float letter, float line)
@@ -235,6 +247,9 @@ struct TextImpl : Text
         dup->utf8len = utf8len;
         dup->italicShear = italicShear;
         dup->outlineWidth = outlineWidth;
+        dup->path.cmds.push(path.cmds);
+        dup->path.pts.push(path.pts);
+        dup->offset = offset;
         dup->updated = true;
 
         return text;


### PR DESCRIPTION
Extend Lottie Text Follow Path to URL font rendering, previously embedded-only.

Refactor the path sampling into `RenderPath::pointAt`, simplifying LottieTextFollowPath and removing duplicated logic.

test file :  [font-follow-path.json](https://github.com/user-attachments/files/28910155/font-follow-path.json)

| ThorVG(Now) | lottie-web | Skottie |
|---------|---------|---------|
| <img height="450" alt="CleanShot 2026-06-13 at 18 26 59" src="https://github.com/user-attachments/assets/054391f8-d96e-441d-81e5-e9c8eb0a4caa" /> | <img height="500" alt="CleanShot 2026-06-13 at 18 25 35" src="https://github.com/user-attachments/assets/29ad0ad8-73a1-4319-bf28-5f79699785ad" /> | <img height="500" alt="CleanShot 2026-06-13 at 18 26 08" src="https://github.com/user-attachments/assets/197fe3e8-7861-4f2e-87bf-543493cfa182" /> |

