### PR TITLE
cpu_engine: enhance thread-safety of bounds() API

### DIFF
--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -468,7 +468,7 @@ bool shapeGenFillColors(SwShape& shape, const Fill* fill, const Matrix& transfor
 bool shapeGenStrokeFillColors(SwShape& shape, const Fill* fill, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable);
 void shapeResetFill(SwShape& shape);
 void shapeResetStrokeFill(SwShape& shape);
-bool shapeStrokeBBox(SwShape& shape, const RenderShape* rshape, Point* pt4, const Matrix& m, SwMpool* mpool);
+bool shapeStrokeBBox(const RenderShape* rshape, Point* pt4, const Matrix& m);
 void shapeDelFill(SwShape& shape);
 
 void strokeReset(SwStroke* stroke, const RenderShape* shape, const Matrix& transform, SwMpool* mpool, unsigned tid);

--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -694,7 +694,7 @@ bool SwRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
     auto task = static_cast<SwShapeTask*>(data);
     task->done();
 
-    return shapeStrokeBBox(task->shape, task->rshape, pt4, m, task->renderer->mpool);
+    return shapeStrokeBBox(task->rshape, pt4, m);
 }
 
 

--- a/src/renderer/cpu_engine/tvgSwShape.cpp
+++ b/src/renderer/cpu_engine/tvgSwShape.cpp
@@ -554,14 +554,17 @@ void shapeDelFill(SwShape& shape)
 }
 
 
-bool shapeStrokeBBox(SwShape& shape, const RenderShape* rshape, Point* pt4, const Matrix& m, SwMpool* mpool)
+bool shapeStrokeBBox(const RenderShape* rshape, Point* pt4, const Matrix& m)
 {
     if (rshape->strokeWidth() > 0.0f) {
-        auto outline = _genOutline(rshape, mpool, 0, rshape->trimpath());
+        SwMpool mpool(0);
+        SwStroke stroke{};
+
+        auto outline = _genOutline(rshape, &mpool, 0, rshape->trimpath());
         if (!outline) return false;
 
-        strokeReset(shape.stroke, rshape, m, mpool, 0);
-        strokeParseOutline(shape.stroke, *outline, mpool, 0);
+        strokeReset(&stroke, rshape, m, &mpool, 0);
+        strokeParseOutline(&stroke, *outline, &mpool, 0);
 
         auto func = [](SwStrokeBorder* border, const Matrix& m, Point& min, Point& max) {
             ARRAY_FOREACH(pts, border->pts)
@@ -576,8 +579,8 @@ bool shapeStrokeBBox(SwShape& shape, const RenderShape* rshape, Point* pt4, cons
 
         Point min = {FLT_MAX, FLT_MAX};
         Point max = {-FLT_MAX, -FLT_MAX};
-        func(shape.stroke->borders[0], m, min, max);
-        func(shape.stroke->borders[1], m, min, max);
+        func(stroke.borders[0], m, min, max);
+        func(stroke.borders[1], m, min, max);
 
         pt4[0] = min;
         pt4[1] = {max.x, min.y};


### PR DESCRIPTION
bounds() internally used a fixed slot (tid 0) of the shared pool. Calling it from multiple threads thus raced on that slot and crashed at runtime. (_working well in GPU engines_)

Isolate the pool used by bounds() per call to make it thread-safe and fix the crash.

### Reproduce

Currently, `bounds` isn't internally referenced, test in caller-side multi-threaded env to reproduce this:
```cpp
void query(int callerIdx)
{
    for (size_t i = callerIdx; i < shapes.size(); i += NUM_CALLERS) {
        float x, y, w, h;
        if (shapes[i]->bounds(&x, &y, &w, &h) == tvg::Result::Success) {
            aabb[i * 2 + 0] = {x, y};
            aabb[i * 2 + 1] = {w, h};
        } else {
            aabb[i * 2 + 1] = {0.0f, 0.0f};
        }
    }
}

// query `bounds()` concurrently (cpu -> crash, gpu -> no issue)
std::vector<std::thread> pool;
for (int t = 0; t < NUM_CALLERS; ++t) {
    pool.emplace_back(&UserExample::query, this, t);
}
for (auto& th : pool) th.join();
```

full source : [BoundingBoxThreaded.cpp](https://github.com/user-attachments/files/28947726/BoundingBoxThreaded.cpp)
