### PR TITLE
lottie/text: fix box text vertical alignment

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1023,10 +1023,11 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     paint->translate(doc.bbox.pos.x, doc.bbox.pos.y);
     if (doc.bbox.size.x > 0.0f) paint->wrap(TextWrap::Word);
 
-    //align the text to the base line
+    //align the text to the base line, or top within the box
     TextMetrics metrics;
     paint->metrics(metrics);
-    paint->align(doc.justify, metrics.ascent / (metrics.ascent - metrics.descent));
+    auto valign = (doc.bbox.size.y > 0.0f) ? 0.0f : metrics.ascent / (metrics.ascent - metrics.descent);
+    paint->align(doc.justify, valign);
 
     //apply spacing
     auto hspacing = 1.0f + doc.tracking * doc.size / metrics.ascent;


### PR DESCRIPTION
In the URL font, baseline-align is always applied to both
- point text (without "sz")
- box text (when "sz" sets)

With the box text, vertical alignment should anchor from the top, not baseline.

issue: https://github.com/thorvg/thorvg/issues/4334

test file : [font_box_auto_resize_sample.json](https://github.com/user-attachments/files/28924992/font_box_auto_resize_sample.json)


| Before | After | Expectation |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-14 at 17 52 15@2x" src="https://github.com/user-attachments/assets/01af6b30-841f-4650-8155-504f14346bbe" /> | <img height="500" alt="CleanShot 2026-06-14 at 17 51 05@2x" src="https://github.com/user-attachments/assets/db432690-70d4-4a10-a1e9-8935bca10871" /> | <img height="500" alt="image" src="https://github.com/user-attachments/assets/fe1434cc-c66c-44df-a1de-97ad0b6323ce" /> |