### PR TITLE
lottie/text: fix box word-wrap overhang in local font

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1301,6 +1301,11 @@ void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieTex
 
         // draw matched glyphs
         if (glyph) {
+            auto advance = (glyph->width + doc.tracking) * ctx.capScale;
+            if (doc.bbox.size.x > 0.0f && ctx.cursor.x > 0.0f && (ctx.cursor.x + advance) * ctx.scale > doc.bbox.size.x) {
+                lineWrapped = true;
+                continue;
+            }
             if (text->alignOp.group == LottieText::AlignOption::Group::Chars || text->alignOp.group == LottieText::AlignOption::Group::All) {
                 ctx.textScene->add(ctx.lineScene);
                 ctx.lineScene = Scene::gen();
@@ -1308,8 +1313,7 @@ void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieTex
             }
             auto shape = textShape(text, frameNo, doc, glyph, ctx);
             if (!updateTextRange(text, frameNo, shape, doc, ctx)) _commit(glyph, shape, ctx);
-            if (doc.bbox.size.x > 0.0f && ctx.cursor.x * ctx.scale >= doc.bbox.size.x) lineWrapped = true;
-            else ctx.cursor.x += (glyph->width + doc.tracking) * ctx.capScale;
+            ctx.cursor.x += advance;
             ctx.p += glyph->len;
             ctx.idx += glyph->len;
         } else {


### PR DESCRIPTION
Local fonts placed each glyph before checking whether it overflowed the box, causing a one-character overhang at the right edge on long lines.

Test the glyph advance against the box before committing instead of after.

test file : [embedded_box_wrap_test.json](https://github.com/user-attachments/files/28924209/embedded_box_wrap_test.json)


| Before | After | Expectation |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-14 at 16 45 01@2x" src="https://github.com/user-attachments/assets/667f65f2-8ab7-4cd0-979c-e3c327077217" /> | <img height="500" alt="CleanShot 2026-06-14 at 16 44 35@2x" src="https://github.com/user-attachments/assets/4364744f-7d40-4cdb-baab-9dd5b2e6d1e8" /> | <img height="500" alt="image" src="https://github.com/user-attachments/assets/b438192a-6097-4ff4-b833-ed44cec9905e" /> |