### PR TITLE
loaders: neat code++

### DIFF
--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -28,9 +28,8 @@
 using tjhandle = void*;
 
 //TODO: Use Task?
-class JpgLoader : public ImageLoader
+struct JpgLoader : ImageLoader
 {
-public:
     JpgLoader();
     ~JpgLoader();
 

--- a/src/loaders/external_png/tvgPngLoader.h
+++ b/src/loaders/external_png/tvgPngLoader.h
@@ -26,9 +26,8 @@
 #include <png.h>
 #include "tvgLoader.h"
 
-class PngLoader : public ImageLoader
+struct PngLoader : ImageLoader
 {
-public:
     PngLoader();
     ~PngLoader();
 

--- a/src/loaders/external_webp/tvgWebpLoader.h
+++ b/src/loaders/external_webp/tvgWebpLoader.h
@@ -26,9 +26,8 @@
 #include "tvgLoader.h"
 #include "tvgTaskScheduler.h"
 
-class WebpLoader : public ImageLoader, public Task
+struct WebpLoader : ImageLoader, Task
 {
-public:
     WebpLoader();
     ~WebpLoader();
 

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -27,17 +27,8 @@
 #include "tvgTaskScheduler.h"
 #include "tvgJpgd.h"
 
-class JpgLoader : public ImageLoader, public Task
+struct JpgLoader : ImageLoader, Task
 {
-private:
-    jpeg_decoder* decoder = nullptr;
-    char* data = nullptr;
-    bool freeData = false;
-
-    void clear();
-    void run(unsigned tid) override;
-
-public:
     JpgLoader();
     ~JpgLoader();
 
@@ -47,6 +38,14 @@ public:
     bool close() override;
 
     RenderSurface* bitmap() override;
+
+private:
+    jpeg_decoder* decoder = nullptr;
+    char* data = nullptr;
+    bool freeData = false;
+
+    void clear();
+    void run(unsigned tid) override;
 };
 
 #endif //_TVG_JPG_LOADER_H_

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -51,9 +51,8 @@ struct LottieCustomSlot
     ~LottieCustomSlot();
 };
 
-class LottieLoader : public AnimLoader, public Task
+struct LottieLoader : AnimLoader, Task
 {
-public:
     const char* content = nullptr;      //lottie file data
     uint32_t size = 0;                  //lottie data size
     float frameNo = 0.0f;               //current frame number

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -26,18 +26,8 @@
 #include "tvgLodePng.h"
 #include "tvgTaskScheduler.h"
 
-
-class PngLoader : public ImageLoader, public Task
+struct PngLoader : ImageLoader, Task
 {
-private:
-    LodePNGState state;
-    unsigned char* data = nullptr;
-    uint32_t size = 0;
-    bool freeData = false;
-
-    void run(unsigned tid) override;
-
-public:
     PngLoader();
     ~PngLoader();
 
@@ -46,6 +36,14 @@ public:
     bool read() override;
 
     RenderSurface* bitmap() override;
+
+private:
+    LodePNGState state;
+    unsigned char* data = nullptr;
+    uint32_t size = 0;
+    bool freeData = false;
+
+    void run(unsigned tid) override;
 };
 
 #endif //_TVG_PNG_LOADER_H_

--- a/src/loaders/raw/tvgRawLoader.h
+++ b/src/loaders/raw/tvgRawLoader.h
@@ -23,9 +23,8 @@
 #ifndef _TVG_RAW_LOADER_H_
 #define _TVG_RAW_LOADER_H_
 
-class RawLoader : public ImageLoader
+struct RawLoader : ImageLoader
 {
-public:
     bool copy = false;
 
     RawLoader();

--- a/src/loaders/webp/tvgWebpLoader.h
+++ b/src/loaders/webp/tvgWebpLoader.h
@@ -23,17 +23,8 @@
 #include "tvgLoader.h"
 #include "tvgTaskScheduler.h"
 
-class WebpLoader : public ImageLoader, public Task
+struct WebpLoader : ImageLoader, Task
 {
-private:
-    uint8_t* data = nullptr;
-    uint32_t size = 0;
-    bool freeData = false;
-
-    void clear();
-    void run(unsigned tid) override;
-
-public:
     WebpLoader();
     ~WebpLoader();
 
@@ -43,6 +34,14 @@ public:
     bool close() override;
 
     RenderSurface* bitmap() override;
+
+private:
+    uint8_t* data = nullptr;
+    uint32_t size = 0;
+    bool freeData = false;
+
+    void clear();
+    void run(unsigned tid) override;
 };
 
 #endif //_TVG_WEBP_LOADER_H_

--- a/src/savers/gif/tvgGifSaver.h
+++ b/src/savers/gif/tvgGifSaver.h
@@ -29,8 +29,14 @@
 namespace tvg
 {
 
-class GifSaver : public SaveModule, public Task
+struct GifSaver : SaveModule, Task
 {
+    ~GifSaver();
+
+    bool save(Paint* paint, Paint* bg, const char* filename, uint32_t quality) override;
+    bool save(Animation* animation, Paint* bg, const char* filename, uint32_t quality, uint32_t fps) override;
+    bool close() override;
+
 private:
     uint32_t* buffer = nullptr;
     Animation* animation = nullptr;
@@ -40,13 +46,6 @@ private:
     float fps = 0.0f;
 
     void run(unsigned tid) override;
-
-public:
-    ~GifSaver();
-
-    bool save(Paint* paint, Paint* bg, const char* filename, uint32_t quality) override;
-    bool save(Animation* animation, Paint* bg, const char* filename, uint32_t quality, uint32_t fps) override;
-    bool close() override;
 };
 
 }


### PR DESCRIPTION
Use structs to remove non-essential visibility specifiers.