### PR TITLE
wg_engine: texture view api

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -561,7 +561,7 @@ struct TVG_API Paint
      * @param[out] pt4 An array of four points representing the bounding box. The array size must be 4.
      *
      * @retval Result::InsufficientCondition If the paint has not been updated by the canvas.
-     * 
+     *
      * @see Paint::bounds(float* x, float* y, float* w, float* h)
      * @see Canvas::update()
      *
@@ -769,7 +769,7 @@ struct TVG_API Paint
     /**
      * @brief Safely releases a Paint object.
      *
-     * This is the counterpart to the `gen()` API, and releases the given Paint object safely, 
+     * This is the counterpart to the `gen()` API, and releases the given Paint object safely,
      * handling @c nullptr and managing ownership properly.
      *
      * @param[in] paint A Paint object to release.
@@ -986,7 +986,7 @@ struct TVG_API Canvas
      *         This may occur if Canvas::target() has not been set or if draw() is called multiple times
      *         without calling Canvas::sync() in between.
      *
-     * @note Clearing the buffer is unnecessary if the canvas will be fully covered 
+     * @note Clearing the buffer is unnecessary if the canvas will be fully covered
      *       with opaque content. Skipping the clear can improve performance.
      * @note Drawing may be performed asynchronously if the thread count is greater than zero.
      *       To ensure the drawing process is complete, call sync() afterwards.
@@ -1400,7 +1400,7 @@ struct TVG_API Shape : Paint
      * @param[in] miterlimit The miterlimit imposes a limit on the extent of the stroke join, when the @c StrokeJoin::Miter join style is set. The initial value is 4.
      *
      * @retval Result::InvalidArgument for @p miterlimit values less than zero.
-     * 
+     *
      * @since 0.11
      */
     Result strokeMiterlimit(float miterlimit) noexcept;
@@ -1501,7 +1501,7 @@ struct TVG_API Shape : Paint
     /**
      * @brief Retrieves the current fill rule used by the shape.
      *
-     * This function returns the fill rule, which determines how the interior 
+     * This function returns the fill rule, which determines how the interior
      * regions of the shape are calculated when it overlaps itself.
      *
      * @see Shape::fillRule(FillRule r)
@@ -1748,7 +1748,7 @@ struct TVG_API Picture : Paint
      *                 This can be used to maintain context or access external resources.
      *
      * @retval Result::InsufficientCondition If the picture is already loaded.
-     * 
+     *
      * @warning This function must be called before @ref Picture::load()
      *          Setting the resolver after loading will have no effect on asset resolution for that asset.
      * @note @p src will be either a font path or a font name. In the case of a font name, @p src will begin with "name:", e.g., "name:FreeSans-Medium".
@@ -1855,8 +1855,8 @@ struct TVG_API Scene : Paint
     /**
      * @brief Adds a paint object to the scene.
      *
-     * Appends a paint object to the scene. If the optional @p at parameter is provided, 
-     * the paint object is inserted immediately before the specified paint in the scene. 
+     * Appends a paint object to the scene. If the optional @p at parameter is provided,
+     * the paint object is inserted immediately before the specified paint in the scene.
      * If @p at is @c nullptr, the paint object is appended to the end of the scene.
      *
      * @param[in] target A pointer to the Paint object to be added to the scene.
@@ -2287,7 +2287,7 @@ struct TVG_API Text : Paint
      *
      * @note If the font data is currently in use, it will not be immediately unloaded.
      * @see Text::load(const char* filename)
-     * 
+     *
      * @since 0.15
      */
     static Result unload(const char* filename) noexcept;
@@ -2502,6 +2502,26 @@ struct TVG_API WgCanvas final : Canvas
      * @note Experimental API
      */
     Result target(const Context& context, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0) noexcept;
