### PR TITLE
wg_engine: support straight-alpha surface output

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -2420,14 +2420,17 @@ struct TVG_API WgCanvas final : Canvas
      * @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture.
      * @param[in] w The width of the target.
      * @param[in] h The height of the target.
-     * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it only allows @c ColorSpace::ABGR8888S as @c WGPUTextureFormat_RGBA8Unorm.
+     * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it allows @c ColorSpace::ABGR8888 and @c ColorSpace::ABGR8888S.
      * @param[in] type @c 0: surface, @c 1: texture are used as pesentable target.
      *
      * @retval Result::InsufficientCondition if the canvas is performing rendering. Please ensure the canvas is synced.
      * @retval Result::NonSupport In case the wg engine is not supported.
      *
+     * @warning Regardless of the value of @p cs, this target API uses the default alpha mode.
+     *
      * @since 1.0
      *
+     * @see WgCanvas::target(const Context&, void*, uint32_t, uint32_t, ColorSpace, int)
      * @see Canvas::viewport()
      * @see Canvas::sync()
      */

--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -2399,9 +2399,23 @@ struct TVG_API WgCanvas final : Canvas
     ~WgCanvas() override;
 
     /**
+     * @brief Encapsulates the WebGPU context required for rendering.
+     *
+     * This structure contains the WebGPU objects used to initialize the rendering backend.
+     *
+     * @note Experimental API
+     */
+    struct Context
+    {
+        void* instance;  // WGPUInstance, context for all other wgpu objects.
+        void* adapter;   // WGPUAdapter, the adapter associated with the rendering device.
+        void* device;    // WGPUDevice, a desired handle for the wgpu device.
+    };
+
+    /**
      * @brief Sets the drawing target for the rasterization.
      *
-     * @param[in] device WGPUDevice, a desired handle for the wgpu device. If it is @c nullptr, ThorVG will assign an appropriate device internally.
+     * @param[in] device WGPUDevice, a desired handle for the wgpu device.
      * @param[in] instance WGPUInstance, context for all other wgpu objects.
      * @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture.
      * @param[in] w The width of the target.
@@ -2418,6 +2432,26 @@ struct TVG_API WgCanvas final : Canvas
      * @see Canvas::sync()
      */
     Result target(void* device, void* instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0) noexcept;
