### PR TITLE
cpu_engine: fix hit-test miss on retained axis-aligned shapes

### DIFF
--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -704,7 +704,7 @@ bool SwRenderer::intersectsShape(RenderData data, const RenderRegion& region)
 
     if (!task->valid || !task->bounds().intersected(region)) return false;
     if (rleIntersect(task->shape.strokeRle, region)) return true;
-    return task->shape.rle ? rleIntersect(task->shape.rle, region): task->shape.fastTrack;
+    return task->shape.fastTrack || rleIntersect(task->shape.rle, region);
 }
 
 


### PR DESCRIPTION

### example

The example contains a single rectangle shape rotating continuously from 0 to 360 degrees. 

It checks intersection at the center of the shape on every frame.

With the buggy Software renderer, the animation stops when the shape reaches 

the axis-aligned state again because `intersects()` incorrectly returns false.




```cpp
struct UserExample : tvgexam::Example
{
    tvg::Scene* scene = nullptr;
    tvg::Shape* status = nullptr;
    bool stopped = false;
    float angle = 0.0f;

    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
    {
        auto bg = tvg::Shape::gen();
        bg->appendRect(0, 0, w, h);
        bg->fill(25, 28, 34);
        canvas->add(bg);

        scene = tvg::Scene::gen();
        scene->translate(150, 150);

        auto rect = tvg::Shape::gen();
        rect->appendRect(-50, -50, 100, 100);
        rect->fill(255, 255, 255);
        scene->add(rect);
        canvas->add(scene);

        status = tvg::Shape::gen();
        status->appendCircle(150, 150, 8, 8);
        status->fill(0, 220, 80);
        canvas->add(status);

        return true;
    }

    bool update(tvg::Canvas* canvas, uint32_t elapsed) override
    {
        if (!stopped) angle = float((elapsed / 10) % 361);
        scene->rotate(angle);

        if (!scene->intersects(148, 148, 4, 4)) {
            stopped = true;
            status->fill(255, 0, 0);
        }

        canvas->update();
        return true;
    }
};
```



#### main



https://github.com/user-attachments/assets/4c62d240-690a-484a-836a-835f4f5823bd


#### patch 



https://github.com/user-attachments/assets/2500e4f9-bd56-46b6-a9cb-534a45d1631f


