### PR TITLE
gl_engine: draw post-effect quads above scene depth

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
@@ -591,6 +591,7 @@ void GlGaussianBlurTask::run()
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, mDstFbo->fbo));
 
     GL_CHECK(glDisable(GL_BLEND));
+    GL_CHECK(glDepthFunc(GL_ALWAYS));
     if (effect->direction == 0) {
         GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, mDstFbo->fbo));
         GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mDstCopyFbo1->resolvedFbo));
@@ -616,6 +617,7 @@ void GlGaussianBlurTask::run()
         vertTask->addBindResource({ 0, dstCopyTexId0, vertSrcTextureLoc });
         vertTask->run();
     }
+    GL_CHECK(glDepthFunc(GL_GREATER));
     GL_CHECK(glEnable(GL_BLEND));
 }
 
@@ -655,6 +657,7 @@ void GlEffectDropShadowTask::run()
     GL_CHECK(glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST));
     
     GL_CHECK(glDisable(GL_BLEND));
+    GL_CHECK(glDepthFunc(GL_ALWAYS));
     // when sigma is 0, no blur is applied, and the original image is used directly as the shadow.
     if (!tvg::zero(effect->sigma)) {
         // horizontal blur
@@ -675,6 +678,7 @@ void GlEffectDropShadowTask::run()
     // run drop shadow effect
     GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, mDstFbo->fbo));
     GlRenderTask::run();
+    GL_CHECK(glDepthFunc(GL_GREATER));
     GL_CHECK(glEnable(GL_BLEND));
 }
 
@@ -701,6 +705,8 @@ void GlEffectColorTransformTask::run()
 
     // run transform
     GL_CHECK(glDisable(GL_BLEND));
+    GL_CHECK(glDepthFunc(GL_ALWAYS));
     GlRenderTask::run();
+    GL_CHECK(glDepthFunc(GL_GREATER));
     GL_CHECK(glEnable(GL_BLEND));
 }


### PR DESCRIPTION
## Summary

Fixes a GL-only post-processing regression where effect layers could render incorrectly when their post-effect draw passes reused the normal scene depth state.

This updates GL post-effect tasks to use `GL_ALWAYS` while drawing their effect passes, then restores `GL_GREATER` afterward. The affected tasks are:

- Gaussian blur
- Drop shadow
- Color transform

## Root Cause

GL uses `GL_GREATER` for normal draw ordering. Some post-effect tasks draw fullscreen/effect quads after scene depth has already been populated, so reusing `GL_GREATER` can cause those effect passes to fail depth testing.

WG does not hit this because its equivalent effect pipelines use an always-pass depth comparison.

## Fix

Set `glDepthFunc(GL_ALWAYS)` around the affected GL post-effect draw passes and restore `glDepthFunc(GL_GREATER)` afterward.

This keeps normal GL scene ordering unchanged while aligning GL post-effect behavior with WG for Gaussian blur, DropShadow, and ColorTransform tasks.

## Validation

https://github.com/thorvg/thorvg/issues/4487
<img width="752" height="784" alt="Screenshot 2026-06-30 at 4 53 31 PM" src="https://github.com/user-attachments/assets/7c4d6960-6fe3-43af-82ef-44ca535b84cc" />
The new version shows drop shadow effect correctly
<img width="1857" height="958" alt="image" src="https://github.com/user-attachments/assets/2954d929-63b9-4ab6-8646-97f21e51ac73" />
The previous version:
<img width="624" height="656" alt="image" src="https://github.com/user-attachments/assets/2cf21f16-cdfa-4682-a57f-2a1e0fc73246" />

The new version shows the bottom line and status bar icons with correct colors.
<img width="1022" height="542" alt="image" src="https://github.com/user-attachments/assets/402792e5-0371-496f-8328-4120318c6929" />
The new version doesn't have solid color blocks.
<img width="1277" height="668" alt="image" src="https://github.com/user-attachments/assets/5a90bc88-a5c2-4660-a055-32b5f1e661bf" />