+
+    /**
+     * @brief Sets the drawing target for the rasterization.
+     *
+     * @param[in] context WebGPU context.
+     * @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture.
+     * @param[in] w The width of the target.
+     * @param[in] h The height of the target.
+     * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it allows @c ColorSpace::ABGR8888 and @c ColorSpace::ABGR8888S.
+     * @param[in] type @c 0: surface, @c 1: texture are used as pesentable target.
+     *
+     * @retval Result::InsufficientCondition if the canvas is performing rendering. Please ensure the canvas is synced.
+     * @retval Result::NonSupport In case the wg engine is not supported.
+     *
+     * @note Experimental API
+     *
+     * @see Canvas::viewport()
+     * @see Canvas::sync()
+     */
+    Result target(const Context& context, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0) noexcept;
 
     /**
      * @brief Creates a new WebGPU Canvas object with optional rendering engine settings.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -654,6 +654,10 @@ TVG_API Tvg_Canvas tvg_wgcanvas_create(Tvg_Engine_Option op);
  * @retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
  * @retval TVG_RESULT_NOT_SUPPORTED In case the wg engine is not supported.
  *
+ * @warning Regardless of the value of @p cs, this target API uses the default alpha mode.
+ *
+ * @see tvg_wgcanvas_set_target_with_context()
+ *
  * @since 1.0
  */
 TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type);

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -608,6 +608,20 @@ TVG_API Tvg_Result tvg_glcanvas_set_target(Tvg_Canvas canvas, void* display, voi
 /* WgCanvas API                                                         */
 /************************************************************************/
 
+
+/**
+ * @brief Encapsulates the WebGPU context required for rendering.
+ *
+ * This structure contains the WebGPU objects used to initialize the rendering backend.
+ *
+ * @note Experimental API
+ */
+typedef struct {
+        void* instance;  // WGPUInstance, context for all other wgpu objects.
+        void* adapter;   // WGPUAdapter, the adapter associated with the rendering device.
+        void* device;    // WGPUDevice, a desired handle for the wgpu device.
+} Tvg_WgContext;
+
 /**
  * @brief Creates a new WebGPU Canvas object with optional rendering engine settings.
  *
@@ -629,13 +643,13 @@ TVG_API Tvg_Canvas tvg_wgcanvas_create(Tvg_Engine_Option op);
 /**
  * @brief Sets the drawing target for the rasterization.
  *
- * @param[in] device WGPUDevice, a desired handle for the wgpu device. If it is @c nullptr, ThorVG will assign an appropriate device internally.
+ * @param[in] device WGPUDevice, a desired handle for the wgpu device.
  * @param[in] instance WGPUInstance, context for all other wgpu objects.
  * @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture.
  * @param[in] w The width of the target.
  * @param[in] h The height of the target.
- * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it only allows @c TVG_COLORSPACE_ABGR8888S as @c WGPUTextureFormat_RGBA8Unorm.
- * @param[in] type @c 0: surface, @c 1: texture are used as pesentable target.
+ * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it allows @c TVG_COLORSPACE_ABGR8888 and @c TVG_COLORSPACE_ABGR8888S.
+ * @param[in] type @c 0: surface, @c 1: texture are used as presentable target.
  *
  * @retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
  * @retval TVG_RESULT_NOT_SUPPORTED In case the wg engine is not supported.
@@ -643,6 +657,23 @@ TVG_API Tvg_Canvas tvg_wgcanvas_create(Tvg_Engine_Option op);
  * @since 1.0
  */
 TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas canvas, void* device, void* instance, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type);
