### PR TITLE
svg_loader: Fix incorrect font ascent

### DIFF
--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -914,13 +914,6 @@ static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const
 
     auto text = Text::gen();
 
-    Matrix textTransform;
-    if (transform) textTransform = *transform;
-    else textTransform = tvg::identity();
-
-    translateR(&textTransform, {textNode->x + textNode->dx, textNode->y + textNode->dy - textNode->fontSize});
-    text->transform(textTransform);
-
     //TODO: handle def values of font and size as used in a system?
     auto size = textNode->fontSize * 0.75f; //1 pt = 1/72; 1 in = 96 px; -> 72/96 = 0.75
     if (text->font(textNode->fontFamily) != Result::Success) {
@@ -931,6 +924,12 @@ static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const
     auto processedText = _processText(textNode->text, xmlSpace);
     text->text(processedText);
     tvg::free(processedText);
+
+    TextMetrics tm;
+    text->metrics(tm);
+    auto textTransform = transform ? *transform : tvg::identity();
+    translateR(&textTransform, {textNode->x + textNode->dx, textNode->y + textNode->dy - tm.ascent});
+    text->transform(textTransform);
 
     return text;
 }


### PR DESCRIPTION
SVG text y coordinates refer to the alphabetic baseline. The loader was translating text by the requested font size, effectively using the em size as the ascent and placing glyphs too high compared to browsers.
Query TextMetrics and translate by the actual ascent instead, falling back to the font size when metrics are unavailable.

<img width="2327" height="1459" alt="Screenshot from 2026-07-02 19-49-23" src="https://github.com/user-attachments/assets/6c87512e-62b5-4c05-95aa-528e60518ab1" />
