### PR TITLE
loader: fix a font sharing count leak on cached data loading

### DIFF
--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -364,7 +364,10 @@ tvg::Loader* LoaderMgr::loader(const char* name, const char* data, uint32_t size
 {
 #ifdef THORVG_SFNT_LOADER_SUPPORT
     // TODO: add check for mimetype ?
-    if (auto loader = font(name)) return loader;
+    if (auto loader = font(name)) {
+        if (loader->sharing > 0) --loader->sharing;   //font loading doesn't mean sharing.
+        return loader;
+    }
 
     // function is dedicated for SFNT-based font loading
     auto loader = new SfntLoader;


### PR DESCRIPTION
LoaderMgr::loader(name, data, ...) returns early when the font is already cached, but font() increments the sharing count on that hit and the caller (Text::load) discards the result, so the count was never balanced and the loader leaked at unload. Loading the same font data twice (e.g. a lottie with an embedded font, loaded twice) strands the loader past Initializer::term().

Apply the same compensation Text::load() already performs for the file-path route (extends d50632d0 to the data path).
