### PR TITLE
lottie/text: support character precomp (basic)

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -936,9 +936,11 @@ void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp,
     }
 
     //clip the layer viewport
-    auto clipper = precomp->statical.pooling(true);
-    clipper->transform(precomp->cache.matrix);
-    precomp->scene->clip(clipper);
+    if (precomp->w > 0.0f && precomp->h > 0.0f) {
+        auto clipper = precomp->statical.pooling(true);
+        clipper->transform(precomp->cache.matrix);
+        precomp->scene->clip(clipper);
+    }
 }
 
 
@@ -1109,6 +1111,14 @@ Shape* LottieBuilder::textShape(LottieText* text, float frameNo, const TextDocum
 }
 
 
+Scene* LottieBuilder::textPrecomp(LottieComposition* comp, float frameNo, LottieGlyph* glyph)
+{
+    auto scene = Scene::gen();
+    updateLayer(comp, scene, glyph->layer, frameNo);
+    return scene;
+}
+
+
 bool LottieBuilder::updateTextRange(LottieText* text, float frameNo, Shape* shape, const TextDocument& doc, RenderText& ctx)
 {
     if (text->ranges.empty()) return false;
@@ -1193,9 +1203,9 @@ bool LottieBuilder::updateTextRange(LottieText* text, float frameNo, Shape* shap
 }
 
 
-static void _commit(LottieGlyph* glyph, Shape* shape, const RenderText& ctx)
+static void _commit(LottieGlyph* glyph, Paint* paint, const RenderText& ctx)
 {
-    auto& matrix = shape->transform();
+    auto& matrix = paint->transform();
 
     if (ctx.follow) {
         tvg::identity(&matrix);
@@ -1210,8 +1220,8 @@ static void _commit(LottieGlyph* glyph, Shape* shape, const RenderText& ctx)
         matrix.e13 = ctx.cursor.x;
         matrix.e23 = ctx.cursor.y;
     }
-    shape->transform(matrix);
-    ctx.textScene->add(shape);
+    paint->transform(matrix);
+    ctx.textScene->add(paint);
 }
 
 static LottieGlyph* _searchGlyph(const LottieFont* font, const char* p, const TextDocument& doc, float& capScale)
@@ -1252,7 +1262,7 @@ static float _nextWordWidth(const LottieText* text, const TextDocument& doc, con
     return w;
 }
 
-void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc)
+void LottieBuilder::updateLocalFont(LottieComposition* comp, LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc)
 {
     RenderText ctx(text, doc);
     ctx.follow = (text->follow && ((uint32_t)text->follow->maskIdx < layer->masks.count)) ? text->follow : nullptr;
@@ -1326,8 +1336,13 @@ void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieTex
                 ctx.lineScene = Scene::gen();
                 ctx.lineScene->translate(ctx.cursor.x, ctx.cursor.y);
             }
-            auto shape = textShape(text, frameNo, doc, glyph, ctx);
-            if (!updateTextRange(text, frameNo, shape, doc, ctx)) _commit(glyph, shape, ctx);
+            if (glyph->layer) {
+                auto scene = textPrecomp(comp, frameNo, glyph);
+                _commit(glyph, scene, ctx);
+            } else {
+                auto shape = textShape(text, frameNo, doc, glyph, ctx);
+                if (!updateTextRange(text, frameNo, shape, doc, ctx)) _commit(glyph, shape, ctx);
+            }
             ctx.cursor.x += advance;
             ctx.p += glyph->len;
             ctx.idx += glyph->len;
@@ -1338,7 +1353,7 @@ void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieTex
     }
 }
 
-void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
+void LottieBuilder::updateText(LottieComposition* comp, LottieLayer* layer, float frameNo)
 {
     if (layer->children.empty()) return;
 
@@ -1347,7 +1362,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
     if (!doc.text) return;
 
     if (text->font && text->font->origin == LottieFont::Origin::Local && !text->font->chars.empty()) {
-        updateLocalFont(layer, frameNo, text, doc);
+        updateLocalFont(comp, layer, frameNo, text, doc);
     } else {
         updateURLFont(layer, frameNo, text, doc);
     }
@@ -1585,7 +1600,7 @@ void LottieBuilder::updateLayer(LottieComposition* comp, Scene* scene, LottieLay
             break;
         }
         case LottieLayer::Text: {
-            updateText(layer, frameNo);
+            updateText(comp, layer, frameNo);
             break;
         }
         default: {
@@ -1776,6 +1791,14 @@ void LottieBuilder::build(LottieComposition* comp)
     comp->root->scene = Scene::gen();
 
     _buildComposition(comp, comp->root);
+
+    //resolve character precomp
+    ARRAY_FOREACH(f, comp->fonts) {
+        ARRAY_FOREACH(g, (*f)->chars) {
+            auto glyph = *g;
+            if (glyph->layer && glyph->layer->rid) _buildReference(comp, glyph->layer);
+        }
+    }
 
     //viewport clip
     auto clip = Shape::gen();

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -936,9 +936,11 @@ void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp,
     }
 
     //clip the layer viewport
-    auto clipper = precomp->statical.pooling(true);
-    clipper->transform(precomp->cache.matrix);
-    precomp->scene->clip(clipper);
+    if (precomp->w > 0.0f && precomp->h > 0.0f) {
+        auto clipper = precomp->statical.pooling(true);
+        clipper->transform(precomp->cache.matrix);
+        precomp->scene->clip(clipper);
+    }
 }
 
 void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, LottieTween& tween)
