### PR TITLE
gl_engine: align drop shadow uniform layout

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
@@ -109,6 +109,7 @@ GlRenderTask* GlEffect::render(RenderEffectGaussianBlur* effect, GlRenderTarget*
 struct GlDropShadow: GlGaussianBlur {
     float color[4];
     float offset[2];
+    float dummy1[2];  // padding for std140 block alignment
 };
 
 


### PR DESCRIPTION
issue: #4129

Firefox/WebGL reported Buffer for uniform block is smaller than `UNIFORM_BLOCK_DATA_SIZE` when rendering the drop shadow effect. 

`GlDropShadow` uniform data was missing std140 tail padding, so its bound range was `40` bytes while the shader block size required `48` bytes.



|before | after |
|-|-|
|<img width="973" height="828" alt="image" src="https://github.com/user-attachments/assets/62ee79bb-00af-4ff0-ae0c-f9d154b9febb" />|<img width="1173" height="958" alt="image" src="https://github.com/user-attachments/assets/286ada0e-48d0-4e24-830e-ef47b151e94f" />|