### PR TITLE
lottie/text: box text y-alignment enhancements

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1040,8 +1040,9 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     //layout
     auto ascent = (text->font && text->font->ascent > 0.0f && doc.bbox.size.y > 0.0f) ? (metrics.ascent - text->font->ascent * doc.size) : 0.0f;
     paint->layout(doc.bbox.size.x, doc.bbox.size.y);
-    paint->translate(doc.bbox.pos.x, doc.bbox.pos.y - ascent);
     if (doc.bbox.size.x > 0.0f) paint->wrap(TextWrap::Word);
+    auto baselineY = (tvg::zero(doc.bbox.pos.y) && doc.bbox.size.y > 0.0f) ? -metrics.ascent : doc.bbox.pos.y - ascent;
+    paint->translate(doc.bbox.pos.x, baselineY);
 
     //align the text to the base line, or top within the box
     auto valign = (doc.bbox.size.y > 0.0f) ? 0.0f : metrics.ascent / (metrics.ascent - metrics.descent);

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1033,13 +1033,17 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     paint->size(doc.size * 75.0f); //1 pt = 1/72; 1 in = 96 px; -> 72/96 = 0.75
     if (text->font && text->font->style && strstr(text->font->style, "Italic")) paint->italic();
     paint->text(buf);
+
+    TextMetrics metrics;
+    paint->metrics(metrics);
+
+    //layout
+    auto ascent = (text->font && text->font->ascent > 0.0f && doc.bbox.size.y > 0.0f) ? (metrics.ascent - text->font->ascent * doc.size) : 0.0f;
     paint->layout(doc.bbox.size.x, doc.bbox.size.y);
-    paint->translate(doc.bbox.pos.x, doc.bbox.pos.y);
+    paint->translate(doc.bbox.pos.x, doc.bbox.pos.y - ascent);
     if (doc.bbox.size.x > 0.0f) paint->wrap(TextWrap::Word);
 
     //align the text to the base line, or top within the box
-    TextMetrics metrics;
-    paint->metrics(metrics);
     auto valign = (doc.bbox.size.y > 0.0f) ? 0.0f : metrics.ascent / (metrics.ascent - metrics.descent);
     paint->align(doc.justify, valign);
 

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1035,7 +1035,8 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     TextMetrics metrics;
     paint->metrics(metrics);
     auto ascent = (doc.bbox.size.y > 0.0f) ? ((text->font && text->font->ascent > 0.0f) ? metrics.ascent - text->font->ascent * doc.size : 0.0f) : metrics.ascent;
-    paint->translate(doc.bbox.pos.x, doc.bbox.pos.y - ascent);
+    auto vpos = (doc.bbox.size.y > 0.0f && tvg::zero(doc.bbox.pos.y)) ? -metrics.ascent : doc.bbox.pos.y - ascent;
+    paint->translate(doc.bbox.pos.x, vpos);
     paint->align(doc.justify, 0.0f);
 
     //apply spacing

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1034,8 +1034,8 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     //align the text to the base line, or top within the box
     TextMetrics metrics;
     paint->metrics(metrics);
-    auto vpos = doc.bbox.pos.y - (doc.bbox.size.y > 0.0f ? 0.0f : metrics.ascent);
-    paint->translate(doc.bbox.pos.x, vpos);
+    auto ascent = (doc.bbox.size.y > 0.0f) ? ((text->font && text->font->ascent > 0.0f) ? metrics.ascent - text->font->ascent * doc.size : 0.0f) : metrics.ascent;
+    paint->translate(doc.bbox.pos.x, doc.bbox.pos.y - ascent);
     paint->align(doc.justify, 0.0f);
 
     //apply spacing


### PR DESCRIPTION
## Issues
### 1. ascent correctness
In the URL font, box text ignored the embedded ascent (the "ascent" value in the Lottie JSON) and used the font metrics' ascent instead, placing the box text incorrectly when the two values differ.

Use the Lottie ascent for box text, falling back to the face ascent when the document omits it.


<img width="1848" height="1098" alt="CleanShot 2026-06-14 at 19 50 00@2x" src="https://github.com/user-attachments/assets/4af80f89-1523-46c6-bd24-4320c5da5eec" />


Since the Lottie `ascent` value controls text position, it should not be ignored.
(_Previously ignored in URL font path, it only sees calculated ascent in TextMetrics_)

<img width="1778" height="592" alt="CleanShot 2026-06-14 at 19 55 16@2x" src="https://github.com/user-attachments/assets/dbd8e3a5-e6c3-4b3f-a04f-43ccee8f04cc" />

### 2. baseline correctness

When box position is absent, box should be translated to it's first baseline

## Tests

- ascent test : [lottie - 2026-06-14T195746.157.json](https://github.com/user-attachments/files/28926263/lottie.-.2026-06-14T195746.157.json)

| Before | After | Expectation |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-14 at 19 58 14@2x" src="https://github.com/user-attachments/assets/b689096f-ceff-407c-af13-1ec728d86347" /> | <img height="500" alt="CleanShot 2026-06-14 at 19 57 38@2x" src="https://github.com/user-attachments/assets/4464320c-b244-4c33-b73d-c29e0180a718" /> | <img height="500" alt="CleanShot 2026-06-14 at 19 58 19@2x" src="https://github.com/user-attachments/assets/f78005bd-4ecf-411b-a415-fbb6d16423dc" /> |

- baseline test : [sample.json](https://github.com/user-attachments/files/28993882/sample.json)

| Before | After | Expectation |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-16 at 17 52 55@2x" src="https://github.com/user-attachments/assets/dc5bc6ca-0fdb-4938-9fec-09bb13990e3c" /> | <img height="500" alt="CleanShot 2026-06-16 at 17 53 10@2x" src="https://github.com/user-attachments/assets/f84c1611-f920-41bf-b8d0-e7554033c839" /> | <img height="500" alt="CleanShot 2026-06-16 at 17 53 23@2x" src="https://github.com/user-attachments/assets/4f0b259d-98b2-4541-b93a-68d820e7b8ac" /> |

- combined test :  [lottie - 2026-06-16T175551.015.json](https://github.com/user-attachments/files/28994029/lottie.-.2026-06-16T175551.015.json)

| Before | After | Expectation |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-16 at 17 54 48@2x" src="https://github.com/user-attachments/assets/2d8fc021-4f96-474a-99bd-281465f31d25" /> | <img height="500" alt="CleanShot 2026-06-16 at 17 55 16@2x" src="https://github.com/user-attachments/assets/47c87133-c4e6-4008-a8a8-799f3349682e" /> | <img height="500" alt="CleanShot 2026-06-16 at 17 55 24@2x" src="https://github.com/user-attachments/assets/85210808-6e42-4565-863a-7b1c05029037" /> |


issue: https://github.com/thorvg/thorvg/issues/4334