@@ -1103,6 +1105,14 @@ Shape* LottieBuilder::textShape(LottieText* text, float frameNo, const TextDocum
 }
 
 
+Scene* LottieBuilder::textPrecomp(LottieComposition* comp, float frameNo, LottieGlyph* glyph)
+{
+    auto scene = Scene::gen();
+    updateLayer(comp, scene, glyph->layer, frameNo);
+    return scene;
+}
+
+
 bool LottieBuilder::updateTextRange(LottieText* text, float frameNo, Shape* shape, const TextDocument& doc, RenderText& ctx)
 {
     if (text->ranges.empty()) return false;
@@ -1187,9 +1197,9 @@ bool LottieBuilder::updateTextRange(LottieText* text, float frameNo, Shape* shap
 }
 
 
-static void _commit(LottieGlyph* glyph, Shape* shape, const RenderText& ctx)
+static void _commit(LottieGlyph* glyph, Paint* paint, const RenderText& ctx)
 {
-    auto& matrix = shape->transform();
+    auto& matrix = paint->transform();
 
     if (ctx.follow) {
         tvg::identity(&matrix);
@@ -1204,8 +1214,8 @@ static void _commit(LottieGlyph* glyph, Shape* shape, const RenderText& ctx)
         matrix.e13 = ctx.cursor.x;
         matrix.e23 = ctx.cursor.y;
     }
-    shape->transform(matrix);
-    ctx.textScene->add(shape);
+    paint->transform(matrix);
+    ctx.textScene->add(paint);
 }
 
 static LottieGlyph* _searchGlyph(const LottieFont* font, const char* p, const TextDocument& doc, float& capScale)
@@ -1246,7 +1256,7 @@ static float _nextWordWidth(const LottieText* text, const TextDocument& doc, con
     return w;
 }
 
-void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc)
+void LottieBuilder::updateLocalFont(LottieComposition* comp, LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc)
 {
     RenderText ctx(text, doc);
     ctx.follow = (text->follow && ((uint32_t)text->follow->maskIdx < layer->masks.count)) ? text->follow : nullptr;
@@ -1321,8 +1331,13 @@ void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieTex
                 ctx.lineScene = Scene::gen();
                 ctx.lineScene->translate(ctx.cursor.x, ctx.cursor.y);
             }
-            auto shape = textShape(text, frameNo, doc, glyph, ctx);
-            if (!updateTextRange(text, frameNo, shape, doc, ctx)) _commit(glyph, shape, ctx);
+            if (glyph->layer) {
+                auto scene = textPrecomp(comp, frameNo, glyph);
+                _commit(glyph, scene, ctx);
+            } else {
+                auto shape = textShape(text, frameNo, doc, glyph, ctx);
+                if (!updateTextRange(text, frameNo, shape, doc, ctx)) _commit(glyph, shape, ctx);
+            }
             ctx.cursor.x += advance;
             ctx.p += glyph->len;
             ctx.idx += glyph->len;
@@ -1333,7 +1348,7 @@ void LottieBuilder::updateLocalFont(LottieLayer* layer, float frameNo, LottieTex
     }
 }
 
