### PR TITLE
media: add experimental Apple video playback support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,7 @@ lottie_loader = all_loaders or get_option('loaders').contains('lottie') or lotti
 ttf_loader = all_loaders or get_option('loaders').contains('ttf')
 otf_loader = all_loaders or get_option('loaders').contains('otf')
 webp_loader = all_loaders or get_option('loaders').contains('webp')
+media_loader = all_loaders or get_option('loaders').contains('media')
 
 # Savers
 all_savers = get_option('savers').contains('all')
@@ -97,6 +98,10 @@ endif
 
 if webp_loader
     config_h.set10('THORVG_WEBP_LOADER_SUPPORT', true)
+endif
+
+if media_loader
+    config_h.set10('THORVG_MEDIA_LOADER_SUPPORT', true)
 endif
 
 if gif_saver
@@ -211,6 +216,7 @@ summary(
     'PNG': png_loader,
     'JPG': jpg_loader,
     'WEBP': webp_loader,
+    'MEDIA': media_loader,
   },
   section: 'Loader',
   bool_yn: true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,7 +11,7 @@ option('partial',
 
 option('loaders',
    type: 'array',
-   choices: ['', 'svg', 'png', 'jpg', 'lottie', 'ttf', 'otf', 'webp', 'all'],
+   choices: ['', 'svg', 'png', 'jpg', 'lottie', 'ttf', 'otf', 'webp', 'media', 'all'],
    value: ['svg', 'lottie', 'ttf'],
    description: 'Enable File Loaders in thorvg')
 

--- a/src/common/tvgCommon.h
+++ b/src/common/tvgCommon.h
@@ -74,14 +74,15 @@ namespace tvg
 {
     enum class FileType
     {
-        Png = 0,
-        Jpg,
-        Webp,
-        Svg,
+        Svg = 0,
         Lot,
         Sfnt,
+        Png,
+        Jpg,
+        Webp,
         Raw,
         Gif,
+        Media,
         Unknown
     };
 

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -426,7 +426,7 @@ float LottieLoader::duration()
 }
 
 
-void LottieLoader::sync()
+bool LottieLoader::sync()
 {
     done();
 
@@ -434,6 +434,7 @@ void LottieLoader::sync()
         if (comp) comp->clear();
         run(0);
     }
+    return true;
 }
 
 

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -89,7 +89,7 @@ struct LottieLoader : AnimLoader, Task
     float totalFrame() override;
     float curFrame() override;
     float duration() override;
-    void sync() override;
+    bool sync() override;
 
     //Marker Supports
     uint32_t markersCnt();

--- a/src/loaders/media/apple/meson.build
+++ b/src/loaders/media/apple/meson.build
@@ -1,0 +1,11 @@
+compiler_flags += ['-DTHORVG_APPLE_MEDIA_SUPPORT=1']
+
+source_file = [
+   'tvgAvfMediaLoader.h'
+]
+
+media_dep += [declare_dependency(
+    dependencies : dependency('appleframeworks', modules : ['AVFoundation']),
+    include_directories : include_directories('.'),
+    sources : source_file
+)]

--- a/src/loaders/media/apple/meson.build
+++ b/src/loaders/media/apple/meson.build
@@ -1,11 +1,13 @@
 compiler_flags += ['-DTHORVG_APPLE_MEDIA_SUPPORT=1']
+add_languages('objcpp', native : false, required : true)
 
 source_file = [
-   'tvgAvfMediaLoader.h'
+   'tvgAvfMediaLoader.h',
+   'tvgAvfMediaLoader.mm'
 ]
 
 media_dep += [declare_dependency(
-    dependencies : dependency('appleframeworks', modules : ['AVFoundation']),
+    dependencies : dependency('appleframeworks', modules : ['AVFoundation', 'CoreVideo', 'CoreMedia', 'Foundation', 'CoreFoundation']),
     include_directories : include_directories('.'),
     sources : source_file
 )]

--- a/src/loaders/media/apple/tvgAvfMediaLoader.h
+++ b/src/loaders/media/apple/tvgAvfMediaLoader.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_AVF_LOADER_H_
+#define _TVG_AVF_LOADER_H_
+
+#include "tvgMediaLoader.h"
+
+struct AvfMediaLoader : MediaLoader
+{
+    AvfMediaLoader() :
+        MediaLoader(FileType::Media) {}
+    ~AvfMediaLoader(){};
+
+    Result play() override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result pause() override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result stop() override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result seek(float seconds) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result loop(bool on) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result volume(float volume) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result mute(bool on) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+};
+
+#endif  //_TVG_AVF_LOADER_H_

--- a/src/loaders/media/apple/tvgAvfMediaLoader.h
+++ b/src/loaders/media/apple/tvgAvfMediaLoader.h
@@ -25,53 +25,28 @@
 
 #include "tvgMediaLoader.h"
 
+struct AvfImpl;
+
 struct AvfMediaLoader : MediaLoader
 {
-    AvfMediaLoader() :
-        MediaLoader(FileType::Media) {}
-    ~AvfMediaLoader(){};
+    AvfImpl* pImpl;
 
-    Result play() override
-    {
-        // TODO:
-        return Result::NonSupport;
-    }
+    AvfMediaLoader();
+    ~AvfMediaLoader();
 
-    Result pause() override
-    {
-        // TODO:
-        return Result::NonSupport;
-    }
+    bool open(const char* path, const LoaderOps* ops) override;
+    bool read() override;
+    bool close() override;
+    RenderSurface* bitmap() override;
+    bool sync() override;
 
-    Result stop() override
-    {
-        // TODO:
-        return Result::NonSupport;
-    }
-
-    Result seek(float seconds) override
-    {
-        // TODO:
-        return Result::NonSupport;
-    }
-
-    Result loop(bool on) override
-    {
-        // TODO:
-        return Result::NonSupport;
-    }
-
-    Result volume(float volume) override
-    {
-        // TODO:
-        return Result::NonSupport;
-    }
-
-    Result mute(bool on) override
-    {
-        // TODO:
-        return Result::NonSupport;
-    }
+    Result play() override;
+    Result pause() override;
+    Result stop() override;
+    Result seek(float seconds) override;
+    Result loop(bool on) override;
+    Result volume(float volume) override;
+    Result mute(bool on) override;
 };
 
 #endif  //_TVG_AVF_LOADER_H_

