### PR TITLE
api: add visibility-aware paint intersection API

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -591,6 +591,11 @@ struct TVG_API Paint
     Result bounds(float* x, float* y, float* w, float* h) noexcept;
 
     /**
+     * @deprecated see bool intersects(int32_t, int32_t, int32_t, int32_t, bool)
+     */
+    TVG_DEPRECATED bool intersects(int32_t x, int32_t y, int32_t w = 1, int32_t h = 1) noexcept;
+
+    /**
      * @brief Checks whether a given region intersects the filled area of the paint.
      *
      * This function determines whether the specified rectangular region—defined by (`x`, `y`, `w`, `h`)—
@@ -604,18 +609,20 @@ struct TVG_API Paint
      *
      * @param[in] x The x-coordinate of the top-left corner of the test region.
      * @param[in] y The y-coordinate of the top-left corner of the test region.
-     * @param[in] w The width of the region to test. Must be greater than 0; defaults to 1.
-     * @param[in] h The height of the region to test. Must be greater than 0; defaults to 1.
+     * @param[in] w The width of the region to test. Must be greater than 0.
+     * @param[in] h The height of the region to test. Must be greater than 0.
+     * @param[in] visibleOnly If @c true, hidden paints are excluded from the intersection test.
      *
      * @return @c true if any part of the region intersects the filled area; otherwise, @c false.
      *
      * @note To test a single point, set the region size to w = 1, h = 1.
-     * @note For efficiency, an AABB (axis-aligned bounding box) test is performed internally before precise hit detection.
      * @note This test does not take into account the results of blending or masking.
-     * @note This test does take into account the the hidden paints as well. @see Paint::visible()
-     * @since 1.0
+     *
+     * @see Paint::visible(bool on)
+     *
+     * @since 1.1
      */
-    bool intersects(int32_t x, int32_t y, int32_t w = 1, int32_t h = 1) noexcept;
+    bool intersects(int32_t x, int32_t y, int32_t w, int32_t h, bool visibleOnly) noexcept;
 
     /**
      * @brief Duplicates the object.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1085,6 +1085,11 @@ TVG_API Tvg_Result tvg_paint_get_opacity(const Tvg_Paint paint, uint8_t* opacity
 TVG_API Tvg_Paint tvg_paint_duplicate(Tvg_Paint paint);
 
 /**
+ * @deprecated see tvg_paint_intersects_region()
+ */
+TVG_API TVG_DEPRECATED bool tvg_paint_intersects(Tvg_Paint paint, int32_t x, int32_t y, int32_t w, int32_t h);
+
+/**
  * @brief Checks whether a given region intersects the filled area of the paint.
  *
  * This function determines whether the specified rectangular region—defined by (`x`, `y`, `w`, `h`)—
@@ -1096,21 +1101,22 @@ TVG_API Tvg_Paint tvg_paint_duplicate(Tvg_Paint paint);
  * The paint must be updated in a Canvas beforehand—typically after the Canvas has been
  * drawn and synchronized.
  *
- * @param[in] paint The shape object to be tested.
+ * @param[in] paint The paint object to be tested.
  * @param[in] x The x-coordinate of the top-left corner of the test region.
  * @param[in] y The y-coordinate of the top-left corner of the test region.
- * @param[in] w The width of the region to test. Must be greater than 0; defaults to 1.
- * @param[in] h The height of the region to test. Must be greater than 0; defaults to 1.
+ * @param[in] w The width of the region to test. Must be greater than 0.
+ * @param[in] h The height of the region to test. Must be greater than 0.
+ * @param[in] visibleOnly If @c true, hidden paints are excluded from the intersection test.
  *
  * @return @c true if any part of the region intersects the filled area; otherwise, @c false.
  *
  * @note To test a single point, set the region size to w = 1, h = 1.
- * @note For efficiency, an AABB (axis-aligned bounding box) test is performed internally before precise hit detection.
  * @note This test does not take into account the results of blending or masking.
- * @note This test does take into account the the hidden paints as well. @see tvg_paint_set_visible().
- * @since 1.0
+ *
+ * @see tvg_paint_set_visible()
+ * @since 1.1
  */