-void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
+void LottieBuilder::updateText(LottieComposition* comp, LottieLayer* layer, float frameNo)
 {
     if (layer->children.empty()) return;
 
@@ -1342,7 +1357,7 @@ void LottieBuilder::updateText(LottieLayer* layer, float frameNo)
     if (!doc.text) return;
 
     if (text->font && text->font->origin == LottieFont::Origin::Local && !text->font->chars.empty()) {
-        updateLocalFont(layer, frameNo, text, doc);
+        updateLocalFont(comp, layer, frameNo, text, doc);
     } else {
         updateURLFont(layer, frameNo, text, doc);
     }
@@ -1584,7 +1599,7 @@ void LottieBuilder::updateLayer(LottieComposition* comp, Scene* scene, LottieLay
             break;
         }
         case LottieLayer::Text: {
-            updateText(layer, frameNo);
+            updateText(comp, layer, frameNo);
             break;
         }
         default: {
@@ -1766,6 +1781,14 @@ void LottieBuilder::build(LottieComposition* comp)
     comp->root->scene = Scene::gen();
 
     _buildComposition(comp, comp->root);
+
+    //resolve character precomp
+    ARRAY_FOREACH(f, comp->fonts) {
+        ARRAY_FOREACH(g, (*f)->chars) {
+            auto glyph = *g;
+            if (glyph->layer && glyph->layer->rid) _buildReference(comp, glyph->layer);
+        }
+    }
 
     //viewport clip
     auto clip = Shape::gen();

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -200,6 +200,7 @@ private:
     void appendCircle(LottieEllipse* ellipse, Shape* shape, Point& center, Point& radius, bool clockwise, RenderContext* ctx);
     bool fragmented(LottieGroup* parent, LottieObject** child, Inlist<RenderContext>& contexts, RenderContext* ctx, RenderFragment fragment);
     Shape* textShape(LottieText* text, float frameNo, const TextDocument& doc, LottieGlyph* glyph, const RenderText& ctx);
+    Scene* textPrecomp(LottieComposition* comp, float frameNo, LottieGlyph* glyph);
 
     void updateStrokeEffect(LottieLayer* layer, LottieFxStroke* effect, float frameNo);
     void updateEffect(LottieLayer* layer, float frameNo, uint8_t quality);
@@ -210,9 +211,9 @@ private:
     void updateSolid(LottieLayer* layer);
     void updateImage(LottieGroup* layer);
     void updateURLFont(LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc);
-    void updateLocalFont(LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc);
+    void updateLocalFont(LottieComposition* comp, LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc);
     bool updateTextRange(LottieText* text, float frameNo, Shape* shape, const TextDocument& doc, RenderText& ctx);
-    void updateText(LottieLayer* layer, float frameNo);
+    void updateText(LottieComposition* comp, LottieLayer* layer, float frameNo);
     void updateMasks(LottieLayer* layer, float frameNo);
     void updateTransform(LottieLayer* layer, float frameNo);
     void updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderContext>& contexts);

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -185,6 +185,7 @@ private:
     void appendCircle(LottieEllipse* ellipse, Shape* shape, Point& center, Point& radius, bool clockwise, RenderContext* ctx);
     bool fragmented(LottieGroup* parent, LottieObject** child, Inlist<RenderContext>& contexts, RenderContext* ctx, RenderFragment fragment);
     Shape* textShape(LottieText* text, float frameNo, const TextDocument& doc, LottieGlyph* glyph, const RenderText& ctx);
+    Scene* textPrecomp(LottieComposition* comp, float frameNo, LottieGlyph* glyph);
 
     void updateStrokeEffect(LottieLayer* layer, LottieFxStroke* effect, float frameNo);
     void updateEffect(LottieLayer* layer, float frameNo, uint8_t quality);
@@ -195,9 +196,9 @@ private:
     void updateSolid(LottieLayer* layer);
     void updateImage(LottieLayer* layer, float frameNo);
     void updateURLFont(LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc);
-    void updateLocalFont(LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc);
+    void updateLocalFont(LottieComposition* comp, LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc);
     bool updateTextRange(LottieText* text, float frameNo, Shape* shape, const TextDocument& doc, RenderText& ctx);
-    void updateText(LottieLayer* layer, float frameNo);
+    void updateText(LottieComposition* comp, LottieLayer* layer, float frameNo);
     void updateMasks(LottieLayer* layer, float frameNo);
     void updateTransform(LottieLayer* layer, float frameNo);
     void updateChildren(LottieGroup* parent, float frameNo, Inlist<RenderContext>& contexts);

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -575,6 +575,16 @@ LottieLayer::LottieLayer()
     effect = false;
 }
 
+LottieGlyph::~LottieGlyph()
+{
+    ARRAY_FOREACH(p, children) delete(*p);
+    delete(layer);
+    tvg::free(code);
+    tvg::free(family);
+    tvg::free(style);
+}
+
+
 LottieLayer::~LottieLayer()
 {
     //No need to free assets children because the Composition owns them.

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -629,6 +629,16 @@ LottieLayer::LottieLayer() : LottieRootLayer(LottieObject::Layer)
     matteSrc = false;
 }
 
