### PR TITLE
svg_loader: support the alignment-baseline attribute

### DIFF
--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -928,7 +928,37 @@ static char* _processText(const char* text, SvgXmlSpace space)
     return processed;
 }
 
-static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const Matrix* transform)
+static void _applyTextBaseline(Text* text, SvgBaseline baseline, Matrix& transform)
+{
+    if (baseline == SvgBaseline::Auto || baseline == SvgBaseline::Alphabetic) return;
+
+    TextMetrics tm;
+    if (text->metrics(tm) != Result::Success) return;  // ascent > 0, descent < 0
+
+    auto shift = 0.0f;
+    // baseline geometry: https://www.w3.org/TR/css-inline-3/#baseline-types
+    // hanging/mathematical are synthesized from the ascent when the font provides no baseline table,
+    // see https://www.w3.org/TR/css-inline-3/#baseline-synthesis-fonts
+    switch (baseline) {
+        case SvgBaseline::BeforeEdge: shift = tm.ascent; break;
+        case SvgBaseline::AfterEdge: shift = tm.descent; break;
+        case SvgBaseline::Central: shift = 0.5f * (tm.ascent + tm.descent); break;
+        case SvgBaseline::Middle: {  // half the x-height (top extent of 'x')
+            GlyphMetrics gm;
+            if (text->metrics("x", gm) == Result::Success && gm.max.y > 0.0f) shift = 0.5f * gm.max.y;
+            else shift = 0.27f * tm.ascent;  // fallback when the 'x' glyph is missing
+            break;
+        }
+        case SvgBaseline::Hanging: shift = 0.8f * tm.ascent; break;
+        case SvgBaseline::Mathematical: shift = 0.5f * tm.ascent; break;
+        default: return;
+    }
+
+    translateR(&transform, {0.0f, shift});
+    text->transform(transform);
+}
+
+static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const Matrix* transform, SvgBaseline baseline)
 {
     if (!textNode->text) return nullptr;
 
@@ -950,6 +980,8 @@ static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const
     auto textTransform = transform ? *transform : tvg::identity();
     translateR(&textTransform, {textNode->x + textNode->dx, textNode->y + textNode->dy - tm.ascent});
     text->transform(textTransform);
+
+    _applyTextBaseline(text, baseline, textTransform);
 
     return text;
 }
@@ -1009,7 +1041,7 @@ static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* 
             if (textNode.x == FLT_MAX) textNode.x = textPos.x;
             if (textNode.y == FLT_MAX) textNode.y = textPos.y;
 
