### PR TITLE
renderer: support raw bitmap reloading in Picture::load()

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1612,6 +1612,7 @@ struct TVG_API Picture : Paint
      *
      * @retval Result::InvalidArguments In case no data are provided or the @p size is zero or less.
      * @retval Result::NonSupport When trying to load a file with an unknown extension.
+     * @retval Result::InsufficientCondition If a vector asset has already been loaded into the picture.
      *
      * @warning It's the user responsibility to release the @p data memory.
      *
@@ -1698,6 +1699,8 @@ struct TVG_API Picture : Paint
      * @param[in] h The height of the image in pixels.
      * @param[in] cs Specifies how the 32-bit color values should be interpreted.
      * @param[in] copy If @c true, the data is copied into the engine's local buffer. If @c false, the data is not copied.
+     *
+     * @note If the memory data pointed to by @p data is modified, calling this API will re-upload the updated content to the canvas.
      *
      * @since 0.9
      */

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -155,7 +155,7 @@ struct PictureImpl : Picture
     Result load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
     {
         if (!data || w <= 0 || h <= 0 || cs == ColorSpace::Unknown)  return Result::InvalidArguments;
-        if (vector || bitmap) return Result::InsufficientCondition;
+        if (vector) return Result::InsufficientCondition;
         return load(LoaderMgr::loader(data, w, h, cs, copy));
     }
 
@@ -306,15 +306,10 @@ struct PictureImpl : Picture
     {
         if (!loader) return Result::NonSupport;
 
-        // fonts are not expected in the picture
-        if (loader->type == FileType::Sfnt) {
-            LoaderMgr::retrieve(loader);
-            return Result::InvalidArguments;
-        }
-
         //Same resource has been loaded.
         if (this->loader == loader) {
             this->loader->sharing--;  //make it sure the reference counting.
+            if (bitmap) impl.mark(RenderUpdateFlag::Image);  // force the bitmap updated
             return Result::Success;
         } else if (this->loader) {
             LoaderMgr::retrieve(this->loader);


### PR DESCRIPTION
- Allow raw bitmap data to be reloaded unless the picture contains a vector asset.
- Mark bitmap reloads as image updates so renderer caches are refreshed.

issue: #4473