### PR TITLE
lottie/slot: fix image slot type confusion in parseAsset

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -949,6 +949,8 @@ struct LottieImage : LottieObject
     LottieBitmap bitmap;
     bool resolved = false;
 
+    LottieImage() { LottieObject::type = LottieObject::Image; }
+
     LottieProperty* override(LottieProperty* prop, bool release) override
     {
         LottieProperty* backup = nullptr;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1060,7 +1060,7 @@ void LottieParser::parseImage(LottieImage* image, const char* data, const char* 
 }
 
 
-LottieObject* LottieParser::parseAsset()
+LottieObject* LottieParser::parseAsset(bool image)
 {
     enterObject();
 
@@ -1094,7 +1094,7 @@ LottieObject* LottieParser::parseAsset()
         else skip();
     }
     if (data) {
-        if (!strncmp(data, "data:image/", 11) || width != 0.0f || height != 0.0f) {
+        if (image || !strncmp(data, "data:image/", 11) || width != 0.0f || height != 0.0f) {
             auto asset = new LottieImage;
             parseImage(asset, data, subPath, embedded, width, height);
             if (sid) registerSlot(asset, sid, asset->bitmap);
@@ -1757,10 +1757,13 @@ LottieProperty* LottieParser::parse(LottieSlot* slot)
         case LottieProperty::Type::Image: {
             LottieObject* obj = nullptr;
             while (auto key = nextObjectKey()) {
-                if (KEY_AS("p")) obj = parseAsset();
+                if (KEY_AS("p")) obj = parseAsset(true);
                 else skip();
             }
-            if (!obj) return nullptr;
+            if (!obj || obj->type != LottieObject::Type::Image) {
+                delete(obj);
+                return nullptr;
+            }
             prop = new LottieBitmap(static_cast<LottieImage*>(obj)->bitmap);
             delete(obj);
             break;

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -75,7 +75,7 @@ private:
     template<typename T> void parseSlotProperty(T& prop);
 
     LottieObject* parseObject(const char* type);
-    LottieObject* parseAsset();
+    LottieObject* parseAsset(bool image = false);
     void parseImage(LottieImage* image, const char* data, const char* subPath, bool embedded, float width, float height);
     void parseAudio(LottieAudio* audio, const char* data, const char* subPath, bool embedded);
     void parseVolume(LottieLayer* layer);


### PR DESCRIPTION
An image slot whose asset json has no width/height and e:0 was classified as audio by parseAsset()'s data heuristic, then blindly cast to LottieImage, reading garbage past the LottieAudio allocation (intermittent SIGSEGV in Paint::ref during slot json parsing).

Since the slot property type is already known to be Image, pass that to parseAsset() to force the image branch, and reject non-image results (e.g. a precomp asset with "layers") instead of casting them — the same guard LottieBuilder::updateImage already applies on the builder side.

Reproduce with an animation whose slotted image asset carries a path and no dimensions:

```json
{"v":"5.7.4","fr":30,"ip":0,"op":30,"w":100,"h":100,
 "assets":[{"id":"img_0","sid":"image_slot","p":"cat.png","u":"images/","e":0}],
 "layers":[{"ddd":0,"ind":1,"ty":2,"refId":"img_0","ks":{},"ip":0,"op":30,"st":0}]}
```

and override the slot:

```json
{"image_slot":{"p":{"p":"dog.png","u":"images/","e":0}}}
```

Unit tests pass (meson -Dtests=true -Dloaders=all -Dsavers=all -Dbindings=capi -Dtools=all).