-TVG_API bool tvg_paint_intersects(Tvg_Paint paint, int32_t x, int32_t y, int32_t w, int32_t h);
+TVG_API bool tvg_paint_intersects_region(Tvg_Paint paint, int32_t x, int32_t y, int32_t w, int32_t h, bool visibleOnly);
 
 /**
  * @brief Retrieves the axis-aligned bounding box (AABB) of the paint object in canvas space.
@@ -3128,14 +3134,6 @@ TVG_API Tvg_Result tvg_lottie_animation_set_marker(Tvg_Animation animation, cons
 TVG_API Tvg_Result tvg_lottie_animation_get_markers_cnt(Tvg_Animation animation, uint32_t* cnt);
 
 /**
- * @brief Gets the marker name by a given index.
- *
- * @param[in] animation The Lottie animation object.
- * @param[in] idx The index of the animation marker, starts from 0.
- * @param[out] name The name of marker when succeed.
- *
- * @retval TVG_RESULT_INVALID_ARGUMENT In case @c nullptr is passed as the argument or @c idx is out of range.
- *
  * @deprecated see tvg_lottie_animation_get_marker_info()
  */
 TVG_API TVG_DEPRECATED Tvg_Result tvg_lottie_animation_get_marker(Tvg_Animation animation, uint32_t idx, const char** name);

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -278,13 +278,16 @@ TVG_API Tvg_Paint tvg_paint_duplicate(Tvg_Paint paint)
     return nullptr;
 }
 
-
-TVG_API bool tvg_paint_intersects(Tvg_Paint paint, int32_t x, int32_t y, int32_t w, int32_t h)
+TVG_API TVG_DEPRECATED bool tvg_paint_intersects(Tvg_Paint paint, int32_t x, int32_t y, int32_t w, int32_t h)
 {
-    if (paint) return reinterpret_cast<Paint*>(paint)->intersects(x, y, w, h);
-    return false;
+    return tvg_paint_intersects_region(paint, x, y, w, h, false);
 }
 
+TVG_API bool tvg_paint_intersects_region(Tvg_Paint paint, int32_t x, int32_t y, int32_t w, int32_t h, bool visibleOnly)
+{
+    if (paint) return reinterpret_cast<Paint*>(paint)->intersects(x, y, w, h, visibleOnly);
+    return false;
+}
 
 TVG_API Tvg_Result tvg_paint_set_opacity(Tvg_Paint paint, uint8_t opacity)
 {

--- a/src/loaders/lottie/thorvg_lottie.h
+++ b/src/loaders/lottie/thorvg_lottie.h
@@ -138,13 +138,6 @@ struct TVG_API LottieAnimation final : Animation
     uint32_t markersCnt() noexcept;
 
     /**
-     * @brief Gets the marker name by a given index.
-     *
-     * @param[in] idx The index of the animation marker, starts from 0.
-     *
-     * @retval The name of marker when succeed, @c nullptr otherwise.
-     *
-     * @see LottieAnimation::markersCnt()
      * @deprecated see marker(uint32_t, float*, float*)
      */
     TVG_DEPRECATED const char* marker(uint32_t idx) noexcept;

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -279,12 +279,12 @@ bool Paint::Impl::bounds(Point* pt4, const Matrix* pm, bool obb)
     return ret;
 }
 
-
-bool Paint::Impl::intersects(const RenderRegion& region)
+bool Paint::Impl::intersects(const RenderRegion& region, bool visibleOnly)
 {
+    if (visibleOnly && hidden) return false;
     if (renderer) {
         bool ret;
-        PAINT_METHOD(ret, intersects(region));
+        PAINT_METHOD(ret, intersects(region, visibleOnly));
         return ret;
     }
     return false;
@@ -369,11 +369,15 @@ Result Paint::bounds(Point* pt4) noexcept
     return Result::InsufficientCondition;
 }
 
+TVG_DEPRECATED bool Paint::intersects(int32_t x, int32_t y, int32_t w, int32_t h) noexcept
+{
+    return intersects(x, y, w, h, false);
+}
 
-bool Paint::intersects(int32_t x, int32_t y, int32_t w, int32_t h) noexcept
+bool Paint::intersects(int32_t x, int32_t y, int32_t w, int32_t h, bool visibleOnly) noexcept
 {
     if (w <= 0 || h <= 0) return false;
-    return pImpl->intersects({{x, y}, {x + w, y + h}});
+    return pImpl->intersects({{x, y}, {x + w, y + h}}, visibleOnly);
 }
 
 

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -298,7 +298,7 @@ struct Paint::Impl
         return Result::Success;
     }
 
-    bool intersects(const RenderRegion& region);
+    bool intersects(const RenderRegion& region, bool visibleOnly);
     RenderRegion bounds();
     bool bounds(Point* pt4, const Matrix* pm, bool obb);
     AccessorIterator* iterator();
