### PR TITLE
renderer: delegate target validation to engines

### DIFF
--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -512,7 +512,7 @@ void mpoolInit(uint32_t threads);
 void mpoolTerm();
 SwMpool* mpoolReq();
 
-bool rasterCompositor(SwSurface* surface);
+Result rasterCompositor(SwSurface* surface);
 bool rasterShape(SwSurface* surface, SwShape* shape, const RenderRegion& bbox, RenderColor& c);
 bool rasterTexmapPolygon(SwSurface* surface, const SwImage& image, const Matrix& transform, const RenderRegion& bbox, uint8_t opacity);
 bool rasterScaledImage(SwSurface* surface, const SwImage& image, const Matrix& transform, const RenderRegion& bbox, uint8_t opacity);

--- a/src/renderer/cpu_engine/tvgSwRaster.cpp
+++ b/src/renderer/cpu_engine/tvgSwRaster.cpp
@@ -1503,10 +1503,8 @@ void rasterPixel32(uint32_t *dst, uint32_t val, uint32_t offset, int32_t len)
 #endif
 }
 
-
-bool rasterCompositor(SwSurface* surface)
+Result rasterCompositor(SwSurface* surface)
 {
-    //See MaskMethod, Alpha:1, InvAlpha:2, Luma:3, InvLuma:4
     surface->alphas[0] = _alpha;
     surface->alphas[1] = _ialpha;
 
@@ -1520,9 +1518,9 @@ bool rasterCompositor(SwSurface* surface)
         surface->alphas[3] = _argbInvLuma;
     } else {
         TVGERR("SW_ENGINE", "Unsupported Colorspace(%d) is expected!", (int)surface->cs);
-        return false;
+        return Result::NonSupport;
     }
-    return true;
+    return Result::Success;
 }
 
 

--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -278,10 +278,9 @@ bool SwRenderer::sync()
     return true;
 }
 
-
-bool SwRenderer::target(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs)
+Result SwRenderer::target(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs)
 {
-    if (!data || stride == 0 || w == 0 || h == 0 || w > stride) return false;
+    if (!data || stride == 0 || w == 0 || h == 0 || w > stride) return Result::InvalidArguments;
 
     clearCompositors();
 

--- a/src/renderer/cpu_engine/tvgSwRenderer.h
+++ b/src/renderer/cpu_engine/tvgSwRenderer.h
@@ -54,7 +54,7 @@ struct SwRenderer : RenderMethod
     bool sync() override;
     bool intersectsShape(RenderData data, const RenderRegion& region) override;
     bool intersectsImage(RenderData data, const RenderRegion& region) override;
-    bool target(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs);
+    Result target(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs);
 
     //composition
     SwSurface* request(int channelSize, bool square);

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -919,11 +919,12 @@ bool GlRenderer::clear()
     return true;
 }
 
-
-bool GlRenderer::target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs)
+Result GlRenderer::target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs)
 {
+    if (cs != ColorSpace::ABGR8888S) return Result::NonSupport;
+
     //assume the context zero is invalid
-    if (!context || w == 0 || h == 0) return false;
+    if (!context || w == 0 || h == 0) return Result::InvalidArguments;
 
     if (mContext) {
         currentContext();
@@ -947,7 +948,7 @@ bool GlRenderer::target(void* display, void* surface, void* context, int32_t id,
     mRootTarget.viewport = {{0, 0}, {int32_t(this->surface.w), int32_t(this->surface.h)}};
     mRootTarget.init(this->surface.w, this->surface.h, mTargetFboId);
 
-    return ret;
+    return ret ? Result::Success : Result::InsufficientCondition;
 }
 
 

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.h
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.h
@@ -165,7 +165,7 @@ struct GlRenderer : RenderMethod
     bool clear() override;
     bool intersectsShape(RenderData data, const RenderRegion& region) override;
     bool intersectsImage(RenderData data, const RenderRegion& region) override;
-    bool target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs);
+    Result target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs);
 
     //composition
     RenderCompositor* target(const RenderRegion& region, ColorSpace cs, CompositionFlag flags) override;

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -389,15 +389,16 @@ bool WgRenderer::sync()
     return true;
 }
 
-
-bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type)
+Result WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type)
 {
+    if (cs != ColorSpace::ABGR8888S) return Result::NonSupport;
+
     if (!instance || !device || !target) {
         release();
-        return true;
+        return Result::Success;
     }
 
-    if (w == 0 || h == 0) return false;
+    if (w == 0 || h == 0) return Result::InvalidArguments;
 
     // device or instance was changed, need to recreate all instances
     if ((mContext.device != device) || (mContext.instance != instance)) {
@@ -430,7 +431,7 @@ bool WgRenderer::target(WGPUDevice device, WGPUInstance instance, void* target, 
     mTargetSurface.h = h;
     mTargetSurface.cs = cs;
 
-    return true;
+    return Result::Success;
 }
 
 WgRenderer::~WgRenderer()

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -47,7 +47,7 @@ struct WgRenderer : RenderMethod
     bool sync() override;
     bool intersectsImage(RenderData data, const RenderRegion& region) override;
     bool intersectsShape(RenderData data, const RenderRegion& region) override;
-    bool target(WGPUDevice device, WGPUInstance instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0);
+    Result target(WGPUDevice device, WGPUInstance instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0);
 
     //composition
     RenderCompositor* target(const RenderRegion& region, ColorSpace cs, CompositionFlag flags) override;

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -120,26 +120,17 @@ SwCanvas::~SwCanvas()
 Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs) noexcept
 {
 #ifdef THORVG_CPU_ENGINE_SUPPORT
-    if (cs == ColorSpace::Unknown) return Result::InvalidArguments;
-    if (cs == ColorSpace::Grayscale8) return Result::NonSupport;
+    if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) return Result::InsufficientCondition;
 
-    if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) {
-        return Result::InsufficientCondition;
-    }
+    auto ret = static_cast<SwRenderer*>(pImpl->renderer)->target(buffer, stride, w, h, cs);
+    if (ret != Result::Success) return ret;
 
