### PR TITLE
media: add experimental video playback

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,9 @@ ttf_loader = all_loaders or get_option('loaders').contains('ttf')
 otf_loader = all_loaders or get_option('loaders').contains('otf')
 webp_loader = all_loaders or get_option('loaders').contains('webp')
 
+# experimental in the development
+media_loader = get_option('loaders').contains('media')
+
 # Savers
 all_savers = get_option('savers').contains('all')
 gif_saver = all_savers or get_option('savers').contains('gif') or lottie2gif
@@ -97,6 +100,10 @@ endif
 
 if webp_loader
     config_h.set10('THORVG_WEBP_LOADER_SUPPORT', true)
+endif
+
+if media_loader
+    config_h.set10('THORVG_MEDIA_LOADER_SUPPORT', true)
 endif
 
 if gif_saver
@@ -211,6 +218,7 @@ summary(
     'PNG': png_loader,
     'JPG': jpg_loader,
     'WEBP': webp_loader,
+    'MEDIA': media_loader,
   },
   section: 'Loader',
   bool_yn: true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,7 +11,7 @@ option('partial',
 
 option('loaders',
    type: 'array',
-   choices: ['', 'svg', 'png', 'jpg', 'lottie', 'ttf', 'otf', 'webp', 'all'],
+   choices: ['', 'svg', 'png', 'jpg', 'lottie', 'ttf', 'otf', 'webp', 'media', 'all'],
    value: ['svg', 'lottie', 'ttf'],
    description: 'Enable File Loaders in thorvg')
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -91,6 +91,13 @@ typedef struct _Tvg_Animation* Tvg_Animation;
 typedef struct _Tvg_Accessor* Tvg_Accessor;
 
 /**
+ * @brief A structure representing a video playback controller object.
+ *
+ * @note Experimental API
+ */
+typedef struct _Tvg_Video* Tvg_Video;
+
+/**
  * @brief Enumeration specifying the result from the APIs.
  *
  * All ThorVG APIs could potentially return one of the values in the list.
@@ -3321,6 +3328,187 @@ typedef void (*Tvg_Audio_Resolver)(const Tvg_Audio_Info* info, void* data);
 TVG_API Tvg_Result tvg_lottie_animation_set_audio_resolver(Tvg_Animation animation, Tvg_Audio_Resolver resolver, void* data);
 
 /** \} */   // end addtogroup ThorVGCapi_LottieAnimation
+
+/**
+ * @defgroup ThorVGCapi_Video Video
+ * @brief A module for controlling video playback.
+ *
+ * The module enables control of video playback features.
+ *
+ * @{
+ */
+
+/**
+ * @brief Creates a new video playback.
+ *
+ * @return Tvg_Video A new video object.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Video tvg_video_new(void);
+
+/**
+ * @brief Releases the given video object and its resources.
+ *
+ * @param[in] video The video object to release.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_video_del(Tvg_Video video);
+
+/**
+ * @brief Retrieves the picture instance associated with this video object.
+ *
+ * This function provides access to the internal picture used by the video object
+ * for rendering video frames. After obtaining the picture, it can be added to a canvas
+ * enabling control over video frames with this Video object.
+ *
+ * @param[in] video The video object.
+ *
+ * @return A picture instance representing the visual content of the video.
+ *
+ * @warning The picture instance is owned by the video object and should not be deleted manually.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Paint tvg_video_get_picture(Tvg_Video video);
+
+/**
+ * @brief Starts or resumes playback.
+ *
+ * @param[in] video The video object.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_video_play(Tvg_Video video);
+
+/**
+ * @brief Pauses playback while keeping the current position.
+ *
+ * @param[in] video The video object.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_video_pause(Tvg_Video video);
+
+/**
+ * @brief Stops playback and rewinds to the start.
+ *
+ * @param[in] video The video object.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_video_stop(Tvg_Video video);
+
+/**
+ * @brief Sets the playback position.
+ *
+ * @param[in] video The video object.
+ * @param[in] seconds The target playback position in seconds.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_video_seek(Tvg_Video video, float seconds);
+
+/**
+ * @brief Enables or disables repeated playback.
+ *
+ * @param[in] video The video object.
+ * @param[in] on @c true to repeat playback, @c false to play once.
+ *
+ * @see tvg_video_get_loop()
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_video_set_loop(Tvg_Video video, bool on);
+
+/**
+ * @brief Retrieves whether repeated playback is enabled.
+ *
+ * @return @c true if repeated playback is enabled, @c false otherwise.
+ *
+ * @see tvg_video_set_loop()
+ *
+ * @note Experimental API
+ */
+TVG_API bool tvg_video_get_loop(Tvg_Video video);
+
+/**
+ * @brief Sets the audio volume level.
+ *
+ * @param[in] video The video object.
+ * @param[in] volume The audio volume level in the range [0.0, 1.0].
+ *
+ * @see tvg_video_get_volume()
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_video_set_volume(Tvg_Video video, float volume);
+
+/**
+ * @brief Retrieves the current audio volume level.
+ *
+ * @param[in] video The video object.
+ *
+ * @return The current audio volume level in the range [0.0, 1.0].
+ *
+ * @see tvg_video_set_volume()
+ *
+ * @note Experimental API
+ */
+TVG_API float tvg_video_get_volume(Tvg_Video video);
+
+/**
+ * @brief Mutes or unmutes the audio without changing the volume level.
+ *
+ * @param[in] video The video object.
+ * @param[in] on @c true to mute the audio, @c false to unmute.
+ *
+ * @see tvg_video_get_muted()
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_video_set_mute(Tvg_Video video, bool on);
+
+/**
+ * @brief Retrieves whether the audio is currently muted.
+ *
+ * @param[in] video The video object.
+ *
+ * @return @c true if the audio is muted, @c false otherwise.
+ *
+ * @see tvg_video_set_mute()
+ *
+ * @note Experimental API
+ */
+TVG_API bool tvg_video_get_muted(Tvg_Video video);
+
+/**
+ * @brief Retrieves the current playback position.
+ *
+ * @param[in] video The video object.
+ *
+ * @return The current playback position in seconds.
+ *
+ * @see tvg_video_seek()
+ * @see tvg_video_get_duration()
+ *
+ * @note Experimental API
+ */
+TVG_API float tvg_video_get_time(Tvg_Video video);
+
+/**
+ * @brief Retrieves the total duration of the video.
+ *
+ * @param[in] video The video object.
+ *
+ * @return The total duration in seconds.
+ *
+ * @note Experimental API
+ */
+TVG_API float tvg_video_get_duration(Tvg_Video video);
+
+/** @} */  // end addtogroup ThorVGCapi_Video
 
 /** \} */   // end defgroup ThorVGCapi
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -27,6 +27,9 @@
 #ifdef THORVG_LOTTIE_LOADER_SUPPORT
 #include <thorvg_lottie.h>
 #endif
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+#include <thorvg_media.h>
+#endif
 
 using namespace std;
 using namespace tvg;
@@ -1328,6 +1331,140 @@ TVG_API Tvg_Result tvg_lottie_animation_set_audio_resolver(Tvg_Animation animati
 #endif
     return TVG_RESULT_NOT_SUPPORTED;
 }
+
+/************************************************************************/
+/* Video API                                                            */
+/************************************************************************/
+
+TVG_API Tvg_Video tvg_video_new()
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    return (Tvg_Video)Video::gen();
+#endif
+    return nullptr;
+}
+
+TVG_API Tvg_Result tvg_video_del(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (!video) return TVG_RESULT_INVALID_ARGUMENT;
+    delete (reinterpret_cast<Video*>(video));
+    return TVG_RESULT_SUCCESS;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+TVG_API Tvg_Paint tvg_video_get_picture(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return (Tvg_Paint) reinterpret_cast<Video*>(video)->picture();
+#endif
+    return nullptr;
+}
+
+TVG_API Tvg_Result tvg_video_play(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return (Tvg_Result) reinterpret_cast<Video*>(video)->play();
+    return TVG_RESULT_INVALID_ARGUMENT;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+TVG_API Tvg_Result tvg_video_pause(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return (Tvg_Result) reinterpret_cast<Video*>(video)->pause();
+    return TVG_RESULT_INVALID_ARGUMENT;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+TVG_API Tvg_Result tvg_video_stop(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return (Tvg_Result) reinterpret_cast<Video*>(video)->stop();
+    return TVG_RESULT_INVALID_ARGUMENT;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+TVG_API Tvg_Result tvg_video_seek(Tvg_Video video, float seconds)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return (Tvg_Result) reinterpret_cast<Video*>(video)->seek(seconds);
+    return TVG_RESULT_INVALID_ARGUMENT;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+TVG_API Tvg_Result tvg_video_set_loop(Tvg_Video video, bool on)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return (Tvg_Result) reinterpret_cast<Video*>(video)->loop(on);
+    return TVG_RESULT_INVALID_ARGUMENT;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+TVG_API bool tvg_video_get_loop(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return reinterpret_cast<Video*>(video)->loop();
+#endif
+    return false;
+}
+
+TVG_API Tvg_Result tvg_video_set_volume(Tvg_Video video, float volume)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return (Tvg_Result) reinterpret_cast<Video*>(video)->volume(volume);
+    return TVG_RESULT_INVALID_ARGUMENT;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+TVG_API float tvg_video_get_volume(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return reinterpret_cast<Video*>(video)->volume();
+#endif
+    return 0.0f;
+}
+
+TVG_API Tvg_Result tvg_video_set_mute(Tvg_Video video, bool on)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return (Tvg_Result) reinterpret_cast<Video*>(video)->mute(on);
+    return TVG_RESULT_INVALID_ARGUMENT;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+TVG_API bool tvg_video_get_muted(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return reinterpret_cast<Video*>(video)->muted();
+#endif
+    return false;
+}
+
+TVG_API float tvg_video_get_time(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return reinterpret_cast<Video*>(video)->time();
+#endif
+    return 0.0f;
+}
+
+TVG_API float tvg_video_get_duration(Tvg_Video video)
+{
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    if (video) return reinterpret_cast<Video*>(video)->duration();
+#endif
+    return 0.0f;
+}
+
 
 #ifdef __cplusplus
 }

--- a/src/common/tvgCommon.h
+++ b/src/common/tvgCommon.h
@@ -76,6 +76,7 @@ namespace tvg
         Png,
         Jpg,
         Webp,
+        Media,
         Raw,
         Gif,
         Unknown

--- a/src/loaders/media/apple/meson.build
+++ b/src/loaders/media/apple/meson.build
@@ -1,0 +1,11 @@
+add_languages('objcpp', native : false, required : true)
+
+source_file += files(
+   'tvgAvfMediaLoader.h',
+   'tvgAvfMediaLoader.mm'
+)
+
+media_dep += [dependency(
+    'appleframeworks',
+    modules : ['AVFoundation', 'CoreVideo', 'CoreMedia', 'Foundation', 'CoreFoundation']
+)]

--- a/src/loaders/media/apple/tvgAvfMediaLoader.h
+++ b/src/loaders/media/apple/tvgAvfMediaLoader.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_AVF_LOADER_H_
+#define _TVG_AVF_LOADER_H_
+
+#import <AVFoundation/AVFoundation.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+#include <dispatch/dispatch.h>
+
+#include "tvgMediaLoader.h"
+
+static constexpr uint32_t BUFFER_COUNT = 3;
+
+struct AvfMediaLoader : MediaLoader
+{
+    // AVFoundation execution and playback state
+    dispatch_queue_t queue = nullptr;
+
+    AVAsset* asset = nil;
+    AVAssetTrack* track = nil;
+    AVVideoComposition* composition = nil;
+    AVQueuePlayer* player = nil;
+    AVPlayerLooper* looper = nil;
+    id endObserver = nil;
+    dispatch_source_t timer = nullptr;
+    bool playing = false;
+    bool repeating = false;
+
+    // Decoded frame ring buffer and synchronized publication state
+    uint32_t* frames[BUFFER_COUNT] = {};
+    StrictKey key;
+
+    float latestTime = 0.0f;
+    uint32_t write = 0;
+    uint32_t latest = 0;
+    bool frameUpdated = false;
+
+    // Lifecycle
+    AvfMediaLoader();
+    ~AvfMediaLoader();
+
+    // Loader interface
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool read() override;
+    bool close() override;
+    bool sync() override;
+
+    // Playback controls
+    Result play() override;
+    Result pause() override;
+    Result stop() override;
+    Result seek(float seconds) override;
+    Result loop(bool on) override;
+    Result volume(float volume) override;
+    Result mute(bool on) override;
+};
+
+#endif  //_TVG_AVF_LOADER_H_

--- a/src/loaders/media/apple/tvgAvfMediaLoader.mm
+++ b/src/loaders/media/apple/tvgAvfMediaLoader.mm
@@ -1,0 +1,577 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#import <AVFoundation/AVFoundation.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+#include <dispatch/dispatch.h>
+#include <math.h>
+
+#include "tvgAvfMediaLoader.h"
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
+
+// CMTime ticks/sec; 600 is a multiple of standard fps (24/30/25) for exact frame times.
+// https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/AVFoundationPG/Articles/06_MediaRepresentations.html
+static constexpr int32_t TIMESCALE = 600;
+static constexpr float TIME_EPSILON = 1.0f / static_cast<float>(TIMESCALE);
+
+static dispatch_queue_t _queue = nullptr;
+static uint32_t _queueRefCnt = 0;
+static StrictKey _queueKey;
+
+static dispatch_queue_t _refQueue()
+{
+    ScopedLock lock(_queueKey);
+
+    if (!_queue) _queue = dispatch_queue_create("org.thorvg.media.avfoundation", DISPATCH_QUEUE_SERIAL);
+    ++_queueRefCnt;
+    return _queue;
+}
+
+static void _unrefQueue()
+{
+    ScopedLock lock(_queueKey);
+    if (_queueRefCnt == 0 || --_queueRefCnt > 0) return;
+
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(_queue);
+#endif
+    _queue = nullptr;
+}
+
+static float _seconds(CMTime time)
+{
+    if (!CMTIME_IS_NUMERIC(time)) return 0.0f;
+
+    auto seconds = CMTimeGetSeconds(time);
+    if (!isfinite(seconds) || seconds < 0.0) return 0.0f;
+    return static_cast<float>(seconds);
+}
+
+static NSDictionary* _pixelAttrs()
+{
+    return @{(__bridge NSString*)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA)};
+}
+
+static AVPlayerItemVideoOutput* _videoOutput(AVPlayerItem* item)
+{
+    for (AVPlayerItemOutput* output in item.outputs) {
+        if ([output isKindOfClass:[AVPlayerItemVideoOutput class]]) return (AVPlayerItemVideoOutput*)output;
+    }
+
+    auto output = [[AVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:_pixelAttrs()];
+    if (!output) return nil;
+    [item addOutput:output];
+    [output release];
+    return output;
+}
+
+static AVVideoComposition* _composition(AVAsset* asset, AVAssetTrack* track, CGSize& displaySize)
+{
+    auto transform = track.preferredTransform;
+    if (transform.a == 1.0 && transform.b == 0.0 && transform.c == 0.0 && transform.d == 1.0 && transform.tx == 0.0 && transform.ty == 0.0) return nil;
+
+    __block AVVideoComposition* composition = nil;
+    auto semaphore = dispatch_semaphore_create(0);
+
+    [AVVideoComposition videoCompositionWithPropertiesOfAsset:asset completionHandler:^(AVVideoComposition* videoComposition, TVG_UNUSED NSError* error) {
+        composition = [videoComposition retain];
+        dispatch_semaphore_signal(semaphore);
+    }];
+
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(semaphore);
+#endif
+
+    if (!composition) return nil;
+    displaySize = composition.renderSize;
+    return composition;
+}
+
+static void _resetFrame(AvfMediaLoader& loader, float seconds)
+{
+    ScopedLock lock(loader.key);
+    loader.latestTime = seconds;
+    loader.frameUpdated = false;
+}
+
+// Copy a decoded CVPixelBuffer into ThorVG-owned frame ring buffer.
+static bool _push(AvfMediaLoader& loader, CVPixelBufferRef pixelBuffer, float seconds)
+{
+    auto width = static_cast<uint32_t>(CVPixelBufferGetWidth(pixelBuffer));
+    auto height = static_cast<uint32_t>(CVPixelBufferGetHeight(pixelBuffer));
+    if (width == 0 || height == 0 || width != loader.surface.w || height != loader.surface.h) return false;
+
+    // Copy the decoded pixel buffer into the loader-owned ring buffer.
+    if (CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly) != kCVReturnSuccess) return false;
+
+    auto src = static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer));
+    auto srcStride = CVPixelBufferGetBytesPerRow(pixelBuffer);
+    auto rowBytes = width * sizeof(uint32_t);
+
+    auto ret = false;
+    if (src) {
+        auto dst = loader.frames[loader.write];
+        if (!dst) dst = loader.frames[loader.write] = tvg::malloc<uint32_t>(rowBytes * height);
+        if (srcStride == rowBytes) memcpy(dst, src, rowBytes * height);
+        else {
+            for (auto y = 0U; y < height; ++y) {
+                memcpy(reinterpret_cast<uint8_t*>(dst) + y * rowBytes, src + y * srcStride, rowBytes);
+            }
+        }
+        ScopedLock lock(loader.key);
+        loader.latestTime = seconds;
+        loader.latest = loader.write;
+        loader.write = (loader.write + 1) % BUFFER_COUNT;
+        loader.frameUpdated = true;
+        ret = true;
+    }
+
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+    return ret;
+}
+
+static void _clearItems(AvfMediaLoader& loader)
+{
+    [loader.looper disableLooping];
+    [loader.looper release];
+    loader.looper = nil;
+
+    [loader.player removeAllItems];
+}
+
+static void _stopTimer(AvfMediaLoader& loader)
+{
+    if (!loader.timer) return;
+
+    dispatch_source_cancel(loader.timer);
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(loader.timer);
+#endif
+    loader.timer = nullptr;
+}
+
+static bool _readStillFrame(AvfMediaLoader& loader, float seconds)
+{
+    // Keep the target just before the end so at least one frame remains to read.
+    auto readTime = seconds;
+    if (readTime >= loader.totalTime) readTime = loader.totalTime - TIME_EPSILON;
+
+    auto reader = [[AVAssetReader alloc] initWithAsset:loader.asset error:nil];
+    if (!reader) {
+        TVGLOG("AVF", "Failed to create asset reader.");
+        return false;
+    }
+
+    AVAssetReaderOutput* output = nil;
+    if (loader.composition) {
+        auto videoOutput = [[AVAssetReaderVideoCompositionOutput alloc] initWithVideoTracks:@[loader.track] videoSettings:_pixelAttrs()];
+        videoOutput.videoComposition = loader.composition;
+        output = videoOutput;
+    } else {
+        output = [[AVAssetReaderTrackOutput alloc] initWithTrack:loader.track outputSettings:_pixelAttrs()];
+    }
+
+    if (!output || ![reader canAddOutput:output]) {
+        [output release];
+        [reader release];
+        return false;
+    }
+
+    output.alwaysCopiesSampleData = NO;
+    [reader addOutput:output];
+    //only the first sample is read, so the range end is irrelevant
+    reader.timeRange = CMTimeRangeMake(CMTimeMakeWithSeconds(static_cast<double>(readTime), TIMESCALE), kCMTimePositiveInfinity);
+
+    auto ret = false;
+    if ([reader startReading]) {
+        if (auto sample = [output copyNextSampleBuffer]) {
+            if (auto pixelBuffer = CMSampleBufferGetImageBuffer(sample)) ret = _push(loader, pixelBuffer, seconds);
+            CFRelease(sample);
+        }
+    }
+
+    [reader cancelReading];
+    [output release];
+    [reader release];
+    return ret;
+}
+
+static void _finishPlayback(AvfMediaLoader& loader)
+{
+    [loader.player pause];
+    _stopTimer(loader);
+    loader.playing = false;
+    _resetFrame(loader, loader.totalTime);
+    _readStillFrame(loader, loader.totalTime);
+}
+
+static bool _buildQueue(AvfMediaLoader& loader, float start)
+{
+    _clearItems(loader);
+
+    auto item = [[AVPlayerItem alloc] initWithAsset:loader.asset];
+    if (!item) return false;
+    if (loader.composition) item.videoComposition = loader.composition;
+
+    auto seek = start > 0.0f;
+    auto time = CMTimeMakeWithSeconds(static_cast<double>(start), TIMESCALE);
+
+    // Keep playback looper-backed; loop state only decides whether the end observer stops.
+    loader.looper = [[AVPlayerLooper alloc] initWithPlayer:loader.player templateItem:item timeRange:kCMTimeRangeInvalid];
+    for (AVPlayerItem* loopItem in loader.looper.loopingPlayerItems) _videoOutput(loopItem);
+    if (seek) [loader.player seekToTime:time toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+
+    [item release];
+    return loader.player.currentItem != nil;
+}
+
+static void _startEndObserver(AvfMediaLoader& loader)
+{
+    if (loader.endObserver) return;
+
+    auto end = CMTimeMakeWithSeconds(static_cast<double>(loader.totalTime), TIMESCALE);
+    auto state = &loader;
+    loader.endObserver = [[loader.player addBoundaryTimeObserverForTimes:@[[NSValue valueWithCMTime:end]] queue:loader.queue usingBlock:^{
+        if (!state->player || !state->playing || state->repeating) return;
+        _finishPlayback(*state);
+    }] retain];
+}
+
+static void _tick(AvfMediaLoader& loader)
+{
+    auto item = loader.player.currentItem;
+    if (!item) return;
+
+    auto output = _videoOutput(item);
+    if (!output) return;
+
+    auto time = item.currentTime;
+    if (!CMTIME_IS_NUMERIC(time)) return;
+
+    // Poll only if AVFoundation has a decoded frame for this item's current time.
+    if (![output hasNewPixelBufferForItemTime:time]) return;
+
+    if (auto buffer = [output copyPixelBufferForItemTime:time itemTimeForDisplay:nullptr]) {
+        _push(loader, buffer, _seconds(time));
+        CVPixelBufferRelease(buffer);
+    }
+}
+
+static void _startTimer(AvfMediaLoader& loader)
+{
+    auto created = false;
+    if (!loader.timer) {
+        auto state = &loader;
+        loader.timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, loader.queue);
+        dispatch_source_set_event_handler(loader.timer, ^{
+            if (state->playing) _tick(*state);
+        });
+        created = true;
+    }
+
+    // Derive the poll interval from the track frame rate.
+    constexpr auto DefaultFps = 30.0;
+    auto track = loader.track;
+    auto fps = DefaultFps;
+    if (track.nominalFrameRate > 0.0f) {
+        fps = track.nominalFrameRate;
+    } else {
+        auto seconds = _seconds(track.minFrameDuration);
+        if (seconds > 0.0) fps = 1.0 / seconds;
+    }
+    if (!isfinite(fps) || fps <= 0.0) fps = DefaultFps;
+
+    auto interval = static_cast<uint64_t>(NSEC_PER_SEC / fps);
+    if (interval == 0) interval = 1;
+
+    dispatch_source_set_timer(loader.timer, dispatch_time(DISPATCH_TIME_NOW, 0), interval, NSEC_PER_MSEC);
+
+    if (created) dispatch_resume(loader.timer);
+}
+
+static void _close(AvfMediaLoader& loader)
+{
+    _stopTimer(loader);
+    [loader.player pause];
+    loader.playing = false;
+    _clearItems(loader);
+
+    if (loader.endObserver) {
+        [loader.player removeTimeObserver:loader.endObserver];
+        [loader.endObserver release];
+        loader.endObserver = nil;
+    }
+
+    [loader.player release];
+    [loader.composition release];
+    [loader.track release];
+    [loader.asset release];
+
+    loader.player = nil;
+    loader.composition = nil;
+    loader.track = nil;
+    loader.asset = nil;
+}
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
+
+AvfMediaLoader::AvfMediaLoader()
+{
+    queue = _refQueue();
+}
+
+AvfMediaLoader::~AvfMediaLoader()
+{
+    dispatch_sync(queue, ^{
+        _close(*this);
+    });
+
+    for (auto data : frames) {
+        tvg::free(data);
+    }
+    tvg::free(surface.data);
+    _unrefQueue();
+}
+
+bool AvfMediaLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
+{
+    if (!path) return false;
+
+    // Open the media asset and keep the first video track.
+    auto url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path]];
+    auto asset = [[AVURLAsset alloc] initWithURL:url options:nil];
+    if (!asset || !asset.playable) {
+        TVGLOG("AVF", "Failed to open media: %s", path);
+        [asset release];
+        return false;
+    }
+
+    // Use the async track loader to avoid the deprecated sync API.
+    __block AVAssetTrack* track = nil;
+    auto semaphore = dispatch_semaphore_create(0);
+
+    [asset loadTracksWithMediaType:AVMediaTypeVideo completionHandler:^(NSArray<AVAssetTrack*>* tracks, TVG_UNUSED NSError* error) {
+        track = [tracks.firstObject retain];
+        dispatch_semaphore_signal(semaphore);
+    }];
+
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(semaphore);
+#endif
+
+    if (!track) {
+        TVGLOG("AVF", "No video track found: %s", path);
+        [asset release];
+        return false;
+    }
+
+    auto duration = _seconds(asset.duration);
+    if (duration <= TIME_EPSILON) {
+        TVGLOG("AVF", "Invalid media duration: %s", path);
+        [track release];
+        [asset release];
+        return false;
+    }
+
+    this->asset = asset;
+    this->track = track;
+
+    // Publish the display video size to Picture.
+    auto displaySize = track.naturalSize;
+    composition = _composition(asset, track, displaySize);
+    w = static_cast<float>(fabs(displaySize.width));
+    h = static_cast<float>(fabs(displaySize.height));
+
+    totalTime = duration;
+    curTime = 0.0f;
+
+    return true;
+}
+
+bool AvfMediaLoader::read()
+{
+    if (!Loader::read()) return true;
+    if (!asset || !track || w == 0 || h == 0) return false;
+
+    surface.cs = ColorSpace::ARGB8888S;
+    surface.w = static_cast<uint32_t>(w);
+    surface.h = static_cast<uint32_t>(h);
+    surface.stride = surface.w;
+    surface.channelSize = sizeof(uint32_t);
+    surface.premultiplied = false;
+    surface.alphaIgnored = true;
+
+    // Prime the first frame so Picture can render immediately after load().
+    _readStillFrame(*this, 0.0f);
+    sync();
+
+    // Prepare playback; the timer starts only when play() is called.
+    player = [[AVQueuePlayer alloc] init];
+    if (!player) return false;
+
+    player.automaticallyWaitsToMinimizeStalling = NO;
+    player.volume = audioVolume;
+    player.muted = muted;
+    _startEndObserver(*this);
+    paused = true;
+
+    return _buildQueue(*this, 0.0f);
+}
+
+bool AvfMediaLoader::close()
+{
+    if (!Loader::close()) return false;
+
+    dispatch_sync(queue, ^{
+        _close(*this);
+    });
+
+    return true;
+}
+
+bool AvfMediaLoader::sync()
+{
+    ScopedLock lock(key);
+
+    curTime = latestTime;
+    if (!frameUpdated) return false;
+
+    auto frame = frames[latest];
+    if (!frame) return false;
+
+    auto size = surface.stride * surface.h * surface.channelSize;
+    if (!surface.data) surface.data = tvg::malloc<pixel_t>(size);
+    memcpy(surface.data, frame, size);
+    surface.cs = ColorSpace::ARGB8888S;   // rasterConvertCS() can update this.
+    surface.premultiplied = false;        // rasterPremultiply() can update this.
+    frameUpdated = false;
+
+    return true;
+}
+
+Result AvfMediaLoader::play()
+{
+    if (!player) return Result::InsufficientCondition;
+
+    auto restart = curTime >= totalTime;
+    paused = false;
+    dispatch_async(queue, ^{
+        if (restart) [player seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+        playing = true;
+        [player play];
+        _startTimer(*this);
+    });
+    return Result::Success;
+}
+
+Result AvfMediaLoader::pause()
+{
+    if (!player) return Result::InsufficientCondition;
+
+    paused = true;
+    dispatch_async(queue, ^{
+        playing = false;
+        [player pause];
+        _stopTimer(*this);
+    });
+    return Result::Success;
+}
+
+Result AvfMediaLoader::stop()
+{
+    if (!player) return Result::InsufficientCondition;
+
+    curTime = 0.0f;
+    paused = true;
+    dispatch_async(queue, ^{
+        [player pause];
+        _stopTimer(*this);
+        playing = false;
+        _resetFrame(*this, 0.0f);
+
+        [player seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+        _readStillFrame(*this, 0.0f);
+    });
+    return Result::Success;
+}
+
+Result AvfMediaLoader::seek(float seconds)
+{
+    if (seconds < 0.0f || (totalTime > 0.0f && seconds > totalTime)) return Result::InvalidArguments;
+    if (!player) return Result::InsufficientCondition;
+
+    curTime = seconds;
+    auto loop = looping;
+    dispatch_async(queue, ^{
+        auto end = totalTime > 0.0f && seconds >= totalTime;
+        _resetFrame(*this, seconds);
+
+        if (end) {
+            [player.currentItem cancelPendingSeeks];
+            [player seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+            if (!loop) _finishPlayback(*this);
+            else _readStillFrame(*this, seconds);
+            return;
+        }
+
+        if (!playing) _readStillFrame(*this, seconds);
+        [player.currentItem cancelPendingSeeks];
+        [player seekToTime:CMTimeMakeWithSeconds(static_cast<double>(seconds), TIMESCALE) toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+    });
+    return Result::Success;
+}
+
+Result AvfMediaLoader::loop(bool on)
+{
+    looping = on;
+    dispatch_async(queue, ^{
+        repeating = on;
+    });
+    return Result::Success;
+}
+
+Result AvfMediaLoader::volume(float volume)
+{
+    audioVolume = volume;
+    if (player) player.volume = volume;
+    return Result::Success;
+}
+
+Result AvfMediaLoader::mute(bool on)
+{
+    muted = on;
+    if (player) player.muted = on;
+    return Result::Success;
+}
+
+MediaLoader* MediaLoader::gen()
+{
+    return new AvfMediaLoader;
+}

--- a/src/loaders/media/meson.build
+++ b/src/loaders/media/meson.build
@@ -1,13 +1,18 @@
 media_inc = ['.']
 system = host_machine.system()
 
-media_dep = []
-
 source_file = [
    'tvgMediaLoader.h',
-   'tvgMediaLoader.cpp',
    'tvgVideo.cpp'
 ]
+
+media_dep = []
+if system == 'darwin' or system == 'ios'
+    subdir('apple')
+else
+    # Use the fallback factory when no platform-specific media backend is available.
+    source_file += ['tvgMediaLoader.cpp']
+endif
 
 subloader_dep += [declare_dependency(
     dependencies : media_dep,

--- a/src/loaders/media/meson.build
+++ b/src/loaders/media/meson.build
@@ -1,0 +1,19 @@
+media_inc = ['.']
+system = host_machine.system()
+
+media_dep = []
+
+source_file = [
+   'tvgMediaLoader.h',
+   'tvgMediaLoader.cpp',
+   'tvgVideo.cpp'
+]
+
+subloader_dep += [declare_dependency(
+    dependencies : media_dep,
+    include_directories : include_directories(media_inc),
+    sources : source_file
+)]
+
+install_headers('thorvg_media.h', subdir: 'thorvg-' + vmaj)
+headers += include_directories('.')

--- a/src/loaders/media/thorvg_media.h
+++ b/src/loaders/media/thorvg_media.h
@@ -1,0 +1,174 @@
+#ifndef _THORVG_MEDIA_H_
+#define _THORVG_MEDIA_H_
+
+#include "thorvg.h"
+
+namespace tvg
+{
+
+/**
+ * @class Video
+ *
+ * @brief The Video class enables control of video playback.
+ *
+ * @note Experimental API
+ */
+struct TVG_API Video final
+{
+    ~Video();
+
+    /**
+     * @brief Starts or resumes video playback.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     *
+     * @see stop()
+     * @see pause()
+     */
+    Result play() noexcept;
+
+    /**
+     * @brief Pauses video playback.
+     *
+     * @retval Result::InsufficientCondition If the video is not started playing.
+     *
+     * @see play()
+     */
+    Result pause() noexcept;
+
+    /**
+     * @brief Stops video playback.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     *
+     * @see play()
+     */
+    Result stop() noexcept;
+
+    /**
+     * @brief Specifies the current video position in seconds.
+     *
+     * @param[in] seconds The playback position in seconds. The value should be in the range from 0.0 to duration().
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     * @retval Result::InvalidArguments If @p seconds is out of range.
+     *
+     * @see Video::time()
+     * @see Video::duration()
+     */
+    Result seek(float seconds) noexcept;
+
+    /**
+     * @brief Enables or disables repeated playback.
+     *
+     * @param[in] on @c true to repeat playback, @c false otherwise.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     *
+     * @see Video::loop()
+     */
+    Result loop(bool on) noexcept;
+
+    /**
+     * @brief Retrieves whether repeated playback is enabled.
+     *
+     * @return @c true if repeated playback is enabled, @c false otherwise.
+     *
+     * @see Video::loop(bool)
+     */
+    bool loop() noexcept;
+
+    /**
+     * @brief Retrieves a picture instance associated with this video player instance.
+     *
+     * This function provides access to the picture instance that can be added to the designated canvas,
+     * enabling control over video frames with this Video instance.
+     *
+     * @return A picture instance that is tied to this video player.
+     *
+     * @warning The returned picture remains valid until the Video object is destroyed.
+     */
+    Picture* picture() const noexcept;
+
+    /**
+     * @brief Retrieves the current playback position of the video.
+     *
+     * @return The current playback position in seconds.
+     *
+     * @see Video::seek()
+     * @see Video::duration()
+     */
+    float time() const noexcept;
+
+    /**
+     * @brief Retrieves the duration of the video in seconds.
+     *
+     * @return The duration of the video in seconds.
+     */
+    float duration() const noexcept;
+
+    /**
+     * @brief Sets the audio volume level of the video.
+     *
+     * @param[in] volume The volume level in the range [0.0, 1.0],
+     *                   where 0.0 is silent and 1.0 is the original volume.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     * @retval Result::InvalidArguments If @p volume is out of range.
+     *
+     * @see Video::volume()
+     * @see Video::mute()
+     */
+    Result volume(float volume) noexcept;
+
+    /**
+     * @brief Retrieves the current audio volume level of the video.
+     *
+     * @return The current volume level in the range [0.0, 1.0].
+     *
+     * @note It returns @c 0, if the video is not loaded.
+     *
+     * @see Video::volume(float)
+     */
+    float volume() const noexcept;
+
+    /**
+     * @brief Enables or disables audio muting.
+     *
+     * When muted, the video audio is silenced without modifying the current
+     * volume level. Unmuting restores audio playback using the previously
+     * configured volume.
+     *
+     * @param[in] on @c true to mute the audio, @c false to unmute it.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     *
+     * @see Video::muted()
+     * @see Video::volume()
+     */
+    Result mute(bool on) noexcept;
+
+    /**
+     * @brief Retrieves whether the video audio is currently muted.
+     *
+     * @return @c true if the audio is muted, @c false otherwise.
+     *
+     * @note It returns @c false, if the video is not loaded.
+     *
+     * @see Video::mute()
+     */
+    bool muted() const noexcept;
+
+    /**
+     * @brief Creates a new Video object.
+     *
+     * @return A new Video object.
+     */
+    static Video* gen() noexcept;
+
+    _TVG_DECLARE_PRIVATE_BASE(Video);
+};
+
+}  // namespace tvg
+
+#endif  //_THORVG_MEDIA_H_

--- a/src/loaders/media/tvgMediaLoader.cpp
+++ b/src/loaders/media/tvgMediaLoader.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+ #include "tvgMediaLoader.h"
+
+MediaLoader* MediaLoader::gen()
+{
+    TVGLOG("MEDIA", "Couldn't find a proper Media loader.");
+    return nullptr;
+}

--- a/src/loaders/media/tvgMediaLoader.h
+++ b/src/loaders/media/tvgMediaLoader.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_MEDIA_LOADER_H_
+#define _TVG_MEDIA_LOADER_H_
+
+#include "tvgLoader.h"
+
+struct MediaLoader : ImageLoader
+{
+    float curTime = 0.0f;      // current playback position in seconds
+    float totalTime = 0.0f;    // media duration in seconds
+    float audioVolume = 1.0f;  // [0 - 1]
+    bool paused = false;
+    bool muted = false;
+    bool looping = false;
+
+    MediaLoader() : ImageLoader(FileType::Media, true) {}
+    virtual ~MediaLoader(){};
+
+    virtual Result play() = 0;                // start or resume playback
+    virtual Result pause() = 0;               // pause playback
+    virtual Result stop() = 0;                // stop playback
+    virtual Result seek(float seconds) = 0;   // set the playback position in seconds
+    virtual Result loop(bool on) = 0;         // enable or disable repeated playback
+    virtual Result volume(float volume) = 0;  // set the audio volume level
+    virtual Result mute(bool on) = 0;         // enable or disable audio muting
+
+    static MediaLoader* gen();
+};
+
+#endif  //_TVG_MEDIA_LOADER_H_

--- a/src/loaders/media/tvgVideo.cpp
+++ b/src/loaders/media/tvgVideo.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "thorvg_media.h"
+#include "tvgMediaLoader.h"
+#include "tvgPicture.h"
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
+
+#define FETCH_LOADER(RET_VAL) \
+    auto loader = tvg::to<PictureImpl>(pImpl->picture)->fetch<MediaLoader>(FileType::Media); \
+    if (!loader) return RET_VAL
+
+struct Video::Impl
+{
+    Picture* picture;
+
+    Impl()
+    {
+        picture = Picture::gen();
+        picture->ref();
+    }
+
+    ~Impl()
+    {
+        picture->unref();
+    }
+};
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
+
+Video::Video() : pImpl(new Impl)
+{
+}
+
+Video::~Video()
+{
+    delete (pImpl);
+}
+
+Result Video::play() noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->play();
+}
+
+Result Video::pause() noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->pause();
+}
+
+Result Video::stop() noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->stop();
+}
+
+Result Video::seek(float seconds) noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    if (seconds < 0.0f || seconds > loader->totalTime) return Result::InvalidArguments;
+    return loader->seek(seconds);
+}
+
+Result Video::loop(bool on) noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->loop(on);
+}
+
+bool Video::loop() noexcept
+{
+    FETCH_LOADER(false);
+    return loader->looping;
+}
+
+Picture* Video::picture() const noexcept
+{
+    return pImpl->picture;
+}
+
+float Video::time() const noexcept
+{
+    FETCH_LOADER(0.0f);
+    return loader->curTime;
+}
+
+float Video::duration() const noexcept
+{
+    FETCH_LOADER(0.0f);
+    return loader->totalTime;
+}
+
+Result Video::volume(float volume) noexcept
+{
+    if (volume < 0.0f || volume > 1.0f) return Result::InvalidArguments;
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->volume(volume);
+}
+
+float Video::volume() const noexcept
+{
+    FETCH_LOADER(0.0f);
+    return loader->audioVolume;
+}
+
+Result Video::mute(bool on) noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->mute(on);
+}
+
+bool Video::muted() const noexcept
+{
+    FETCH_LOADER(false);
+    return loader->muted;
+}
+
+Video* Video::gen() noexcept
+{
+    return new Video;
+}

