### PR TITLE
lottie/text: fix box word-wrap overhang in url font

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1035,7 +1035,7 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     paint->text(buf);
     paint->layout(doc.bbox.size.x, doc.bbox.size.y);
     paint->translate(doc.bbox.pos.x, doc.bbox.pos.y);
-    if (doc.bbox.size.x > 0.0f) paint->wrap(TextWrap::Word);
+    if (doc.bbox.size.x > 0.0f) paint->wrap(TextWrap::Smart);
 
     //align the text to the base line, or top within the box
     TextMetrics metrics;


### PR DESCRIPTION
Previously, text box wrap of url font constrained to be word-wrapped, causing long word to be overflown.

In the box text, long word should also be wrapped.


| Before | After | Expectation |
|---------|---------|---------|
| <img height="500" alt="CleanShot 2026-06-16 at 16 55 28@2x" src="https://github.com/user-attachments/assets/65036c70-5211-4798-a614-1b70490f1efd" /> | <img height="500" alt="CleanShot 2026-06-16 at 16 55 11@2x" src="https://github.com/user-attachments/assets/75601306-068e-4871-9727-03c295258a9a" /> | <img height="500" alt="image" src="https://github.com/user-attachments/assets/b7d9e2e1-36b6-4472-9b62-af92d7e3b02e" /> |
