### PR TITLE
test: fix the GL/WG unit tests on macOS

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -27,21 +27,26 @@ test_file = [
 ]
 
 if gl_engine
-    test_egl_dep = dependency('egl', required: false)
-
-    if gl_variant == 'OpenGL ES'
-        test_gl_dep = dependency('glesv2', required: false)
-        if not test_gl_dep.found()
-            test_gl_dep = cc.find_library('GLESv2', required: false)
-        endif
-    else
-        test_gl_dep = dependency('gl', required: false)
-    endif
-
-    if test_egl_dep.found() and test_gl_dep.found()
-        test_dep += [test_egl_dep, test_gl_dep]
+    if host_machine.system() == 'darwin'
+        test_dep += dependency('appleframeworks', modules: ['OpenGL'])
         test_compiler_flags += ['-DTHORVG_GL_TEST_SUPPORT']
         test_file += ['testGlCanvas.cpp', 'testGlEngine.cpp']
+    else
+        test_egl_dep = dependency('egl', required: false)
+        if gl_variant == 'OpenGL ES'
+            test_gl_dep = dependency('glesv2', required: false)
+            if not test_gl_dep.found()
+                test_gl_dep = cc.find_library('GLESv2', required: false)
+            endif
+        else
+            test_gl_dep = dependency('gl', required: false)
+        endif
+
+        if test_egl_dep.found() and test_gl_dep.found()
+            test_dep += [test_egl_dep, test_gl_dep]
+            test_compiler_flags += ['-DTHORVG_GL_TEST_SUPPORT']
+            test_file += ['testGlCanvas.cpp', 'testGlEngine.cpp']
+        endif
     endif
 endif
 

--- a/test/testGlEngine.h
+++ b/test/testGlEngine.h
@@ -29,6 +29,74 @@
 
 #include <thorvg.h>
 
+#ifdef __APPLE__
+
+// macOS has no native EGL; the engine loads Apple's OpenGL.framework, so test with CGL.
+#define GL_SILENCE_DEPRECATION 1
+#include <OpenGL/OpenGL.h>
+#include <OpenGL/gl3.h>
+
+using namespace tvg;
+
+struct TestGLEngine
+{
+    CGLContextObj context = nullptr;
+    GLuint fbo = 0;
+    GLuint colorBuf = 0;
+    GLuint depthStencilBuf = 0;
+    uint32_t width;
+    uint32_t height;
+    ColorSpace colorSpace;
+
+    TestGLEngine(uint32_t w = 100, uint32_t h = 100, ColorSpace cs = ColorSpace::ABGR8888S) : width(w), height(h), colorSpace(cs)
+    {
+        CGLPixelFormatAttribute attrs[] = {
+            kCGLPFAOpenGLProfile, (CGLPixelFormatAttribute)kCGLOGLPVersion_GL3_Core,
+            kCGLPFAColorSize, (CGLPixelFormatAttribute)32,
+            kCGLPFADepthSize, (CGLPixelFormatAttribute)24,
+            kCGLPFAStencilSize, (CGLPixelFormatAttribute)8,
+            (CGLPixelFormatAttribute)0};
+
+        CGLPixelFormatObj pixelFormat = nullptr;
+        GLint numFormats = 0;
+        CGLChoosePixelFormat(attrs, &pixelFormat, &numFormats);
+        CGLCreateContext(pixelFormat, nullptr, &context);
+        CGLDestroyPixelFormat(pixelFormat);
+        CGLSetCurrentContext(context);
+
+        // render into an offscreen fbo
+        glGenFramebuffers(1, &fbo);
+        glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+        glGenRenderbuffers(1, &colorBuf);
+        glBindRenderbuffer(GL_RENDERBUFFER, colorBuf);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, width, height);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, colorBuf);
+        glGenRenderbuffers(1, &depthStencilBuf);
+        glBindRenderbuffer(GL_RENDERBUFFER, depthStencilBuf);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthStencilBuf);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+
+    ~TestGLEngine()
+    {
+        CGLSetCurrentContext(context);
+        glDeleteFramebuffers(1, &fbo);
+        glDeleteRenderbuffers(1, &colorBuf);
+        glDeleteRenderbuffers(1, &depthStencilBuf);
+        CGLSetCurrentContext(nullptr);
+        CGLDestroyContext(context);
+    }
+
+    void target(GlCanvas* canvas)
+    {
+        CGLSetCurrentContext(context);
+        canvas->target(nullptr, nullptr, context, static_cast<int32_t>(fbo), width, height, colorSpace);
+    }
+};
+
+#else
+
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
@@ -146,5 +214,6 @@ struct TestGLEngine
     }
 };
 
+#endif
 #endif
 #endif

--- a/test/testWgEngine.cpp
+++ b/test/testWgEngine.cpp
@@ -130,9 +130,10 @@ TEST_CASE("WG Basic draw", "[tvgWgEngine]")
                 if (maskOp != MaskMethod::None) REQUIRE(shape4->mask(mask(), maskOp) == Result::Success);
                 REQUIRE(canvas->add(shape4) == Result::Success);
             }
+            REQUIRE(canvas->draw(true) == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+            REQUIRE(canvas->remove() == Result::Success);
         }
-        REQUIRE(canvas->draw(true) == Result::Success);
-        REQUIRE(canvas->sync() == Result::Success);
     }
     REQUIRE(Initializer::term() == Result::Success);
 }
@@ -235,10 +236,10 @@ TEST_CASE("WG Image Draw", "[tvgWgEngine]")
                 REQUIRE(picture7->scale(2.0f) == Result::Success);
                 REQUIRE(canvas->add(picture7) == Result::Success);
             }
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+            REQUIRE(canvas->remove() == Result::Success);
         }
-
-        REQUIRE(canvas->draw() == Result::Success);
-        REQUIRE(canvas->sync() == Result::Success);
         free(data);
     }
     REQUIRE(Initializer::term() == Result::Success);


### PR DESCRIPTION
### [test: support the GL unit tests on macOS](https://github.com/thorvg/thorvg/commit/1a483b7edeef144100414eb5050be4f27cdfc044)

The EGL cannot create a desktop GL context on macOS
due to the EGL compatibility (no system EGL, ANGLE is GLES-only).
Introduce a CGL-based harness to make the tests work with
desktop GL on macOS, rendering into an offscreen FBO.
The EGL path remains for Linux and GLES.

### [test: fix wgpu crash on macOS](https://github.com/thorvg/thorvg/commit/fb14dccf0f5690ecf4936c5bef849f25181e7225)

WG Basic Draw and WG Image Draw processed every blend and mask
combination in a single draw call. On macOS, this exceeded wgpu's
internal Metal command buffer limit and caused:

    Error in wgpuQueueSubmit: Validation Error
    Caused by: Parent device is lost

Counting pass creation in beginRenderPassMS() and beginRenderPass(),
together with copy encoding regions between passes, confirmed:

    Metal backend limit: 4,096
    WG Basic Draw:       >4,096
    WG Image Draw:       >4,096

WebGPU does not define this command buffer limit. It is internal to
wgpu's Metal backend.

Run draw, sync, and remove after each blend method to bound the number
of pending command buffers.

References:
- https://github.com/gfx-rs/wgpu/pull/8574