### PR TITLE
media: refresh media frames as image updates

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -1262,6 +1262,7 @@ RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matr
     sdata->viewWd = static_cast<float>(surface.w);
     sdata->viewHt = static_cast<float>(surface.h);
 
+    auto refreshTexture = ((flags & RenderUpdateFlag::Image) != RenderUpdateFlag::None);
     auto sourceChanged = (sdata->texSource != image) || (sdata->texFilter != filter);
     if (sdata->texId == 0 || sourceChanged || cacheStale) {
         auto ownsTexture = sdata->texId && (sdata->texStamp == mTextures.stamp);
@@ -1271,7 +1272,7 @@ RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matr
         sdata->texFilter = filter;
         sdata->texStamp = mTextures.stamp;
         sdata->geometry = GlGeometry();
-    }
+    } else if (refreshTexture) TextureMgr::upload(sdata->texId, image, filter);
 
     sdata->texColorSpace = image->cs;
     sdata->texFlipY = 1;

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -56,8 +56,8 @@ struct PictureImpl : Picture
 
     bool skip(RenderUpdateFlag flag)
     {
-        if (flag == RenderUpdateFlag::None) return true;
-        return false;
+        if (flag != RenderUpdateFlag::None) return false;
+        return !loader || loader->type != FileType::Media;
     }
 
     bool update(RenderMethod* renderer, const Matrix& transform, Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flag, TVG_UNUSED bool clipper)
@@ -67,6 +67,15 @@ struct PictureImpl : Picture
         auto pivot = Point{-origin.x * float(w), -origin.y * float(h)};
 
         if (bitmap) {
+            if (loader->type == FileType::Media) {
+                if (auto frame = loader->bitmap()) {
+                    bitmap = frame;
+                    flag = flag | RenderUpdateFlag::Image;
+                } else if (loader->sharing > 0) {
+                    // Update duplicated video pictures sharing this loader.
+                    flag = flag | RenderUpdateFlag::Image;
+                }
+            }
             if (bitmap->cs == ColorSpace::Unknown) {
                 TVGERR("RENDERER", "Unknown colorspace picture data");
                 return false;


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is intended to be applied on top of the `hermet/video` branch.

Keep media pictures on the update path even when no render flag is set, so bitmap() can fetch newly decoded frames during playback.

Mark fetched media frames with the existing Image update flag, and refresh GL textures when surface pixels change in-place.

### macOS Video Frame Flow


<img width="1759" height="581" alt="image" src="https://github.com/user-attachments/assets/a1f39dc3-c5ea-478c-ada3-0353090bbd0f" />

The diagram shows how video playback works on macOS: a serial dispatch
queue fills a 3-frame ring buffer, while `Picture::update()` fetches the
latest frame through `bitmap()` and refreshes renderer image data with
`RenderUpdateFlag::Image`.