--- a/src/loaders/media/apple/tvgAvfMediaLoader.mm
+++ b/src/loaders/media/apple/tvgAvfMediaLoader.mm
@@ -1,0 +1,619 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#import <AVFoundation/AVFoundation.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+#include <dispatch/dispatch.h>
+#include <math.h>
+
+#include "tvgAvfMediaLoader.h"
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
+
+// Ring buffer depth for decoded pixels copied from CVPixelBuffer.
+static constexpr uint32_t BUFFER_COUNT = 3;
+
+struct AvfImpl
+{
+    // ThorVG loader state updated from the AVFoundation queue.
+    AvfMediaLoader* loader = nullptr;
+    dispatch_queue_t queue = nullptr;
+
+    // AVFoundation objects for metadata, playback, and looping.
+    AVAsset* asset = nil;
+    AVAssetTrack* track = nil;
+    AVVideoComposition* composition = nil;
+    AVQueuePlayer* player = nil;
+    AVPlayerLooper* looper = nil;
+    id endObserver = nil;
+
+    // Polling timer and frame availability flag.
+    dispatch_source_t timer = nullptr;
+    bool frameUpdated = false;
+
+    // Owned frame ring for decoded pixels synchronized into surface.
+    uint32_t* frames[BUFFER_COUNT] = {};
+    float latestTime = 0.0f;
+    uint32_t write = 0;
+    uint32_t latest = 0;
+
+    // Protects frame publication to sync().
+    tvg::StrictKey key;
+};
+
+// CMTime ticks/sec; 600 is a multiple of standard fps (24/30/25) for exact frame times.
+// https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/AVFoundationPG/Articles/06_MediaRepresentations.html
+static constexpr int32_t TIMESCALE = 600;
+static constexpr float TIME_EPSILON = 1.0f / static_cast<float>(TIMESCALE);
+
+static dispatch_queue_t _queue = nullptr;
+static uint32_t _queueRefCnt = 0;
+static tvg::StrictKey _queueKey;
+
+static dispatch_queue_t _refQueue()
+{
+    tvg::ScopedLock lock(_queueKey);
+
+    if (!_queue) _queue = dispatch_queue_create("org.thorvg.media.avfoundation", DISPATCH_QUEUE_SERIAL);
+    ++_queueRefCnt;
+    return _queue;
+}
+
+static void _unrefQueue()
+{
+    tvg::ScopedLock lock(_queueKey);
+    if (_queueRefCnt == 0 || --_queueRefCnt > 0) return;
+
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(_queue);
+#endif
+    _queue = nullptr;
+}
+
+static void _sync(AvfImpl* impl, dispatch_block_t block)
+{
+    dispatch_sync(impl->queue, block);
+}
+
+static float _seconds(CMTime time)
+{
+    if (!CMTIME_IS_NUMERIC(time)) return 0.0f;
+
+    auto seconds = CMTimeGetSeconds(time);
+    if (!isfinite(seconds) || seconds < 0.0) return 0.0f;
+    return static_cast<float>(seconds);
+}
+
+static NSDictionary* _pixelAttrs()
+{
+    return @{(__bridge NSString*)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA)};
+}
+
+static AVPlayerItemVideoOutput* _videoOutput(AVPlayerItem* item)
+{
+    for (AVPlayerItemOutput* output in item.outputs) {
+        if ([output isKindOfClass:[AVPlayerItemVideoOutput class]]) return static_cast<AVPlayerItemVideoOutput*>(output);
+    }
+
+    auto output = [[AVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:_pixelAttrs()];
+    if (!output) return nil;
+    [item addOutput:output];
+    [output release];
+    return output;
+}
+
+static AVVideoComposition* _composition(AVAsset* asset, AVAssetTrack* track, CGSize& displaySize)
+{
+    auto transform = track.preferredTransform;
+    if (transform.a == 1.0 && transform.b == 0.0 && transform.c == 0.0 && transform.d == 1.0 && transform.tx == 0.0 && transform.ty == 0.0) return nil;
+
+    __block AVVideoComposition* composition = nil;
+    auto semaphore = dispatch_semaphore_create(0);
+
+    [AVVideoComposition videoCompositionWithPropertiesOfAsset:asset completionHandler:^(AVVideoComposition* videoComposition, TVG_UNUSED NSError* error) {
+        composition = [videoComposition retain];
+        dispatch_semaphore_signal(semaphore);
+    }];
+
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(semaphore);
+#endif
+
+    if (!composition) return nil;
+    displaySize = composition.renderSize;
+    return composition;
+}
+
+// Copy a decoded CVPixelBuffer into ThorVG-owned frame ring buffer.
+static bool _push(AvfImpl* impl, CVPixelBufferRef pixelBuffer, float seconds)
+{
+    auto width = static_cast<uint32_t>(CVPixelBufferGetWidth(pixelBuffer));
+    auto height = static_cast<uint32_t>(CVPixelBufferGetHeight(pixelBuffer));
+    if (width == 0 || height == 0 || width != impl->loader->surface.w || height != impl->loader->surface.h) return false;
+
+    // Copy the decoded pixel buffer into the loader-owned ring buffer.
+    if (CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly) != kCVReturnSuccess) return false;
+
+    auto src = static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer));
+    auto srcStride = CVPixelBufferGetBytesPerRow(pixelBuffer);
+    auto rowBytes = width * sizeof(uint32_t);
+
+    auto ret = false;
+    if (src) {
+        auto dst = impl->frames[impl->write];
+        if (!dst) dst = impl->frames[impl->write] = tvg::malloc<uint32_t>(rowBytes * height);
+
+        if (dst) {
+            if (srcStride == rowBytes) memcpy(dst, src, rowBytes * height);
+            else {
+                for (auto y = 0U; y < height; ++y) {
+                    memcpy(reinterpret_cast<uint8_t*>(dst) + y * rowBytes, src + y * srcStride, rowBytes);
+                }
+            }
+
+            tvg::ScopedLock lock(impl->key);
+            impl->latestTime = seconds;
+            impl->latest = impl->write;
+            impl->write = (impl->write + 1) % BUFFER_COUNT;
+            impl->frameUpdated = true;
+            ret = true;
+        }
+    }
+
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+    return ret;
+}
+
+static void _clearItems(AvfImpl* impl)
+{
+    [impl->looper disableLooping];
+    [impl->looper release];
+    impl->looper = nil;
+
+    [impl->player removeAllItems];
+}
+
+static void _stopTimer(AvfImpl* impl)
+{
+    if (!impl->timer) return;
+
+    dispatch_source_cancel(impl->timer);
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(impl->timer);
+#endif
+    impl->timer = nullptr;
+}
+
+static bool _readStillFrame(AvfImpl* impl, float seconds)
+{
+    // Keep the target just before the end so at least one frame remains to read.
+    auto readTime = seconds;
+    if (readTime >= impl->loader->totalTime) readTime = impl->loader->totalTime - TIME_EPSILON;
+
+    auto reader = [[AVAssetReader alloc] initWithAsset:impl->asset error:nil];
+    if (!reader) {
+        TVGLOG("AVF", "Failed to create asset reader.");
+        return false;
+    }
+
+    AVAssetReaderOutput* output = nil;
+    if (impl->composition) {
+        auto videoOutput = [[AVAssetReaderVideoCompositionOutput alloc] initWithVideoTracks:@[impl->track] videoSettings:_pixelAttrs()];
+        videoOutput.videoComposition = impl->composition;
+        output = videoOutput;
+    } else {
+        output = [[AVAssetReaderTrackOutput alloc] initWithTrack:impl->track outputSettings:_pixelAttrs()];
+    }
+
+    if (!output || ![reader canAddOutput:output]) {
+        [output release];
+        [reader release];
+        return false;
+    }
+
+    output.alwaysCopiesSampleData = NO;
+    [reader addOutput:output];
+    //only the first sample is read, so the range end is irrelevant
+    reader.timeRange = CMTimeRangeMake(CMTimeMakeWithSeconds(static_cast<double>(readTime), TIMESCALE), kCMTimePositiveInfinity);
+
+    auto ret = false;
+    if ([reader startReading]) {
+        if (auto sample = [output copyNextSampleBuffer]) {
+            if (auto pixelBuffer = CMSampleBufferGetImageBuffer(sample)) ret = _push(impl, pixelBuffer, seconds);
+            CFRelease(sample);
+        }
+    }
+
+    [reader cancelReading];
+    [output release];
+    [reader release];
+    return ret;
+}
+
+static void _finishPlayback(AvfImpl* impl)
+{
+    [impl->player pause];
+    _stopTimer(impl);
+    impl->loader->paused = true;
+    if (!_readStillFrame(impl, impl->loader->totalTime)) {
+        tvg::ScopedLock lock(impl->key);
+        impl->latestTime = impl->loader->totalTime;
+    }
+}
+
+static bool _buildQueue(AvfImpl* impl, float start)
+{
+    _clearItems(impl);
+
+    auto item = [[AVPlayerItem alloc] initWithAsset:impl->asset];
+    if (!item) return false;
+    if (impl->composition) item.videoComposition = impl->composition;
+
+    auto seek = start > 0.0f;
+    auto time = CMTimeMakeWithSeconds(static_cast<double>(start), TIMESCALE);
+
+    // Keep playback looper-backed; loop state only decides whether the end observer stops.
+    impl->looper = [[AVPlayerLooper alloc] initWithPlayer:impl->player templateItem:item timeRange:kCMTimeRangeInvalid];
+    for (AVPlayerItem* loopItem in impl->looper.loopingPlayerItems) _videoOutput(loopItem);
+    if (seek) [impl->player seekToTime:time toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+
+    [item release];
+    return impl->player.currentItem != nil;
+}
+
+static void _startEndObserver(AvfImpl* impl)
+{
+    if (impl->endObserver) return;
+
+    auto end = CMTimeMakeWithSeconds(static_cast<double>(impl->loader->totalTime), TIMESCALE);
+    impl->endObserver = [[impl->player addBoundaryTimeObserverForTimes:@[[NSValue valueWithCMTime:end]] queue:impl->queue usingBlock:^{
+        if (!impl->player || impl->loader->paused || impl->loader->looping) return;
+        _finishPlayback(impl);
+    }] retain];
+}
+
+static void _tick(AvfImpl* impl)
+{
+    if (impl->loader->paused) return;
+
+    auto item = impl->player.currentItem;
+    if (!item) {
+        if (!impl->loader->looping) _finishPlayback(impl);
+        return;
+    }
+
+    auto output = _videoOutput(item);
+    if (!output) return;
+
+    auto time = item.currentTime;
+    if (!CMTIME_IS_NUMERIC(time)) return;
+
+    // Poll only if AVFoundation has a decoded frame for this item's current time.
+    if (![output hasNewPixelBufferForItemTime:time]) return;
+
+    if (auto buffer = [output copyPixelBufferForItemTime:time itemTimeForDisplay:nullptr]) {
+        _push(impl, buffer, _seconds(time));
+        CVPixelBufferRelease(buffer);
+    }
+}
+
+static void _startTimer(AvfImpl* impl)
+{
+    auto created = false;
+    if (!impl->timer) {
+        impl->timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, impl->queue);
+        dispatch_source_set_event_handler(impl->timer, ^{ _tick(impl); });
+        created = true;
+    }
+
+    // Derive the poll interval from the track frame rate.
+    constexpr auto DefaultFps = 30.0;
+    auto track = impl->track;
+    auto fps = DefaultFps;
+    if (track.nominalFrameRate > 0.0f) {
+        fps = track.nominalFrameRate;
+    } else {
+        auto seconds = _seconds(track.minFrameDuration);
+        if (seconds > 0.0) fps = 1.0 / seconds;
+    }
+    if (!isfinite(fps) || fps <= 0.0) fps = DefaultFps;
+
+    auto interval = static_cast<uint64_t>(NSEC_PER_SEC / fps);
+    if (interval == 0) interval = 1;
+
+    dispatch_source_set_timer(impl->timer, dispatch_time(DISPATCH_TIME_NOW, 0), interval, NSEC_PER_MSEC);
+
+    if (created) dispatch_resume(impl->timer);
+}
+
+static void _close(AvfImpl* impl)
+{
+    _stopTimer(impl);
+    [impl->player pause];
+    _clearItems(impl);
+
+    if (impl->endObserver) {
+        [impl->player removeTimeObserver:impl->endObserver];
+        [impl->endObserver release];
+        impl->endObserver = nil;
+    }
+
+    [impl->player release];
+    [impl->composition release];
+    [impl->track release];
+    [impl->asset release];
+
+    impl->player = nil;
+    impl->composition = nil;
+    impl->track = nil;
+    impl->asset = nil;
+}
+
+// Run a playback command on the avf queue: succeeds only when a player exists.
+static Result _run(AvfImpl* impl, Result (^block)())
+{
+    __block auto ret = Result::InsufficientCondition;
+
+    _sync(impl, ^{
+        if (!impl->player) return;
+        ret = block();
+    });
+
+    return ret;
+}
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
+
+AvfMediaLoader::AvfMediaLoader() :
+    MediaLoader(FileType::Media),
+    pImpl(new AvfImpl)
+{
+    pImpl->queue = _refQueue();
+    pImpl->loader = this;
+}
+
+AvfMediaLoader::~AvfMediaLoader()
+{
+    _sync(pImpl, ^{
+        _close(pImpl);
+    });
+
+    for (auto data : pImpl->frames) tvg::free(data);
+    tvg::free(surface.data);
+    _unrefQueue();
+    delete pImpl;
+}
+
+bool AvfMediaLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
+{
+    if (!path) return false;
+
+    // Open the media asset and keep the first video track.
+    auto url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path]];
+    auto asset = [[AVURLAsset alloc] initWithURL:url options:nil];
+    if (!asset || !asset.playable) {
+        TVGLOG("AVF", "Failed to open media: %s", path);
+        [asset release];
+        return false;
+    }
+
+    // Use the async track loader to avoid the deprecated sync API.
+    __block AVAssetTrack* track = nil;
+    auto semaphore = dispatch_semaphore_create(0);
+
+    [asset loadTracksWithMediaType:AVMediaTypeVideo completionHandler:^(NSArray<AVAssetTrack*>* tracks, TVG_UNUSED NSError* error) {
+        track = [tracks.firstObject retain];
+        dispatch_semaphore_signal(semaphore);
+    }];
+
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(semaphore);
+#endif
+
+    if (!track) {
+        TVGLOG("AVF", "No video track found: %s", path);
+        [asset release];
+        return false;
+    }
+
+    auto duration = _seconds(asset.duration);
+    if (duration <= TIME_EPSILON) {
+        TVGLOG("AVF", "Invalid media duration: %s", path);
+        [track release];
+        [asset release];
+        return false;
+    }
+
+    pImpl->asset = asset;
+    pImpl->track = track;
+
+    // Publish the display video size to Picture.
+    auto displaySize = track.naturalSize;
+    pImpl->composition = _composition(asset, track, displaySize);
+    w = static_cast<float>(fabs(displaySize.width));
+    h = static_cast<float>(fabs(displaySize.height));
+
+    totalTime = duration;
+    curTime = 0.0f;
+
+    return true;
+}
+
+bool AvfMediaLoader::read()
+{
+    if (!Loader::read()) return true;
+    if (!pImpl->asset || !pImpl->track || w == 0 || h == 0) return false;
+
+    surface.cs = ColorSpace::ARGB8888S;
+    surface.w = static_cast<uint32_t>(w);
+    surface.h = static_cast<uint32_t>(h);
+    surface.stride = surface.w;
+    surface.channelSize = sizeof(uint32_t);
+    surface.premultiplied = false;
+    surface.alphaIgnored = true;
+
+    // Prime the first frame so Picture can render immediately after load().
+    _readStillFrame(pImpl, 0.0f);
+    sync();
+
+    // Prepare playback; the timer starts only when play() is called.
+    pImpl->player = [[AVQueuePlayer alloc] init];
+    if (!pImpl->player) return false;
+
+    pImpl->player.automaticallyWaitsToMinimizeStalling = NO;
+    pImpl->player.volume = audioVolume;
+    pImpl->player.muted = muted;
+    _startEndObserver(pImpl);
+    paused = true;
+
+    return _buildQueue(pImpl, 0.0f);
+}
+
+bool AvfMediaLoader::close()
+{
+    if (!Loader::close()) return false;
+
+    _sync(pImpl, ^{
+        _close(pImpl);
+    });
+
+    return true;
+}
+
+RenderSurface* AvfMediaLoader::bitmap()
+{
+    return ImageLoader::bitmap();
+}
+
+bool AvfMediaLoader::sync()
+{
+    tvg::ScopedLock lock(pImpl->key);
+
+    curTime = pImpl->latestTime;
+    if (!pImpl->frameUpdated) return sharing > 0;
+
+    auto frame = pImpl->frames[pImpl->latest];
+    if (!frame) return false;
+
+    auto size = surface.stride * surface.h * surface.channelSize;
+    if (!surface.data) surface.data = tvg::malloc<pixel_t>(size);
+    if (!surface.data) return false;
+
+    memcpy(surface.data, frame, size);
+    surface.cs = ColorSpace::ARGB8888S;   // rasterConvertCS() can update this.
+    surface.premultiplied = false;        // rasterPremultiply() can update this.
+    pImpl->frameUpdated = false;
+
+    return true;
+}
+
+Result AvfMediaLoader::play()
+{
+    return _run(pImpl, ^{
+        paused = false;
+        [pImpl->player play];
+        _startTimer(pImpl);
+        return Result::Success;
+    });
+}
+
+Result AvfMediaLoader::pause()
+{
+    return _run(pImpl, ^{
+        paused = true;
+        [pImpl->player pause];
+        _stopTimer(pImpl);
+        return Result::Success;
+    });
+}
+
+Result AvfMediaLoader::stop()
+{
+    return _run(pImpl, ^{
+        [pImpl->player pause];
+        _stopTimer(pImpl);
+        paused = true;
+        curTime = 0.0f;
+
+        [pImpl->player seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+        _readStillFrame(pImpl, 0.0f);
+        return Result::Success;
+    });
+}
+
+Result AvfMediaLoader::seek(float seconds)
+{
+    if (seconds < 0.0f || (totalTime > 0.0f && seconds > totalTime)) return Result::InvalidArguments;
+
+    return _run(pImpl, ^{
+        auto end = totalTime > 0.0f && seconds >= totalTime;
+
+        if (end) {
+            [pImpl->player.currentItem cancelPendingSeeks];
+            [pImpl->player seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+            curTime = seconds;
+            if (!looping) _finishPlayback(pImpl);
+            else _readStillFrame(pImpl, seconds);
+            return Result::Success;
+        }
+
+        if (paused) _readStillFrame(pImpl, seconds);
+        [pImpl->player.currentItem cancelPendingSeeks];
+        [pImpl->player seekToTime:CMTimeMakeWithSeconds(static_cast<double>(seconds), TIMESCALE) toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+
+        curTime = seconds;
+        return Result::Success;
+    });
+}
+
+Result AvfMediaLoader::loop(bool on)
+{
+    return _run(pImpl, ^{
+        looping = on;
+        return Result::Success;
+    });
+}
+
+Result AvfMediaLoader::volume(float volume)
+{
+    return _run(pImpl, ^{
+        audioVolume = volume;
+        pImpl->player.volume = volume;
+        return Result::Success;
+    });
+}
+
+Result AvfMediaLoader::mute(bool on)
+{
+    return _run(pImpl, ^{
+        muted = on;
+        pImpl->player.muted = on;
+        return Result::Success;
+    });
+}

--- a/src/loaders/media/linux/meson.build
+++ b/src/loaders/media/linux/meson.build
@@ -1,0 +1,15 @@
+gst_dep = dependency('gstreamer-1.0', required: false)
+
+if gst_dep.found()
+    compiler_flags += ['-DTHORVG_LINUX_MEDIA_SUPPORT=1']
+
+    source_file = [
+        'tvgGstMediaLoader.h'
+    ]
+
+    media_dep += [declare_dependency(
+        dependencies : gst_dep,
+        include_directories : include_directories('.'),
+        sources : source_file
+    )]
+endif

--- a/src/loaders/media/linux/tvgGstMediaLoader.h
+++ b/src/loaders/media/linux/tvgGstMediaLoader.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_GST_LOADER_H_
+#define _TVG_GST_LOADER_H_
+
+#include "tvgMediaLoader.h"
+
+struct GstMediaLoader : MediaLoader
+{
+    GstMediaLoader() :
+        MediaLoader(FileType::Media) {}
+    ~GstMediaLoader(){};
+
+    Result play() override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result pause() override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result stop() override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result seek(float seconds) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result loop(bool on) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result volume(float volume) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result mute(bool on) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+};
+
+#endif  //_TVG_GST_LOADER_H_

--- a/src/loaders/media/meson.build
+++ b/src/loaders/media/meson.build
@@ -1,0 +1,26 @@
+media_inc = ['.']
+system = host_machine.system()
+
+media_dep = []
+if system == 'linux'
+    subdir('linux')
+elif system == 'darwin' or system == 'ios'
+    subdir('apple')
+elif system == 'emscripten'
+    subdir('web')
+endif
+
+source_file = [
+   'tvgMediaLoader.h',
+   'tvgMediaLoader.cpp',
+   'tvgVideo.cpp'
+]
+
+subloader_dep += [declare_dependency(
+    dependencies : media_dep,
+    include_directories : include_directories(media_inc),
+    sources : source_file
+)]
+
+install_headers('thorvg_media.h', subdir: 'thorvg-' + vmaj)
+headers += include_directories('.')

--- a/src/loaders/media/thorvg_media.h
+++ b/src/loaders/media/thorvg_media.h
@@ -1,0 +1,165 @@
+#ifndef _THORVG_MEDIA_H_
+#define _THORVG_MEDIA_H_
+
+#include "thorvg.h"
+
+namespace tvg
+{
+
+/**
+ * @class Video
+ *
+ * @brief The Video class enables control of video playback.
+ *
+ * @note Experimental API
+ */
+struct TVG_API Video final
+{
+    ~Video();
+
+    /**
+     * @brief Starts or resumes video playback.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     *
+     * @see stop()
+     * @see pause()
+     */
+    Result play() noexcept;
+
+    /**
+     * @brief Pauses video playback.
+     *
+     * @retval Result::InsufficientCondition If the video is not started playing.
+     *
+     * @see play()
+     */
+    Result pause() noexcept;
+
+    /**
+     * @brief Stops video playback.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     *
+     * @see play()
+     */
+    Result stop() noexcept;
+
+    /**
+     * @brief Specifies the current video position in seconds.
+     *
+     * @param[in] seconds The playback position in seconds. The value should be in the range from 0.0 to duration().
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     * @retval Result::InvalidArguments If @p seconds is out of range.
+     *
+     * @see Video::time()
+     * @see Video::duration()
+     */
+    Result seek(float seconds) noexcept;
+
+    /**
+     * @brief Enables or disables repeated playback.
+     *
+     * @param[in] on @c true to repeat playback, @c false otherwise.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     *
+     * @see Video::loop()
+     */
+    Result loop(bool on) noexcept;
+
+    /**
+     * @brief Retrieves a picture instance associated with this video player instance.
+     *
+     * This function provides access to the picture instance that can be added to the designated canvas,
+     * enabling control over video frames with this Video instance.
+     *
+     * @return A picture instance that is tied to this video player.
+     *
+     * @warning The returned picture remains valid until the Video object is destroyed.
+     */
+    Picture* picture() const noexcept;
+
+    /**
+     * @brief Retrieves the current playback position of the video.
+     *
+     * @return The current playback position in seconds.
+     *
+     * @see Video::seek()
+     * @see Video::duration()
+     */
+    float time() const noexcept;
+
+    /**
+     * @brief Retrieves the duration of the video in seconds.
+     *
+     * @return The duration of the video in seconds.
+     */
+    float duration() const noexcept;
+
+    /**
+     * @brief Sets the audio volume level of the video.
+     *
+     * @param[in] volume The volume level in the range [0.0, 1.0],
+     *                   where 0.0 is silent and 1.0 is the original volume.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     * @retval Result::InvalidArguments If @p volume is out of range.
+     *
+     * @see Video::volume()
+     * @see Video::mute()
+     */
+    Result volume(float volume) noexcept;
+
+    /**
+     * @brief Retrieves the current audio volume level of the video.
+     *
+     * @return The current volume level in the range [0.0, 1.0].
+     *
+     * @note It returns @c 0, if the video is not loaded.
+     *
+     * @see Video::volume(float)
+     */
+    float volume() const noexcept;
+
+    /**
+     * @brief Enables or disables audio muting.
+     *
+     * When muted, the video audio is silenced without modifying the current
+     * volume level. Unmuting restores audio playback using the previously
+     * configured volume.
+     *
+     * @param[in] on @c true to mute the audio, @c false to unmute it.
+     *
+     * @retval Result::InsufficientCondition If the video is not loaded.
+     *
+     * @see Video::muted()
+     * @see Video::volume()
+     */
+    Result mute(bool on) noexcept;
+
+    /**
+     * @brief Retrieves whether the video audio is currently muted.
+     *
+     * @return @c true if the audio is muted, @c false otherwise.
+     *
+     * @note It returns @c false, if the video is not loaded.
+     *
+     * @see Video::mute()
+     */
+    bool muted() const noexcept;
+
+    /**
+     * @brief Creates a new Video object.
+     *
+     * @return A new Video object.
+     */
+    static Video* gen() noexcept;
+
+    _TVG_DECLARE_PRIVATE_BASE(Video);
+};
+
+}  // namespace tvg
+
+#endif  //_THORVG_MEDIA_H_

--- a/src/loaders/media/tvgMediaLoader.cpp
+++ b/src/loaders/media/tvgMediaLoader.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+ #include "tvgMediaLoader.h"
+
+ #if defined(THORVG_APPLE_MEDIA_SUPPORT)
+    #include "tvgAvfMediaLoader.h"
+
+    MediaLoader* MediaLoader::gen()
+    {
+        return new AvfMediaLoader;
+    }
+#elif defined(THORVG_LINUX_MEDIA_SUPPORT)
+    #include "tvgGstMediaLoader.h"
+
+    MediaLoader* MediaLoader::gen()
+    {
+        return new GstMediaLoader;
+    }
+#elif defined(THORVG_WEB_MEDIA_SUPPORT)
+    #include "tvgWebMediaLoader.h"
+
+    MediaLoader* MediaLoader::gen()
+    {
+        return new WebMediaLoader;
+    }
+#else
+    MediaLoader* MediaLoader::gen()
+    {
+        TVGLOG("MEDIA", "Couldn't find a proper Media loader.");
+        return nullptr;
+    }
+#endif

--- a/src/loaders/media/tvgMediaLoader.h
+++ b/src/loaders/media/tvgMediaLoader.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_MEDIA_LOADER_H_
+#define _TVG_MEDIA_LOADER_H_
+
+#include "tvgLoader.h"
+
+struct MediaLoader : ImageLoader
+{
+    float curTime = 0.0f;      // current playback position in seconds
+    float totalTime = 0.0f;    // media duration in seconds
+    float audioVolume = 0.0f;  // [0 - 1]
+    bool paused = false;
+    bool muted = false;
+    bool looping = false;
+
+    MediaLoader(FileType type) :
+        ImageLoader(type, true) {}
+    virtual ~MediaLoader(){};
+
+    virtual Result play() = 0;                // start or resume playback
+    virtual Result pause() = 0;               // pause playback
+    virtual Result stop() = 0;                // stop playback
+    virtual Result seek(float seconds) = 0;   // set the playback position in seconds
+    virtual Result loop(bool on) = 0;         // enable or disable repeated playback
+    virtual Result volume(float volume) = 0;  // set the audio volume level
+    virtual Result mute(bool on) = 0;         // enable or disable audio muting
+
+    static MediaLoader* gen();
+};
+
+#endif  //_TVG_MEDIA_LOADER_H_

--- a/src/loaders/media/tvgVideo.cpp
+++ b/src/loaders/media/tvgVideo.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "thorvg_media.h"
+#include "tvgMediaLoader.h"
+#include "tvgPicture.h"
+
+/************************************************************************/
+/* Internal Class Implementation                                        */
+/************************************************************************/
+
+#define FETCH_LOADER(RET_VAL)                                                              \
+    auto loader = static_cast<MediaLoader*>(tvg::to<PictureImpl>(pImpl->picture)->loader); \
+    if (!loader) return RET_VAL
+
+struct Video::Impl
+{
+    Picture* picture;
+
+    Impl()
+    {
+        picture = Picture::gen();
+        picture->ref();
+    }
+
+    ~Impl()
+    {
+        picture->unref();
+    }
+};
+
+/************************************************************************/
+/* External Class Implementation                                        */
+/************************************************************************/
+
+Video::Video() :
+    pImpl(new Impl)
+{
+}
+
+Video::~Video()
+{
+    delete (pImpl);
+}
+
+Result Video::play() noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->play();
+}
+
+Result Video::pause() noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->pause();
+}
+
+Result Video::stop() noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->stop();
+}
+
+Result Video::seek(float seconds) noexcept
+{
+    if (seconds < 0.0f) return Result::InvalidArguments;
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->seek(seconds);
+}
+
+Result Video::loop(bool on) noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->loop(on);
+}
+
+Picture* Video::picture() const noexcept
+{
+    return pImpl->picture;
+}
+
+float Video::time() const noexcept
+{
+    FETCH_LOADER(0.0f);
+    return loader->curTime;
+}
+
+float Video::duration() const noexcept
+{
+    FETCH_LOADER(0.0f);
+    return loader->totalTime;
+}
+
+Result Video::volume(float volume) noexcept
+{
+    if (volume < 0.0f || volume > 1.0f) return Result::InvalidArguments;
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->volume(volume);
+}
+
+float Video::volume() const noexcept
+{
+    FETCH_LOADER(0.0f);
+    return loader->audioVolume;
+}
+
+Result Video::mute(bool on) noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    return loader->mute(on);
+}
+
+bool Video::muted() const noexcept
+{
+    FETCH_LOADER(false);
+    return loader->muted;
+}
+
+Video* Video::gen() noexcept
+{
+    return new Video;
+}

