### PR TITLE
API: promote & deprecation for v1.1

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -193,11 +193,10 @@ enum struct FillRule : uint8_t
     EvenOdd      ///< A line from the point to a location outside the shape is drawn and its intersections with the path segments of the shape are counted. If the number of intersections is an odd number, the point is inside the shape.
 };
 
-
 /**
  * @brief Defines the image filtering method used during image scaling or transformation.
  *
- * @note Experimental API
+ * @since 1.1
  */
 enum struct FilterMethod : uint8_t
 {
@@ -1741,7 +1740,7 @@ struct TVG_API Picture : Paint
      * @return Always returns @c Result::Success.
      *
      * @see FilterMethod
-     * @note Experimental API
+     * @since 1.1
      */
     Result filter(FilterMethod method) noexcept;
 
@@ -2050,7 +2049,7 @@ struct TVG_API Text : Paint
      * @return The total number of lines.
      *
      * @see Text::wrap()
-     * @since Experimental API
+     * @since 1.1
      */
     uint32_t lines() noexcept;
 
@@ -2431,11 +2430,11 @@ struct TVG_API WgCanvas final : Canvas
      *
      * @warning Regardless of the value of @p cs, this target API uses the default alpha mode.
      *
-     * @since 1.0
-     *
      * @see WgCanvas::target(const Context&, void*, uint32_t, uint32_t, ColorSpace, int)
      * @see Canvas::viewport()
      * @see Canvas::sync()
+     *
+     * @since 1.0
      */
     Result target(void* device, void* instance, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0) noexcept;
 
@@ -2452,10 +2451,10 @@ struct TVG_API WgCanvas final : Canvas
      * @retval Result::InsufficientCondition if the canvas is performing rendering. Please ensure the canvas is synced.
      * @retval Result::NonSupport In case the wg engine is not supported.
      *
-     * @note Experimental API
-     *
      * @see Canvas::viewport()
      * @see Canvas::sync()
+     *
+     * @note Experimental API
      */
     Result target(const Context& context, void* target, uint32_t w, uint32_t h, ColorSpace cs, int type = 0) noexcept;
 
@@ -2824,8 +2823,8 @@ struct TVG_API Accessor
      * @see Accessor::set()
      * @see Picture::accessible
      *
-     * @note This function is only availble within Accessor callbacks registered via @ref Accessor::set().
-     * @note Experimental API
+     * @note This function is only available within Accessor callbacks registered via @ref Accessor::set().
+     * @since 1.1
      */
     const char* name(uint32_t id) noexcept;
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -346,7 +346,7 @@ typedef enum
 /**
  * @brief Defines the image filtering method used during image scaling or transformation.
  *
- * @note Experimental API
+ * @since 1.1
  */
 typedef enum
 {
@@ -969,7 +969,7 @@ TVG_API bool tvg_paint_get_visible(const Tvg_Paint paint);
  * @see tvg_accessor_generate_id()
  * @see tvg_paint_set_id()
  *
- * @note Experimental API
+ * @since 1.1
  */
 TVG_API uint32_t tvg_paint_get_id(const Tvg_Paint paint);
 
@@ -985,7 +985,7 @@ TVG_API uint32_t tvg_paint_get_id(const Tvg_Paint paint);
  * @see tvg_accessor_generate_id()
  * @see tvg_paint_get_id()
  *
- * @note Experimental API
+ * @since 1.1
  */
 TVG_API Tvg_Result tvg_paint_set_id(Tvg_Paint paint, uint32_t id);
 
@@ -2110,7 +2110,7 @@ TVG_API const Tvg_Paint tvg_picture_get_paint(Tvg_Paint picture, uint32_t id);
  * @param[in] method The filtering method to apply. Default is @c TVG_FILTER_METHOD_BILINEAR.
  *
  * @see Tvg_Filter_Method
- * @note Experimental API
+ * @since 1.1
  */
 TVG_API Tvg_Result tvg_picture_set_filter(Tvg_Paint picture, Tvg_Filter_Method method);
 
@@ -2504,9 +2504,9 @@ TVG_API Tvg_Result tvg_text_wrap_mode(Tvg_Paint text, Tvg_Text_Wrap mode);
  * @return The total number of lines.
  *
  * @see tvg_text_wrap_mode()
- * @note Experimental API
+ * @since 1.1
  */
- TVG_API uint32_t tvg_text_line_count(Tvg_Paint text);
+TVG_API uint32_t tvg_text_line_count(Tvg_Paint text);
 
 /**
  * @brief Set the spacing scale factors for text layout.
@@ -3032,7 +3032,7 @@ TVG_API uint32_t tvg_accessor_generate_id(const char* name);
  * @see tvg_picture_set_accessible()
  *
  * @note This function is only available within Accessor callbacks registered via @ref tvg_accessor_set().
- * @note Experimental API
+ * @since 1.1
  */
 TVG_API const char* tvg_accessor_get_name(Tvg_Accessor accessor, uint32_t id);
 
@@ -3136,9 +3136,9 @@ TVG_API Tvg_Result tvg_lottie_animation_get_markers_cnt(Tvg_Animation animation,
  *
  * @retval TVG_RESULT_INVALID_ARGUMENT In case @c nullptr is passed as the argument or @c idx is out of range.
  *
- * @since 1.0
+ * @deprecated see tvg_lottie_animation_get_marker_info()
  */
-TVG_API Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation, uint32_t idx, const char** name);
+TVG_API TVG_DEPRECATED Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation, uint32_t idx, const char** name);
 
 /**
  * @brief Retrieves marker information by index.
@@ -3156,7 +3156,7 @@ TVG_API Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation, uint
  * @retval TVG_RESULT_INSUFFICIENT_CONDITION In case the animation is not loaded.
  *
  * @see tvg_lottie_animation_get_markers_cnt()
- * @note Experimental API
+ * @since 1.1
  */
 TVG_API Tvg_Result tvg_lottie_animation_get_marker_info(Tvg_Animation animation, uint32_t idx, const char** name, float* begin, float* end);
 

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -1254,27 +1254,19 @@ TVG_API Tvg_Result tvg_lottie_animation_get_markers_cnt(Tvg_Animation animation,
     return TVG_RESULT_NOT_SUPPORTED;
 }
 
-
-TVG_API Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation, uint32_t idx, const char** name)
+TVG_API TVG_DEPRECATED Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation, uint32_t idx, const char** name)
 {
-#ifdef THORVG_LOTTIE_LOADER_SUPPORT
-    if (animation && name) {
-        *name = reinterpret_cast<LottieAnimation*>(animation)->marker(idx);
-        if (!(*name)) return TVG_RESULT_INVALID_ARGUMENT;
-        return TVG_RESULT_SUCCESS;
-    }
-    return TVG_RESULT_INVALID_ARGUMENT;
-#endif
-    return TVG_RESULT_NOT_SUPPORTED;
+    if (!name) return TVG_RESULT_INVALID_ARGUMENT;  // for backward compat.
+    return tvg_lottie_animation_get_marker_info(animation, idx, name, nullptr, nullptr);
 }
 
 TVG_API Tvg_Result tvg_lottie_animation_get_marker_info(Tvg_Animation animation, uint32_t idx, const char** name, float* begin, float* end)
 {
 #ifdef THORVG_LOTTIE_LOADER_SUPPORT
-    const char* n = nullptr;
-    if (animation) n = reinterpret_cast<LottieAnimation*>(animation)->marker(idx, begin, end);
-    if (name) *name = n;
-    if (n) return TVG_RESULT_SUCCESS;
+    if (!animation) return TVG_RESULT_INVALID_ARGUMENT;
+    auto ret = reinterpret_cast<LottieAnimation*>(animation)->marker(idx, begin, end);
+    if (name) *name = ret;
+    if (ret) return TVG_RESULT_SUCCESS;
     auto markerCnt = reinterpret_cast<LottieAnimation*>(animation)->markersCnt();
     if (markerCnt > 0 && idx >= markerCnt) return TVG_RESULT_INVALID_ARGUMENT;
     return TVG_RESULT_INSUFFICIENT_CONDITION;

--- a/src/loaders/lottie/thorvg_lottie.h
+++ b/src/loaders/lottie/thorvg_lottie.h
@@ -145,9 +145,9 @@ struct TVG_API LottieAnimation final : Animation
      * @retval The name of marker when succeed, @c nullptr otherwise.
      *
      * @see LottieAnimation::markersCnt()
-     * @since 1.0
+     * @deprecated see marker(uint32_t, float*, float*)
      */
-    const char* marker(uint32_t idx) noexcept;
+    TVG_DEPRECATED const char* marker(uint32_t idx) noexcept;
 
     /**
      * @brief Retrieves the name and frame range of a marker by index.
@@ -161,7 +161,7 @@ struct TVG_API LottieAnimation final : Animation
      * @return The name of the marker on success, or @c nullptr otherwise.
      *
      * @see LottieAnimation::markersCnt()
-     * @note Experimental API
+     * @since 1.1
      */
     const char* marker(uint32_t idx, float* begin, float* end) noexcept;
 
@@ -242,9 +242,10 @@ struct TVG_API LottieAnimation final : Animation
      * @retval Result::InsufficientCondition The animation has not been loaded.
      *
      * @note To disable audio notifications, pass @c nullptr as @p func.
-     * @note Experimental API.
      *
      * @see LottieAudioResolver
+     *
+     * @note Experimental API
      */
     Result resolver(std::function<void(const LottieAudioResolver& info, void* data)> func, void* data) noexcept;
 

--- a/src/loaders/lottie/tvgLottieAnimation.cpp
+++ b/src/loaders/lottie/tvgLottieAnimation.cpp
@@ -111,8 +111,7 @@ uint32_t LottieAnimation::markersCnt() noexcept
     return loader->markersCnt();
 }
 
