### PR TITLE
common: implement custom allocator support (take 2) 

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -5,6 +5,8 @@
 #include <functional>
 #include <list>
 #include <cstdarg>
+#include <cstddef>
+#include <cstdlib>
 
 #define TVG_VERSION_MAJOR 1  // for compile-time checks
 #define TVG_VERSION_MINOR 0  // for compile-time checks
@@ -348,6 +350,20 @@ struct Matrix
     float e11, e12, e13;
     float e21, e22, e23;
     float e31, e32, e33;
+};
+
+/**
+ * @brief Heap allocator callbacks
+ *
+ * The default heap allocator points to std::malloc, std::calloc, std::realloc and std::free.
+ * Change to equivalent heap allocator functions when necessary.
+ */
+struct HeapAllocator
+{
+    void* (*alloc)(size_t) = std::malloc;
+    void* (*calloc)(size_t, size_t) = std::calloc;
+    void* (*realloc)(void*, size_t) = std::realloc;
+    void (*free)(void*) = std::free;
 };
 
 
@@ -2542,6 +2558,9 @@ struct TVG_API Initializer final
      * @param[in] threads The number of worker threads to launch.
      *                    A value of 0 indicates that only the main thread will be used.
      *
+     * @param[in] allocator The custom allocator callback struct
+     *                      Leave it default to use std::malloc/std::calloc/std::realloc/std::free
+     *
      * @return Result indicating success or failure of initialization.
      *
      * @note This function uses internal reference counting to allow multiple init() calls.
@@ -2550,7 +2569,7 @@ struct TVG_API Initializer final
      *
      * @see Initializer::term()
      */
-    static Result init(uint32_t threads = 0) noexcept;
+    static Result init(uint32_t threads = 0, const HeapAllocator &allocator = {}) noexcept;
 
     /**
      * @brief Terminates the ThorVG engine.

--- a/src/common/tvgAllocator.h
+++ b/src/common/tvgAllocator.h
@@ -25,32 +25,39 @@
 
 #include <cstdlib>
 #include <cstddef>
+#include "thorvg.h"
 
-//separate memory alloators for clean customization
+//separate memory allocators for clean customization
 namespace tvg
 {
+    extern HeapAllocator _heapAllocator;
+
     template<typename T = void>
     static inline T* malloc(size_t size)
     {
+        if (_heapAllocator.alloc) return static_cast<T*>(_heapAllocator.alloc(size));
         return static_cast<T*>(std::malloc(size));
     }
 
     template<typename T = void>
     static inline T* calloc(size_t nmem, size_t size)
     {
+        if (_heapAllocator.calloc) return static_cast<T*>(_heapAllocator.calloc(nmem, size));
         return static_cast<T*>(std::calloc(nmem, size));
     }
 
     template<typename T = void>
     static inline T* realloc(T* ptr, size_t size)
     {
+        if (_heapAllocator.realloc) return static_cast<T*>(_heapAllocator.realloc(ptr, size));
         return static_cast<T*>(std::realloc(ptr, size));
     }
 
     template<typename T = void>
     static inline void free(T* ptr)
     {
-        std::free(ptr);
+        if (_heapAllocator.free) return _heapAllocator.free(ptr);
+        return std::free(ptr);
     }
 }
 

--- a/src/renderer/tvgInitializer.cpp
+++ b/src/renderer/tvgInitializer.cpp
@@ -43,6 +43,7 @@
 
 namespace tvg {
     int engineInit = 0;
+    HeapAllocator _heapAllocator = {};
 }
 
 static uint16_t _version = 0;
@@ -80,9 +81,11 @@ static bool _buildVersionInfo(uint32_t* major, uint32_t* minor, uint32_t* micro)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-Result Initializer::init(uint32_t threads) noexcept
+Result Initializer::init(uint32_t threads, const HeapAllocator &allocator) noexcept
 {
     if (engineInit++ > 0) return Result::Success;
+
+    _heapAllocator = allocator;
 
     if (!_buildVersionInfo(nullptr, nullptr, nullptr)) return Result::Unknown;
 


### PR DESCRIPTION
Hi @hermet 

As per discussed I reworked the custom allocator implementation and resubmitted the PR. 

This change previously was tested working fine on ESP32 with PSRAM allocators (`heap_caps_malloc()` etc.).

Regards,
Jackson