+LottieGlyph::~LottieGlyph()
+{
+    ARRAY_FOREACH(p, children) delete(*p);
+    delete(layer);
+    tvg::free(code);
+    tvg::free(family);
+    tvg::free(style);
+}
+
+
 LottieLayer::~LottieLayer()
 {
     //No need to free assets children because the Composition owns them.

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -33,6 +33,7 @@
 
 
 struct LottieComposition;
+struct LottieLayer;
 
 struct LottieStroke
 {
@@ -300,6 +301,7 @@ struct LottieObject
 struct LottieGlyph
 {
     Array<LottieObject*> children;   //glyph shapes.
+    LottieLayer* layer = nullptr;    //character precomp
     float width;
     char* code = nullptr;
     char* family = nullptr;
@@ -313,13 +315,7 @@ struct LottieGlyph
         return len > 0;
     }
 
-    ~LottieGlyph()
-    {
-        ARRAY_FOREACH(p, children) delete(*p);
-        tvg::free(code);
-        tvg::free(family);
-        tvg::free(style);
-    }
+    ~LottieGlyph();
 };
 
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -38,6 +38,7 @@
 #endif
 
 struct LottieComposition;
+struct LottieLayer;
 
 struct LottieStroke
 {
@@ -301,6 +302,7 @@ struct LottieObject
 struct LottieGlyph
 {
     Array<LottieObject*> children;   //glyph shapes.
+    LottieLayer* layer = nullptr;    //character precomp
     float width;
     char* code = nullptr;
     char* family = nullptr;
@@ -314,13 +316,7 @@ struct LottieGlyph
         return len > 0;
     }
 
-    ~LottieGlyph()
-    {
-        ARRAY_FOREACH(p, children) delete(*p);
-        tvg::free(code);
-        tvg::free(family);
-        tvg::free(style);
-    }
+    ~LottieGlyph();
 };
 
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1216,10 +1216,17 @@ void LottieParser::parseChars(Array<LottieGlyph*>& glyphs)
             else if (KEY_AS("w")) glyph->width = getFloat();
             else if (KEY_AS("fFamily")) glyph->family = getStringCopy();
             else if (KEY_AS("data"))
-            {   //glyph shapes
-                enterObject();
-                while (auto key = nextObjectKey()) {
-                    if (KEY_AS("shapes")) parseShapes(glyph->children);
+            {
+                auto layer = parseLayer(comp->root);
+                if (layer->rid) {
+                    //character precomp
+                    layer->type = LottieLayer::Precomp;
+                    glyph->layer = layer;
+                } else {
+                    //glyph shapes
+                    layer->children.move(glyph->children);
+                    context.layer = nullptr;
+                    delete(layer);
                 }
             } else skip();
         }
@@ -1652,7 +1659,7 @@ LottieLayer* LottieParser::parseLayer(LottieLayer* precomp)
     layer->prepare(&color);
 
     layer->effect = !layer->effects.empty();
-    precomp->effect |= layer->effect;
+    if (precomp) precomp->effect |= layer->effect;
 
     return layer;
 }

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1184,10 +1184,17 @@ void LottieParser::parseChars(Array<LottieGlyph*>& glyphs)
             else if (KEY_AS("w")) glyph->width = getFloat();
             else if (KEY_AS("fFamily")) glyph->family = getStringCopy();
             else if (KEY_AS("data"))
-            {   //glyph shapes
-                enterObject();
-                while (auto key = nextObjectKey()) {
-                    if (KEY_AS("shapes")) parseShapes(glyph->children);
+            {
+                auto layer = parseLayer(comp->root);
+                if (layer->rid) {
+                    //character precomp
+                    layer->type = LottieLayer::Precomp;
+                    glyph->layer = layer;
+                } else {
+                    //glyph shapes
+                    layer->children.move(glyph->children);
+                    context.layer = nullptr;
+                    delete(layer);
                 }
             } else skip();
         }
@@ -1619,7 +1626,7 @@ LottieLayer* LottieParser::parseLayer(LottieRootLayer* precomp)
     layer->prepare(&color);
 
     layer->effect = !layer->effects.empty();
-    precomp->effect |= layer->effect;
+    if (precomp) precomp->effect |= layer->effect;
 
     return layer;
 }


### PR DESCRIPTION
Note: text range selectors are not yet applied

see: https://lottiefiles.github.io/lottie-docs/text/#character-precomp

issue: https://github.com/thorvg/thorvg/issues/4452 (Partially fixed)

| [test1.json](https://github.com/user-attachments/files/29174888/test1.1.json)  | [test4.json](https://github.com/user-attachments/files/29174891/test4.json)  |
|---------|---------|
| <img height="500" alt="CleanShot 2026-06-21 at 19 50 35" src="https://github.com/user-attachments/assets/3d9704eb-14e0-4ee5-8d4e-4b6b794a90a0" /> | <img height="500" alt="CleanShot 2026-06-21 at 19 49 23" src="https://github.com/user-attachments/assets/7b1194d6-f83a-436d-baf1-ccef0773624b" /> |