@@ -309,4 +309,4 @@ struct Paint::Impl
 
 }
 
-#endif //_TVG_PAINT_H_
+#endif  //_TVG_PAINT_H_

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -114,12 +114,12 @@ struct PictureImpl : Picture
         return Result::Success;
     }
 
-    bool intersects(const RenderRegion& region)
+    bool intersects(const RenderRegion& region, bool visibleOnly)
     {
         if (!impl.renderer) return false;
         load();
         if (impl.rd) return impl.renderer->intersectsImage(impl.rd, region);
-        else if (vector) return to<SceneImpl>(vector)->intersects(region);
+        else if (vector) return PAINT(vector)->intersects(region, visibleOnly);
         return false;
     }
 

--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -231,14 +231,13 @@ struct SceneImpl : Scene
         return ret;
     }
 
-
-    bool intersects(const RenderRegion& region)
+    bool intersects(const RenderRegion& region, bool visibleOnly)
     {
         if (!impl.renderer) return false;
 
         if (this->bounds().intersected(region)) {
             for (auto paint : paints) {
-                if (PAINT(paint)->intersects(region)) return true;
+                if (PAINT(paint)->intersects(region, visibleOnly)) return true;
             }
         }
 

--- a/src/renderer/tvgShape.h
+++ b/src/renderer/tvgShape.h
@@ -241,7 +241,7 @@ struct ShapeImpl : Shape
         return Result::Success;
     }
 
-    bool intersects(const RenderRegion& region)
+    bool intersects(const RenderRegion& region, TVG_UNUSED bool visibleOnly)
     {
         if (!impl.rd || !impl.renderer) return false;
         return impl.renderer->intersectsShape(impl.rd, region);

--- a/src/renderer/tvgText.h
+++ b/src/renderer/tvgText.h
@@ -202,10 +202,10 @@ struct TextImpl : Text
         return true;
     }
 
-    bool intersects(const RenderRegion& region)
+    bool intersects(const RenderRegion& region, TVG_UNUSED bool visibleOnly)
     {
         if (!load()) return false;
-        return to<ShapeImpl>(shape)->intersects(region);
+        return to<ShapeImpl>(shape)->intersects(region, false);
     }
 
     bool bounds(Point* pt4, const Matrix& m, bool obb)

--- a/test/testPaint.cpp
+++ b/test/testPaint.cpp
@@ -313,19 +313,21 @@ TEST_CASE("Intersection", "[tvgPaint]")
         REQUIRE(canvas->draw() == Result::Success);
 
         // Case1. Fully contained
-        REQUIRE(shape->intersects(0, 0, 200, 200) == true);
+        REQUIRE(shape->intersects(0, 0, 200, 200, true) == true);
 
         // Case2. Partially overlapping
-        REQUIRE(shape->intersects(25, 25, 50, 50) == true);
-        REQUIRE(shape->intersects(125, 125, 50, 50) == true);
+        REQUIRE(shape->intersects(25, 25, 50, 50, false) == true);
+        REQUIRE(shape->intersects(125, 125, 50, 50, false) == true);
+
+        shape->visible(false);
 
         // Case3. Edge-touching
-        REQUIRE(shape->intersects(49, 49, 2, 2) == true);
-        REQUIRE(shape->intersects(149, 149, 2, 2) == true);
+        REQUIRE(shape->intersects(49, 49, 2, 2, true) == false);
+        REQUIRE(shape->intersects(149, 149, 2, 2, false) == true);
 
         // Case4. Fully separated
-        REQUIRE(shape->intersects(0, 0, 25, 25) == false);
-        REQUIRE(shape->intersects(175, 175, 25, 25) == false);
+        REQUIRE(shape->intersects(0, 0, 25, 25, true) == false);
+        REQUIRE(shape->intersects(175, 175, 25, 25, true) == false);
     }
     REQUIRE(Initializer::term() == Result::Success);
 }


### PR DESCRIPTION
Add a new Paint::intersects() overload that allows callers to exclude
hidden paints from intersection checks.

Expose the same behavior in the C API through
tvg_paint_intersects_region(), and deprecate the previous intersection
APIs that always included hidden paints.

C++
```
+ bool Paint::intersects(int32_t x, int32_t y, int32_t w, int32_t h, bool visibleOnly)
```

CAPI
```
+ bool tvg_paint_intersects_region(Tvg_Paint paint, int32_t x, int32_t y, int32_t w, int32_t h, bool visibleOnly)
```