### PR TITLE
gl: enhance the alpha-premultiplied quality

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlCommon.h
+++ b/src/renderer/gpu_engine/gl/tvgGlCommon.h
@@ -133,8 +133,6 @@ struct GlShape
   GLuint texId = 0;
   const RenderSurface* texSource = nullptr;
   FilterMethod texFilter = FilterMethod::Bilinear;
-  uint32_t texFlipY = 0;
-  ColorSpace texColorSpace = ColorSpace::ABGR8888;
   GlGeometry geometry;
   Array<RenderData> clips;
   uint16_t texStamp = 0;  // Tracks TextureMgr::stamp ownership of texId.

--- a/src/renderer/gpu_engine/gl/tvgGlCommon.h
+++ b/src/renderer/gpu_engine/gl/tvgGlCommon.h
@@ -131,8 +131,6 @@ struct GlShape
   GLuint texId = 0;
   const RenderSurface* texSource = nullptr;
   FilterMethod texFilter = FilterMethod::Bilinear;
-  uint32_t texFlipY = 0;
-  ColorSpace texColorSpace = ColorSpace::ABGR8888;
   GlGeometry geometry;
   Array<RenderData> clips;
   uint16_t texStamp = 0;  // Tracks TextureMgr::stamp ownership of texId.

--- a/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
@@ -251,10 +251,10 @@ void GlGeometry::tesselateImage(const RenderSurface* image)
         fill.vertex.push(v);
     };
 
-    appendVertex(leftTop, 0.f, 1.f);
-    appendVertex(leftBottom, 0.f, 0.f);
-    appendVertex(rightTop, 1.f, 1.f);
-    appendVertex(rightBottom, 1.f, 0.f);
+    appendVertex(leftTop, 0.f, 0.f);
+    appendVertex(leftBottom, 0.f, 1.f);
+    appendVertex(rightTop, 1.f, 0.f);
+    appendVertex(rightBottom, 1.f, 1.f);
 
     fill.index.push(0);
     fill.index.push(1);

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -856,8 +856,7 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
 #else // TODO: create partial buffer when MSAA is disabled
             auto dstCopyFbo = mBlendPool[1]->getRenderTarget(currentPass()->getViewport());
 #endif
-            // image info
-            uint32_t info[4] = {(uint32_t)ColorSpace::ABGR8888, 0, cmp->opacity, 0};
+            uint32_t info[4] = {cmp->opacity, 0, 0, 0};
 
             auto program = getBlendProgram(glCmp->blendMethod, BlendSource::Scene);
             auto task = renderPass->endRenderPass<GlSceneBlendTask>(program, currentPass()->getFboId());
@@ -894,8 +893,7 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
             task->setDrawDepth(currentPass()->nextDrawDepth());
             task->setViewMatrix(tvg::identity());
 