+
+/**
+ * @brief Sets the drawing target for the rasterization.
+ *
+ * @param[in] context Tvg_WgContext context.
+ * @param[in] target Either WGPUSurface or WGPUTexture, serving as handles to a presentable surface or texture.
+ * @param[in] w The width of the target.
+ * @param[in] h The height of the target.
+ * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it allows @c TVG_COLORSPACE_ABGR8888 and @c TVG_COLORSPACE_ABGR8888S.
+ * @param[in] type @c 0: surface, @c 1: texture are used as presentable target.
+ *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
+ * @retval TVG_RESULT_NOT_SUPPORTED In case the wg engine is not supported.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_wgcanvas_set_target_with_context(Tvg_Canvas canvas, const Tvg_WgContext* context, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type);
 
 /** \} */   // end defgroup ThorVGCapi_WgCanvas
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -110,6 +110,14 @@ TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas canvas, void* device, void
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
+TVG_API Tvg_Result tvg_wgcanvas_set_target_with_context(Tvg_Canvas canvas, const Tvg_WgContext* context, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type)
+{
+    if (canvas && context) {
+        auto ctx = reinterpret_cast<WgCanvas::Context*>(const_cast<Tvg_WgContext*>(context));
+        return (Tvg_Result) reinterpret_cast<WgCanvas*>(canvas)->target(*ctx, target, w, h, static_cast<ColorSpace>(cs), type);
+    }
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
 
 TVG_API Tvg_Result tvg_canvas_add(Tvg_Canvas canvas, Tvg_Paint paint)
 {

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
@@ -24,10 +24,11 @@
 #include "tvgWgCommon.h"
 #include "tvgArray.h"
 
-void WgContext::initialize(WGPUInstance instance, WGPUDevice device)
+void WgContext::initialize(const WgCanvas::Context& ctx)
 {
-    this->instance = instance;
-    this->device = device;
+    this->instance = (WGPUInstance)ctx.instance;
+    this->adapter = (WGPUAdapter)ctx.adapter;
+    this->device = (WGPUDevice)ctx.device;
 
     queue = wgpuDeviceGetQueue(device);
 

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.h
@@ -23,6 +23,7 @@
 #ifndef _TVG_WG_COMMON_H_
 #define _TVG_WG_COMMON_H_
 
+#include <webgpu/webgpu.h>
 #include "tvgGpuCommon.h"
 #include "tvgWgBindGroups.h"
 

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.h
@@ -28,6 +28,7 @@
 
 struct WgContext {
     WGPUInstance instance{};
+    WGPUAdapter adapter{};
     WGPUDevice device{};
     WGPUQueue queue{};
     WGPUTextureFormat format = WGPUTextureFormat_BGRA8Unorm;
@@ -38,7 +39,7 @@ struct WgContext {
     WGPUSampler samplerLinearClamp;
     WgBindGroupLayouts layouts;
 
-    void initialize(WGPUInstance instance, WGPUDevice device);
+    void initialize(const WgCanvas::Context& ctx);
     void release();
     
     // create common objects

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -367,8 +367,7 @@ void WgCompositor::composeScene(WgContext& context, WgRenderTarget* src, WgRende
     drawMeshImage(context, &meshDataBlit);
 }
 
-
-void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView)
+void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView, bool premultiplied)
 {
     assert(!renderPassEncoder);
     const WGPURenderPassDepthStencilAttachment depthStencilAttachment{
@@ -387,7 +386,7 @@ void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRender
     const WGPURenderPassDescriptor renderPassDesc{ .colorAttachmentCount = 1, .colorAttachments = &colorAttachment, .depthStencilAttachment = &depthStencilAttachment };
     renderPassEncoder = wgpuCommandEncoderBeginRenderPass(encoder, &renderPassDesc);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, src->bindGroupTexture, 0, nullptr);
-    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.blit);
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, premultiplied ? pipelines.blit : pipelines.blit_unpremultiplied);
     drawMeshImage(context, &meshDataBlit);
     wgpuRenderPassEncoderEnd(renderPassEncoder);
     wgpuRenderPassEncoderRelease(renderPassEncoder);

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.h
@@ -132,7 +132,7 @@ public:
     void composeScene(WgContext& context, WgRenderTarget* src, WgRenderTarget* mask, WgCompose* compose);
 
     // blit render target to texture view (f.e. screen buffer)
-    void blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView);
+    void blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView, bool premultiplied);
 
     // effects
     bool gaussianBlur(WgContext& context, WgRenderTarget* dst, const RenderEffectGaussianBlur* params, const WgCompose* compose);

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
@@ -473,9 +473,17 @@ void WgPipelines::initialize(WgContext& context)
     // render pipeline blit
     blit = createRenderPipeline(
         context.device, "The render pipeline blit",
-        shader_blit, "vs_main", "fs_main", 
+        shader_blit, "vs_main", "fs_main",
         layout_blit, vertexBufferLayoutsImage, 2,
-        WGPUColorWriteMask_All, context.format, blendStateSrc, // must be preferred screen pixel format
+        WGPUColorWriteMask_All, context.format, blendStateSrc,  // must be preferred screen pixel format
+        depthStencilStateScene, multisampleStateX1);
+
+    // TODO: either premultiplied blit or unpremultplied bit used.
+    blit_unpremultiplied = createRenderPipeline(
+        context.device, "The render pipeline blit unpremultiplied",
+        shader_blit, "vs_main", "fs_main_unpremultiplied",
+        layout_blit, vertexBufferLayoutsImage, 2,
+        WGPUColorWriteMask_All, context.format, blendStateSrc,  // must be preferred screen pixel format
         depthStencilStateScene, multisampleStateX1);
 
     // effects
@@ -533,6 +541,7 @@ void WgPipelines::releaseGraphicHandles(WgContext& context)
     releaseRenderPipeline(gaussian_vert);
     releaseRenderPipeline(dropshadow);
     // pipeline blit
+    releaseRenderPipeline(blit_unpremultiplied);
     releaseRenderPipeline(blit);
     // pipelines compose
     for (uint32_t i = 0; i < 11; i++)

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.h
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.h
@@ -100,6 +100,7 @@ public:
     WGPURenderPipeline scene_compose[11]{};
     // pipeline blit
     WGPURenderPipeline blit{};