--- a/src/loaders/meson.build
+++ b/src/loaders/meson.build
@@ -45,6 +45,10 @@ if webp_loader
     endif
 endif
 
+if media_loader
+    subdir('media')
+endif
+
 subdir('raw')
 
 loader_dep = declare_dependency(

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -78,6 +78,8 @@ struct Loader
     {
         if (type == FileType::Lot) return false;
         if (type == FileType::Gif) return false;
+        if (type == FileType::Media) return false;
+
         return true;
     }
 

--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -49,6 +49,10 @@
     #include "tvgLottieLoader.h"
 #endif
 
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    #include "tvgMediaLoader.h"
+#endif
+
 #include "tvgRawLoader.h"
 
 uintptr_t HASH_KEY(const char* data)
@@ -87,6 +91,9 @@ static tvg::Loader* _find(FileType type)
 #ifdef THORVG_WEBP_LOADER_SUPPORT
         case FileType::Webp: return new WebpLoader;
 #endif
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+        case FileType::Media: return MediaLoader::gen();
+#endif
         case FileType::Raw: return new RawLoader;
         default: break;
     }
@@ -100,6 +107,7 @@ static tvg::Loader* _find(FileType type)
             case FileType::Png:  return "PNG";
             case FileType::Jpg:  return "JPG";
             case FileType::Webp: return "WEBP";