-            // image info
-            uint32_t info[4] = {(uint32_t)ColorSpace::ABGR8888, 0, cmp->opacity, 0};
+            uint32_t info[4] = {cmp->opacity, 0, 0, 0};
 
             task->addBindResource(GlBindingResource{
                 1,
@@ -1056,6 +1054,7 @@ bool GlRenderer::preRender()
     if (mRootTarget.invalid()) return false;
 
     currentContext();
+    if (!mTextures.flushPreprocess(mStateCache, mTargetFboId)) return false;
     if (mPrograms.empty()) initShaders();
     mRenderPassStack.push(new GlRenderPass(&mRootTarget));
 
@@ -1191,8 +1190,7 @@ bool GlRenderer::renderImage(void* data)
     if (complexBlend) vp = currentPass()->getViewport();
     task->setViewMatrix(currentPass()->getViewMatrix());
 
-    // image info
-    uint32_t info[4] = {(uint32_t)sdata->texColorSpace, sdata->texFlipY, sdata->opacity, 0};
+    uint32_t info[4] = {sdata->opacity, 0, 0, 0};
 
     task->addBindResource(GlBindingResource{
         1,
@@ -1309,11 +1307,9 @@ RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matr
         sdata->texStamp = mTextures.stamp;
         sdata->geometry = GlGeometry();
     } else if (flags & RenderUpdateFlag::Image) {
-        TextureMgr::upload(mStateCache, sdata->texId, image, filter);
+        mTextures.upload(mStateCache, sdata->texId, image, filter);
     }
 
-    sdata->texColorSpace = image->cs;
-    sdata->texFlipY = 1;
     sdata->opacity = opacity;
     sdata->geometry.setMatrix(transform);
     sdata->geometry.viewport = vport;

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -857,8 +857,7 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
 #else // TODO: create partial buffer when MSAA is disabled
             auto dstCopyFbo = mBlendPool[1]->getRenderTarget(currentPass()->getViewport());
 #endif
-            // image info
-            uint32_t info[4] = {(uint32_t)ColorSpace::ABGR8888, 0, cmp->opacity, 0};
+            uint32_t info[4] = {cmp->opacity, 0, 0, 0};
 
             auto program = getBlendProgram(glCmp->blendMethod, BlendSource::Scene);
             auto task = renderPass->endRenderPass<GlSceneBlendTask>(program, currentPass()->getFboId());
@@ -895,8 +894,7 @@ void GlRenderer::endRenderPass(RenderCompositor* cmp)
             task->setDrawDepth(currentPass()->nextDrawDepth());
             task->setViewMatrix(tvg::identity());
 
-            // image info
-            uint32_t info[4] = {(uint32_t)ColorSpace::ABGR8888, 0, cmp->opacity, 0};
+            uint32_t info[4] = {cmp->opacity, 0, 0, 0};
 
             task->addBindResource(GlBindingResource{
                 1,
@@ -1041,6 +1039,7 @@ bool GlRenderer::preRender()
     if (mRootTarget.invalid()) return false;
 
     currentContext();
+    if (!mTextures.flushPreprocess(mTargetFboId)) return false;
     if (mPrograms.empty()) initShaders();
     mRenderPassStack.push(new GlRenderPass(&mRootTarget));
 
@@ -1176,8 +1175,7 @@ bool GlRenderer::renderImage(void* data)
     if (complexBlend) vp = currentPass()->getViewport();
     task->setViewMatrix(currentPass()->getViewMatrix());
 
-    // image info
-    uint32_t info[4] = {(uint32_t)sdata->texColorSpace, sdata->texFlipY, sdata->opacity, 0};
+    uint32_t info[4] = {sdata->opacity, 0, 0, 0};
 
     task->addBindResource(GlBindingResource{
         1,
@@ -1294,11 +1292,9 @@ RenderData GlRenderer::prepare(RenderSurface* image, RenderData data, const Matr
         sdata->texStamp = mTextures.stamp;
         sdata->geometry = GlGeometry();
     } else if (flags & RenderUpdateFlag::Image) {
-        TextureMgr::upload(sdata->texId, image, filter);
+        mTextures.upload(sdata->texId, image, filter);
     }
 
-    sdata->texColorSpace = image->cs;
-    sdata->texFlipY = 1;
     sdata->opacity = opacity;
     sdata->geometry.setMatrix(transform);
     sdata->geometry.viewport = vport;

--- a/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
@@ -333,10 +333,7 @@ const char* IMAGE_VERT_SHADER = TVG_COMPOSE_SHADER(
 
 const char* IMAGE_FRAG_SHADER = TVG_COMPOSE_SHADER(
     layout(std140) uniform ColorInfo {                                                      \n
-        int format;                                                                         \n
-        int flipY;                                                                          \n
-        int opacity;                                                                        \n
-        int dummy;                                                                          \n
+        ivec4 params;                                                                       \n
     } uColorInfo;                                                                           \n
     uniform sampler2D uTexture;                                                             \n
     in vec2 vUV;                                                                            \n
@@ -344,20 +341,7 @@ const char* IMAGE_FRAG_SHADER = TVG_COMPOSE_SHADER(
                                                                                             \n
     void main()                                                                             \n
     {                                                                                       \n
-        vec2 uv = vUV;                                                                      \n
-        if (uColorInfo.flipY == 1) { uv.y = 1.0 - uv.y; }                                   \n
-        vec4 color = texture(uTexture, uv);                                                 \n
-        vec4 result;                                                                        \n
-        if (uColorInfo.format == 0) { /* FMT_ABGR8888 */                                    \n
-            result = color;                                                                 \n
-        } else if (uColorInfo.format == 1) { /* FMT_ARGB8888 */                             \n
-            result = color.bgra;                                                            \n
-        } else if (uColorInfo.format == 2) { /* FMT_ABGR8888S */                            \n
-            result = vec4(color.rgb * color.a, color.a);                                    \n
-        } else if (uColorInfo.format == 3) { /* FMT_ARGB8888S */                            \n
-            result = vec4(color.bgr * color.a, color.a);                                    \n
-        }                                                                                   \n
-        FragColor = result * float(uColorInfo.opacity) / 255.0;                             \n
+        FragColor = texture(uTexture, vUV) * float(uColorInfo.params.x) / 255.0;             \n
    }                                                                                        \n
 );
 
@@ -716,10 +700,7 @@ vec4 postProcess(vec4 R) { return mix(vec4(d.Dc, d.Da), R, d.Sa * d.So); }
 
 const char* BLEND_SCENE_FRAG_HEADER = R"(
 layout(std140) uniform ColorInfo {
-    int format;
-    int flipY;
-    int opacity;
-    int dummy;
+    ivec4 params;
 } uColorInfo;
 uniform sampler2D uSrcTexture;
 uniform sampler2D uDstTexture;
@@ -738,7 +719,7 @@ void getFragData() {
     // fill fragment data
     d.Sc = colorSrc.rgb;
     d.Sa = colorSrc.a;
-    d.So = float(uColorInfo.opacity) / 255.0;
+    d.So = float(uColorInfo.params.x) / 255.0;
     d.Dc = colorDst.rgb;
     d.Da = colorDst.a;
     if (d.Sa > 0.0) {d.Sc = d.Sc / d.Sa; }
@@ -781,10 +762,7 @@ vec4 postProcess(vec4 R) { return mix(vec4(d.Dc, d.Da), R, d.Sa * d.So); }
 
 const char* BLEND_SCENE_FRAG_HEADER = R"(
 layout(std140) uniform ColorInfo {
-    int format;
-    int flipY;
-    int opacity;
-    int dummy;
+    ivec4 params;
 } uColorInfo;
 
 layout(std140) uniform BlendRegion {
@@ -809,7 +787,7 @@ void getFragData() {
     // fill fragment data
     d.Sc = colorSrc.rgb;
     d.Sa = colorSrc.a;
-    d.So = float(uColorInfo.opacity) / 255.0;
+    d.So = float(uColorInfo.params.x) / 255.0;
     d.Dc = colorDst.rgb;
     d.Da = colorDst.a;
     if (d.Sa > 0.0) {d.Sc = d.Sc / d.Sa; }

--- a/src/renderer/gpu_engine/gl/tvgGlTextureMgr.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlTextureMgr.cpp
@@ -21,6 +21,105 @@
  */
 
 #include "tvgGlTextureMgr.h"
+#include "tvgGlProgram.h"
+
+static constexpr int32_t PREP_PREMULTIPLY = 1 << 0;
+static constexpr int32_t PREP_BGR = 1 << 1;
+
+static constexpr char TEX_PREPROCESS_VERT_SHADER[] = R"(void main(){vec2 p=vec2(gl_VertexID==2?3.0:-1.0,gl_VertexID==1?3.0:-1.0);gl_Position=vec4(p,0.0,1.0);})";
+
+static constexpr char TEX_PREPROCESS_FRAG_SHADER[] = R"(uniform sampler2D uTexture;uniform int uFlags;out vec4 FragColor;void main(){vec4 c=texelFetch(uTexture,ivec2(gl_FragCoord.xy),0);if((uFlags&2)!=0)c=c.bgra;if((uFlags&1)!=0)c.rgb*=c.a;FragColor=c;})";
+
+void TextureMgr::requestPreprocess(GLuint texId, uint32_t width, uint32_t height, int32_t flags)
+{
+    if (!texId) return;
+    for (uint32_t i = 0; i < prepRequests.count; ++i) {
+        if (prepRequests[i].texId != texId) continue;
+        if (flags && width && height) prepRequests[i] = {texId, width, height, flags};
+        else {
+            prepRequests[i] = prepRequests.last();
+            prepRequests.pop();
+        }
+        return;
+    }
+    if (flags && width && height) prepRequests.push(Request{texId, width, height, flags});
+}
+
+bool TextureMgr::flushPreprocess(GlStateCache& state, GLint restoreFbo)
+{
+    if (prepRequests.empty()) return true;
+
+    if (!prepProgram) {
+        prepProgram = new GlProgram(TEX_PREPROCESS_VERT_SHADER, TEX_PREPROCESS_FRAG_SHADER);
+        GL_CHECK(prepFlagsLoc = glGetUniformLocation(prepProgram->getProgramId(), "uFlags"));
+    }
+    if (!prepStagingFbo) {
+        GL_CHECK(glGenFramebuffers(1, &prepStagingFbo));
+    }
+    if (!prepTargetFbo) {
+        GL_CHECK(glGenFramebuffers(1, &prepTargetFbo));
+    }
+    if (!prepVao) {
+        GL_CHECK(glGenVertexArrays(1, &prepVao));
+    }
+    if (!prepStagingTex) {
+        GL_CHECK(glGenTextures(1, &prepStagingTex));
+    }
+    if (!prepProgram || !prepStagingFbo || !prepTargetFbo || !prepVao || !prepStagingTex) return false;
+
+    state.bindFramebuffer(GL_FRAMEBUFFER, prepStagingFbo);
+    state.colorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    state.disable(GL_BLEND);
+    state.disable(GL_CULL_FACE);
+    state.disable(GL_DITHER);
+    state.disable(GL_RASTERIZER_DISCARD);
+    state.disable(GL_SCISSOR_TEST);
+#if defined(THORVG_GL_TARGET_GL)
+    state.disable(GL_COLOR_LOGIC_OP);
+#endif
+
+    state.useProgram(prepProgram->getProgramId());
+    prepProgram->setSampler(GlShaderUniform::Texture, 0);
+    state.bindVertexArray(prepVao);
+
+    int32_t currentFlags = 0;
+    ARRAY_FOREACH(p, prepRequests)
+    {
+        auto& request = *p;
+        if (request.width > prepStagingWidth || request.height > prepStagingHeight) {
+            auto attach = (prepStagingWidth == 0);
+            state.bindTexture2D(TVG_GL_TEXTURE_SETUP_UNIT, prepStagingTex);
+            // This texture is only a non-layered level-0 FBO attachment and is never sampled,
+            // so sampling parameters and mipmap completeness do not affect the framebuffer.
+            GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, request.width, request.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr));
+            prepStagingWidth = request.width;
+            prepStagingHeight = request.height;
+            if (attach) {
+                GL_CHECK(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, prepStagingTex, 0));
+            }
+        }
+        state.bindFramebuffer(GL_DRAW_FRAMEBUFFER, prepStagingFbo);
+        state.viewport(0, 0, request.width, request.height);
+        state.bindTexture2D(TVG_GL_TEXTURE_SETUP_UNIT, request.texId);
+        if (currentFlags != request.flags) {
+            currentFlags = request.flags;
+            GL_CHECK(glUniform1iv(prepFlagsLoc, 1, &currentFlags));
+        }
+        GL_CHECK(glDrawArrays(GL_TRIANGLES, 0, 3));
+
+        state.bindFramebuffer(GL_DRAW_FRAMEBUFFER, prepTargetFbo);
+        GL_CHECK(glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, request.texId, 0));
+        GL_CHECK(glBlitFramebuffer(0, 0, request.width, request.height, 0, 0, request.width, request.height, GL_COLOR_BUFFER_BIT, GL_NEAREST));
+    }
+    prepRequests.clear();
+
+    GL_CHECK(glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0));
+    state.bindTexture2D(TVG_GL_TEXTURE_SETUP_UNIT, 0);
+    state.bindVertexArray(0);
+    state.bindFramebuffer(GL_FRAMEBUFFER, restoreFbo);
+    state.enable(GL_DITHER);
+    return true;
+}
 
 TextureMgr::SurfaceEntry* TextureMgr::find(const RenderSurface* surface)
 {
@@ -31,15 +130,27 @@ TextureMgr::SurfaceEntry* TextureMgr::find(const RenderSurface* surface)
     return nullptr;
 }
 
-void TextureMgr::upload(GlStateCache& state, GLuint texId, const RenderSurface* surface, FilterMethod filter)
+void TextureMgr::upload(GlStateCache& state, GLuint texId, const RenderSurface* surface, FilterMethod filter, bool initialize)
 {
+    int32_t flags = 0;
+    if (surface->channelSize == sizeof(uint32_t)) {
+        auto supported = true;
+        if (surface->cs == ColorSpace::ARGB8888 || surface->cs == ColorSpace::ARGB8888S) flags |= PREP_BGR;
+        else if (surface->cs != ColorSpace::ABGR8888 && surface->cs != ColorSpace::ABGR8888S) supported = false;
+        if (supported && !surface->premultiplied) flags |= PREP_PREMULTIPLY;
+    }
+
     state.bindTexture2D(TVG_GL_TEXTURE_SETUP_UNIT, texId);
     GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, surface->w, surface->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, surface->data));
-    GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-    GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-    GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
-    GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
+    if (initialize) {
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
+    }
     state.bindTexture2D(TVG_GL_TEXTURE_SETUP_UNIT, 0);
+
+    requestPreprocess(texId, surface->w, surface->h, flags);
 }
 
 GLuint TextureMgr::retain(GlStateCache& state, const RenderSurface* surface, FilterMethod filter)
@@ -59,7 +170,7 @@ GLuint TextureMgr::retain(GlStateCache& state, const RenderSurface* surface, Fil
 
     GLuint texId = 0;
     GL_CHECK(glGenTextures(1, &texId));
-    upload(state, texId, surface, filter);
+    upload(state, texId, surface, filter, true);
 
     entry.texId = texId;
     entry.refCnt = 1;
@@ -79,6 +190,7 @@ GLuint TextureMgr::release(const RenderSurface* surface, FilterMethod filter, GL
     texId = entry.texId;
     entry.texId = 0;
     entry.refCnt = 0;
+    requestPreprocess(texId, 0, 0, 0);
 
     if (!surfaceEntry->bilinear.texId && !surfaceEntry->nearest.texId) {
         surfaces.remove(surfaceEntry);
@@ -98,6 +210,24 @@ void TextureMgr::clear()
         if (entry->nearest.texId) textures.push(entry->nearest.texId);
     }
     surfaces.free();
+    prepRequests.clear();
+    delete prepProgram;
+    prepProgram = nullptr;
+    if (prepStagingFbo) {
+        GL_CHECK(glDeleteFramebuffers(1, &prepStagingFbo));
+    }
+    if (prepTargetFbo) {
+        GL_CHECK(glDeleteFramebuffers(1, &prepTargetFbo));
+    }
+    if (prepStagingTex) {
+        GL_CHECK(glDeleteTextures(1, &prepStagingTex));
+    }
+    if (prepVao) {
+        GL_CHECK(glDeleteVertexArrays(1, &prepVao));
+    }
+    prepStagingFbo = prepTargetFbo = prepStagingTex = prepVao = 0;
+    prepStagingWidth = prepStagingHeight = 0;
+    prepFlagsLoc = -1;
     if (++stamp == 0) stamp = 1;  // avoid zero stamp, which is used to indicate stale cache.
     if (!textures.empty()) {
         GL_CHECK(glDeleteTextures(textures.count, textures.data));

--- a/src/renderer/gpu_engine/gl/tvgGlTextureMgr.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlTextureMgr.cpp
@@ -21,6 +21,108 @@
  */
 
 #include "tvgGlTextureMgr.h"
+#include "tvgGlProgram.h"
+
+static constexpr int32_t PREP_PREMULTIPLY = 1 << 0;
+static constexpr int32_t PREP_BGR = 1 << 1;
+
+static constexpr char TEX_PREPROCESS_VERT_SHADER[] = R"(void main(){vec2 p=vec2(gl_VertexID==2?3.0:-1.0,gl_VertexID==1?3.0:-1.0);gl_Position=vec4(p,0.0,1.0);})";
+
+static constexpr char TEX_PREPROCESS_FRAG_SHADER[] = R"(uniform sampler2D uTexture;uniform int uFlags;out vec4 FragColor;void main(){vec4 c=texelFetch(uTexture,ivec2(gl_FragCoord.xy),0);if((uFlags&2)!=0)c=c.bgra;if((uFlags&1)!=0)c.rgb*=c.a;FragColor=c;})";
+
+void TextureMgr::requestPreprocess(GLuint texId, uint32_t width, uint32_t height, int32_t flags)
+{
+    if (!texId) return;
+    for (uint32_t i = 0; i < prepRequests.count; ++i) {
+        if (prepRequests[i].texId != texId) continue;
+        if (flags && width && height) prepRequests[i] = {texId, width, height, flags};
+        else {
+            prepRequests[i] = prepRequests.last();
+            prepRequests.pop();
+        }
+        return;
+    }
+    if (flags && width && height) prepRequests.push(Request{texId, width, height, flags});
+}
+
+bool TextureMgr::flushPreprocess(GLint restoreFbo)
+{
+    if (prepRequests.empty()) return true;
+
+    if (!prepProgram) {
+        prepProgram = new GlProgram(TEX_PREPROCESS_VERT_SHADER, TEX_PREPROCESS_FRAG_SHADER);
+        prepFlagsLoc = prepProgram->getUniformLocation("uFlags");
+    }
+    if (!prepStagingFbo) {
+        GL_CHECK(glGenFramebuffers(1, &prepStagingFbo));
+    }
+    if (!prepTargetFbo) {
+        GL_CHECK(glGenFramebuffers(1, &prepTargetFbo));
+    }
+    if (!prepVao) {
+        GL_CHECK(glGenVertexArrays(1, &prepVao));
+    }
+    if (!prepStagingTex) {
+        GL_CHECK(glGenTextures(1, &prepStagingTex));
+    }
+    if (!prepProgram || !prepStagingFbo || !prepTargetFbo || !prepVao || !prepStagingTex) return false;
+
+    GL_CHECK(glActiveTexture(GL_TEXTURE0));
+    GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, prepStagingFbo));
+    GL_CHECK(glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE));
+    GL_CHECK(glDisable(GL_BLEND));
+    GL_CHECK(glDisable(GL_CULL_FACE));
+    GL_CHECK(glDisable(GL_DITHER));
+    GL_CHECK(glDisable(GL_RASTERIZER_DISCARD));
+    GL_CHECK(glDisable(GL_SCISSOR_TEST));
+#if defined(THORVG_GL_TARGET_GL)
+    GL_CHECK(glDisable(GL_COLOR_LOGIC_OP));
+#endif
+
+    GlProgram::unload();
+    prepProgram->load();
+    GL_CHECK(glBindVertexArray(prepVao));
+
+    int32_t currentFlags = 0;
+    ARRAY_FOREACH(p, prepRequests)
+    {
+        auto& request = *p;
+        if (request.width > prepStagingWidth || request.height > prepStagingHeight) {
+            auto attach = (prepStagingWidth == 0);
+            GL_CHECK(glBindTexture(GL_TEXTURE_2D, prepStagingTex));
+            // This texture is only a non-layered level-0 FBO attachment and is never sampled,
+            // so sampling parameters and mipmap completeness do not affect the framebuffer.
+            GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, request.width, request.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr));
+            prepStagingWidth = request.width;
+            prepStagingHeight = request.height;
+            if (attach) {
+                GL_CHECK(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, prepStagingTex, 0));
+            }
+        }
+        GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prepStagingFbo));
+        GL_CHECK(glViewport(0, 0, request.width, request.height));
+        GL_CHECK(glBindTexture(GL_TEXTURE_2D, request.texId));
+        if (currentFlags != request.flags) {
+            currentFlags = request.flags;
+            prepProgram->setUniform1Value(prepFlagsLoc, 1, &currentFlags);
+        }
+        GL_CHECK(glDrawArrays(GL_TRIANGLES, 0, 3));
+
+        GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, prepTargetFbo));
+        GL_CHECK(glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, request.texId, 0));
+        GL_CHECK(glBlitFramebuffer(0, 0, request.width, request.height, 0, 0, request.width, request.height, GL_COLOR_BUFFER_BIT, GL_NEAREST));
+    }
+    prepRequests.clear();
+
+    GL_CHECK(glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0));
+    GL_CHECK(glBindTexture(GL_TEXTURE_2D, 0));
+    GL_CHECK(glBindVertexArray(0));
+    GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, restoreFbo));
+    GL_CHECK(glUseProgram(0));
+    GlProgram::unload();
+    GL_CHECK(glEnable(GL_DITHER));
+    return true;
+}
 
 TextureMgr::SurfaceEntry* TextureMgr::find(const RenderSurface* surface)
 {
@@ -31,15 +133,27 @@ TextureMgr::SurfaceEntry* TextureMgr::find(const RenderSurface* surface)
     return nullptr;
 }
 