-            auto text = _buildText(&textNode, xmlSpace, nullptr);
+            auto text = _buildText(&textNode, xmlSpace, nullptr, child->style->alignmentBaseline);
             if (text) {
                 text->align(child->style->textAnchor, 0.0f);
                 _updatePos(text, textNode, child->style->textAnchor, textPos);
@@ -1035,7 +1067,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
     if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
 
     if (!_hasPositionedTspan(node, 0)) {
-        auto text = _buildText(textNode, xmlSpace, node->transform);
+        auto text = _buildText(textNode, xmlSpace, node->transform, node->style->alignmentBaseline);
         if (!text) return nullptr;
         text->align(node->style->textAnchor, 0.0f);
         _applyTextFill(node->style, text, vBox, ctx.parser->global);
@@ -1049,7 +1081,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
 
     Point textPos = {textNode->x, textNode->y};
 
-    if (auto text = _buildText(textNode, xmlSpace, nullptr)) {
+    if (auto text = _buildText(textNode, xmlSpace, nullptr, node->style->alignmentBaseline)) {
         text->align(node->style->textAnchor, 0.0f);
         _updatePos(text, *textNode, node->style->textAnchor, textPos);
         _applyTextFill(node->style, text, vBox, ctx.parser->global);

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -172,7 +172,8 @@ enum struct SvgStyleFlags
     StrokeDashOffset = 0x40000,
     Filter = 0x80000,
     BlendMode = 0x100000,
-    TextAnchor = 0x200000
+    TextAnchor = 0x200000,
+    AlignmentBaseline = 0x400000
 };
 
 constexpr bool operator&(SvgStyleFlags a, SvgStyleFlags b)
@@ -530,6 +531,18 @@ struct SvgFilter
     SvgNode* node;
 };
 
+enum class SvgBaseline : uint8_t
+{
+    Auto = 0,
+    Alphabetic,
+    BeforeEdge,
+    AfterEdge,
+    Central,
+    Middle,
+    Hanging,
+    Mathematical
+};
+
 struct SvgStyleProperty
 {
     SvgStyleFill fill;
@@ -541,6 +554,7 @@ struct SvgStyleProperty
     SvgColor color;
     char* cssClass;
     float textAnchor;  // 0=start, 0.5=middle, 1=end
+    SvgBaseline alignmentBaseline;
     SvgStyleFlags flags;
     SvgStyleFlags flagsImportance; //indicates the importance of the flag - if set, higher priority is applied (https://drafts.csswg.org/css-cascade-4/#importance)
     bool curColorSet;

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -150,6 +150,11 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from, bool 
         to->flags |= SvgStyleFlags::TextAnchor;
         if (from->flagsImportance & SvgStyleFlags::TextAnchor) to->flagsImportance |= SvgStyleFlags::TextAnchor;
     }
+    if (((from->flags & SvgStyleFlags::AlignmentBaseline) && (overwrite || !(to->flags & SvgStyleFlags::AlignmentBaseline))) || _isImportanceApplicable(to->flagsImportance, from->flagsImportance, SvgStyleFlags::AlignmentBaseline)) {
+        to->alignmentBaseline = from->alignmentBaseline;
+        to->flags |= SvgStyleFlags::AlignmentBaseline;
+        if (from->flagsImportance & SvgStyleFlags::AlignmentBaseline) to->flagsImportance |= SvgStyleFlags::AlignmentBaseline;
+    }
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1105,6 +1105,24 @@ static void _handleTextAnchorAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* nod
     else node->style->textAnchor = 0.0f;
 }
 
+static SvgBaseline _toBaseline(const char* str)
+{
+    if (STR_AS(str, "alphabetic")) return SvgBaseline::Alphabetic;
+    if (STR_AS(str, "before-edge") || STR_AS(str, "text-before-edge")) return SvgBaseline::BeforeEdge;
+    if (STR_AS(str, "after-edge") || STR_AS(str, "text-after-edge") || STR_AS(str, "ideographic")) return SvgBaseline::AfterEdge;
+    if (STR_AS(str, "central")) return SvgBaseline::Central;
+    if (STR_AS(str, "middle")) return SvgBaseline::Middle;
+    if (STR_AS(str, "hanging")) return SvgBaseline::Hanging;
+    if (STR_AS(str, "mathematical")) return SvgBaseline::Mathematical;
+    return SvgBaseline::Auto;
+}
+
+static void _handleAlignmentBaselineAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* node, const char* value)
+{
+    node->style->flags |= SvgStyleFlags::AlignmentBaseline;
+    node->style->alignmentBaseline = _toBaseline(value);
+}
+
 static void _handleCssClassAttr(SvgParserContext* ctx, SvgNode* node, const char* value)
 {
     auto cssClass = &node->style->cssClass;
@@ -1128,6 +1146,8 @@ static constexpr struct
     styleMethod tagHandler;
     SvgStyleFlags flag;
 } styleTags[] = {
+    // hyphenated names below are macro identifiers, not subtraction; keep them intact
+    // clang-format off
     STYLE_DEF(color, Color, SvgStyleFlags::Color),
     STYLE_DEF(fill, Fill, SvgStyleFlags::Fill),
     STYLE_DEF(fill-rule, FillRule, SvgStyleFlags::FillRule),
@@ -1149,7 +1169,9 @@ static constexpr struct
     STYLE_DEF(paint-order, PaintOrder, SvgStyleFlags::PaintOrder),
     STYLE_DEF(filter, Filter, SvgStyleFlags::Filter),
     STYLE_DEF(mix-blend-mode, MixBlendMode, SvgStyleFlags::BlendMode),
-    STYLE_DEF(text-anchor, TextAnchor, SvgStyleFlags::TextAnchor)};
+    STYLE_DEF(text-anchor, TextAnchor, SvgStyleFlags::TextAnchor),
+    STYLE_DEF(alignment-baseline, AlignmentBaseline, SvgStyleFlags::AlignmentBaseline)};
+// clang-format on
 
 static SvgXmlSpace _toXmlSpace(const char* str)
 {
@@ -2990,6 +3012,7 @@ static void _styleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
     if (from->flags & SvgStyleFlags::Display) to->display = from->display;
     if (from->flags & SvgStyleFlags::BlendMode) to->blendMode = from->blendMode;
     if (from->flags & SvgStyleFlags::TextAnchor) to->textAnchor = from->textAnchor;
+    if (from->flags & SvgStyleFlags::AlignmentBaseline) to->alignmentBaseline = from->alignmentBaseline;
 
     //Fill
     to->fill.flags = (to->fill.flags | from->fill.flags);


### PR DESCRIPTION
Shift the tspan run vertically from the alphabetic baseline to the requested baseline using the font metrics.

Supported values:
- auto, baseline: follow the dominant baseline of the text (no shift)
- alphabetic: no shift
- before-edge, text-before-edge: shift by the ascent
- after-edge, text-after-edge, ideographic: shift by the descent
- central: half of (ascent + descent)
- middle: half of the x-height, measured from the x glyph bounding box
- hanging: 0.8 x ascent
- mathematical: 0.5 x ascent

Baseline geometry follows CSS Inline Layout Level 3 (https://www.w3.org/TR/css-inline-3/#baseline-types).

<img width="790" height="309" alt="Screenshot from 2026-07-10 20-18-48" src="https://github.com/user-attachments/assets/5d5e0c75-cdba-4d94-b882-74db80df8afb" />

issue : #4107