+    WGPURenderPipeline blit_unpremultiplied{};
     // effects
     WGPURenderPipeline gaussian_vert{};
     WGPURenderPipeline gaussian_horz{};

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -97,34 +97,48 @@ void WgRenderer::clearTargets()
 
 }
 
-
-bool WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height)
+void WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height, ColorSpace cs)
 {
     this->surface = surface;
-    if (width == 0 || height == 0 || !surface) return false;
 
     // setup surface configuration
-    WGPUSurfaceConfiguration surfaceConfiguration {
+    WGPUSurfaceConfiguration surfaceConfig{
         .device = context.device,
         .format = context.format,
         .usage = WGPUTextureUsage_RenderAttachment,
         .width = width,
         .height = height,
-    #ifdef __EMSCRIPTEN__
-        .alphaMode = WGPUCompositeAlphaMode_Premultiplied,
+#ifdef __EMSCRIPTEN__
+        .alphaMode = WGPUCompositeAlphaMode_Premultiplied,  // for v1.0 backward compat. this can be removed with old target() api.
         .presentMode = WGPUPresentMode_Fifo
-    #elif defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) || (defined(_WIN32) && !defined(__CYGWIN__))
+#elif defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) || (defined(_WIN32) && !defined(__CYGWIN__))
         // Use Immediate only where it is known to be supported on desktop surfaces.
         .presentMode = WGPUPresentMode_Immediate
-    #else
+#else
         // Use the WebGPU default present mode (Fifo).
         .presentMode = WGPUPresentMode_Undefined
-    #endif
+#endif
     };
-    wgpuSurfaceConfigure(surface, &surfaceConfiguration);
-    return true;
-}
 
+    // safe-guard for the system compatibility
+    if (context.adapter) {
+        auto premultiplied = (cs == ColorSpace::ABGR8888);
+        auto alphaMode = premultiplied ? WGPUCompositeAlphaMode_Premultiplied : WGPUCompositeAlphaMode_Unpremultiplied;
+        WGPUSurfaceCapabilities capabilities;
+        if (wgpuSurfaceGetCapabilities(surface, context.adapter, &capabilities) == WGPUStatus_Success) {
+            for (size_t i = 0; i < capabilities.alphaModeCount; ++i) {
+                if (capabilities.alphaModes[i] == alphaMode) {
+                    surfaceConfig.alphaMode = alphaMode;
+                    mTargetSurface.premultiplied = premultiplied;
+                    break;
+                }
+            }
+            wgpuSurfaceCapabilitiesFreeMembers(capabilities);
+        }
+    }
+
+    wgpuSurfaceConfigure(surface, &surfaceConfig);
+}
 
 /************************************************************************/
 /* External Class Implementation                                        */
@@ -380,7 +394,7 @@ bool WgRenderer::sync()
         WGPUTextureView dstTextureView = mContext.createTextureView(dstTexture);
         WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
         // show root offscreen buffer
-        mCompositor.blit(mContext, commandEncoder, &mRenderTargetRoot, dstTextureView);
+        mCompositor.blit(mContext, commandEncoder, &mRenderTargetRoot, dstTextureView, mTargetSurface.premultiplied);
         mContext.submitCommandEncoder(commandEncoder);
         mContext.releaseCommandEncoder(commandEncoder);
         mContext.releaseTextureView(dstTextureView);