-void TextureMgr::upload(GLuint texId, const RenderSurface* surface, FilterMethod filter)
+void TextureMgr::upload(GLuint texId, const RenderSurface* surface, FilterMethod filter, bool initialize)
 {
+    int32_t flags = 0;
+    if (surface->channelSize == sizeof(uint32_t)) {
+        auto supported = true;
+        if (surface->cs == ColorSpace::ARGB8888 || surface->cs == ColorSpace::ARGB8888S) flags |= PREP_BGR;
+        else if (surface->cs != ColorSpace::ABGR8888 && surface->cs != ColorSpace::ABGR8888S) supported = false;
+        if (supported && !surface->premultiplied) flags |= PREP_PREMULTIPLY;
+    }
+
     GL_CHECK(glBindTexture(GL_TEXTURE_2D, texId));
     GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, surface->w, surface->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, surface->data));
-    GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-    GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-    GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
-    GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
+    if (initialize) {
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
+        GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, (filter == FilterMethod::Bilinear) ? GL_LINEAR : GL_NEAREST));
+    }
     GL_CHECK(glBindTexture(GL_TEXTURE_2D, 0));
+
+    requestPreprocess(texId, surface->w, surface->h, flags);
 }
 
 GLuint TextureMgr::retain(const RenderSurface* surface, FilterMethod filter)
