### PR TITLE
wg: enable surface color space configuration

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -2406,7 +2406,8 @@ struct TVG_API WgCanvas final : Canvas
      * @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture.
      * @param[in] w The width of the target.
      * @param[in] h The height of the target.
-     * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it only allows @c ColorSpace::ABGR8888S as @c WGPUTextureFormat_RGBA8Unorm.
+     * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it allows @c ColorSpace::ABGR8888
+     *               and @c ColorSpace::ABGR8888S.
      * @param[in] type @c 0: surface, @c 1: texture are used as pesentable target.
      *
      * @retval Result::InsufficientCondition if the canvas is performing rendering. Please ensure the canvas is synced.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -634,7 +634,7 @@ TVG_API Tvg_Canvas tvg_wgcanvas_create(Tvg_Engine_Option op);
  * @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture.
  * @param[in] w The width of the target.
  * @param[in] h The height of the target.
- * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it only allows @c TVG_COLORSPACE_ABGR8888S as @c WGPUTextureFormat_RGBA8Unorm.
+ * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it allows @c TVG_COLORSPACE_ABGR8888 and @c TVG_COLORSPACE_ABGR8888S.
  * @param[in] type @c 0: surface, @c 1: texture are used as pesentable target.
  *
  * @retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -367,8 +367,7 @@ void WgCompositor::composeScene(WgContext& context, WgRenderTarget* src, WgRende
     drawMeshImage(context, &meshDataBlit);
 }
 
-
-void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView)
+void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView, bool unpremultiply)
 {
     assert(!renderPassEncoder);
     const WGPURenderPassDepthStencilAttachment depthStencilAttachment{
@@ -387,7 +386,7 @@ void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRender
     const WGPURenderPassDescriptor renderPassDesc{ .colorAttachmentCount = 1, .colorAttachments = &colorAttachment, .depthStencilAttachment = &depthStencilAttachment };
     renderPassEncoder = wgpuCommandEncoderBeginRenderPass(encoder, &renderPassDesc);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, src->bindGroupTexture, 0, nullptr);
-    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.blit);
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, unpremultiply ? pipelines.blit_unpremultiplied : pipelines.blit);
     drawMeshImage(context, &meshDataBlit);
     wgpuRenderPassEncoderEnd(renderPassEncoder);
     wgpuRenderPassEncoderRelease(renderPassEncoder);

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.h
@@ -132,7 +132,7 @@ public:
     void composeScene(WgContext& context, WgRenderTarget* src, WgRenderTarget* mask, WgCompose* compose);
 
     // blit render target to texture view (f.e. screen buffer)
-    void blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView);
+    void blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView, bool unpremultiply);
 
     // effects
     bool gaussianBlur(WgContext& context, WgRenderTarget* dst, const RenderEffectGaussianBlur* params, const WgCompose* compose);

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
@@ -473,9 +473,15 @@ void WgPipelines::initialize(WgContext& context)
     // render pipeline blit
     blit = createRenderPipeline(
         context.device, "The render pipeline blit",
-        shader_blit, "vs_main", "fs_main", 
+        shader_blit, "vs_main", "fs_main",
         layout_blit, vertexBufferLayoutsImage, 2,
-        WGPUColorWriteMask_All, context.format, blendStateSrc, // must be preferred screen pixel format
+        WGPUColorWriteMask_All, context.format, blendStateSrc,  // must be preferred screen pixel format
+        depthStencilStateScene, multisampleStateX1);
+    blit_unpremultiplied = createRenderPipeline(
+        context.device, "The render pipeline blit unpremultiplied",
+        shader_blit, "vs_main", "fs_main_unpremultiplied",
+        layout_blit, vertexBufferLayoutsImage, 2,
+        WGPUColorWriteMask_All, context.format, blendStateSrc,  // must be preferred screen pixel format
         depthStencilStateScene, multisampleStateX1);
 
     // effects