+
+    /**
+     * @brief Sets a caller-managed WebGPU texture view as the drawing target for the rasterization.
+     *
+     * @param[in] device WGPUDevice, the handle for the wgpu device backing the encoder and view.
+     * @param[in] commandEncoder WGPUCommandEncoder, the encoder ThorVG records into.
+     * @param[in] view WGPUTextureView, the destination view the result is blitted to.
+     * @param[in] w The width of the target.
+     * @param[in] h The height of the target.
+     * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it allows @c ColorSpace::ABGR8888 and @c ColorSpace::ABGR8888S.
+     *
+     * @retval Result::InsufficientCondition if the canvas is performing rendering. Please ensure the canvas is synced.
+     * @retval Result::NonSupport In case the wg engine is not supported.
+     *
+     * @note Experimental API
+     *
+     * @see Canvas::viewport()
+     * @see Canvas::sync()
+     */
+    Result targetView(void* device, void* commandEncoder, void* view, uint32_t w, uint32_t h, ColorSpace cs) noexcept;
 
     /**
      * @brief Creates a new WebGPU Canvas object with optional rendering engine settings.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -679,6 +679,24 @@ TVG_API Tvg_Result tvg_wgcanvas_set_target(Tvg_Canvas canvas, void* device, void
  */
 TVG_API Tvg_Result tvg_wgcanvas_set_target_with_context(Tvg_Canvas canvas, const Tvg_WgContext* context, void* target, uint32_t w, uint32_t h, Tvg_Colorspace cs, int type);
 
+/**
+ * @brief Sets a caller-managed WebGPU texture view as the drawing target for the rasterization.
+ *
+ * @param[in] canvas The Tvg_Canvas object to set the target for.
+ * @param[in] device WGPUDevice, the handle for the wgpu device backing the encoder and view.
+ * @param[in] command_encoder WGPUCommandEncoder, the encoder ThorVG records into.
+ * @param[in] view WGPUTextureView, the destination view the result is blitted to.
+ * @param[in] w The width of the target.
+ * @param[in] h The height of the target.
+ * @param[in] cs Specifies how the pixel values should be interpreted. Currently, it allows @c TVG_COLORSPACE_ABGR8888 and @c TVG_COLORSPACE_ABGR8888S.
+ *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
+ * @retval TVG_RESULT_NOT_SUPPORTED In case the wg engine is not supported.
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_wgcanvas_set_target_view(Tvg_Canvas canvas, void* device, void* command_encoder, void* view, uint32_t w, uint32_t h, Tvg_Colorspace cs);
+
 /** \} */   // end defgroup ThorVGCapi_WgCanvas
 
 /************************************************************************/
