### PR TITLE
renderer: keep the required composition when the target region is degenerate

### DIFF
--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -140,6 +140,8 @@ struct SceneImpl : Scene
 
         if (!incomposite && impl.cmpFlag) {
             cmp = renderer->target(bounds(), renderer->colorSpace(), impl.cmpFlag);
+            //A degenerate region must not drop the required composition (children would rasterize unblended). Retry with the viewport.
+            if (!cmp) cmp = renderer->target(renderer->viewport(), renderer->colorSpace(), impl.cmpFlag);
             renderer->beginComposite(cmp, MaskMethod::None, opacity);
         }
 


### PR DESCRIPTION
## Problem

A `Scene` that requires composition (e.g. `opacity < 255`) can silently render **without** it when the compositor allocation fails. In `Scene::render()`:

```cpp
if (!incomposite && impl.cmpFlag) {
    cmp = renderer->target(bounds(), renderer->colorSpace(), impl.cmpFlag);
    renderer->beginComposite(cmp, MaskMethod::None, opacity);
}
```

`SwRenderer::target()` returns `nullptr` when the region does not intersect the surface. `bounds()` serves a cached region, and when a retained scene tree is driven by rapid per-frame property updates (a host app scrubbing/seeking every frame), that cached region can go stale/degenerate. `beginComposite(nullptr, ...)` then no-ops and the children - prepared at opacity 255 by the composition path in `update()` - rasterize unblended directly onto the surface: the scene's opacity is silently dropped for that frame. If the host uses partial rendering, the wrong pixels also persist, because nothing re-damages that region afterwards.

## Reproduction / evidence

Retained-scene host (LottieFiles Creator canvas, sw engine) rendering a Lottie in which a 25%-opacity nested scene sits under an ancestor whose opacity fades to 0 at the timeline end, while a sibling animates opacity every frame. Scrubbing to the last frame and back reproduces the drop reliably. With counters placed at this exact gate, one reproducing scrub measured, for the 25%-opacity scene:

| renders requiring composition | compositor created | `target()` returned `nullptr` |
|---|---|---|
| 397 | 236 (rendered dim, correct) | **161 (rendered at full opacity, wrong)** |

In every one of the 161 drops the paint's own state was still correct (`tvg_paint_get_opacity` = 64, `cmpFlag` = Opacity, stash = 64); only the missing compositor changed the output.

## Fix

When the compositor is required but `target(bounds())` fails, retry with `renderer->viewport()` - always a valid on-surface region - so the required composition still happens. The retry executes only on the previously-broken path; behavior is unchanged whenever `target(bounds())` succeeds. Cost on a fallback frame is a viewport-sized composite target instead of a (wrong) tight one.

## Screenshots

Same animation frame before/after the fix, after a scrub to the last frame and back (the 25%-opacity "ghost" digits should stay dim; before the fix they render at full opacity and cover the value):

| Before (bug) | After (fix) |
|---|---|
| ![25%-opacity ghost digits rendered at full opacity, covering the value](https://raw.githubusercontent.com/ShinyChang/thorvg/pr-4519-assets/assets/ghost-before-fix-full-opacity.png) | ![ghost digits correctly dim at 25%, value readable](https://raw.githubusercontent.com/ShinyChang/thorvg/pr-4519-assets/assets/ghost-after-fix-dim-correct.png) |

## Notes

- Why `bounds()` goes degenerate under retained-tree update storms likely deserves its own investigation (cache invalidation across frames). This change guards the invariant regardless: a failed compositor allocation must not change compositing semantics.
- Verified on the sw engine; the fallback only uses the renderer-agnostic API.

