### PR TITLE
lottie: correct path tweening transform

### DIFF
--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -625,7 +625,7 @@ struct LottiePathSet : LottieProperty
         }
 
         // apply modifiers
-        if (modifier) modifier->path(tmp, out, transform);
+        if (modifier) modifier->path(tmp, out, nullptr);
 
         return true;
     }


### PR DESCRIPTION
The source path used for tweening has already been transformed. Avoid applying the transform a second time in the modifier application.