### PR TITLE
gl_engine: Fix GL_CHECK usage in conditional statements

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
@@ -94,8 +94,11 @@ void GlRenderTask::run()
         }
     }
 
-    if (mUseDrawArrays) GL_CHECK(glDrawArrays(mArrayMode, mArrayOffset, mIndexCount));
-    else GL_CHECK(glDrawElements(GL_TRIANGLES, mIndexCount, GL_UNSIGNED_INT, reinterpret_cast<void*>(mIndexOffset)));
+    if (mUseDrawArrays) {
+        GL_CHECK(glDrawArrays(mArrayMode, mArrayOffset, mIndexCount));
+    } else {
+        GL_CHECK(glDrawElements(GL_TRIANGLES, mIndexCount, GL_UNSIGNED_INT, reinterpret_cast<void*>(mIndexOffset)));
+    }
 
     // setup attribute layout
     for (uint32_t i = 0; i < mVertexLayout.count; i++) {

--- a/src/renderer/gpu_engine/gl/tvgGlTextureMgr.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlTextureMgr.cpp
@@ -99,5 +99,7 @@ void TextureMgr::clear()
     }
     surfaces.free();
     if (++stamp == 0) stamp = 1;  // avoid zero stamp, which is used to indicate stale cache.
-    if (!textures.empty()) GL_CHECK(glDeleteTextures(textures.count, textures.data));
+    if (!textures.empty()) {
+        GL_CHECK(glDeleteTextures(textures.count, textures.data));
+    }
 }


### PR DESCRIPTION
## Summary

This fixes unsafe uses of `GL_CHECK` inside conditional statements in the GL renderer.

In debug builds, `GL_CHECK` expands to more than one statement:

```cpp
stmt;
assert(glGetError() == GL_NO_ERROR);
```

When it is used directly as a single-line `if` or `if/else` body, the macro expansion can either break the `if/else` control flow or cause the error check to run outside the intended condition.

This PR wraps the affected `GL_CHECK` calls in braces so the expanded statements remain inside the correct conditional blocks.

## Trigger

https://github.com/thorvg/thorvg/blob/e753da99ba8ea19905a69f9eb76a51b1470e8e74/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp#L97-L98
