### PR TITLE
lottie/slot: reset the image resolved state on overriding

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -975,8 +975,7 @@ void LottieBuilder::updateImage(LottieGroup* layer)
     if (!picture) return;
 
     //resolve an image asset if need
-    if (resolver && !image->resolved) {
-        resolver->func(picture, image->bitmap.path, resolver->data);
+    if (resolver && !image->resolved && resolver->func(picture, image->bitmap.path, resolver->data)) {
         if (image->bitmap.width > 0.0f && image->bitmap.height > 0.0f) picture->size(image->bitmap.width, image->bitmap.height);
         image->resolved = true;
     }

--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -977,7 +977,7 @@ void LottieBuilder::updateImage(LottieGroup* layer)
     //resolve an image asset if need
     if (resolver && !image->resolved) {
         resolver->func(picture, image->bitmap.path, resolver->data);
-        picture->size(image->bitmap.width, image->bitmap.height);
+        if (image->bitmap.width > 0.0f && image->bitmap.height > 0.0f) picture->size(image->bitmap.width, image->bitmap.height);
         image->resolved = true;
     }
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -305,7 +305,7 @@ void LottieImage::prepare(bool external)
     if (bitmap.size > 0) result = picture->load((const char*)bitmap.data, bitmap.size, bitmap.mimeType);
     else if (external) result = picture->load(bitmap.path);
     if (result == Result::Success) resolved = true;
-    picture->size(bitmap.width, bitmap.height);
+    if (resolved || (bitmap.width > 0.0f && bitmap.height > 0.0f)) picture->size(bitmap.width, bitmap.height);
     bitmap.picture = picture;
     picture->ref();
 }

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -305,7 +305,8 @@ void LottieImage::prepare(bool external)
     if (bitmap.size > 0) result = picture->load((const char*)bitmap.data, bitmap.size, bitmap.mimeType);
     else if (external) result = picture->load(bitmap.path);
     if (result == Result::Success) resolved = true;
-    if (resolved || (bitmap.width > 0.0f && bitmap.height > 0.0f)) picture->size(bitmap.width, bitmap.height);
+    //json may omit the dimensions (e.g. slot override); keep the natural size instead of collapsing to 0x0
+    if (bitmap.width > 0.0f && bitmap.height > 0.0f) picture->size(bitmap.width, bitmap.height);
     bitmap.picture = picture;
     picture->ref();
 }

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -955,6 +955,8 @@ struct LottieImage : LottieObject
         if (release) bitmap.release();
         else backup = new LottieBitmap(bitmap);
         bitmap.copy(*static_cast<LottieBitmap*>(prop), false);
+        //embedded data was already loaded synchronously; a path needs re-resolving
+        resolved = bitmap.size > 0;
         return backup;
     }
 

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -955,8 +955,8 @@ struct LottieImage : LottieObject
         if (release) bitmap.release();
         else backup = new LottieBitmap(bitmap);
         bitmap.copy(*static_cast<LottieBitmap*>(prop), false);
-        //embedded data was already loaded synchronously; a path needs re-resolving
-        resolved = bitmap.size > 0;
+        //embedded data was already loaded synchronously; a path needs re-resolving unless its picture is loaded
+        resolved = bitmap.size > 0 || (bitmap.picture && bitmap.picture->size(nullptr, nullptr) == Result::Success);
         return backup;
     }
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1060,7 +1060,7 @@ void LottieParser::parseImage(LottieImage* image, const char* data, const char* 
 }
 
 
