### PR TITLE
gl: fix Zero-opacity shapes consume update

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlCommon.h
+++ b/src/renderer/gpu_engine/gl/tvgGlCommon.h
@@ -127,6 +127,7 @@ struct GlShape
   float viewWd;
   float viewHt;
   uint32_t opacity = 0;
+  RenderUpdateFlag deferredFlags = RenderUpdateFlag::None;
   GLuint texId = 0;
   const RenderSurface* texSource = nullptr;
   FilterMethod texFilter = FilterMethod::Bilinear;

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -1315,7 +1315,16 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
         flags = RenderUpdateFlag::All;
     }
 
-    if ((opacity == 0 && !clipper) || flags == RenderUpdateFlag::None) return sdata;
+    // Defer updates while transparent.
+    if (opacity == 0 && !clipper) {
+        sdata->opacity = 0;
+        sdata->deferredFlags |= flags;
+        return sdata;
+    }
+
+    flags |= sdata->deferredFlags;
+    sdata->deferredFlags = RenderUpdateFlag::None;
+    if (flags == RenderUpdateFlag::None) return sdata;
 
     sdata->viewWd = static_cast<float>(surface.w);
     sdata->viewHt = static_cast<float>(surface.h);


### PR DESCRIPTION
Zero-opacity shapes consumed their initial geometry flags without preparing render data, so later opacity updates could not rebuild their meshes.

Defer and replay skipped flags when the shape becomes visible while preserving intermediate opacity values.

issue: #4549


https://github.com/user-attachments/assets/358da7fa-369d-4af0-b971-511c90018330

