### PR TITLE
lottie: invalidate the layer transform cache when a tween is turned off

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -178,7 +178,7 @@ static bool _update(LottieTransform* transform, float frameNo, Matrix& matrix, u
 
 void LottieBuilder::updateTransform(LottieLayer* layer, float frameNo)
 {
-    if (!layer || (!tween.active && tvg::equal(layer->cache.frameNo, frameNo))) return;
+    if (!layer || (!tween.active && !tween.dirty && tvg::equal(layer->cache.frameNo, frameNo))) return;
 
     auto transform = layer->transform;
     auto parent = layer->parent;
@@ -1754,6 +1754,8 @@ bool LottieBuilder::update(LottieComposition* comp, float frameNo)
         auto layer = static_cast<LottieLayer*>(*child);
         if (!layer->matteSrc) updateLayer(comp, comp->root->scene, layer, frameNo);
     }
+
+    tween.dirty = false;
 
     return true;
 }

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -386,7 +386,7 @@ bool LottieLoader::frame(float no)
     no = shorten(no);
 
     //Skip update if frame diff is too small.
-    if (!builder->tween.active && fabsf(this->frameNo - no) <= 0.0009f) return false;
+    if (!builder->tween.active && !builder->tween.dirty && fabsf(this->frameNo - no) <= 0.0009f) return false;
 
     this->done();
 

--- a/src/loaders/lottie/tvgLottieTween.h
+++ b/src/loaders/lottie/tvgLottieTween.h
@@ -123,6 +123,7 @@ public:
     float progress = 0.0f;  // [0 - 1]
     bool active = false;
     bool legacy = false;  // for legacy backward compat
+    bool dirty = false;
 
     ~LottieTween()
     {
@@ -156,6 +157,7 @@ public:
     {
         if (active) {
             active = legacy = false;
+            dirty = true;
             release();
         }
     }


### PR DESCRIPTION
While a dynamic tween is active the builder writes the interpolated matrix into the layer transform cache, but stamps it with the un-tweened frame number. Turning the tween off leaves that matrix in place: `updateTransform()` sees the cache is already on the requested frame and returns early, so the scene stays frozen on the tweened pose instead of falling back to the real frame.

It shows up when a tween is cancelled mid-flight. Calling `frame()` with the frame the animation is already on turns the tween off, but nothing rebuilds, so the last interpolated pose sticks.

Mark the tween dirty in `off()` and let one update pass through, so the transform is rebuilt from the actual frame.