### PR TITLE
capi: support unsetting the asset resolver with a null callback

### DIFF
--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -652,10 +652,11 @@ TVG_API Tvg_Result tvg_picture_load_data(Tvg_Paint picture, const char *data, ui
 
 TVG_API Tvg_Result tvg_picture_set_asset_resolver(Tvg_Paint picture, Tvg_Picture_Asset_Resolver resolver, void* data)
 {
-    if (picture) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->resolver([resolver](Paint* paint, const char* src, void* data) -> bool {
+    if (!picture) return TVG_RESULT_INVALID_ARGUMENT;
+    if (!resolver) return (Tvg_Result) reinterpret_cast<Picture*>(picture)->resolver(nullptr, nullptr);
+    return (Tvg_Result) reinterpret_cast<Picture*>(picture)->resolver([resolver](Paint* paint, const char* src, void* data) -> bool {
         return resolver(reinterpret_cast<Tvg_Paint>(paint), src, data);
     }, data);
-    return TVG_RESULT_INVALID_ARGUMENT;
 }
 
 


### PR DESCRIPTION
tvg_picture_set_asset_resolver() wrapped a null callback in a valid lambda, so passing NULL installed a resolver that dereferences NULL once an asset is resolved, instead of clearing it as the API doc states ("To unset the resolver, pass nullptr").

Forward the null callback to Picture::resolver(), which already supports clearing, matching what tvg_lottie_animation_set_audio_resolver() does. As with setting, clearing after the picture is loaded returns InsufficientCondition.
