### PR TITLE
lottie: add dynamic tweening support

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -3178,6 +3178,42 @@ TVG_API Tvg_Result tvg_lottie_animation_get_marker_info(Tvg_Animation animation,
 TVG_API Tvg_Result tvg_lottie_animation_tween(Tvg_Animation animation, float from, float to, float progress);
 
 /**
+ * @brief Sets the target frame for dynamic tweening.
+ *
+ * This method starts a dynamic interpolation from the current animation frame
+ * toward @p to. Use tvg_lottie_animation_tween_go() to update the interpolation progress.
+ *
+ * @param[in] animation The Lottie animation object.
+ * @param[in] to The target frame number of the interpolation.
+ *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the animation is not loaded.
+ *
+ * @note The dynamic tweening set by this method is discarded when @ref tvg_animation_set_frame()
+ *       or @ref tvg_lottie_animation_tween() is called.
+ *
+ * @see tvg_lottie_animation_tween_go()
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_lottie_animation_tween_to(Tvg_Animation animation, float to);
+
+/**
+ * @brief Updates the current tween toward the target frame.
+ *
+ * This method advances the interpolation started by @ref tvg_lottie_animation_tween_to() using the
+ * given @p progress value.
+ *
+ * @param[in] animation The Lottie animation object.
+ * @param[in] progress The current progress of the interpolation (range: 0.0 to 1.0).
+ *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the animation is not loaded.
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If @ref tvg_lottie_animation_tween_to() has not been called.
+ *
+ * @see tvg_lottie_animation_tween_to()
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_lottie_animation_tween_go(Tvg_Animation animation, float progress);
+
+/**
  * @brief Sets the quality level for Lottie effects.
  *
  * This function controls the rendering quality of effects like blur, shadows, etc.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -1291,6 +1291,24 @@ TVG_API Tvg_Result tvg_lottie_animation_tween(Tvg_Animation animation, float fro
     return TVG_RESULT_NOT_SUPPORTED;
 }
 
+TVG_API Tvg_Result tvg_lottie_animation_tween_to(Tvg_Animation animation, float to)
+{
+#ifdef THORVG_LOTTIE_LOADER_SUPPORT
+    if (animation) return (Tvg_Result) reinterpret_cast<LottieAnimation*>(animation)->tweenTo(to);
+    return TVG_RESULT_INVALID_ARGUMENT;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
+TVG_API Tvg_Result tvg_lottie_animation_tween_go(Tvg_Animation animation, float progress)
+{
+#ifdef THORVG_LOTTIE_LOADER_SUPPORT
+    if (animation) return (Tvg_Result) reinterpret_cast<LottieAnimation*>(animation)->tween(progress);
+    return TVG_RESULT_INVALID_ARGUMENT;
+#endif
+    return TVG_RESULT_NOT_SUPPORTED;
+}
+
 TVG_API Tvg_Result tvg_lottie_animation_set_quality(Tvg_Animation animation, uint8_t value)
 {
 #ifdef THORVG_LOTTIE_LOADER_SUPPORT

--- a/src/loaders/lottie/meson.build
+++ b/src/loaders/lottie/meson.build
@@ -14,6 +14,7 @@ source_file = [
    'tvgLottieParserHandler.h',
    'tvgLottieProperty.h',
    'tvgLottieRenderPooler.h',
+   'tvgLottieTween.h',
    'tvgLottieAnimation.cpp',
    'tvgLottieBuilder.cpp',
    'tvgLottieExpressions.cpp',

--- a/src/loaders/lottie/thorvg_lottie.h
+++ b/src/loaders/lottie/thorvg_lottie.h
@@ -87,9 +87,45 @@ struct TVG_API LottieAnimation final : Animation
      *
      * @retval Result::InsufficientCondition In case the animation is not loaded.
      *
+     * @see tweenTo(float)
+     *
      * @since 1.0
      */
     Result tween(float from, float to, float progress) noexcept;
+
+    /**
+     * @brief Sets the target frame for dynamic tweening.
+     *
+     * This method starts a dynamic interpolation from the current animation frame
+     * toward @p to. Use tween(float progress) to update the interpolation progress.
+     *
+     * @param[in] to The target frame number of the interpolation.
+     *
+     * @retval Result::InsufficientCondition If the animation is not loaded.
+     *
+     * @note The dynamic tweening set by this method is discarded when @ref Animation::frame()
+     *       or @ref LottieAnimation::tween(float,float,float) is called.
+     *
+     * @see tween(float)
+     * @note Experimental API
+     */
+    Result tweenTo(float to) noexcept;
+
+    /**
+     * @brief Updates the current tween toward the target frame.
+     *
+     * This method advances the interpolation started by tweenTo() using the
+     * given @p progress value.
+     *
+     * @param[in] progress The current progress of the interpolation (range: 0.0 to 1.0).
+     *
+     * @retval Result::InsufficientCondition If the animation is not loaded.
+     * @retval Result::InsufficientCondition If @ref tweenTo() has not been called.
+     *
+     * @see tweenTo()
+     * @note Experimental API
+     */
+    Result tween(float progress) noexcept;
 
     /**
      * @brief Gets the marker count of the animation.

--- a/src/loaders/lottie/tvgLottieAnimation.cpp
+++ b/src/loaders/lottie/tvgLottieAnimation.cpp
@@ -90,6 +90,20 @@ Result LottieAnimation::tween(float from, float to, float progress) noexcept
     return Result::Success;
 }
 
+Result LottieAnimation::tween(float progress) noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    if (!loader->tween(progress)) return Result::InsufficientCondition;
+    PAINT(pImpl->picture)->mark(RenderUpdateFlag::All);
+    return Result::Success;
+}
+
+Result LottieAnimation::tweenTo(float to) noexcept
+{
+    FETCH_LOADER(Result::InsufficientCondition);
+    if (static_cast<LottieLoader*>(loader)->tweenTo(to)) return Result::Success;
+    return Result::InsufficientCondition;
+}
 
 uint32_t LottieAnimation::markersCnt() noexcept
 {

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -29,7 +29,7 @@
 #include "tvgLottieModel.h"
 #include "tvgLottieBuilder.h"
 #include "tvgLottieExpressions.h"
-
+#include "tvgLottieTween.h"
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -38,7 +38,7 @@
 static bool _buildComposition(LottieComposition* comp, LottieLayer* parent);
 static bool _draw(LottieGroup* parent, LottieShape* shape, RenderContext* ctx);
 
-static void _dimension3d(LottieTransform* transform, float frameNo, Matrix& m, float angle, Tween& tween, LottieExpressions* exps)
+static void _dimension3d(LottieTransform* transform, float frameNo, Matrix& m, float angle, LottieTween& tween, LottieExpressions* exps)
 {
     auto x = deg2rad(transform->ddd->rx(frameNo, tween, exps));
     auto y = deg2rad(transform->ddd->ry(frameNo, tween, exps));
@@ -86,7 +86,7 @@ static void _dimension3d(LottieTransform* transform, float frameNo, Matrix& m, f
     m.e22 = ri10 * ro01 + ri11 * ro11 + ri12 * ro21;
 }
 
-static void _rotate(LottieTransform* transform, float frameNo, Matrix& m, float angle, Tween& tween, LottieExpressions* exps)
+static void _rotate(LottieTransform* transform, float frameNo, Matrix& m, float angle, LottieTween& tween, LottieExpressions* exps)
 {
     if (transform->ddd) {
         _dimension3d(transform, frameNo, m, angle, tween, exps);
@@ -138,8 +138,7 @@ static void _skew(Matrix* m, float angleDeg, float axisDeg)
     m->e22 = B * e21 + (1.0f + A) * m->e22;
 }
 
-
-static bool _update(LottieTransform* transform, float frameNo, Matrix& matrix, uint8_t& opacity, bool autoOrient, Tween& tween, LottieExpressions* exps)
+static bool _update(LottieTransform* transform, float frameNo, Matrix& matrix, uint8_t& opacity, bool autoOrient, LottieTween& tween, LottieExpressions* exps)
 {
     tvg::identity(&matrix);
 
@@ -179,7 +178,7 @@ static bool _update(LottieTransform* transform, float frameNo, Matrix& matrix, u
 
 void LottieBuilder::updateTransform(LottieLayer* layer, float frameNo)
 {
-    if (!layer || (!tweening() && tvg::equal(layer->cache.frameNo, frameNo))) return;
+    if (!layer || (!tween.active && tvg::equal(layer->cache.frameNo, frameNo))) return;
 
     auto transform = layer->transform;
     auto parent = layer->parent;
@@ -273,8 +272,7 @@ void LottieBuilder::updateGroup(LottieGroup* parent, LottieObject** child, float
     updateChildren(group, frameNo, contexts);
 }
 
-
-static void _update(LottieStroke* stroke, float frameNo, RenderContext* ctx, Tween& tween, LottieExpressions* exps)
+static void _update(LottieStroke* stroke, float frameNo, RenderContext* ctx, LottieTween& tween, LottieExpressions* exps)
 {
     ctx->propagator->strokeWidth(stroke->width(frameNo, tween, exps));
     ctx->propagator->strokeCap(stroke->cap);
@@ -537,9 +535,8 @@ void LottieBuilder::updatePath(LottieGroup* parent, LottieObject** child, float 
 
     if (ctx->repeaters.empty()) {
         _draw(parent, path, ctx);
-        if (path->pathset(frameNo, to<ShapeImpl>(ctx->merging)->rs.path, ctx->transform, tween, exps, ctx->modifiers)) {
-            PAINT(ctx->merging)->mark(RenderUpdateFlag::Path);
-        }
+        path->pathset(frameNo, to<ShapeImpl>(ctx->merging)->rs.path, ctx->transform, tween, exps, ctx->modifiers);
+        PAINT(ctx->merging)->mark(RenderUpdateFlag::Path);
     } else {
         auto shape = path->pooling();
         shape->reset();
@@ -555,8 +552,7 @@ static void _close(Array<Point>& pts, const Point& p, bool round)
     pts.last() = p;
 }
 
-
-void LottieBuilder::updateStar(LottiePolyStar* star, float frameNo, Matrix* transform, Shape* merging, RenderContext* ctx, Tween& tween, LottieExpressions* exps)
+void LottieBuilder::updateStar(LottiePolyStar* star, float frameNo, Matrix* transform, Shape* merging, RenderContext* ctx, LottieTween& tween, LottieExpressions* exps)
 {
     static constexpr auto POLYSTAR_MAGIC_NUMBER = 0.47829f / 0.28f;
 
@@ -669,8 +665,7 @@ void LottieBuilder::updateStar(LottiePolyStar* star, float frameNo, Matrix* tran
     if (ctx->modifiers) ctx->modifiers->polystar(to<ShapeImpl>(shape)->rs.path, to<ShapeImpl>(merging)->rs.path, outerRoundness, hasRoundness);
 }
 
-
-void LottieBuilder::updatePolygon(LottieGroup* parent, LottiePolyStar* star, float frameNo, Matrix* transform, Shape* merging, RenderContext* ctx, Tween& tween, LottieExpressions* exps)
+void LottieBuilder::updatePolygon(LottieGroup* parent, LottiePolyStar* star, float frameNo, Matrix* transform, Shape* merging, RenderContext* ctx, LottieTween& tween, LottieExpressions* exps)
 {
     static constexpr auto POLYGON_MAGIC_NUMBER = 0.25f;
 
@@ -941,16 +936,15 @@ void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp,
     precomp->scene->clip(clipper);
 }
 
-
-void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, Tween& tween)
+void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, LottieTween& tween)
 {
     //record & recover the tweening frame number before remapping
-    auto record = tween.frameNo;
-    tween.frameNo = precomp->remap(comp, record, exps);
+    auto record = tween.to;
+    tween.to = precomp->remap(comp, record, exps);
 
     updatePrecomp(comp, precomp, frameNo);
 
-    tween.frameNo = record;
+    tween.to = record;
 }
 
 
@@ -1090,9 +1084,8 @@ Shape* LottieBuilder::textShape(LottieText* text, float frameNo, const TextDocum
     ARRAY_FOREACH(p, glyph->children) {
         auto group = static_cast<LottieGroup*>(*p);
         ARRAY_FOREACH(p, group->children) {
-            if (static_cast<LottiePath*>(*p)->pathset(frameNo, to<ShapeImpl>(shape)->rs.path, nullptr, tween, exps)) {
-                PAINT(shape)->mark(RenderUpdateFlag::Path);
-            }
+            static_cast<LottiePath*>(*p)->pathset(frameNo, to<ShapeImpl>(shape)->rs.path, nullptr, tween, exps);
+            PAINT(shape)->mark(RenderUpdateFlag::Path);
         }
     }
     shape->fill(doc.color.r, doc.color.g, doc.color.b);
@@ -1573,7 +1566,7 @@ void LottieBuilder::updateLayer(LottieComposition* comp, Scene* scene, LottieLay
 
     switch (layer->type) {
         case LottieLayer::Precomp: {
-            if (!tweening()) updatePrecomp(comp, layer, frameNo);
+            if (!tween.active) updatePrecomp(comp, layer, frameNo);
             else updatePrecomp(comp, layer, frameNo, tween);
             break;
         }
@@ -1752,11 +1745,7 @@ bool LottieBuilder::update(LottieComposition* comp, float frameNo)
 
     comp->clamp(frameNo);
 
-    if (tweening()) {
-        comp->clamp(tween.frameNo);
-        //tweening is not necessary.
-        if (equal(frameNo, tween.frameNo)) offTween();
-    }
+    if (tween.active) comp->clamp(tween.to);
 
     if (exps && comp->expressions) exps->update(comp->timeAtFrame(frameNo));
 

--- a/src/loaders/lottie/tvgLottieBuilder.h
+++ b/src/loaders/lottie/tvgLottieBuilder.h
@@ -28,6 +28,7 @@
 #include "tvgShape.h"
 #include "tvgLottieExpressions.h"
 #include "tvgLottieModifier.h"
+#include "tvgLottieTween.h"
 #include "thorvg_lottie.h"
 
 struct LottieComposition;
@@ -171,28 +172,12 @@ struct LottieBuilder
         return exps ? true : false;
     }
 
-    void offTween()
-    {
-        if (tween.active) tween.active = false;
-    }
-
-    void onTween(float to, float progress)
-    {
-        tween.frameNo = to;
-        tween.progress = progress;
-        tween.active = true;
-    }
-
-    bool tweening()
-    {
-        return tween.active;
-    }
-
     bool update(LottieComposition* comp, float progress);
     void build(LottieComposition* comp);
 
     const AssetResolver* resolver = nullptr;  //do not free this
     AudioResolver audioResolver;
+    LottieTween tween;
 
 private:
     void updateAudio(LottieComposition* comp, LottieLayer* layer, float frameNo);
@@ -206,7 +191,7 @@ private:
     void updateLayer(LottieComposition* comp, Scene* scene, LottieLayer* layer, float frameNo);
     bool updateMatte(LottieComposition* comp, float frameNo, Scene* scene, LottieLayer* layer);
     void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo);
-    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, Tween& tween);
+    void updatePrecomp(LottieComposition* comp, LottieLayer* precomp, float frameNo, LottieTween& tween);
     void updateSolid(LottieLayer* layer);
     void updateImage(LottieGroup* layer);
     void updateURLFont(LottieLayer* layer, float frameNo, LottieText* text, const TextDocument& doc);
@@ -226,8 +211,8 @@ private:
     void updateEllipse(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updatePath(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updatePolystar(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
-    void updateStar(LottiePolyStar* star, float frameNo, Matrix* transform, Shape* merging, RenderContext* ctx, Tween& tween, LottieExpressions* exps);
-    void updatePolygon(LottieGroup* parent, LottiePolyStar* star, float frameNo, Matrix* transform, Shape* merging, RenderContext* ctx, Tween& tween, LottieExpressions* exps);
+    void updateStar(LottiePolyStar* star, float frameNo, Matrix* transform, Shape* merging, RenderContext* ctx, LottieTween& tween, LottieExpressions* exps);
+    void updatePolygon(LottieGroup* parent, LottiePolyStar* star, float frameNo, Matrix* transform, Shape* merging, RenderContext* ctx, LottieTween& tween, LottieExpressions* exps);
     void updateTrimpath(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updateRepeater(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
     void updateRoundedCorner(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
@@ -236,7 +221,6 @@ private:
     void updateZigZag(LottieGroup* parent, LottieObject** child, float frameNo, Inlist<RenderContext>& contexts, RenderContext* ctx);
 
     LottieExpressions* exps;
-    Tween tween;
 };
 
 #endif //_TVG_LOTTIE_BUILDER_H

--- a/src/loaders/lottie/tvgLottieCommon.h
+++ b/src/loaders/lottie/tvgLottieCommon.h
@@ -96,15 +96,6 @@ struct TextDocument
     }
 };
 
-
-struct Tween
-{
-    float frameNo = 0.0f;
-    float progress = 0.0f;  //greater than 0 and smaller than 1
-    bool active = false;
-};
-
-
 static inline int32_t REMAP255(float val)
 {
     return (int32_t)nearbyintf(val * 255.0f);

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -386,13 +386,13 @@ bool LottieLoader::frame(float no)
     no = shorten(no);
 
     //Skip update if frame diff is too small.
-    if (!builder->tweening() && fabsf(this->frameNo - no) <= 0.0009f) return false;
+    if (!builder->tween.active && fabsf(this->frameNo - no) <= 0.0009f) return false;
 
     this->done();
 
     this->frameNo = no;
 
-    builder->offTween();
+    builder->tween.off();
 
     if (comp) comp->clear();     //clear synchronously
 
@@ -487,23 +487,50 @@ bool LottieLoader::ready()
         if (comp) return true;
     }
     done();
-    if (comp) return true;
-    return false;
+    return comp ? true : false;
 }
 
-
-bool LottieLoader::tween(float from, float to, float progress)
+bool LottieLoader::tweenTo(float to)
 {
-    //tweening is not necessary
-    if (tvg::zero(progress)) return frame(from);
-    else if (tvg::equal(progress, 1.0f)) return frame(to);
+    done();
+
+    builder->tween.on(shorten(to));
+
+    return true;
+}
+
+bool LottieLoader::tween(float progress)
+{
+    if (!builder->tween.active || builder->tween.legacy) return false;
+
+    // Skip update if frame diff is too small.
+    progress = shorten(progress);
+    if (tvg::equal(progress, builder->tween.progress)) return true;
 
     done();
 
+    if (tvg::equal(progress, 1.0f)) frameNo = builder->tween.to;
+    builder->tween.progress = progress;
+    if (comp) comp->clear();  // clear synchronously
+
+    TaskScheduler::request(this);
+
+    return true;
+}
+
+bool LottieLoader::tween(float from, float to, float progress)
+{
+    builder->tween.off();  // Not allowed dynamic tweening during the new tween mode
+
+    //tweening is not necessary
+    if (tvg::zero(progress)) return frame(from);
+    if (tvg::equal(progress, 1.0f)) return frame(to);
+
+    done();
+
+    progress = shorten(progress);
     frameNo = shorten(from);
-
-    builder->onTween(shorten(to), progress);
-
+    builder->tween.on(shorten(to), progress);
     if (comp) comp->clear();     //clear synchronously
 
     TaskScheduler::request(this);

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -99,6 +99,8 @@ struct LottieLoader : AnimLoader, Task
 
     float shorten(float frameNo);  //Reduce the accuracy for performance
     bool tween(float from, float to, float progress);
+    bool tweenTo(float to);
+    bool tween(float progress);
     bool quality(uint8_t value);
     void resolver(std::function<void(const tvg::LottieAudioResolver&, void*)> func, void* data);
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -69,7 +69,7 @@ void LottieTextFollowPath::rewind()
     currentLen = 0.0f;
 }
 
-float LottieTextFollowPath::prepare(LottieMask* mask, float frameNo, float scale, Tween& tween, LottieExpressions* exps)
+float LottieTextFollowPath::prepare(LottieMask* mask, float frameNo, float scale, LottieTween& tween, LottieExpressions* exps)
 {
     this->mask = mask;
     Matrix m{1.0f / scale, 0.0f, 0.0f, 0.0f, 1.0f / scale, 0.0f, 0.0f, 0.0f, 1.0f};
@@ -310,8 +310,7 @@ void LottieImage::prepare(bool external)
     picture->ref();
 }
 
-
-void LottieTrimpath::segment(float frameNo, float& start, float& end, Tween& tween, LottieExpressions* exps)
+void LottieTrimpath::segment(float frameNo, float& start, float& end, LottieTween& tween, LottieExpressions* exps)
 {
     start = tvg::clamp(this->start(frameNo, tween, exps) * 0.01f, 0.0f, 1.0f);
     end = tvg::clamp(this->end(frameNo, tween, exps) * 0.01f, 0.0f, 1.0f);
@@ -427,8 +426,7 @@ uint32_t LottieGradient::populate(ColorStop& color, size_t count)
     return output.count;
 }
 
-
-Fill* LottieGradient::fill(float frameNo, uint8_t opacity, Tween& tween, LottieExpressions* exps)
+Fill* LottieGradient::fill(float frameNo, uint8_t opacity, LottieTween& tween, LottieExpressions* exps)
 {
     if (opacity == 0) return nullptr;
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -30,7 +30,7 @@
 #include "tvgRender.h"
 #include "tvgLottieProperty.h"
 #include "tvgLottieRenderPooler.h"
-
+#include "tvgLottieTween.h"
 
 struct LottieComposition;
 
@@ -377,7 +377,7 @@ struct LottieTextRange : LottieObject
 
     float factor(float frameNo, float totalLen, float idx);
 
-    void color(float frameNo, RGB32& fillColor, RGB32& strokeColor, float factor, Tween& tween, LottieExpressions* exps)
+    void color(float frameNo, RGB32& fillColor, RGB32& strokeColor, float factor, LottieTween& tween, LottieExpressions* exps)
     {
         if (style.flags.fillColor) {
             auto color = style.fillColor(frameNo, tween, exps);
@@ -510,7 +510,7 @@ public:
     int8_t maskIdx = -1;
 
     Point position(float lenSearched, float& angle);
-    float prepare(LottieMask* mask, float frameNo, float scale, Tween& tween, LottieExpressions* exps);
+    float prepare(LottieMask* mask, float frameNo, float scale, LottieTween& tween, LottieExpressions* exps);
 };
 
 
@@ -579,7 +579,7 @@ struct LottieTrimpath : LottieObject
         return nullptr;
     }
 
-    void segment(float frameNo, float& start, float& end, Tween& tween, LottieExpressions* exps);
+    void segment(float frameNo, float& start, float& end, LottieTween& tween, LottieExpressions* exps);
 
     LottieFloat start = 0.0f;
     LottieFloat end = 100.0f;
@@ -901,7 +901,7 @@ struct LottieGradient : LottieObject
     }
 
     uint32_t populate(ColorStop& color, size_t count);
-    Fill* fill(float frameNo, uint8_t opacity, Tween& tween, LottieExpressions* exps);
+    Fill* fill(float frameNo, uint8_t opacity, LottieTween& tween, LottieExpressions* exps);
 
     LottieScalar start = Point{0.0f, 0.0f};
     LottieScalar end = Point{0.0f, 0.0f};

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -30,7 +30,7 @@
 #include "tvgLottieInterpolator.h"
 #include "tvgLottieExpressions.h"
 #include "tvgLottieModifier.h"
-
+#include "tvgLottieTween.h"
 
 struct LottieFont;
 struct LottieLayer;
@@ -390,10 +390,13 @@ struct LottieGenericProperty : LottieProperty
         return frame->interpolate(frame + 1, frameNo);
     }
 
-    Value operator()(float frameNo, Tween& tween, LottieExpressions* exps)
+    Value operator()(float frameNo, LottieTween& tween, LottieExpressions* exps)
     {
-        if (DEFAULT_COND) return operator()(frameNo, exps);
-        return tvg::lerp(operator()(frameNo, exps), operator()(tween.frameNo, exps), tween.progress);
+        if (DEFAULT_COND) return (*this)(frameNo, exps);
+        // tweening
+        auto key = tween.key(this, frameNo);
+        if (!tween.inited(key)) tween.capture(key, (*this)(frameNo, exps));
+        return tween.run(key, (*this)(tween.to, exps));
     }
 
     void copy(MyProperty& rhs, bool shallow = true)
@@ -428,10 +431,13 @@ struct LottieGenericProperty : LottieProperty
         return frame->angle(frame + 1, frameNo);
     }
 
-    float angle(float frameNo, Tween& tween)
+    float angle(float frameNo, LottieTween& tween)
     {
         if (DEFAULT_COND) return angle(frameNo);
-        return tvg::lerp(angle(frameNo), angle(tween.frameNo), tween.progress);
+        // tweening
+        auto key = tween.key(this, frameNo);
+        if (!tween.inited(key)) tween.capture(key, angle(frameNo));
+        return tween.run(key, angle(tween.to));
     }
 
     void prepare()
@@ -537,7 +543,7 @@ struct LottiePathSet : LottieProperty
         return true;
     }
 
-    bool modifiedPath(float frameNo, RenderPath& out, Matrix* transform, LottieModifier* modifier)
+    void modifiedPath(float frameNo, RenderPath& out, Matrix* transform, LottieModifier* modifier)
     {
         PathSet* path;
         LottieScalarFrame<PathSet>* frame;
@@ -553,7 +559,7 @@ struct LottiePathSet : LottieProperty
                 _copy(path, out.cmds);
                 _copy(path, out.pts, transform);
             }
-            return true;
+            return;
         }
 
         // interpolation
@@ -577,11 +583,9 @@ struct LottiePathSet : LottieProperty
 
         std::swap(frame->value.pts, backup);
         tvg::free(backup);
-
-        return true;
     }
 
-    bool defaultPath(float frameNo, RenderPath& out, Matrix* transform)
+    void defaultPath(float frameNo, RenderPath& out, Matrix* transform)
     {
         PathSet* path;
         LottieScalarFrame<PathSet>* frame;
@@ -590,7 +594,7 @@ struct LottiePathSet : LottieProperty
         if (dispatch(frameNo, path, frame, t)) {
             _copy(path, out.cmds);
             _copy(path, out.pts, transform);
-            return true;
+            return;
         }
 
         //interpolate 2 frames
@@ -603,48 +607,31 @@ struct LottiePathSet : LottieProperty
             out.pts.push(pt);
         }
         _copy(&frame->value, out.cmds);
-        return true;
     }
 
-    bool tweening(float frameNo, RenderPath& out, Matrix* transform, LottieModifier* modifier, Tween& tween, LottieExpressions* exps)
-    {
-        auto& tmp = RenderPath::scratch();
-        auto pivot = out.pts.count;
-        if (!operator()(frameNo, out, transform, exps)) return false;
-        if (!operator()(tween.frameNo, tmp, transform, exps)) return false;
-
-        if (tmp.pts.count != out.pts.count - pivot) TVGLOG("LOTTIE", "Tweening has different numbers of points in consecutive frames.");
-
-        // tweening interpolation
-        auto from = out.pts.data + pivot;
-        auto interp = modifier ? tmp.pts.data : from;  // the result must be reused as the input of the modifier
-        auto count = std::min(tmp.pts.count, (out.pts.count - pivot));
-
-        for (uint32_t i = 0; i < count; ++i) {
-            interp[i] = tvg::lerp(from[i], tmp.pts[i], tween.progress);
-        }
-
-        // apply modifiers
-        if (modifier) modifier->path(tmp, out, nullptr);
-
-        return true;
-    }
-
-    bool operator()(float frameNo, RenderPath& out, Matrix* transform, LottieExpressions* exps, LottieModifier* modifier = nullptr)
+    void operator()(float frameNo, RenderPath& out, Matrix* transform, LottieExpressions* exps, LottieModifier* modifier = nullptr)
     {
         //overriding with expressions
-        if (exps && exp) {
-            if (exps->result<LottiePathSet>(frameNo, out, transform, modifier, exp)) return true;
-        }
-
-        if (modifier) return modifiedPath(frameNo, out, transform, modifier);
-        else return defaultPath(frameNo, out, transform);
+        if (exps && exp && exps->result<LottiePathSet>(frameNo, out, transform, modifier, exp)) return;
+        if (modifier) modifiedPath(frameNo, out, transform, modifier);
+        else defaultPath(frameNo, out, transform);
     }
 
-    bool operator()(float frameNo, RenderPath& out, Matrix* transform, Tween& tween, LottieExpressions* exps, LottieModifier* modifier = nullptr)
+    void operator()(float frameNo, RenderPath& out, Matrix* transform, LottieTween& tween, LottieExpressions* exps, LottieModifier* modifier = nullptr)
     {
-        if (DEFAULT_COND) return operator()(frameNo, out, transform, exps, modifier);
-        return tweening(frameNo, out, transform, modifier, tween, exps);
+        if (DEFAULT_COND) {
+            (*this)(frameNo, out, transform, exps, modifier);
+        } else {  // tweening
+            auto key = tween.key(this, frameNo);
+            if (!tween.inited(key)) {
+                auto& tmp = RenderPath::scratch();
+                (*this)(frameNo, tmp, transform, exps);
+                tween.capture(key, tmp);
+            }
+            auto& tmp = RenderPath::scratch();
+            (*this)(tween.to, tmp, transform, exps);
+            tween.run(key, tmp, out, modifier);
+        }
     }
 };
 
@@ -729,40 +716,6 @@ struct LottieColorStop : LottieProperty
         return (*frames)[frames->count];
     }
 
-    Result tweening(float frameNo, Fill* fill, Tween& tween, LottieExpressions* exps)
-    {
-        auto frame = frames->data + _bsearch(frames, frameNo);
-        if (tvg::equal(frame->no, frameNo)) return fill->colorStops(frame->value.data, count);
-
-        //from
-        operator()(frameNo, fill, exps);
-
-        //to
-        auto dup = fill->duplicate();
-        operator()(tween.frameNo, dup, exps);
-
-        //interpolate
-        const Fill::ColorStop* from;
-        auto fromCnt = fill->colorStops(&from);
-
-        const Fill::ColorStop* to;
-        auto toCnt = dup->colorStops(&to);
-
-        if (fromCnt != toCnt) TVGLOG("LOTTIE", "Tweening has different numbers of color data in consecutive frames.");
-
-        for (uint32_t i = 0; i < std::min(fromCnt, toCnt); ++i, ++from, ++to) {
-            const_cast<Fill::ColorStop*>(from)->offset = tvg::lerp(from->offset, to->offset, tween.progress);
-            const_cast<Fill::ColorStop*>(from)->r = tvg::lerp(from->r, to->r, tween.progress);
-            const_cast<Fill::ColorStop*>(from)->g = tvg::lerp(from->g, to->g, tween.progress);
-            const_cast<Fill::ColorStop*>(from)->b = tvg::lerp(from->b, to->b, tween.progress);
-            const_cast<Fill::ColorStop*>(from)->a = tvg::lerp(from->a, to->a, tween.progress);
-        }
-
-        delete (dup);
-
-        return Result::Success;
-    }
-
     Result operator()(float frameNo, Fill* fill, LottieExpressions* exps = nullptr)
     {
         //overriding with expressions
@@ -806,10 +759,19 @@ struct LottieColorStop : LottieProperty
         return fill->colorStops(result.data, count);
     }
 
-    Result operator()(float frameNo, Fill* fill, Tween& tween, LottieExpressions* exps)
+    void operator()(float frameNo, Fill* fill, LottieTween& tween, LottieExpressions* exps)
     {
-        if (DEFAULT_COND) return operator()(frameNo, fill, exps);
-        return tweening(frameNo, fill, tween, exps);
+        if (DEFAULT_COND) {
+            (*this)(frameNo, fill, exps);
+        } else {  // tweening
+            auto key = tween.key(this, frameNo);
+            if (!tween.inited(key)) {
+                (*this)(frameNo, fill, exps);
+                tween.capture(key, fill);
+            }
+            (*this)(tween.to, fill, exps);
+            tween.run(key, fill);
+        }
     }
 
     void copy(LottieColorStop& rhs, bool shallow = true)
@@ -938,7 +900,7 @@ struct LottieTextDoc : LottieProperty
 
     TextDocument& operator()(float frameNo, LottieExpressions* exps)
     {
-        auto& out = operator()(frameNo);
+        auto& out = (*this)(frameNo);
 
         //overriding with expressions
         if (exps && exp) exps->result(frameNo, out, exp);

--- a/src/loaders/lottie/tvgLottieTween.h
+++ b/src/loaders/lottie/tvgLottieTween.h
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2026 the ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_LOTTIE_TWEEN_
+#define _TVG_LOTTIE_TWEEN_
+
+#include "tvgMath.h"
+#include "tvgMap.h"
+#include "tvgLottieModifier.h"
+#include "tvgLottieCommon.h"
+
+struct LottieProperty;
+
+struct LottieTween
+{
+private:
+    union Value {
+        PathSet vPath;
+        Fill* vFill;
+        float vFloat;
+        int8_t vInteger;
+        Point vScalar;
+        Point3 vScalar3;
+        RGB32 vColor;
+        uint8_t vOpacity;
+
+        Value() : vPath{} {}
+        ~Value() {}
+    };
+
+    struct ValueSet
+    {
+        Value from;        // "from" scene data
+        Value cur;         // current captured scene data
+        uint8_t type = 0;  // 0: general, 1: path, 2: fill
+        bool inited = false;
+    };
+
+    Map<size_t, ValueSet> data;
+
+    void release()
+    {
+        // delete the fill values
+        for (size_t i = 0; i < data.size; ++i) {
+            INLIST_FOREACH(data.buckets[i], item) {
+                auto& value = item->val;
+                if (value.type == 0) {
+                    continue;
+                } else if (value.type == 1) {  // path
+                    free(value.from.vPath.pts);
+                    free(value.from.vPath.cmds);
+                    free(value.cur.vPath.pts);
+                    free(value.cur.vPath.cmds);
+                } else {  // fill
+                    delete (value.from.vFill);
+                    delete (value.cur.vFill);
+                }
+            }
+        }
+        data.clear();
+    }
+
+    void copy(PathSet& dst, Point* pts, uint32_t ptsCnt, PathCommand* cmds, uint32_t cmdsCnt)
+    {
+        // points
+        if (dst.ptsCnt != ptsCnt) {
+            dst.ptsCnt = ptsCnt;
+            dst.pts = tvg::realloc<Point>(dst.pts, sizeof(Point) * ptsCnt);
+        }
+        memcpy(dst.pts, pts, ptsCnt * sizeof(Point));
+
+        // commands
+        if (dst.cmdsCnt != cmdsCnt) {
+            dst.cmdsCnt = cmdsCnt;
+            dst.cmds = tvg::realloc<PathCommand>(dst.cmds, sizeof(PathCommand) * cmdsCnt);
+            if (cmdsCnt > 0) memcpy(dst.cmds, cmds, cmdsCnt * sizeof(PathCommand));  // commands must be same
+        }
+    }
+
+    void convert(float v, Value& out) { out.vFloat = v; }
+    void convert(int8_t v, Value& out) { out.vInteger = v; }
+    void convert(const Point& v, Value& out) { out.vScalar = v; }
+    void convert(const Point3& v, Value& out) { out.vScalar3 = v; }
+    void convert(const RGB32& v, Value& out) { out.vColor = v; }
+    void convert(uint8_t v, Value& out) { out.vOpacity = v; }
+
+    void convert(const Value& v, float& out) { out = v.vFloat; }
+    void convert(const Value& v, int8_t& out) { out = v.vInteger; }
+    void convert(const Value& v, Point& out) { out = v.vScalar; }
+    void convert(const Value& v, Point3& out) { out = v.vScalar3; }
+    void convert(const Value& v, RGB32& out) { out = v.vColor; }
+    void convert(const Value& v, uint8_t& out) { out = v.vOpacity; }
+
+    bool chainswap(size_t key)
+    {
+        auto set = data.find(key);
+        if (!set) return false;
+        std::swap(set->val.from, set->val.cur);  // FIXME: copy data
+        return true;
+    }
+
+public:
+    float to = 0.0f;        // used as "to frame number"
+    float progress = 0.0f;  // [0 - 1]
+    bool active = false;
+    bool legacy = false;  // for legacy backward compat
+
+    ~LottieTween()
+    {
+        release();
+    }
+
+    // dynamic
+    void on(float to)
+    {
+        this->to = to;
+        active = true;
+        legacy = false;
+
+        // initialize the data
+        for (size_t i = 0; i < data.size; ++i) {
+            INLIST_FOREACH(data.buckets[i], item) {
+                item->val.inited = false;
+            }
+        }
+    }
+
+    // legacy
+    void on(float to, float progress)
+    {
+        this->to = to;
+        this->progress = progress;
+        active = legacy = true;
+    }
+
+    void off()
+    {
+        if (active) {
+            active = legacy = false;
+            release();
+        }
+    }
+
+    bool inited(size_t key)
+    {
+        if (legacy) return false;
+
+        auto set = data.find(key);
+        if (!set) return false;
+        auto ret = set->val.inited;
+        set->val.inited = true;
+        return ret;
+    }
+
+    // TODO: need a stable composite key?
+    size_t key(LottieProperty* prop, float frameNo)
+    {
+        auto h1 = std::hash<LottieProperty*>{}(prop);
+        auto h2 = std::hash<float>{}(frameNo);
+        return h1 ^ (h2 + 0x9e3779b9U + (h1 << 6) + (h1 >> 2));
+    }
+
+    /************************************************************************/
+    /* for General Values                                                   */
+    /************************************************************************/
+
+    template<typename T>
+    void capture(size_t key, const T& from)
+    {
+        if (chainswap(key)) return;
+        convert(from, data[key].from);
+    }
+
+    template<typename T>
+    T run(size_t key, const T& to)
+    {
+        auto& set = data[key];
+        T from;
+        convert(set.from, from);
+        auto cur = tvg::lerp(from, to, progress);
+        convert(cur, set.cur);
+        return cur;
+    }
+
+    /************************************************************************/
+    /* for PathSet Value                                                    */
+    /************************************************************************/
+
+    void capture(size_t key, RenderPath& from)
+    {
+        if (chainswap(key)) return;
+        auto& set = data[key];
+        copy(set.from.vPath, from.pts.data, from.pts.count, from.cmds.data, from.cmds.count);
+        set.type = 1;
+    }
+
+    // interpolate "from" & "to" then out to "to"
+    void run(size_t key, RenderPath& to, RenderPath& out, LottieModifier* modifier)
+    {
+        auto& set = data[key];
+        auto& from = set.from.vPath;
+        if (from.ptsCnt != to.pts.count || from.cmdsCnt != to.cmds.count) {
+            TVGLOG("LOTTIE", "Tweening has different numbers of path in consecutive frames.");
+        }
+
+        auto pivot = out.pts.count;
+        auto ptsCnt = std::min(to.pts.count, (uint32_t)from.ptsCnt);
+
+        // interpolate
+        if (modifier) {
+            for (uint32_t i = 0; i < ptsCnt; ++i) {
+                to.pts[i] = tvg::lerp(from.pts[i], to.pts[i], progress);
+            }
+            modifier->path(to, out, nullptr);
+            ptsCnt = out.pts.count - pivot;
+        } else {
+            for (uint32_t i = 0; i < ptsCnt; ++i) {
+                out.pts.push(tvg::lerp(from.pts[i], to.pts[i], progress));
+            }
+            out.cmds.push(to.cmds);
+        }
+
+        copy(set.cur.vPath, out.pts.data + pivot, ptsCnt, from.cmds, from.cmdsCnt);  // capture the current
+    }
+
+    /************************************************************************/
+    /* for ColorStop Value                                                  */
+    /************************************************************************/
+
+    void capture(size_t key, Fill* from)
+    {
+        if (chainswap(key)) return;
+        auto& set = data[key];
+        set.from.vFill = from->duplicate();
+        set.type = 2;
+    }
+
+    // interpolate "from" & "to" then out to "to"
+    void run(size_t key, Fill* toFill)
+    {
+        auto& set = data[key];
+        auto fromFill = set.from.vFill;
+
+        // interpolate
+        const Fill::ColorStop* from;
+        auto fromCnt = fromFill->colorStops(&from);
+
+        const Fill::ColorStop* to;
+        auto toCnt = toFill->colorStops(&to);
+
+        if (fromCnt != toCnt) TVGLOG("LOTTIE", "Tweening has different numbers of color data in consecutive frames.");
+
+        for (uint32_t i = 0; i < std::min(fromCnt, toCnt); ++i, ++to, ++from) {
+            const_cast<Fill::ColorStop*>(to)->offset = tvg::lerp(from->offset, to->offset, progress);
+            const_cast<Fill::ColorStop*>(to)->r = tvg::lerp(from->r, to->r, progress);
+            const_cast<Fill::ColorStop*>(to)->g = tvg::lerp(from->g, to->g, progress);
+            const_cast<Fill::ColorStop*>(to)->b = tvg::lerp(from->b, to->b, progress);
+            const_cast<Fill::ColorStop*>(to)->a = tvg::lerp(from->a, to->a, progress);
+        }
+
+        // capture the current
+        delete (set.cur.vFill);
+        set.cur.vFill = toFill->duplicate();
+    }
+};
+
+#endif  //_TVG_LOTTIE_TWEEN_


### PR DESCRIPTION
Allow the dynamic tweening APIs to be invoked while a tween is already in progress. The current tweened frame is captured and used as the new starting point, while the requested frame becomes the new target.

To perform dynamic tweening, first call `tweenTo()` to set the target frame, then repeatedly call `tween()` to advance the interpolation.

C++
 + Result LottieAnimation::tweenTo(float to)
 + Result LottieAnimation::tween(float progress)

CAPI
 + Tvg_Result tvg_lottie_animation_tween_to(Tvg_Animation animation, float to)
 + Tvg_Result tvg_lottie_animation_tween_go(Tvg_Animation animation, float progress)

issue: #4295