--- a/src/loaders/media/web/meson.build
+++ b/src/loaders/media/web/meson.build
@@ -1,0 +1,10 @@
+compiler_flags += ['-DTHORVG_WEB_MEDIA_SUPPORT=1']
+
+source_file = [
+   'tvgWebMediaLoader.h'
+]
+
+media_dep += [declare_dependency(
+    include_directories : include_directories('.'),
+    sources : source_file
+)]

--- a/src/loaders/media/web/tvgWebMediaLoader.h
+++ b/src/loaders/media/web/tvgWebMediaLoader.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WEB_LOADER_H_
+#define _TVG_WEB_LOADER_H_
+
+#include "tvgMediaLoader.h"
+
+// TODO: WebMediaLoader is a delegator for web binding support.
+
+struct WebMediaLoader : MediaLoader
+{
+    WebMediaLoader() :
+        MediaLoader(FileType::Media) {}
+    ~WebMediaLoader(){};
+
+    Result play() override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result pause() override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result stop() override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result seek(float seconds) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result loop(bool on) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result volume(float volume) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+
+    Result mute(bool on) override
+    {
+        // TODO:
+        return Result::NonSupport;
+    }
+};
+
+#endif  //_TVG_WEB_LOADER_H_

--- a/src/loaders/meson.build
+++ b/src/loaders/meson.build
@@ -45,6 +45,10 @@ if webp_loader
     endif
 endif
 