@@ -59,7 +173,7 @@ GLuint TextureMgr::retain(const RenderSurface* surface, FilterMethod filter)
 
     GLuint texId = 0;
     GL_CHECK(glGenTextures(1, &texId));
-    upload(texId, surface, filter);
+    upload(texId, surface, filter, true);
 
     entry.texId = texId;
     entry.refCnt = 1;
@@ -79,6 +193,7 @@ GLuint TextureMgr::release(const RenderSurface* surface, FilterMethod filter, GL
     texId = entry.texId;
     entry.texId = 0;
     entry.refCnt = 0;
+    requestPreprocess(texId, 0, 0, 0);
 
     if (!surfaceEntry->bilinear.texId && !surfaceEntry->nearest.texId) {
         surfaces.remove(surfaceEntry);
@@ -98,6 +213,24 @@ void TextureMgr::clear()
         if (entry->nearest.texId) textures.push(entry->nearest.texId);
     }
     surfaces.free();
+    prepRequests.clear();
+    delete prepProgram;
+    prepProgram = nullptr;
+    if (prepStagingFbo) {
+        GL_CHECK(glDeleteFramebuffers(1, &prepStagingFbo));
+    }
+    if (prepTargetFbo) {
+        GL_CHECK(glDeleteFramebuffers(1, &prepTargetFbo));
+    }
+    if (prepStagingTex) {
+        GL_CHECK(glDeleteTextures(1, &prepStagingTex));
+    }
+    if (prepVao) {
+        GL_CHECK(glDeleteVertexArrays(1, &prepVao));
+    }
+    prepStagingFbo = prepTargetFbo = prepStagingTex = prepVao = 0;
+    prepStagingWidth = prepStagingHeight = 0;
+    prepFlagsLoc = -1;
     if (++stamp == 0) stamp = 1;  // avoid zero stamp, which is used to indicate stale cache.
     if (!textures.empty()) {
         GL_CHECK(glDeleteTextures(textures.count, textures.data));

--- a/src/renderer/gpu_engine/gl/tvgGlTextureMgr.h
+++ b/src/renderer/gpu_engine/gl/tvgGlTextureMgr.h
@@ -23,14 +23,19 @@
 #ifndef _TVG_GL_TEXTURE_MGR_H_
 #define _TVG_GL_TEXTURE_MGR_H_
 
+#include "tvgArray.h"
 #include "tvgGlCommon.h"
 #include "tvgInlist.h"
+
+class GlProgram;
 
 struct TextureMgr
 {
     GLuint retain(const RenderSurface* surface, FilterMethod filter);
     GLuint release(const RenderSurface* surface, FilterMethod filter, GLuint texId);
     void clear();
+    void upload(GLuint texId, const RenderSurface* surface, FilterMethod filter, bool initialize = false);
+    bool flushPreprocess(GLint restoreFbo);
 
     struct Entry
     {
@@ -46,11 +51,28 @@ struct TextureMgr
         Entry nearest;
     };
 
+    struct Request
+    {
+        GLuint texId;
+        uint32_t width;
+        uint32_t height;
+        int32_t flags;
+    };
+
     SurfaceEntry* find(const RenderSurface* surface);
-    static void upload(GLuint texId, const RenderSurface* surface, FilterMethod filter);
+    void requestPreprocess(GLuint texId, uint32_t width, uint32_t height, int32_t flags);
 
     tvg::Inlist<SurfaceEntry> surfaces;  // Cached textures keyed by RenderSurface.
     uint16_t stamp = 1;                  // Non-zero rolling stamp for stale texture ownership checks.
+    GLint prepFlagsLoc = -1;
+    GlProgram* prepProgram = nullptr;
+    GLuint prepStagingFbo = 0;
+    GLuint prepTargetFbo = 0;
+    GLuint prepStagingTex = 0;
+    GLuint prepVao = 0;
+    uint32_t prepStagingWidth = 0;
+    uint32_t prepStagingHeight = 0;
+    Array<Request> prepRequests;
 };
 
 #endif /* _TVG_GL_TEXTURE_MGR_H_ */

--- a/src/renderer/gpu_engine/gl/tvgGlTextureMgr.h
+++ b/src/renderer/gpu_engine/gl/tvgGlTextureMgr.h
@@ -23,15 +23,20 @@
 #ifndef _TVG_GL_TEXTURE_MGR_H_
 #define _TVG_GL_TEXTURE_MGR_H_
 
+#include "tvgArray.h"
 #include "tvgGlCommon.h"
 #include "tvgInlist.h"
 #include "tvgGlStateCache.h"
+
+struct GlProgram;
 
 struct TextureMgr
 {
     GLuint retain(GlStateCache& state, const RenderSurface* surface, FilterMethod filter);
     GLuint release(const RenderSurface* surface, FilterMethod filter, GLuint texId);
     void clear();
+    void upload(GlStateCache& state, GLuint texId, const RenderSurface* surface, FilterMethod filter, bool initialize = false);
+    bool flushPreprocess(GlStateCache& state, GLint restoreFbo);
 
     struct Entry
     {
@@ -47,11 +52,28 @@ struct TextureMgr
         Entry nearest;
     };
 
+    struct Request
+    {
+        GLuint texId;
+        uint32_t width;
+        uint32_t height;
+        int32_t flags;
+    };
+
     SurfaceEntry* find(const RenderSurface* surface);
-    static void upload(GlStateCache& state, GLuint texId, const RenderSurface* surface, FilterMethod filter);
+    void requestPreprocess(GLuint texId, uint32_t width, uint32_t height, int32_t flags);
 
     tvg::Inlist<SurfaceEntry> surfaces;  // Cached textures keyed by RenderSurface.
     uint16_t stamp = 1;                  // Non-zero rolling stamp for stale texture ownership checks.
+    GLint prepFlagsLoc = -1;
+    GlProgram* prepProgram = nullptr;
+    GLuint prepStagingFbo = 0;
+    GLuint prepTargetFbo = 0;
+    GLuint prepStagingTex = 0;
+    GLuint prepVao = 0;
+    uint32_t prepStagingWidth = 0;
+    uint32_t prepStagingHeight = 0;
+    Array<Request> prepRequests;
 };
 
 #endif /* _TVG_GL_TEXTURE_MGR_H_ */


### PR DESCRIPTION
Add a GL image texture preprocessing pass. Texture uploads queue conversion requests, and preRender() flushes the pending work immediately before render-pass setup. Each flush renders the source texture through a small shader into one reusable RGBA8 staging texture, then blits the result back to the cached texture.

Motivation: keep cached image textures in premultiplied RGBA so the image draw shader no longer carries color-space and straight-alpha branches. This follows the WebGPU preprocessing model while using GL rendering and framebuffer blits instead of compute.

The staging texture avoids sampling from and rendering to the same GL texture during conversion.

Related issue: https://github.com/thorvg/thorvg/issues/4041

### After

<img width="1136" height="784" alt="Screenshot 2026-07-27 at 11 01 43 AM" src="https://github.com/user-attachments/assets/35cffa5e-d710-4dad-a55c-96529fa76363" />

### Before

<img width="1136" height="784" alt="Screenshot 2026-07-27 at 10 53 46 AM" src="https://github.com/user-attachments/assets/08014862-2e8d-4e0b-a3c8-910687dc80fd" />