@@ -391,7 +405,7 @@ bool WgRenderer::sync()
 
 Result WgRenderer::target(const WgCanvas::Context& ctx, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type)
 {
-    if (cs != ColorSpace::ABGR8888S) return Result::NonSupport;
+    if (cs != ColorSpace::ABGR8888 && cs != ColorSpace::ABGR8888S) return Result::NonSupport;
 
     if (!ctx.instance || !ctx.device || !target) {
         release();
@@ -417,18 +431,15 @@ Result WgRenderer::target(const WgCanvas::Context& ctx, void* target, uint32_t w
         mCompositor.resize(mContext, w, h);
     }
 
-    // configure surface (must be called after context creation)
-    if (type == 0) {
-        surface = (WGPUSurface)target;
-        surfaceConfigure(surface, mContext, w, h);
-    } else {
-        targetTexture = (WGPUTexture)target;
-    }
-
     mTargetSurface.stride = w;
     mTargetSurface.w = w;
     mTargetSurface.h = h;
     mTargetSurface.cs = cs;
+    mTargetSurface.premultiplied = true;  // TODO: by default for v1 backward compat. properly addressed later v2 by aligning with actual alpha mode.
+
+    // configure surface (must be called after context creation)
+    if (type == 0) surfaceConfigure((WGPUSurface)target, mContext, w, h, cs);
+    else targetTexture = (WGPUTexture)target;
 
     return Result::Success;
 }

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -389,25 +389,24 @@ bool WgRenderer::sync()
     return true;
 }
 
-Result WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type)
+Result WgRenderer::target(const WgCanvas::Context& ctx, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type)
 {
     if (cs != ColorSpace::ABGR8888S) return Result::NonSupport;
 
-    if (!instance || !device || !target) {
+    if (!ctx.instance || !ctx.device || !target) {
         release();
         return Result::Success;
     }
 
     if (w == 0 || h == 0) return Result::InvalidArguments;
 
-    // device or instance was changed, need to recreate all instances
-    if ((mContext.device != device) || (mContext.instance != instance)) {
+    // context has been changed, need to recreate all instances
+    if ((mContext.device != ctx.device) || (mContext.instance != ctx.instance) || mContext.adapter != ctx.adapter) {
         release();
-        mContext.initialize(instance, device);
+        mContext.initialize(ctx);
         mRenderTargetPool.initialize(mContext, w, h);
         mRenderTargetRoot.initialize(mContext, w, h);
         mCompositor.initialize(mContext, w, h);
-
     // update render targets dimensions
     } else if ((mTargetSurface.w != w) || (mTargetSurface.h != h) || (type == 0 ? (surface != (WGPUSurface)target) : (targetTexture != (WGPUTexture)target))) {
         mRenderTargetPool.release(mContext);

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -74,7 +74,7 @@ private:
     void releaseSurfaceTexture();
 
     void clearTargets();
-    bool surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height);
+    void surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height, ColorSpace cs);
 
     // render tree stacks
     WgRenderTarget mRenderTargetRoot;

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -47,7 +47,7 @@ struct WgRenderer : RenderMethod
     bool sync() override;
     bool intersectsImage(RenderData data, const RenderRegion& region) override;
     bool intersectsShape(RenderData data, const RenderRegion& region) override;
-    Result target(WGPUDevice device, WGPUInstance instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0);
+    Result target(const WgCanvas::Context& ctx, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0);
 
     //composition
     RenderCompositor* target(const RenderRegion& region, ColorSpace cs, CompositionFlag flags) override;

--- a/src/renderer/gpu_engine/wg/tvgWgShaderSrc.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgShaderSrc.cpp
@@ -826,6 +826,15 @@ fn vs_main(in: VertexInput) -> VertexOutput {
 fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     return textureSample(uTextureSrc, uSamplerSrc, in.texCoord.xy);
 };
+
+@fragment
+fn fs_main_unpremultiplied(in: VertexOutput) -> @location(0) vec4f {
+    let src = textureSample(uTextureSrc, uSamplerSrc, in.texCoord.xy);
+    if (src.a <= 0.0) {
+        return vec4f(0.0);
+    }
+    return vec4f(clamp(src.rgb / src.a, vec3f(0.0), vec3f(1.0)), src.a);
+};
 )";
 
 //************************************************************************

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -217,20 +217,23 @@ WgCanvas::WgCanvas() = default;
 WgCanvas::~WgCanvas()
 {
 #ifdef THORVG_WG_ENGINE_SUPPORT
-    auto renderer = static_cast<WgRenderer*>(pImpl->renderer);
-    renderer->target(nullptr, nullptr, nullptr, 0, 0, ColorSpace::Unknown);
+    static_cast<WgRenderer*>(pImpl->renderer)->target({}, nullptr, 0, 0, ColorSpace::Unknown);
 
     WgRenderer::term();
 #endif
 }
 
-
 Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type) noexcept