+if media_loader
+    subdir('media')
+endif
+
 subdir('raw')
 
 loader_dep = declare_dependency(

--- a/src/renderer/tvgAnimation.cpp
+++ b/src/renderer/tvgAnimation.cpp
@@ -40,7 +40,7 @@ Result Animation::frame(float no) noexcept
     auto loader = to<PictureImpl>(pImpl->picture)->loader;
 
     if (!loader) return Result::InsufficientCondition;
-    if (!loader->animatable()) return Result::NonSupport;
+    if (!loader->animatable) return Result::NonSupport;
 
     if (static_cast<AnimLoader*>(loader)->frame(no)) {
         PAINT(pImpl->picture)->mark(RenderUpdateFlag::All);
@@ -61,7 +61,7 @@ float Animation::curFrame() const noexcept
     auto loader = to<PictureImpl>(pImpl->picture)->loader;
 
     if (!loader) return 0;
-    if (!loader->animatable()) return 0;
+    if (!loader->animatable) return 0;
 
     return static_cast<AnimLoader*>(loader)->curFrame();
 }
@@ -72,7 +72,7 @@ float Animation::totalFrame() const noexcept
     auto loader = to<PictureImpl>(pImpl->picture)->loader;
 
     if (!loader) return 0;
-    if (!loader->animatable()) return 0;
+    if (!loader->animatable) return 0;
 
     return static_cast<AnimLoader*>(loader)->totalFrame();
 }
