### PR TITLE
lottie: tritone color effect bug

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -205,7 +205,7 @@ struct LottieFxTritone : LottieEffect
     LottieColor bright;
     LottieColor midtone;
     LottieColor dark;
-    LottieOpacity blend;
+    LottieOpacity blend = 0;
 
     LottieFxTritone()
     {


### PR DESCRIPTION
#4478

### Summary

This was an issue that occurred very randomly.


The asset did not contain an element corresponding to blend, which caused a garbage value to be used. 
As a result, a bug occurred where the color changed randomly.


This issue was reproduced only in the Ubuntu environment and the WASM web environment. (CPU, GL, WG)


Setting blend = 0 should be sufficient, but I think we need to initialize default values for structures where certain elements may be missing.

### Screenshot

|before | after| 
|-|-|
|<img width="1197" height="452" alt="Screenshot 2026-06-27 at 04 24 32" src="https://github.com/user-attachments/assets/a8dba51f-443b-450c-9fff-5d0131255d7b" />|<img width="1197" height="452" alt="Screenshot 2026-06-27 at 04 25 58" src="https://github.com/user-attachments/assets/93b5c4fa-33e2-4f6e-aaaf-f06bb0741b00" />|

### Details

The asset contains only three tritone effect properties:

```json
// triton.json
"ef": [
                {
                    "ty": 23,
                    "en": 1,
                    "ef": [
                        {
                            "ty": 2,
                            "v": {
                                "k": [
                                    1,
                                    0.8,
                                    1,
                                    1
                                ],
                                "a": 0
                            }
                        },
                        {
                            "ty": 2,
                            "v": {
                                "k": [
                                    0.1,
                                    0.8,
                                    1,
                                    1
                                ],
                                "a": 0
                            }
                        },
                        {
                            "ty": 2,
                            "v": {
                                "k": [
                                    0.4,
                                    0.8,
                                    0,
                                    1
                                ],
                                "a": 0
                            }
                        }
                    ]
                }
            ],
```

The parser maps tritone properties by array index:

```cpp
  //src/loaders/lottie/tvgLottieParser.cpp:1491
  
  if (idx == 0) parsePropertyInternal(tritone->bright);
  else if (idx == 1) parsePropertyInternal(tritone->midtone);
  else if (idx == 2) parsePropertyInternal(tritone->dark);
  else if (idx == 3) parsePropertyInternal(tritone->blend);
```

Since idx == 3 is missing in this asset, blend keeps its default value. The builder later uses it when adding the render effect:

```cpp
  // src/loaders/lottie/tvgLottieBuilder.cpp
            case LottieEffect::Tritone: {
                auto effect = static_cast<LottieFxTritone*>(*p);
                auto dark = effect->dark(frameNo);
                auto midtone = effect->midtone(frameNo);
                auto bright = effect->bright(frameNo);
                layer->scene->add(SceneEffect::Tritone, dark.r, dark.g, dark.b, midtone.r, midtone.g, midtone.b, bright.r, bright.g, bright.b, (int)effect->blend(frameNo));
                break;
            }
```

