### PR TITLE
lottie/text: fix point text vertical alignment

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1033,14 +1033,14 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     if (text->font && text->font->style && strstr(text->font->style, "Italic")) paint->italic();
     paint->text(buf);
     paint->layout(doc.bbox.size.x, doc.bbox.size.y);
-    paint->translate(doc.bbox.pos.x, doc.bbox.pos.y);
     if (doc.bbox.size.x > 0.0f) paint->wrap(TextWrap::Smart);
 
     //align the text to the base line, or top within the box
     TextMetrics metrics;
     paint->metrics(metrics);
-    auto valign = (doc.bbox.size.y > 0.0f) ? 0.0f : metrics.ascent / (metrics.ascent - metrics.descent);
-    paint->align(doc.justify, valign);
+    auto vpos = doc.bbox.pos.y - (doc.bbox.size.y > 0.0f ? 0.0f : metrics.ascent);
+    paint->translate(doc.bbox.pos.x, vpos);
+    paint->align(doc.justify, 0.0f);
 
     //apply spacing
     auto hspacing = 1.0f + doc.tracking * doc.size / metrics.ascent;


### PR DESCRIPTION
Follow-up to #4462 (which fixed **box** text) — this fixes the **point** text case of #4334.

## Problem

For point text (no `sz`), `updateURLFont` places the first baseline ~one ascent plus a valign-slack shift too high:

1. the sfnt loader bakes `m[5] = hhea.ascent * scale` into every glyph (`tvgSfntLoader.cpp`), so the first baseline sits **one ascent below the drawable top** — correct for box text (its cap-top meets the box top), wrong for point text;
2. point text also still gets `valign = ascent / (ascent − descent)`.

Net first baseline = `origin + ascent − blockHeight·ascentRatio` instead of `origin`.

## Fix

For point text (`bbox.size.y <= 0`), cancel the loader's ascent offset (translate up by `ascent`) and use `valign 0`, so the first baseline lands on the layer origin — matching lottie-web / After Effects. **Box text is unchanged.**

## Verification

Repro: point text, 4 lines, left-justified, URL/data-URI font (`chars` empty); `fontSize 86`, `lh 75.2`; rendered at 512×512. First-baseline Y (scene coords), with **lottie-web 5.12.2** as the reference renderer:

| line | lottie-web (reference) | ThorVG v1.0.7 (before) | ThorVG patched (after) |
|------|------------------------|------------------------|------------------------|
| 1 | 141 | ~52 *(clipped above top)* | **141.1** |
| 2 | 218 | ~127 | **216.8** |
| 3 | 293 | ~202 | **291.7** |
| 4 | 368 | *(hidden)* | **367.4** |

Patched ThorVG lands within ~1px of lottie-web on every line; the first line is no longer clipped. Screenshot below — left is the editor canvas, right is the dotlottie-web preview built with this patch; the two are now in parity:

![point-text fix parity](https://raw.githubusercontent.com/hoyangtsai/thorvg/pr-assets-4334/assets/point-text-fix-parity.jpg)

A prebuilt dotlottie-web wasm carrying this patch, for quick in-browser testing: [dotlottie-player-thorvg-pointtext-patched.wasm](https://raw.githubusercontent.com/hoyangtsai/thorvg/pr-assets-4334/assets/dotlottie-player-thorvg-pointtext-patched.wasm).

## Notes

- Verified on one scene; more justify / anchor / line-count cases are worth a check.
- This is the `updateURLFont` (URL / data-URI font, `chars` empty) path — the embedded-`chars` glyph path likely needs the same treatment.