@@ -83,7 +83,7 @@ float Animation::duration() const noexcept
     auto loader = to<PictureImpl>(pImpl->picture)->loader;
 
     if (!loader) return 0;
-    if (!loader->animatable()) return 0;
+    if (!loader->animatable) return 0;
 
     return static_cast<AnimLoader*>(loader)->duration();
 }
@@ -93,7 +93,7 @@ Result Animation::segment(float begin, float end) noexcept
 {
     auto loader = to<PictureImpl>(pImpl->picture)->loader;
     if (!loader) return Result::InsufficientCondition;
-    if (!loader->animatable()) return Result::NonSupport;
+    if (!loader->animatable) return Result::NonSupport;
 
     return static_cast<AnimLoader*>(loader)->segment(begin, end);
 }
@@ -103,7 +103,7 @@ Result Animation::segment(float *begin, float *end) noexcept
 {
     auto loader = to<PictureImpl>(pImpl->picture)->loader;
     if (!loader) return Result::InsufficientCondition;
-    if (!loader->animatable()) return Result::NonSupport;
+    if (!loader->animatable) return Result::NonSupport;
     if (!begin && !end) return Result::InvalidArguments;
 
     static_cast<AnimLoader*>(loader)->segment(begin, end);

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -78,6 +78,8 @@ struct Loader
     {
         if (type == FileType::Lot) return false;
         if (type == FileType::Gif) return false;
+        if (type == FileType::Media) return false;
+
         return true;
     }
 
@@ -101,7 +103,7 @@ struct Loader
     virtual bool open(const char* path, const LoaderOps* ops) { return false; }
     virtual bool open(const char* data, uint32_t size, const LoaderOps* ops, bool copy) { return false; }
     virtual bool resize(Paint* paint, float w, float h) { return false; }
-    virtual void sync() {};  // finish immediately if any async update jobs.
+    virtual bool sync() { return false; };  // finish immediately if any async update jobs.
 
     virtual bool read()
     {
@@ -150,10 +152,11 @@ struct ImageLoader : Loader
 
     float w = 0, h = 0;  // default image size
     RenderSurface surface;
+    bool animatable = false;  // true if this loader supports animation.
 
-    ImageLoader(FileType type) : Loader(type) {}
+    ImageLoader(FileType type, bool animatable = false) :
+        Loader(type), animatable(animatable) {}
 
-    virtual bool animatable() { return false; }  // true if this loader supports animation.
     virtual Paint* paint() { return nullptr; }
     virtual const AccessorEntity* access(uint32_t id) { return nullptr; }
     virtual void access(AccessorCallback& cb) {}
@@ -170,7 +173,8 @@ struct AnimLoader : ImageLoader
     float segmentBegin = 0.0f;
     float segmentEnd;  // initialize the value with the total frame number
 
-    AnimLoader(FileType type) : ImageLoader(type) {}
+    AnimLoader(FileType type) :
+        ImageLoader(type, true) {}
     virtual ~AnimLoader() {}
 
     virtual bool frame(float no) = 0;  // set the current frame number
@@ -184,8 +188,6 @@ struct AnimLoader : ImageLoader
         if (begin) *begin = segmentBegin;
         if (end) *end = segmentEnd;
     }
-
-    bool animatable() override { return true; }
 };
 
 struct FontMetrics