+            case FileType::Media: return "MEDIA";
             case FileType::Raw:  return "RAW";
             case FileType::Gif:  return "GIF";
             default:             return "???";
@@ -121,6 +129,7 @@ static tvg::Loader* _findByPath(const char* filename, bool& invalid)
         if (!strcmp(ext, "png")) return _find(FileType::Png);
         if (!strcmp(ext, "jpg")) return _find(FileType::Jpg);
         if (!strcmp(ext, "webp")) return _find(FileType::Webp);
+        if (!strcmp(ext, "mp4")) return _find(FileType::Media);  // TODO: add common media formats        
     }
     invalid = true;  // invalid file path outside ThorVG's scope.
     return nullptr;
@@ -139,6 +148,7 @@ static FileType _convert(const char* mimeType)
     else if (!strcmp(mimeType, "png")) type = FileType::Png;
     else if (!strcmp(mimeType, "jpg") || !strcmp(mimeType, "jpeg")) type = FileType::Jpg;
     else if (!strcmp(mimeType, "webp")) type = FileType::Webp;
+    else if (!strcmp(mimeType, "mp4")) type = FileType::Media;  // TODO: add common media formats
     else if (!strcmp(mimeType, "raw")) type = FileType::Raw;
     else TVGLOG("RENDERER", "Given mimetype is unknown = \"%s\".", mimeType);
 

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -56,7 +56,8 @@ struct PictureImpl : Picture
 
     bool skip(RenderUpdateFlag flag)
     {
-        return (flag == RenderUpdateFlag::None);
+        // The media have its own playback update
+        return !loader || (flag == RenderUpdateFlag::None && loader->type != FileType::Media);
     }
 
     bool update(RenderMethod* renderer, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flag, TVG_UNUSED bool clipper)