@@ -863,7 +881,7 @@ TVG_API Tvg_Result tvg_canvas_set_viewport(Tvg_Canvas canvas, int32_t x, int32_t
 /**
  * @brief Safely releases a Tv_Paint object.
  *
- * This is the counterpart to the `new()` API, and releases the given Paint object safely, 
+ * This is the counterpart to the `new()` API, and releases the given Paint object safely,
  * handling @c nullptr and managing ownership properly.
  *
  * @param[in] paint A paint object to release.
@@ -1039,7 +1057,7 @@ TVG_API Tvg_Result tvg_paint_translate(Tvg_Paint paint, float x, float y);
  *
  * @param[in] paint The paint object to be transformed.
  * @param[in] m The 3x3 augmented matrix.
- * 
+ *
  */
 TVG_API Tvg_Result tvg_paint_set_transform(Tvg_Paint paint, const Tvg_Matrix* m);
 
@@ -1690,7 +1708,7 @@ TVG_API Tvg_Result tvg_shape_set_fill_rule(Tvg_Paint paint, Tvg_Fill_Rule rule);
 /**
  * @brief Retrieves the current fill rule used by the shape.
  *
- * This function returns the fill rule, which determines how the interior 
+ * This function returns the fill rule, which determines how the interior
  * regions of the shape are calculated when it overlaps itself.
  *
  * @param[in] paint The shape object.
@@ -2294,8 +2312,8 @@ TVG_API Tvg_Result tvg_scene_add_effect_gaussian_blur(Tvg_Paint scene, double si
 /**
  * @brief Adds a drop shadow effect to the scene.
  *
- * This function adds a drop shadow with a Gaussian blur to the scene. The shadow 
- * can be customized using color, opacity, angle, distance, blur radius (sigma), 
+ * This function adds a drop shadow with a Gaussian blur to the scene. The shadow
+ * can be customized using color, opacity, angle, distance, blur radius (sigma),
  * and quality parameters.
  *
  * @param[in] scene The scene object.
@@ -2349,7 +2367,7 @@ TVG_API Tvg_Result tvg_scene_add_effect_tint(Tvg_Paint scene, int black_r, int b
 /**
  * @brief Adds a tritone color effect to the scene.
  *
- * This function adds a tritone color effect to the given scene using three sets of RGB values 
+ * This function adds a tritone color effect to the given scene using three sets of RGB values
  * representing shadow, midtone, and highlight colors.
  *
  * @param[in] scene The scene object.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -119,6 +119,13 @@ TVG_API Tvg_Result tvg_wgcanvas_set_target_with_context(Tvg_Canvas canvas, const
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
+TVG_API Tvg_Result tvg_wgcanvas_set_target_view(Tvg_Canvas canvas, void* device, void* command_encoder, void* view, uint32_t w, uint32_t h, Tvg_Colorspace cs)
+{
+    if (canvas) return (Tvg_Result) reinterpret_cast<WgCanvas*>(canvas)->targetView(device, command_encoder, view, w, h, static_cast<ColorSpace>(cs));
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
+
 TVG_API Tvg_Result tvg_canvas_add(Tvg_Canvas canvas, Tvg_Paint paint)
 {
     if (canvas && paint) return (Tvg_Result) reinterpret_cast<Canvas*>(canvas)->add((Paint*)paint);

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
@@ -151,7 +151,6 @@ void WgContext::releaseTexture(WGPUTexture& texture)
         wgpuTextureRelease(texture);
         texture = nullptr;
     }
-    
 }
 
 
@@ -211,7 +210,7 @@ bool WgContext::allocateBufferIndex(WGPUBuffer& buffer, const uint32_t* data, ui
 
 void WgContext::releaseBuffer(WGPUBuffer& buffer)
 {
-    if (buffer) { 
+    if (buffer) {
         wgpuBufferDestroy(buffer);
         wgpuBufferRelease(buffer);
         buffer = nullptr;
@@ -260,5 +259,5 @@ void WgContext::submit()
 
 bool WgContext::invalid()
 {
-    return !instance || !device;
+    return !queue;
 }

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -90,6 +90,10 @@ void WgRenderer::clearTargets()
     if (surface) wgpuSurfaceUnconfigure(surface);
     targetTexture = nullptr;
     surface = nullptr;
+    if (externalView) wgpuTextureViewRelease(externalView);
+    if (externalCommandEncoder) wgpuCommandEncoderRelease(externalCommandEncoder);
+    externalView = nullptr;
+    externalCommandEncoder = nullptr;
     mTargetSurface.stride = 0;
     mTargetSurface.w = 0;
     mTargetSurface.h = 0;
@@ -272,16 +276,22 @@ bool WgRenderer::postRender()
     // flush stage data to gpu
     mCompositor.flush(mContext);
 
-    // create command encoder for drawing
-    WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
-
-    // run rendering (all the fun is here)
     WgSceneTask* sceneTaskRoot = mSceneTaskStack.last();
-    sceneTaskRoot->run(mContext, mCompositor, commandEncoder);
 
-    // execute and release command encoder
-    mContext.submitCommandEncoder(commandEncoder);
-    mContext.releaseCommandEncoder(commandEncoder);
+    if (externalCommandEncoder) {
+        // record into the caller-owned encoder; the caller owns submission
+        sceneTaskRoot->run(mContext, mCompositor, externalCommandEncoder);
+    } else {
+        // create command encoder for drawing
+        WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
+
+        // run rendering (all the fun is here)
+        sceneTaskRoot->run(mContext, mCompositor, commandEncoder);
+
+        // execute and release command encoder
+        mContext.submitCommandEncoder(commandEncoder);
+        mContext.releaseCommandEncoder(commandEncoder);
+    }
 
     // clear the render tasks tree
     mSceneTaskStack.pop();
@@ -377,6 +387,17 @@ bool WgRenderer::sync()
 
     disposeObjects();
 
+    if (externalView) {
+        if (externalCommandEncoder) {
+            mCompositor.blit(mContext, externalCommandEncoder, &mRenderTargetRoot, externalView, mTargetSurface.premultiplied);
+            wgpuCommandEncoderRelease(externalCommandEncoder);
+            externalCommandEncoder = nullptr;
+        }
+        wgpuTextureViewRelease(externalView);
+        externalView = nullptr;
+        return true;
+    }
+
     // if texture buffer used
     WGPUTexture dstTexture = targetTexture;
     if (surface) {
@@ -388,7 +409,7 @@ bool WgRenderer::sync()
     if (!dstTexture) return false;
 
     // insure that surface and offscreen target have the same size
-    if ((wgpuTextureGetWidth(dstTexture) == mRenderTargetRoot.width) && 
+    if ((wgpuTextureGetWidth(dstTexture) == mRenderTargetRoot.width) &&
         (wgpuTextureGetHeight(dstTexture) == mRenderTargetRoot.height)) {
         WGPUTextureView dstTextureView = mContext.createTextureView(dstTexture);
         WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
@@ -439,6 +460,58 @@ Result WgRenderer::target(const WgCanvas::Context& ctx, void* target, uint32_t w
     // configure surface (must be called after context creation)
     if (type == 0) surfaceConfigure((WGPUSurface)target, mContext, w, h, cs);
     else targetTexture = (WGPUTexture)target;
+
+    return Result::Success;
+}
+
+Result WgRenderer::targetView(WGPUDevice device, WGPUCommandEncoder commandEncoder, WGPUTextureView view, uint32_t w, uint32_t h, ColorSpace cs)
+{
+    if (cs != ColorSpace::ABGR8888 && cs != ColorSpace::ABGR8888S) return Result::NonSupport;
+
+    // all handles null clears the target; any partial-null combination is an error
+    if (!device && !commandEncoder && !view) {
+        release();
+        return Result::Success;
+    }
+    if (!device || !commandEncoder || !view) return Result::InvalidArguments;
+
+    if (w == 0 || h == 0) return Result::InvalidArguments;
+
+    if (mContext.device != device) {
+        release();
+        // view targets drive a caller-owned encoder, so only the device is needed;
+        // instance/adapter stay null (no surface configuration in this path).
+        mContext.initialize({nullptr, nullptr, device});
+        mRenderTargetPool.initialize(mContext, w, h);
+        mRenderTargetRoot.initialize(mContext, w, h);
+        mCompositor.initialize(mContext, w, h);
+    } else if ((mTargetSurface.w != w) || (mTargetSurface.h != h)) {
+        mRenderTargetPool.release(mContext);
+        mRenderTargetRoot.release(mContext);
+        clearTargets();
+        mRenderTargetPool.initialize(mContext, w, h);
+        mRenderTargetRoot.initialize(mContext, w, h);
+        mCompositor.resize(mContext, w, h);
+    }
+
+    releaseSurfaceTexture();
+    if (surface) wgpuSurfaceUnconfigure(surface);
+    surface = nullptr;
+    targetTexture = nullptr;
+
+    // retain the caller-owned handles until they are consumed in sync()
+    wgpuCommandEncoderAddRef(commandEncoder);
+    wgpuTextureViewAddRef(view);
+    if (externalCommandEncoder) wgpuCommandEncoderRelease(externalCommandEncoder);
+    if (externalView) wgpuTextureViewRelease(externalView);
+    externalCommandEncoder = commandEncoder;
+    externalView = view;
+
+    mTargetSurface.stride = w;
+    mTargetSurface.w = w;
+    mTargetSurface.h = h;
+    mTargetSurface.cs = cs;
+    mTargetSurface.premultiplied = (cs == ColorSpace::ABGR8888);
 
     return Result::Success;
 }

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -49,6 +49,7 @@ struct WgRenderer : RenderMethod
     bool intersectsImage(RenderData data, const RenderRegion& region) override;
     bool intersectsShape(RenderData data, const RenderRegion& region) override;
     Result target(const WgCanvas::Context& ctx, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0);
+    Result targetView(WGPUDevice device, WGPUCommandEncoder commandEncoder, WGPUTextureView view, uint32_t w, uint32_t h, ColorSpace cs);
 
     //composition
     RenderCompositor* target(const RenderRegion& region, ColorSpace cs, CompositionFlag flags) override;
@@ -109,6 +110,8 @@ private:
     WGPUTexture targetTexture{}; // external handle
     WGPUSurfaceTexture surfaceTexture{};
     WGPUSurface surface{};  // external handle
+    WGPUTextureView externalView{};  // external handle
+    WGPUCommandEncoder externalCommandEncoder{};  // external handle
 };
 
 #endif /* _TVG_WG_RENDERER_H_ */

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -248,6 +248,28 @@ Result WgCanvas::target(const Context& context, void* target, uint32_t w, uint32
     return Result::NonSupport;
 }
 
+
+Result WgCanvas::targetView(void* device, void* commandEncoder, void* view, uint32_t w, uint32_t h, ColorSpace cs) noexcept
+{
+#ifdef THORVG_WG_ENGINE_SUPPORT
+    if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) return Result::InsufficientCondition;
+
+    auto ret = static_cast<WgRenderer*>(pImpl->renderer)->targetView((WGPUDevice)device, (WGPUCommandEncoder)commandEncoder, (WGPUTextureView)view, w, h, cs);
+    if (ret != Result::Success) return ret;
+
+    pImpl->vport = {{0, 0}, {(int32_t)w, (int32_t)h}};
+    pImpl->renderer->viewport(pImpl->vport);
+    pImpl->status = Status::Damaged;  // Paints must be updated again with this new target.
+
+    //FIXME: The value must be associated with an individual canvas instance.
+    ImageLoader::cs = static_cast<ColorSpace>(cs);
+
+    return Result::Success;
+#endif
+    return Result::NonSupport;
+}
+
+
 WgCanvas* WgCanvas::gen(EngineOption op) noexcept
 {
 #ifdef THORVG_WG_ENGINE_SUPPORT

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -254,12 +254,20 @@ Result WgCanvas::targetView(void* device, void* commandEncoder, void* view, uint
 #ifdef THORVG_WG_ENGINE_SUPPORT
     if (pImpl->status == Status::Updating || pImpl->status == Status::Drawing) return Result::InsufficientCondition;
 
+    // A per-frame re-target rotates only the caller's encoder/view; the internal
+    // render target is unchanged, so paints must not be re-tessellated. Only a size
+    // or colorspace change (or the first target) reallocates the render target and
+    // truly damages the paint data. Compare against the renderer's current target
+    // before the call mutates it.
+    auto prev = pImpl->renderer->mainSurface();
+    bool damaged = !prev || prev->w != w || prev->h != h || prev->cs != cs;
+
     auto ret = static_cast<WgRenderer*>(pImpl->renderer)->targetView((WGPUDevice)device, (WGPUCommandEncoder)commandEncoder, (WGPUTextureView)view, w, h, cs);
     if (ret != Result::Success) return ret;
 
     pImpl->vport = {{0, 0}, {(int32_t)w, (int32_t)h}};
     pImpl->renderer->viewport(pImpl->vport);
-    pImpl->status = Status::Damaged;  // Paints must be updated again with this new target.
+    if (damaged) pImpl->status = Status::Damaged;  // new target invalidates paint data
 
     //FIXME: The value must be associated with an individual canvas instance.
     ImageLoader::cs = static_cast<ColorSpace>(cs);


### PR DESCRIPTION
Adds an api for using `WGPUCommandEncoder` and `WGPUTextureView` as a target in the wg canvas