### PR TITLE
gl: stop stencil cover batch merges across clip boundary

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -207,7 +207,7 @@ RenderRegion GlRenderer::viewportRegion(const RenderRegion& vp, const RenderRegi
 static GlRenderTask* drawPrimitiveGeometry(GlProgram* stencilProgram, GlRenderTask* task, const GlGeometry& geometry,
                                            GlStencilCoverBatch& batch, GlRenderPass* pass,
                                            GlStageBuffer* gpuBuffer, RenderUpdateFlag flag, GlStencilMode stencilMode,
-                                           int32_t depth, const Matrix& viewMatrix, const RenderRegion& passViewport, const RenderColor* color,
+                                           bool clipped, int32_t depth, const Matrix& viewMatrix, const RenderRegion& passViewport, const RenderColor* color,
                                            const RenderRegion& viewBounds, RenderRegion& stencilBounds, const GlGeometryBuffer*& stencilBuffer, uint32_t*& stencilIndices, bool& merge)
 {
     if (stencilMode == GlStencilMode::None) {
@@ -218,7 +218,7 @@ static GlRenderTask* drawPrimitiveGeometry(GlProgram* stencilProgram, GlRenderTa
         return nullptr;
     }
 
-    return batch.prepare(stencilProgram, pass, task, geometry, gpuBuffer, flag, stencilMode, depth, viewMatrix, passViewport, color, viewBounds, stencilBounds, stencilBuffer, stencilIndices, merge);
+    return batch.prepare(stencilProgram, pass, task, geometry, gpuBuffer, flag, stencilMode, clipped, depth, viewMatrix, passViewport, color, viewBounds, stencilBounds, stencilBuffer, stencilIndices, merge);
 }
 
 static Matrix _viewMatrix(const GlGeometry& geometry, const Matrix& viewMatrix, RenderUpdateFlag flag)
@@ -315,12 +315,13 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const RenderColor& c, RenderUpdat
     const GlGeometryBuffer* stencilBuffer = nullptr;
     uint32_t* stencilIndices = nullptr;
     bool merge = false;
+    auto clipped = !sdata.clips.empty();
     auto pass = currentPass();
-    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, mStencilCoverBatch, pass, &mGpuBuffer, flag, stencilMode, depth, viewMatrix, vp, &color, viewBounds, stencilBounds, stencilBuffer, stencilIndices, merge);
+    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, mStencilCoverBatch, pass, &mGpuBuffer, flag, stencilMode, clipped, depth, viewMatrix, vp, &color, viewBounds, stencilBounds, stencilBuffer, stencilIndices, merge);
     // Keep BlendRegion on the existing solid-shape blend UBO slot.
     bindBlendTarget(task, dstCopyFbo, viewRegion, 2);
 
-    if (stencilTask) mStencilCoverBatch.draw(pass, stencilTask, task, merge, stencilMode, stencilBounds, viewBounds, stencilBuffer, stencilIndices);
+    if (stencilTask) mStencilCoverBatch.draw(pass, stencilTask, task, merge, stencilMode, clipped, stencilBounds, viewBounds, stencilBuffer, stencilIndices);
     else pass->addRenderTask(task);
 }
 
@@ -386,7 +387,8 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
     uint32_t* stencilIndices = nullptr;
     bool merge = false;
     auto pass = currentPass();
-    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, mStencilCoverBatch, pass, &mGpuBuffer, flag, stencilMode, depth, viewMatrix, vp, nullptr, viewBounds, stencilBounds, stencilBuffer, stencilIndices, merge);
+    auto clipped = !sdata.clips.empty();
+    auto stencilTask = drawPrimitiveGeometry(mPrograms[RT_Stencil], task, sdata.geometry, mStencilCoverBatch, pass, &mGpuBuffer, flag, stencilMode, clipped, depth, viewMatrix, vp, nullptr, viewBounds, stencilBounds, stencilBuffer, stencilIndices, merge);
 
     // transform buffer (inverse fill-space transform)
     float invMat3[GL_MAT3_STD140_SIZE];
@@ -501,7 +503,7 @@ void GlRenderer::drawPrimitive(GlShape& sdata, const Fill* fill, RenderUpdateFla
     // TransformInfo uses slot 0 and GradientInfo uses slot 2, so BlendRegion moves to 3.
     bindBlendTarget(task, dstCopyFbo, viewRegion, 3);
 
-    if (stencilTask) mStencilCoverBatch.draw(pass, stencilTask, task, merge, stencilMode, stencilBounds, viewBounds, stencilBuffer, stencilIndices);
+    if (stencilTask) mStencilCoverBatch.draw(pass, stencilTask, task, merge, stencilMode, clipped, stencilBounds, viewBounds, stencilBuffer, stencilIndices);
     else pass->addRenderTask(task);
 }
 