-LottieObject* LottieParser::parseAsset()
+LottieObject* LottieParser::parseAsset(bool image)
 {
     enterObject();
 
@@ -1094,7 +1094,8 @@ LottieObject* LottieParser::parseAsset()
         else skip();
     }
     if (data) {
-        if (!strncmp(data, "data:image/", 11) || width != 0.0f || height != 0.0f) {
+        //an image slot override may lack both embedded data and dimensions
+        if (image || !strncmp(data, "data:image/", 11) || width != 0.0f || height != 0.0f) {
             auto asset = new LottieImage;
             parseImage(asset, data, subPath, embedded, width, height);
             if (sid) registerSlot(asset, sid, asset->bitmap);
@@ -1757,7 +1758,7 @@ LottieProperty* LottieParser::parse(LottieSlot* slot)
         case LottieProperty::Type::Image: {
             LottieObject* obj = nullptr;
             while (auto key = nextObjectKey()) {
-                if (KEY_AS("p")) obj = parseAsset();
+                if (KEY_AS("p")) obj = parseAsset(true);
                 else skip();
             }
             if (!obj) return nullptr;

--- a/src/loaders/lottie/tvgLottieParser.h
+++ b/src/loaders/lottie/tvgLottieParser.h
@@ -75,7 +75,7 @@ private:
     template<typename T> void parseSlotProperty(T& prop);
 
     LottieObject* parseObject(const char* type);
-    LottieObject* parseAsset();
+    LottieObject* parseAsset(bool image = false);
     void parseImage(LottieImage* image, const char* data, const char* subPath, bool embedded, float width, float height);
     void parseAudio(LottieAudio* audio, const char* data, const char* subPath, bool embedded);
     void parseVolume(LottieLayer* layer);

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -993,8 +993,25 @@ struct LottieBitmap : LottieProperty
             picture->ref();
         }
 
+        size = rhs.size;
         width = rhs.width;
         height = rhs.height;
+
+        if (shallow) {
+            data = rhs.data;
+            mimeType = rhs.mimeType;
+            rhs.data = nullptr;
+            rhs.mimeType = nullptr;
+            rhs.size = 0;
+        } else {
+            if (rhs.size > 0) {
+                data = tvg::malloc<char>(rhs.size);
+                memcpy(data, rhs.data, rhs.size);
+            } else if (rhs.path) {
+                path = tvg::duplicate(rhs.path);
+            }
+            if (rhs.mimeType) mimeType = tvg::duplicate(rhs.mimeType);
+        }
     }
 };
 

--- a/test/testLottie.cpp
+++ b/test/testLottie.cpp
@@ -328,6 +328,47 @@ TEST_CASE("Lottie Asset Resolver", "[tvgLottie]")
 }
 
 
+TEST_CASE("Lottie Slot Image Resolver", "[tvgLottie]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        auto animation = unique_ptr<LottieAnimation>(LottieAnimation::gen());
+        REQUIRE(animation);
+
+        auto picture = animation->picture();
+
+        int callCount = 0;
+        string lastSrc;
+
+        auto resolver = [&](Paint* p, const char* src, void* data) -> bool {
+            if (p->type() != Type::Picture) return false;
+            ++callCount;
+            lastSrc = src ? src : "";
+            return static_cast<Picture*>(p)->load(TEST_DIR"/test.png") == Result::Success;
+        };
+
+        REQUIRE(picture->resolver(resolver, nullptr) == Result::Success);
+        REQUIRE(picture->load(TEST_DIR"/slot.lot") == Result::Success);
+        REQUIRE(animation->frame(1) == Result::Success);
+        REQUIRE(callCount == 1);
+
+        //overriding with a path-based image should re-fire the resolver
+        const char* slotJson = R"({"path_img":{"p":{"p":"dog.png","u":"images/","e":0}}})";
+        auto id = animation->gen(slotJson);
+        REQUIRE(id > 0);
+        REQUIRE(animation->apply(id) == Result::Success);
+        REQUIRE(animation->frame(2) == Result::Success);
+        REQUIRE(callCount == 2);
+        REQUIRE(lastSrc.find("dog.png") != string::npos);
+
+        //a resolved image shouldn't re-trigger the resolver
+        REQUIRE(animation->frame(3) == Result::Success);
+        REQUIRE(callCount == 2);
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
+
 TEST_CASE("Lottie Audio Layer", "[tvgLottie]")
 {
     REQUIRE(Initializer::init() == Result::Success);


### PR DESCRIPTION
LottieImage::override() never cleared the resolved flag, so after a slot swap the asset resolver was skipped and a path-based bitmap with no synchronously loadable data rendered blank. LottieBitmap::copy() also only carried picture/width/height, so even with the flag cleared the resolver would receive the stale source. The first commit carries the bitmap source through copy() and marks path-based bitmaps unresolved on override; embedded data stays resolved (it is loaded synchronously in prepare()), which also avoids invoking the resolver with raw decoded bytes as src for embedded assets.

The second commit skips the explicit picture->size() only when the image is left for the resolver and the json has no dimensions, so the resolver-loaded picture keeps its natural size. Synchronously loaded images keep the existing sizing behavior.

Reproduce: install an asset resolver, load an animation with a slotted path-based image asset, then override the slot with another path-based image ("e": 0, no "w"/"h") — the resolver never re-fires and the layer goes blank:

```json
{"image_slot":{"p":{"p":"dog.png","u":"images/","e":0}}}
```

Builds on #4562 for path-based image slots. Unit tests pass (meson -Dtests=true -Dloaders=all -Dsavers=all -Dbindings=capi -Dtools=all).

issue: #4544