--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -49,6 +49,10 @@
     #include "tvgLottieLoader.h"
 #endif
 
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+    #include "tvgMediaLoader.h"
+#endif
+
 #include "tvgRawLoader.h"
 
 uintptr_t HASH_KEY(const char* data)
@@ -69,6 +73,24 @@ static Inlist<tvg::Loader> _activeLoaders;
 static tvg::Loader* _find(FileType type)
 {
     switch (type) {
+        case FileType::Svg: {
+#ifdef THORVG_SVG_LOADER_SUPPORT
+            return new SvgLoader;
+#endif
+            break;
+        }
+        case FileType::Lot: {
+#ifdef THORVG_LOTTIE_LOADER_SUPPORT
+            return new LottieLoader;
+#endif
+            break;
+        }
+        case FileType::Sfnt: {
+#ifdef THORVG_SFNT_LOADER_SUPPORT
+            return new SfntLoader;
+#endif
+            break;
+        }
         case FileType::Png: {
 #ifdef THORVG_PNG_LOADER_SUPPORT
             return new PngLoader;
@@ -87,26 +109,14 @@ static tvg::Loader* _find(FileType type)
 #endif
             break;
         }
-        case FileType::Svg: {
-#ifdef THORVG_SVG_LOADER_SUPPORT
-            return new SvgLoader;
-#endif
-            break;
-        }
-        case FileType::Sfnt: {
-#ifdef THORVG_SFNT_LOADER_SUPPORT
-            return new SfntLoader;
-#endif
-            break;
-        }
-        case FileType::Lot: {
-#ifdef THORVG_LOTTIE_LOADER_SUPPORT
-            return new LottieLoader;
-#endif
-            break;
-        }
         case FileType::Raw: {
             return new RawLoader;
+            break;
+        }
+        case FileType::Media: {
+#ifdef THORVG_MEDIA_LOADER_SUPPORT
+            return MediaLoader::gen();
+#endif
             break;
         }
         default: {
@@ -121,16 +131,12 @@ static tvg::Loader* _find(FileType type)
             format = "SVG";
             break;
         }
-        case FileType::Sfnt: {
-            format = "SFNT";
-            break;
-        }
         case FileType::Lot: {
             format = "LOT";
             break;
         }
-        case FileType::Raw: {
-            format = "RAW";
+        case FileType::Sfnt: {
+            format = "SFNT";
             break;
         }
         case FileType::Png: {
@@ -143,6 +149,18 @@ static tvg::Loader* _find(FileType type)
         }
         case FileType::Webp: {
             format = "WEBP";
+            break;
+        }
+        case FileType::Raw: {
+            format = "RAW";
+            break;
+        }
+        case FileType::Gif: {
+            format = "GIF";
+            break;
+        }
+        case FileType::Media: {
+            format = "MEDIA";
             break;
         }
         default: {
@@ -163,10 +181,11 @@ static tvg::Loader* _findByPath(const char* filename)
 
     if (!strcmp(ext, "svg")) return _find(FileType::Svg);
     if (!strcmp(ext, "lot") || !strcmp(ext, "json")) return _find(FileType::Lot);
+    if (!strcmp(ext, "ttf") || !strcmp(ext, "otf")) return _find(FileType::Sfnt);
     if (!strcmp(ext, "png")) return _find(FileType::Png);
     if (!strcmp(ext, "jpg")) return _find(FileType::Jpg);
     if (!strcmp(ext, "webp")) return _find(FileType::Webp);
-    if (!strcmp(ext, "ttf") || !strcmp(ext, "ttc") || !strcmp(ext, "otf") || !strcmp(ext, "otc")) return _find(FileType::Sfnt);
+    if (!strcmp(ext, "mp4")) return _find(FileType::Media);  // TODO: add common media formats
     return nullptr;
 }
 #endif
@@ -178,12 +197,13 @@ static FileType _convert(const char* mimeType)
     auto type = FileType::Unknown;
 
     if (!strcmp(mimeType, "svg") || !strcmp(mimeType, "svg+xml")) type = FileType::Svg;
-    else if (!strcmp(mimeType, "ttf") || !strcmp(mimeType, "otf")) type = FileType::Sfnt;
     else if (!strcmp(mimeType, "lot") || !strcmp(mimeType, "lottie+json")) type = FileType::Lot;
-    else if (!strcmp(mimeType, "raw")) type = FileType::Raw;
+    else if (!strcmp(mimeType, "ttf") || !strcmp(mimeType, "otf")) type = FileType::Sfnt;
     else if (!strcmp(mimeType, "png")) type = FileType::Png;
     else if (!strcmp(mimeType, "jpg") || !strcmp(mimeType, "jpeg")) type = FileType::Jpg;
     else if (!strcmp(mimeType, "webp")) type = FileType::Webp;
+    else if (!strcmp(mimeType, "raw")) type = FileType::Raw;
+    else if (!strcmp(mimeType, "mp4")) type = FileType::Media;  // TODO: add common media formats
     else TVGLOG("RENDERER", "Given mimetype is unknown = \"%s\".", mimeType);
 
     return type;

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -56,13 +56,16 @@ struct PictureImpl : Picture
 
     bool skip(RenderUpdateFlag flag)
     {
-        if (flag == RenderUpdateFlag::None) return true;
-        return false;
+        if (!loader) return true;
+        if (loader->type == FileType::Media) return false;  // The media player might have its own playback update
+        return (flag == RenderUpdateFlag::None);
     }
 
     bool update(RenderMethod* renderer, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flag, TVG_UNUSED bool clipper)
     {
-        load();
+        flag |= load();
+
+        if (flag == RenderUpdateFlag::None) return true;
 
         auto pivot = Point{-origin.x * float(w), -origin.y * float(h)};
 
@@ -117,7 +120,7 @@ struct PictureImpl : Picture
     bool intersects(const RenderRegion& region)
     {
         if (!impl.renderer) return false;
-        load();
+        impl.mark(load());
         if (impl.rd) return impl.renderer->intersectsImage(impl.rd, region);
         else if (vector) return to<SceneImpl>(vector)->intersects(region);
         return false;
@@ -178,7 +181,7 @@ struct PictureImpl : Picture
     {
         if (ret) TVGERR("RENDERER", "TODO: duplicate()");
 
-        load();
+        impl.mark(load());
 
         auto picture = Picture::gen();
         auto dup = to<PictureImpl>(picture);
@@ -206,7 +209,7 @@ struct PictureImpl : Picture
 
     AccessorIterator* iterator()
     {
-        load();
+        impl.mark(load());
 
         struct PictureIterator : AccessorIterator
         {
@@ -228,7 +231,7 @@ struct PictureImpl : Picture
     uint32_t* data(uint32_t* w, uint32_t* h)
     {
         //Try it, If not loaded yet.
-        load();
+        impl.mark(load());
 
         if (loader) {
             if (w) *w = static_cast<uint32_t>(loader->w);
@@ -241,11 +244,11 @@ struct PictureImpl : Picture
         else return nullptr;
     }
 
-    void load()
+    RenderUpdateFlag load()
     {
         if (loader) {
-            if (vector) {
-                loader->sync();
+            if (loader->animatable && (vector || bitmap)) {
+                if (loader->sync() && bitmap) return RenderUpdateFlag::Image;
             } else if ((vector = loader->paint())) {
                 vector->ref();
                 PAINT(vector)->parent = this;
@@ -257,10 +260,11 @@ struct PictureImpl : Picture
                     loader->resize(vector, w, h);
                     resizing = false;
                 }
-            } else if (!bitmap) {
+            } else {
                 bitmap = loader->bitmap();
             }
         }
+        return RenderUpdateFlag::None;
     }
 
     void needComposition(uint8_t opacity)

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -96,8 +96,7 @@ struct ShapeImpl : Shape
 
     bool skip(RenderUpdateFlag flag)
     {
-        if (flag == RenderUpdateFlag::None) return true;
-        return false;
+        return (flag == RenderUpdateFlag::None);
     }
 
     bool update(RenderMethod* renderer, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flag, bool clipper)

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -142,8 +142,7 @@ struct TextImpl : Text
 
     bool skip(RenderUpdateFlag flag)
     {
-        if (flag == RenderUpdateFlag::None) return true;
-        return false;
+        return (flag == RenderUpdateFlag::None);
     }
 
     void wrapping(TextWrap mode)


### PR DESCRIPTION
> [!NOTE]
> This is a PR targeting the hermet/video branch.

<img width="2159" height="706" alt="image" src="https://github.com/user-attachments/assets/a5318e3b-1ee2-4f85-9663-2e7a42c3a1e4" />


Implement the AVFoundation media loader for Apple video playback.
Replace the stub Apple media loader with playback, seek, loop,
volume, and mute controls.

Run AVFoundation work on a ref-counted serial dispatch queue.
Poll decoded frames at the media frame rate and copy them into
an owned ring buffer for bitmap() consumption.

Handle preferred video transforms, natural playback finish, still
frames for paused seek, and timer cleanup while paused or closed.

Wire the Objective-C++ source and required Apple frameworks into Meson.