### PR TITLE
svg/sfnt: Fix gpu "Bezier segments" error log from text with spaces

### DIFF
--- a/src/loaders/sfnt/tvgSfntLoader.cpp
+++ b/src/loaders/sfnt/tvgSfntLoader.cpp
@@ -617,12 +617,12 @@ bool SfntLoader::metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& ou
 
     // if no info, calculate it manually
     if (glyph->bbox.zero()) {
-        glyph->bbox.init();
-        glyph->path.bounds(nullptr, glyph->bbox);
-        // convert y since sfnt y coordinates origin is reverted
-        auto temp = glyph->bbox.min.y;
-        glyph->bbox.min.y = -glyph->bbox.max.y;
-        glyph->bbox.max.y = -temp;
+        if (glyph->path.bounds(nullptr, glyph->bbox)) {
+            // convert y since sfnt y coordinates origin is reverted
+            auto temp = glyph->bbox.min.y;
+            glyph->bbox.min.y = -glyph->bbox.max.y;
+            glyph->bbox.max.y = -temp;
+        }
     }
     out.min = glyph->bbox.min * scale;
     out.max = glyph->bbox.max * scale;

--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -936,12 +936,11 @@ static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const
 
 static void _updatePos(Text* text, const SvgTextNode& textNode, float anchor, Point& textPos)
 {
-    auto advance = _bounds(text).w;
+    auto advance = 0.0f;
     if (auto utf8 = text->text()) {
         GlyphMetrics gm;
-        if (text->metrics(utf8, gm) == Result::Success) advance += gm.min.x;
         while (utf8) {
-            if (text->metrics(utf8, gm, &utf8) == Result::Success) advance += gm.advance - gm.max.x;
+            if (text->metrics(utf8, gm, &utf8) == Result::Success) advance += gm.advance;
             else break;
         }
     }

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -200,6 +200,8 @@ bool RenderPath::bounds(const Matrix* m, BBox& box)
 {
     if (cmds.empty() || cmds.first() == PathCommand::CubicTo) return false;
 
+    box.init();
+
     auto pt = pts.begin();
     auto cmd = cmds.begin();
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -129,7 +129,7 @@ struct ShapeImpl : Shape
         }
         //Keep this for legacy. loaders still depend on this logic, remove it if possible.
         if (fallback) {
-            BBox box = {{FLT_MAX, FLT_MAX}, {-FLT_MAX, -FLT_MAX}};
+            BBox box;
             if (!rs.path.bounds(obb ? nullptr : &m, box)) return false;
             if (rs.stroke) {
                 //Use geometric mean for feathering.


### PR DESCRIPTION
Fixes #4522
 
Loading SVG text under the gl/wg backends spammed the log:
  `E] Bezier segments count exceeded the maximum limit.`
 
Space glyphs have no outline, so their bbox is left as garbage(FLT_MAX) in the glyph cache. That turns into a NaN transform for any text run starting with a space, which breaks the run's path and makes the gpu tessellator blow past its segment limit.

  - sfnt: give outline-less glyphs an empty bbox. (Stops the error.)
  - svg_loader: compute run advance by summing glyph advances instead of guessing from ink bounds. (Fixes run positioning too.)
