### PR TITLE
renderer: guard mutex behind flag

### DIFF
--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -34,7 +34,11 @@
 /************************************************************************/
 
 static int32_t _rendererCnt = -1;
+#ifdef __STDCPP_THREADS__
 static mutex _rendererMtx;
+#else
+static struct { void lock() {} void unlock() {} } _rendererMtx;
+#endif
 
 struct SwTask : Task
 {

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -36,7 +36,11 @@
 #define NOISE_LEVEL 0.5f
 
 static int32_t _rendererCnt = -1;
+#ifdef __STDCPP_THREADS__
 static mutex _rendererMtx;
+#else
+static struct { void lock() {} void unlock() {} } _rendererMtx;
+#endif
 
 static constexpr float IDENTITY_VERTEX[] = {-1.f, 1.f, -1.f, -1.f, 1.f, 1.f, 1.f, -1.f};
 static constexpr uint32_t RECT_INDEX[] = {0, 1, 2, 2, 1, 3};

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -28,7 +28,11 @@
 /************************************************************************/
 
 static int32_t _rendererCnt = -1;
+#ifdef __STDCPP_THREADS__
 static mutex _rendererMtx;
+#else
+static struct { void lock() {} void unlock() {} } _rendererMtx;
+#endif
 
 
 void WgRenderer::release()


### PR DESCRIPTION
ThorVG guards its task scheduler's locking behind `THORVG_THREAD_SUPPORT` (`tvgTaskScheduler.h`), but `tvgSwRenderer.cpp`'s `_rendererMtx` misses that guard, so the file does not compile against a single-threaded libc++ (`wasm32-wasip2`, where `std::mutex` does not exist).