### PR TITLE
cpu_engine: fix outdated gradient fill on transform-only updates

### DIFF
--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -124,7 +124,7 @@ struct SwShapeTask : SwTask
     {
         auto strokeWidth = validStrokeWidth(clipper);
         auto updateShape = flags[0] & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform | RenderUpdateFlag::Clip);
-        auto updateFill = (flags[0] & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient));
+        auto updateFill = (flags[0] & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform));
 
         //Shape
         if (updateShape) {


### PR DESCRIPTION
The gradient placement coefficients baked in _prepareLinear/_prepareRadial depend on the shape transform, but SwShapeTask::run's fill-update mask ignored Transform, so in retained mode a transformed gradient stayed pinned to its old position. Add Transform to regenerate the coefficients; the color table stays gated on Gradient.

### Test Code

GradientTransform rewritten in retained mode 

The scene is built once and only re-transformed each frame, which is exactly what triggers the SW gradient-composition bug (the rebuild-every-frame original re-marks Gradient and hides it).


```cpp
// GradientComposition.cpp
struct UserExample : tvgexam::Example
{
    tvg::Shape* shape1 = nullptr;
    tvg::Shape* shape2 = nullptr;
    tvg::Shape* shape3 = nullptr;

    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
    {
        //Shape1 + LinearGradient
        shape1 = tvg::Shape::gen();
        shape1->appendRect(-285, -300, 280, 280);
        shape1->appendRect(-145, -160, 380, 380, 100, 100);
        shape1->appendCircle(195, 180, 140, 140);
        shape1->appendCircle(235, 320, 210, 140);

        auto fill1 = tvg::LinearGradient::gen();
        fill1->linear(-285, -300, 285, 300);
        tvg::Fill::ColorStop colorStops1[3];
        colorStops1[0] = {0, 255, 0, 0, 255};
        colorStops1[1] = {0.5, 255, 255, 0, 255};
        colorStops1[2] = {1, 255, 255, 255, 255};
        fill1->colorStops(colorStops1, 3);
        shape1->fill(fill1);
        shape1->translate(385, 400);
        canvas->add(shape1);

        //Shape2 + LinearGradient
        shape2 = tvg::Shape::gen();
        shape2->appendRect(-50, -50, 180, 180);

        auto fill2 = tvg::LinearGradient::gen();
        fill2->linear(-50, -50, 130, 130);
        tvg::Fill::ColorStop colorStops2[2];
        colorStops2[0] = {0, 0, 0, 0, 255};
        colorStops2[1] = {1, 255, 255, 255, 255};
        fill2->colorStops(colorStops2, 2);
        shape2->fill(fill2);
        canvas->add(shape2);

        //Shape3 + RadialGradient
        shape3 = tvg::Shape::gen();
        shape3->appendRect(100, 100, 150, 100, 20, 20);

        auto fill3 = tvg::RadialGradient::gen();
        fill3->radial(175, 150, 75, 175, 150, 0);
        tvg::Fill::ColorStop colorStops3[4];
        colorStops3[0] = {0, 0, 127, 0, 127};
        colorStops3[1] = {0.25, 0, 170, 170, 170};
        colorStops3[2] = {0.5, 200, 0, 200, 200};
        colorStops3[3] = {1, 255, 255, 255, 255};
        fill3->colorStops(colorStops3, 4);
        shape3->fill(fill3);
        canvas->add(shape3);

        return true;
    }

    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
    {
        auto progress = tvgexam::progress(elapsed, 2.0f, true);  //play time 2 sec.

        //Transform-only updates in retained mode; the gradients must follow.
        shape1->scale(1.0f - 0.75f * progress);
        shape1->rotate(360.0f * progress);

        shape2->rotate(360 * progress);
        shape2->translate(480 + progress * 300, 480);

        //Look, how shape3's origin differs from shape2: the shape's center is
        //the transform anchor.
        shape3->translate(480, 480);
        shape3->rotate(-360.0f * progress);
        shape3->scale(0.5f + progress);

        canvas->update();

        return true;
    }
};

```

#### main 

https://github.com/user-attachments/assets/dd9b8001-2624-458d-8d94-c773a1411087

#### fetch

https://github.com/user-attachments/assets/d6407547-f343-4b12-ab6a-4fa6c6335121


#### GL

https://github.com/user-attachments/assets/794b516f-6c0e-4e1e-b1f3-80ecd82c6556