@@ -533,6 +539,7 @@ void WgPipelines::releaseGraphicHandles(WgContext& context)
     releaseRenderPipeline(gaussian_vert);
     releaseRenderPipeline(dropshadow);
     // pipeline blit
+    releaseRenderPipeline(blit_unpremultiplied);
     releaseRenderPipeline(blit);
     // pipelines compose
     for (uint32_t i = 0; i < 11; i++)

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.h
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.h
@@ -100,6 +100,7 @@ public:
     WGPURenderPipeline scene_compose[11]{};
     // pipeline blit
     WGPURenderPipeline blit{};
+    WGPURenderPipeline blit_unpremultiplied{};
     // effects
     WGPURenderPipeline gaussian_vert{};
     WGPURenderPipeline gaussian_horz{};

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -97,21 +97,21 @@ void WgRenderer::clearTargets()
 
 }
 
-
-bool WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height)
+bool WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height, ColorSpace cs)
 {
     this->surface = surface;
     if (width == 0 || height == 0 || !surface) return false;
+    auto straightAlpha = ((cs == ColorSpace::ABGR8888S) || (cs == ColorSpace::ARGB8888S));
 
     // setup surface configuration
-    WGPUSurfaceConfiguration surfaceConfiguration {
+    WGPUSurfaceConfiguration surfaceConfiguration{
         .device = context.device,
         .format = context.format,
         .usage = WGPUTextureUsage_RenderAttachment,
         .width = width,
         .height = height,
-    #ifdef __EMSCRIPTEN__
-        .alphaMode = WGPUCompositeAlphaMode_Premultiplied,
+        .alphaMode = straightAlpha ? WGPUCompositeAlphaMode_Unpremultiplied : WGPUCompositeAlphaMode_Premultiplied,
+#ifdef __EMSCRIPTEN__
         .presentMode = WGPUPresentMode_Fifo
     #elif defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) || (defined(_WIN32) && !defined(__CYGWIN__))
         // Use Immediate only where it is known to be supported on desktop surfaces.
@@ -124,7 +124,6 @@ bool WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint3
     wgpuSurfaceConfigure(surface, &surfaceConfiguration);
     return true;
 }
-
 
 /************************************************************************/
 /* External Class Implementation                                        */
@@ -379,8 +378,9 @@ bool WgRenderer::sync()
         (wgpuTextureGetHeight(dstTexture) == mRenderTargetRoot.height)) {
         WGPUTextureView dstTextureView = mContext.createTextureView(dstTexture);
         WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
+        auto unpremultiplyBlit = ((mTargetSurface.cs == ColorSpace::ABGR8888S) || (mTargetSurface.cs == ColorSpace::ARGB8888S));
         // show root offscreen buffer
-        mCompositor.blit(mContext, commandEncoder, &mRenderTargetRoot, dstTextureView);
+        mCompositor.blit(mContext, commandEncoder, &mRenderTargetRoot, dstTextureView, unpremultiplyBlit);
         mContext.submitCommandEncoder(commandEncoder);
         mContext.releaseCommandEncoder(commandEncoder);
         mContext.releaseTextureView(dstTextureView);
@@ -399,8 +399,11 @@ bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, 
 
     if (w == 0 || h == 0) return false;
 
+    auto contextChanged = (mContext.device != device) || (mContext.instance != instance);
+    auto targetChanged = (mTargetSurface.w != w) || (mTargetSurface.h != h) || (type == 0 ? (surface != (WGPUSurface)target) : (targetTexture != (WGPUTexture)target));
+
     // device or instance was changed, need to recreate all instances
-    if ((mContext.device != device) || (mContext.instance != instance)) {
+    if (contextChanged) {
         release();
         mContext.initialize(instance, device);
         mRenderTargetPool.initialize(mContext, w, h);
@@ -408,7 +411,7 @@ bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, 
         mCompositor.initialize(mContext, w, h);
 
     // update render targets dimensions
-    } else if ((mTargetSurface.w != w) || (mTargetSurface.h != h) || (type == 0 ? (surface != (WGPUSurface)target) : (targetTexture != (WGPUTexture)target))) {
+    } else if (targetChanged) {
         mRenderTargetPool.release(mContext);
         mRenderTargetRoot.release(mContext);
         clearTargets();
@@ -420,7 +423,7 @@ bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, 
     // configure surface (must be called after context creation)
     if (type == 0) {
         surface = (WGPUSurface)target;
-        surfaceConfigure(surface, mContext, w, h);
+        if (!surfaceConfigure(surface, mContext, w, h, cs)) return false;
     } else {
         targetTexture = (WGPUTexture)target;
     }

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -74,7 +74,7 @@ private:
     void releaseSurfaceTexture();
 
     void clearTargets();
-    bool surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height);
+    bool surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height, ColorSpace cs);
 
     // render tree stacks
     WgRenderTarget mRenderTargetRoot;

--- a/src/renderer/gpu_engine/wg/tvgWgShaderSrc.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgShaderSrc.cpp
@@ -826,6 +826,15 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     return textureSample(uTextureSrc, uSamplerSrc, in.texCoord.xy);
 };
+
+@fragment
+fn fs_main_unpremultiplied(in: VertexOutput) -> @location(0) vec4f {
+    let src = textureSample(uTextureSrc, uSamplerSrc, in.texCoord.xy);
+    if (src.a <= 0.0) {
+        return vec4f(0.0);
+    }
+    return vec4f(clamp(src.rgb / src.a, vec3f(0.0), vec3f(1.0)), src.a);
+};
 )";
 
 //************************************************************************

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -242,7 +242,7 @@ WgCanvas::~WgCanvas()
 Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type) noexcept
 {
 #ifdef THORVG_WG_ENGINE_SUPPORT
-    if (cs != ColorSpace::ABGR8888S) return Result::NonSupport;
+    if (cs != ColorSpace::ABGR8888 && cs != ColorSpace::ABGR8888S) return Result::NonSupport;
 
     if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) {
         return Result::InsufficientCondition;


### PR DESCRIPTION
## Summary

- Enable WebGPU surface configuration from the supported target `ColorSpace`.
- Support both `ColorSpace::ABGR8888` and `ColorSpace::ABGR8888S` for `WgCanvas::target()`.
- Configure surface composite alpha mode from the supported ABGR target format:
  - `ABGR8888` uses `WGPUCompositeAlphaMode_Premultiplied`.
  - `ABGR8888S` uses `WGPUCompositeAlphaMode_Unpremultiplied`.
- Add a final unpremultiply blit path for `ABGR8888S` surface targets so straight-alpha presentation works correctly on iOS WebGPU surfaces.
- Keep `WGPUPresentMode_Immediate` only on known desktop targets, currently macOS and Windows. Other platforms use `WGPUPresentMode_Undefined`, allowing the WebGPU backend to use its default FIFO behavior.
- Keep `ARGB8888` and `ARGB8888S` unsupported for WG targets. Unsupported color spaces return `NonSupport`.

## Scope

This PR does not add ARGB target support for the WG engine. ARGB color spaces remain rejected by `WgCanvas::target()` and can be handled in a separate change if WG gains that support later.

This PR also does not introduce full surface capability negotiation. The current WG canvas target API receives a device, instance, and target handle, but does not pass adapter/surface capability information through the renderer setup path.


## Testing
### ⚠️ This corrects the WebGPU color space from straight-alpha to premultiplied-alpha mode. This may introduce compatibility issues. If necessary, change the target color space from ABGR8888S to ABGR8888.⚠️
All platforms can change the color space setting from `ABGR8888S` to `ABGR8888` in order to get the original result.

The IOS can have transparency of the target surface.
<img width="590" height="1278" alt="IMG_1994" src="https://github.com/user-attachments/assets/e82aa39c-79f4-4ec1-9577-a6ecd5d9eb88" />