@@ -307,7 +308,8 @@ struct PictureImpl : Picture
     RenderRegion bounds()
     {
         if (vector) return vector->pImpl->bounds();
-        return impl.renderer->region(impl.rd);
+        else if (impl.renderer) return impl.renderer->region(impl.rd);
+        return {};
     }
 
     Result load(Loader* loader)


### PR DESCRIPTION
## Main Design

Introduce the media loader path and an experimental Video API for controlling playback through a Picture instance.

Add play, pause, stop, seek, loop, volume, and mute controls, and wire the media loader into Meson options, file type detection, and loader creation for MP4 content.

To enable this feature, use its meson option:
-Dloaders="media"

<img width="3292" height="1956" alt="image" src="https://github.com/user-attachments/assets/0a7dd284-c923-4810-b44f-76f8017214d7" />

## Apple Media Playback Integration

<img width="2159" height="706" alt="image" src="https://github.com/user-attachments/assets/a5318e3b-1ee2-4f85-9663-2e7a42c3a1e4" />


Implement the AVFoundation media loader for Apple video playback.
Replace the stub Apple media loader with playback, seek, loop,
volume, and mute controls.

Run AVFoundation work on a ref-counted serial dispatch queue.
Poll decoded frames at the media frame rate and copy them into
an owned ring buffer for bitmap() consumption.

Handle preferred video transforms, natural playback finish, still
frames for paused seek, and timer cleanup while paused or closed.

Wire the Objective-C++ source and required Apple frameworks into Meson.