-
-const char* LottieAnimation::marker(uint32_t idx) noexcept
+TVG_DEPRECATED const char* LottieAnimation::marker(uint32_t idx) noexcept
 {
     return marker(idx, nullptr, nullptr);
 }

--- a/test/testLottie.cpp
+++ b/test/testLottie.cpp
@@ -192,9 +192,6 @@ TEST_CASE("Lottie Marker", "[tvgLottie]")
         //Get marker count
         REQUIRE(animation->markersCnt() == 3);
 
-        //Get marker name by index
-        REQUIRE(!strcmp(animation->marker(1), "sectionB"));
-
         // Get marker name and segment by index
         REQUIRE(!strcmp(animation->marker(0, &markerBegin, &markerEnd), "sectionA"));
         REQUIRE(markerBegin == 0.0f);
@@ -217,7 +214,6 @@ TEST_CASE("Lottie Marker", "[tvgLottie]")
         REQUIRE(markerEnd == 22.0f);
 
         // Get marker by invalid index
-        REQUIRE(animation->marker(-1) == nullptr);
         REQUIRE(animation->marker(-1, &markerBegin, &markerEnd) == nullptr);
 
         REQUIRE(animation->segment(nullptr) == Result::Success);


### PR DESCRIPTION
C++ promotions:
```
- enum struct FilterMethod
- Result Picture::filter(FilterMethod method)
- uint32_t Text::lines()
- const char* Accessor::name(uint32_t id)
- const char* LottieAnimation::marker(uint32_t idx, float* begin, float* end)
```
C++ deprecations:
```
- const char* LottieAnimation::marker(uint32_t idx)
```

CAPI promotions:
```
- typedef enum Tvg_Filter_Method
- uint32_t tvg_paint_get_id(const Tvg_Paint paint)
- Tvg_Result tvg_paint_set_id(Tvg_Paint paint, uint32_t id)
- Tvg_Result tvg_picture_set_filter(Tvg_Paint picture, Tvg_Filter_Method method)
- uint32_t tvg_text_line_count(Tvg_Paint text)
- const char* tvg_accessor_get_name(Tvg_Accessor accessor, uint32_t id)
- Tvg_Result tvg_lottie_animation_get_marker_info(Tvg_Animation animation, uint32_t idx, const char** name, float* begin, float* end)
```
CAPI deprecations:
```
- Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation, uint32_t idx, const char** name)
```
issue: #4496