-    //We know renderer type, avoid dynamic_cast for performance.
-    auto renderer = static_cast<SwRenderer*>(pImpl->renderer);
-    if (!renderer) return Result::MemoryCorruption;
-
-    if (!renderer->target(buffer, stride, w, h, cs)) return Result::InvalidArguments;
     pImpl->vport = {{0, 0}, {(int32_t)w, (int32_t)h}};
-    renderer->viewport(pImpl->vport);
+    pImpl->renderer->viewport(pImpl->vport);
+    pImpl->status = Status::Damaged;  // Paints must be updated again with this new target.
 
     //FIXME: The value must be associated with an individual canvas instance.
     ImageLoader::cs = static_cast<ColorSpace>(cs);
-
-    //Paints must be updated again with this new target.
-    pImpl->status = Status::Damaged;
 
     return Result::Success;
 #endif
@@ -180,22 +171,17 @@ GlCanvas::~GlCanvas()
 Result GlCanvas::target(void* display, void* surface, void* context, int32_t id, uint32_t w, uint32_t h, ColorSpace cs) noexcept
 {
 #ifdef THORVG_GL_ENGINE_SUPPORT
-    if (cs != ColorSpace::ABGR8888S) return Result::NonSupport;
+    if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) return Result::InsufficientCondition;
 
-    if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) {
-        return Result::InsufficientCondition;
-    }
+    auto ret = static_cast<GlRenderer*>(pImpl->renderer)->target(display, surface, context, id, w, h, cs);
+    if (ret != Result::Success) return ret;
 
-    //We know renderer type, avoid dynamic_cast for performance.
-    auto renderer = static_cast<GlRenderer*>(pImpl->renderer);
-    if (!renderer) return Result::MemoryCorruption;
-
-    if (!renderer->target(display, surface, context, id, w, h, cs)) return Result::Unknown;
     pImpl->vport = {{0, 0}, {(int32_t)w, (int32_t)h}};
-    renderer->viewport(pImpl->vport);
+    pImpl->renderer->viewport(pImpl->vport);
+    pImpl->status = Status::Damaged;  // Paints must be updated again with this new target.
 
-    //Paints must be updated again with this new target.
-    pImpl->status = Status::Damaged;
+    //FIXME: The value must be associated with an individual canvas instance.
+    ImageLoader::cs = static_cast<ColorSpace>(cs);
 
     return Result::Success;
 #endif
@@ -242,22 +228,17 @@ WgCanvas::~WgCanvas()
 Result WgCanvas::target(void* device, void* instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type) noexcept
 {
 #ifdef THORVG_WG_ENGINE_SUPPORT
-    if (cs != ColorSpace::ABGR8888S) return Result::NonSupport;
+    if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) return Result::InsufficientCondition;
 
-    if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) {
-        return Result::InsufficientCondition;
-    }
+    auto ret = static_cast<WgRenderer*>(pImpl->renderer)->target((WGPUDevice)device, (WGPUInstance)instance, target, w, h, cs, type);
+    if (ret != Result::Success) return ret;
 
-    //We know renderer type, avoid dynamic_cast for performance.
-    auto renderer = static_cast<WgRenderer*>(pImpl->renderer);
-    if (!renderer) return Result::MemoryCorruption;
-
-    if (!renderer->target((WGPUDevice)device, (WGPUInstance)instance, target, w, h, cs, type)) return Result::Unknown;
     pImpl->vport = {{0, 0}, {(int32_t)w, (int32_t)h}};
-    renderer->viewport(pImpl->vport);
+    pImpl->renderer->viewport(pImpl->vport);
+    pImpl->status = Status::Damaged;  // Paints must be updated again with this new target.
 
-    //Paints must be updated again with this new target.
-    pImpl->status = Status::Damaged;
+    //FIXME: The value must be associated with an individual canvas instance.
+    ImageLoader::cs = static_cast<ColorSpace>(cs);
 
     return Result::Success;
 #endif


### PR DESCRIPTION
- Let CPU, GL, and WebGPU renderers return Result values from target setup
  so Canvas can propagate InvalidArguments, NonSupport, and other failures
  directly.
- Keep Canvas::target() focused on canvas state updates after the selected
  engine accepts the target.