### PR TITLE
api: revise the text glyph metrics

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -2172,6 +2172,8 @@ struct TVG_API Text : Paint
      *
      * @param[in] ch A pointer to a UTF-8 encoded character.
      * @param[out] metrics A reference to a @ref GlyphMetrics structure to be filled with the resulting values.
+     * @param[out] next An optional pointer that receives the position immediately
+     *                  following the processed UTF-8 character.
      *
      * @return Result::InsufficientCondition if no font or size has been set yet.
      * @return Result::InvalidArguments if the given character is invalid or not supported.
@@ -2180,7 +2182,7 @@ struct TVG_API Text : Paint
      * @note Currently, ThorVG only supports horizontal text layout.
      * @note Experimental API
      */
-    Result metrics(const char* ch, GlyphMetrics& metrics) const noexcept;
+    Result metrics(const char* ch, GlyphMetrics& metrics, const char** next = nullptr) const noexcept;
 
     /**
      * @brief Loads a scalable font data (ttf) from a file.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -2603,6 +2603,8 @@ TVG_API Tvg_Result tvg_text_get_text_metrics(const Tvg_Paint text, Tvg_Text_Metr
  * @param[in] text The text object.
  * @param[in] ch A pointer to a UTF-8 encoded character.
  * @param[out] metrics A pointer to a @ref Tvg_Glyph_Metrics structure to be filled with the resulting values.
+ * @param[out] next An optional pointer that receives the position immediately
+ *                  following the processed UTF-8 character.
  *
  * @return TVG_RESULT_INSUFFICIENT_CONDITION if no font or size has been set yet.
  * @return TVG_RESULT_INVALID_ARGUMENT if the given character is invalid or not supported.
@@ -2611,7 +2613,7 @@ TVG_API Tvg_Result tvg_text_get_text_metrics(const Tvg_Paint text, Tvg_Text_Metr
  * @note Currently, ThorVG only supports horizontal text layout.
  * @note Experimental API
  */
-TVG_API Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics);
+TVG_API Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics, const char** next);
 
 /**
  * @brief Loads a scalable font data from a file.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -999,10 +999,9 @@ TVG_API Tvg_Result tvg_text_get_text_metrics(const Tvg_Paint text, Tvg_Text_Metr
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
-
-TVG_API Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics)
+TVG_API Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics, const char** next)
 {
-    if (text && metrics) return (Tvg_Result) reinterpret_cast<Text*>(text)->metrics(ch, *reinterpret_cast<GlyphMetrics*>(metrics));
+    if (text && metrics) return (Tvg_Result) reinterpret_cast<Text*>(text)->metrics(ch, *reinterpret_cast<GlyphMetrics*>(metrics), next);
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 

--- a/src/loaders/sfnt/tvgSfntLoader.cpp
+++ b/src/loaders/sfnt/tvgSfntLoader.cpp
@@ -608,7 +608,7 @@ void SfntLoader::metrics(const FontMetrics& fm, TextMetrics& out)
     out.linegap = reader->metrics.hhea.linegap * scale;
 }
 
-bool SfntLoader::metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out)
+bool SfntLoader::metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out, const char** next)
 {
     auto code = _codepoints(&ch, ch + strlen(ch));
     auto glyph = request(code);
@@ -629,5 +629,7 @@ bool SfntLoader::metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& ou
     }
     out.min = glyph->bbox.min * scale;
     out.max = glyph->bbox.max * scale;
+
+    if (next) *next = ch;
     return true;
 }

--- a/src/loaders/sfnt/tvgSfntLoader.h
+++ b/src/loaders/sfnt/tvgSfntLoader.h
@@ -58,7 +58,7 @@ struct SfntLoader : public FontLoader
     void copy(const FontMetrics& in, FontMetrics& out) override;
     void release(FontMetrics& fm) override;
     void metrics(const FontMetrics& fm, TextMetrics& out) override;
-    bool metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out) override;
+    bool metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out, const char** next) override;
 
     static SfntReader* gen(uint8_t* data, uint32_t size);
 

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -219,7 +219,7 @@ struct FontLoader : Loader
     virtual void transform(Paint* paint, FontMetrics& fm, float italicShear) = 0;
     virtual void release(FontMetrics& fm) = 0;
     virtual void metrics(const FontMetrics& fm, TextMetrics& out) = 0;
-    virtual bool metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out) = 0;
+    virtual bool metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out, const char** next) = 0;
     virtual void copy(const FontMetrics& in, FontMetrics& out) = 0;
 };
 }

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -163,10 +163,9 @@ Result Text::metrics(TextMetrics& metrics) const noexcept
     return to<TextImpl>(this)->metrics(metrics);
 }
 
-
-Result Text::metrics(const char* ch, GlyphMetrics& metrics) const noexcept
+Result Text::metrics(const char* ch, GlyphMetrics& metrics, const char** next) const noexcept
 {
-    return to<TextImpl>(this)->metrics(ch, metrics);
+    return to<TextImpl>(this)->metrics(ch, metrics, next);
 }
 
 

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -133,10 +133,10 @@ struct TextImpl : Text
         return Result::Success;
     }
 
-    Result metrics(const char* ch, GlyphMetrics& metrics)
+    Result metrics(const char* ch, GlyphMetrics& metrics, const char** next)
     {
         if (!loader || fm.fontSize <= 0.0f) return Result::InsufficientCondition;
-        if (ch && loader->metrics(fm, ch, metrics)) return Result::Success;
+        if (ch && loader->metrics(fm, ch, metrics, next)) return Result::Success;
         return Result::InvalidArguments;
     }
 


### PR DESCRIPTION
- Added a parameter to return the next character pointer for user convenience.
- Updated the experimental APIs.
```
C++:
 * Result Text::metrics(const char* ch, GlyphMetrics& metrics) const; -> Result Text::metrics(const char* ch, GlyphMetrics& metrics, const char** next = nullptr) const

CAPI:
 * Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics) -> Tvg_Result tvg_text_get_glyph_metrics(const Tvg_Paint text, const char* ch, Tvg_Glyph_Metrics* metrics, const char** next)
 ```