### PR TITLE
cpu: unify gradient fill color generation

### DIFF
--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -464,8 +464,7 @@ void shapeResetStroke(SwShape& shape, const RenderShape* rshape, const Matrix& t
 bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& transform, const RenderRegion& clipBox, RenderRegion& renderBox, SwMpool* mpool, unsigned tid, bool antiAlias);
 void shapeFree(SwShape& shape);
 void shapeDelStroke(SwShape& shape);
-bool shapeGenFillColors(SwShape& shape, const Fill* fill, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable);
-bool shapeGenStrokeFillColors(SwShape& shape, const Fill* fill, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable);
+bool shapeGenFillColors(SwFill*& out, const Fill* fill, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable);
 void shapeResetFill(SwShape& shape);
 bool shapeStrokeBBox(SwShape& shape, const RenderShape* rshape, Point* pt4, const Matrix& m, SwMpool* mpool);
 void shapeDelFill(SwShape& shape);

--- a/src/renderer/cpu_engine/tvgSwFill.cpp
+++ b/src/renderer/cpu_engine/tvgSwFill.cpp
@@ -773,8 +773,6 @@ void fillLinear(const SwSurface* surface, const SwFill* fill, uint32_t* dst, uin
 
 bool fillGenColorTable(SwFill* fill, const Fill* fdata, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable)
 {
-    if (!fill) return false;
-
     fill->spread = fdata->spread();
 
     if (fdata->type() == Type::LinearGradient) {

--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -145,10 +145,7 @@ struct SwShapeTask : SwTask
         }
         //Fill
         if (updateFill) {
-            if (auto fill = rshape->fill) {
-                auto ctable = (flags[0] & RenderUpdateFlag::Gradient) ? true : false;
-                if (!shapeGenFillColors(shape, fill, transform, renderer->surface, opacity, ctable)) goto err;
-            }
+            if (!shapeGenFillColors(shape.fill, rshape->fill, transform, renderer->surface, opacity, (flags[0] & RenderUpdateFlag::Gradient))) goto err;
         }
         //Stroke
         if (strokeWidth > 0.0f) {
@@ -156,9 +153,7 @@ struct SwShapeTask : SwTask
             if (updateStroke && !shapeGenStrokeRle(shape, rshape, transform, clipBox, curBox, renderer->mpool, tid, renderer->antiAlias)) goto err;
             auto ctable = flags[0] & RenderUpdateFlag::GradientStroke;
             if (ctable || flags[0] & RenderUpdateFlag::Transform) {
-                if (auto fill = rshape->strokeFill()) {
-                    if (!shapeGenStrokeFillColors(shape, fill, transform, renderer->surface, opacity, ctable)) goto err;
-                }
+                if (!shapeGenFillColors(shape.stroke->fill, rshape->strokeFill(), transform, renderer->surface, opacity, ctable)) goto err;
             }
         } else {
             shapeDelStroke(shape);

--- a/src/renderer/cpu_engine/tvgSwShape.cpp
+++ b/src/renderer/cpu_engine/tvgSwShape.cpp
@@ -511,22 +511,17 @@ bool shapeGenStrokeRle(SwShape& shape, const RenderShape* rshape, const Matrix& 
     return shape.strokeRle ? true : false;
 }
 
-
-bool shapeGenFillColors(SwShape& shape, const Fill* fill, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable)
+bool shapeGenFillColors(SwFill*& out, const Fill* fill, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable)
 {
-    if (ctable) shapeResetFill(shape);
-    return fillGenColorTable(shape.fill, fill, transform, surface, opacity, ctable);
-}
+    if (!fill) return true;  // a normal case
 
-bool shapeGenStrokeFillColors(SwShape& shape, const Fill* fill, const Matrix& transform, SwSurface* surface, uint8_t opacity, bool ctable)
-{
-    if (!shape.stroke->fill) {
-        shape.stroke->fill = tvg::calloc<SwFill>(1, sizeof(SwFill));
+    if (!out) {
+        out = tvg::calloc<SwFill>(1, sizeof(SwFill));
         ctable = true;
     } else if (ctable) {
-        fillReset(shape.stroke->fill);
+        fillReset(out);
     }
-    return fillGenColorTable(shape.stroke->fill, fill, transform, surface, opacity, ctable);
+    return fillGenColorTable(out, fill, transform, surface, opacity, ctable);
 }
 
 void shapeResetFill(SwShape& shape)


### PR DESCRIPTION
Consolidate shape and stroke fill color-table generation into a shared path and allocate fill data on demand.

This fixes a bug that missing of gradient fill updates.