+{
+    return WgCanvas::target({instance, nullptr, device}, target, w, h, cs, type);
+}
+
+Result WgCanvas::target(const Context& context, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type) noexcept
 {
 #ifdef THORVG_WG_ENGINE_SUPPORT
     if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) return Result::InsufficientCondition;
 
-    auto ret = static_cast<WgRenderer*>(pImpl->renderer)->target((WGPUDevice)device, (WGPUInstance)instance, target, w, h, cs, type);
+    auto ret = static_cast<WgRenderer*>(pImpl->renderer)->target(context, target, w, h, cs, type);
     if (ret != Result::Success) return ret;
 
     pImpl->vport = {{0, 0}, {(int32_t)w, (int32_t)h}};
@@ -244,7 +247,6 @@ Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, 
 #endif
     return Result::NonSupport;
 }
-
 
 WgCanvas* WgCanvas::gen(EngineOption op) noexcept
 {

--- a/test/testWgEngine.h
+++ b/test/testWgEngine.h
@@ -35,6 +35,7 @@ using namespace tvg;
 struct TestWgEngine
 {
     WGPUInstance instance = nullptr;
+    WGPUAdapter adapter = nullptr;
     WGPUDevice device = nullptr;
     WGPUTexture texture = nullptr;
     WGPUTextureFormat format = WGPUTextureFormat_BGRA8Unorm;
@@ -42,12 +43,11 @@ struct TestWgEngine
     uint32_t height;
     ColorSpace colorSpace;
 
-    TestWgEngine(uint32_t w = 100, uint32_t h = 100, ColorSpace cs = ColorSpace::ABGR8888S) : width(w), height(h), colorSpace(cs)
+    TestWgEngine(uint32_t w = 100, uint32_t h = 100, ColorSpace cs = ColorSpace::ABGR8888) : width(w), height(h), colorSpace(cs)
     {
         instance = wgpuCreateInstance(nullptr);
 
         // request adapter
-        WGPUAdapter adapter = nullptr;
         auto onAdapterRequestEnded = [](WGPURequestAdapterStatus, WGPUAdapter adapter, WGPUStringView, void* userdata1, void*) {
             *((WGPUAdapter*)userdata1) = adapter;
         };
@@ -105,7 +105,7 @@ struct TestWgEngine
 
     Result target(WgCanvas* canvas)
     {
-        return canvas->target(device, instance, texture, width, height, colorSpace, 1);
+        return canvas->target({instance, adapter, device}, texture, width, height, colorSpace, 1);
     }
 };
 

--- a/test/testWgEngine.h
+++ b/test/testWgEngine.h
@@ -78,8 +78,6 @@ struct TestWgEngine
         requestDeviceCallback.userdata1 = &device;
         wgpuAdapterRequestDevice(adapter, &deviceDesc, requestDeviceCallback);
 
-        wgpuAdapterRelease(adapter);
-
         // create texture
         WGPUTextureDescriptor textureDesc = {};
         textureDesc.usage = WGPUTextureUsage_CopySrc | WGPUTextureUsage_CopyDst | WGPUTextureUsage_RenderAttachment;
@@ -100,6 +98,7 @@ struct TestWgEngine
         wgpuTextureRelease(texture);
         wgpuDeviceDestroy(device);
         wgpuDeviceRelease(device);
+        wgpuAdapterRelease(adapter);
         wgpuInstanceRelease(instance);
     }
 


### PR DESCRIPTION
Configure the WebGPU surface alpha mode from the target color space. For straight-alpha targets, use a dedicated blit pipeline to convert the premultiplied render buffer before presentation.

This adds ABGR8888 target support while preserving correct translucent colors on iOS surfaces.

Please note that this corrects the WebGPU color space from straight-alpha to premultiplied-alpha mode. This may introduce compatibility issues. If necessary, change the target color space from ABGR8888S to ABGR8888.

issue: https://github.com/thorvg/thorvg/issues/4056