### PR TITLE
infra: update pixel inspector's golden ref to v1.0.7

### DIFF
--- a/.github/workflows/pixel_inspector.yml
+++ b/.github/workflows/pixel_inspector.yml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 
 env:
-  THORVG_PIXEL_GOLDEN_REF: v1.0.6
+  THORVG_PIXEL_GOLDEN_REF: v1.0.7
   WGPU_NATIVE_VERSION: v27.0.4.0
 
 jobs:


### PR DESCRIPTION
Update the pixel inspector golden reference from v1.0.6 to v1.0.7.

The v1.0.7 baseline includes rendering fixes and compatibility improvements across Lottie, SVG, CPU, GL, and WebGPU paths.

No unexpected pixel regressions were found in the v1.0.6 to v1.0.7 snapshot comparison.