--- a/src/renderer/gpu_engine/gl/tvgGlStencilCoverBatch.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlStencilCoverBatch.cpp
@@ -125,13 +125,14 @@ void GlStencilCoverBatch::clear()
     vertexCount = 0;
     indexOffset = 0;
     indexCount = 0;
+    clipped = false;
     ySorted = false;
     open = false;
 }
 
 GlRenderTask* GlStencilCoverBatch::prepare(GlProgram* stencilProgram, GlRenderPass* pass, GlRenderTask* coverTask,
                                            const GlGeometry& geometry, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag,
-                                           GlStencilMode stencilMode, int32_t depth, const Matrix& viewMatrix,
+                                           GlStencilMode stencilMode, bool clipped, int32_t depth, const Matrix& viewMatrix,
                                            const RenderRegion& passViewport, const RenderColor* color,
                                            const RenderRegion& viewBounds, RenderRegion& geometryBounds,
                                            const GlGeometryBuffer*& stencilBuffer, uint32_t*& stencilIndices,
@@ -159,7 +160,7 @@ GlRenderTask* GlStencilCoverBatch::prepare(GlProgram* stencilProgram, GlRenderPa
     stencilBuffer = stroke ? &geometry.stroke : &geometry.fill;
     // Cache this before writing stencil indices; the batch needs the
     // pre-mutation answer to keep the index stream mergeable.
-    merge = mergeable(pass, stencilMode, geometryBounds, stencilBuffer);
+    merge = mergeable(pass, stencilMode, clipped, geometryBounds, stencilBuffer);
 
     auto stencilTask = new GlRenderTask(stencilProgram);
     stencilTask->setViewMatrix(viewMatrix);
@@ -198,13 +199,17 @@ void GlStencilCoverBatch::addBounds(const RenderRegion& bounds)
 }
 
 
-bool GlStencilCoverBatch::mergeable(const GlRenderPass* pass, GlStencilMode mode, const RenderRegion& bounds, const GlGeometryBuffer* stencilBuffer) const
+bool GlStencilCoverBatch::mergeable(const GlRenderPass* pass, GlStencilMode mode, bool clipped, const RenderRegion& bounds, const GlGeometryBuffer* stencilBuffer) const
 {
     if (!open) return false;
     // A new current pass is a hard batch boundary; fail before touching the old pass/task pair.
     if (this->pass != pass) return false;
     if (pass->lastTask() != task) return false;
     if (this->mode != mode) return false;
+    // drawClip() clears the batch for every clipped paint, so different clip
+    // chains cannot continue the same batch. Only clipped vs unclipped needs
+    // an extra merge guard here.
+    if (this->clipped != clipped) return false;
     if (bounds.invalid()) return false;
     if (this->bounds.count >= BATCH_REGION_MAX_COUNT) return false;
     auto incomingVertexCount = stencilBuffer ? stencilBuffer->vertex.count / 2 : 0;
@@ -215,7 +220,7 @@ bool GlStencilCoverBatch::mergeable(const GlRenderPass* pass, GlStencilMode mode
 }
 
 
-void GlStencilCoverBatch::draw(GlRenderPass* pass, GlRenderTask* stencil, GlRenderTask* cover, bool merge, GlStencilMode mode, const RenderRegion& bounds, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer, uint32_t* stencilIndices)
+void GlStencilCoverBatch::draw(GlRenderPass* pass, GlRenderTask* stencil, GlRenderTask* cover, bool merge, GlStencilMode mode, bool clipped, const RenderRegion& bounds, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer, uint32_t* stencilIndices)
 {
     if (!stencil || !cover) {
         delete stencil;
@@ -224,11 +229,11 @@ void GlStencilCoverBatch::draw(GlRenderPass* pass, GlRenderTask* stencil, GlRend
     }
 
     if (merge) this->append(stencil, cover, bounds, viewBounds, stencilBuffer, stencilIndices);
-    else emitSingle(pass, stencil, cover, mode, bounds, viewBounds, stencilBuffer);
+    else emitSingle(pass, stencil, cover, mode, clipped, bounds, viewBounds, stencilBuffer);
 }
 
 
-void GlStencilCoverBatch::emitSingle(GlRenderPass* pass, GlRenderTask* stencil, GlRenderTask* cover, GlStencilMode mode, const RenderRegion& bounds, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer)
+void GlStencilCoverBatch::emitSingle(GlRenderPass* pass, GlRenderTask* stencil, GlRenderTask* cover, GlStencilMode mode, bool clipped, const RenderRegion& bounds, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer)
 {
     auto task = new GlStencilCoverTask(stencil, cover, mode);
     pass->addRenderTask(task);
@@ -236,6 +241,7 @@ void GlStencilCoverBatch::emitSingle(GlRenderPass* pass, GlRenderTask* stencil, 
     this->pass = pass;
     this->task = task;
     this->mode = mode;
+    this->clipped = clipped;
     ySorted = pass->getViewport().sh() > pass->getViewport().sw();
     coverViewBounds = viewBounds;
     if (this->bounds.reserved > BATCH_REGION_RESET_THRESHOLD) this->bounds.reset();

--- a/src/renderer/gpu_engine/gl/tvgGlStencilCoverBatch.h
+++ b/src/renderer/gpu_engine/gl/tvgGlStencilCoverBatch.h
@@ -37,16 +37,16 @@ public:
     void clear();
     GlRenderTask* prepare(GlProgram* stencilProgram, GlRenderPass* pass, GlRenderTask* coverTask,
                           const GlGeometry& geometry, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag,
-                          GlStencilMode stencilMode, int32_t depth, const Matrix& viewMatrix,
+                          GlStencilMode stencilMode, bool clipped, int32_t depth, const Matrix& viewMatrix,
                           const RenderRegion& passViewport, const RenderColor* color,
                           const RenderRegion& viewBounds, RenderRegion& geometryBounds,
                           const GlGeometryBuffer*& stencilBuffer, uint32_t*& stencilIndices,
                           bool& merge);
-    bool mergeable(const GlRenderPass* pass, GlStencilMode mode, const RenderRegion& bounds, const GlGeometryBuffer* stencilBuffer) const;
-    void draw(GlRenderPass* pass, GlRenderTask* stencil, GlRenderTask* cover, bool merge, GlStencilMode mode, const RenderRegion& bounds, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer, uint32_t* stencilIndices);
+    bool mergeable(const GlRenderPass* pass, GlStencilMode mode, bool clipped, const RenderRegion& bounds, const GlGeometryBuffer* stencilBuffer) const;
+    void draw(GlRenderPass* pass, GlRenderTask* stencil, GlRenderTask* cover, bool merge, GlStencilMode mode, bool clipped, const RenderRegion& bounds, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer, uint32_t* stencilIndices);
 
 private:
-    void emitSingle(GlRenderPass* pass, GlRenderTask* stencil, GlRenderTask* cover, GlStencilMode mode, const RenderRegion& bounds, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer);
+    void emitSingle(GlRenderPass* pass, GlRenderTask* stencil, GlRenderTask* cover, GlStencilMode mode, bool clipped, const RenderRegion& bounds, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer);
     void append(GlRenderTask* stencil, GlRenderTask* cover, const RenderRegion& bounds, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer, uint32_t* stencilIndices);
     void setStencilMergeTarget(GlRenderTask* stencil, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer);
     bool merge(GlRenderTask* stencil, const RenderRegion& viewBounds, const GlGeometryBuffer* stencilBuffer, uint32_t* stencilIndices);
@@ -64,6 +64,7 @@ private:
     uint32_t vertexCount = 0;
     uint32_t indexOffset = 0;
     uint32_t indexCount = 0;
+    bool clipped = false;
     bool ySorted = false;
     bool open = false;
 };


### PR DESCRIPTION
## Summary
Prevent GlStencilCoverBatch from merging across clipped and unclipped paints.
Thread a small clipped state through the stencil-cover batch path and reject merges when the clip boundary changes.
Keep drawClip() boundaries local to each clipped paint without tracking clip identity or changing geometry processing.

## Why
A stencil-cover batch could continue past a clip boundary after merge, so a shape that should stay masked could be emitted as if it shared the same clip context. This change makes the batch stop at that boundary.

Related issue: https://github.com/thorvg/thorvg/issues/4491

## Validation
The FPS remains constant during execution for all examples on macOS.
https://github.com/user-attachments/assets/9794c60a-7c1e-4571-99ae-77e3fc6e88ed
