### PR TITLE
common/lock: mutex portability++

### DIFF
--- a/src/common/tvgLock.h
+++ b/src/common/tvgLock.h
@@ -32,6 +32,16 @@ namespace tvg
     struct Key
     {
         std::mutex mtx;
+
+        void lock()
+        {
+            mtx.lock();
+        }
+
+        void unlock()
+        {
+            mtx.unlock();
+        }
     };
 
     struct StrictKey : Key
@@ -66,7 +76,23 @@ namespace tvg
 
     struct StrictKey : Key
     {
+#ifdef __STDCPP_THREADS__
         std::mutex mtx;
+#endif
+
+        void lock()
+        {
+#ifdef __STDCPP_THREADS__
+            mtx.lock();
+#endif
+        }
+
+        void unlock()
+        {
+#ifdef __STDCPP_THREADS__
+            mtx.unlock();
+#endif
+        }
     };
 
     struct ScopedLock

--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -20,7 +20,6 @@
  * SOFTWARE.
  */
 
-#include <algorithm>
 #include "tvgSwCommon.h"
 #include "tvgTaskScheduler.h"
 #include "tvgSwRenderer.h"
@@ -34,11 +33,7 @@
 /************************************************************************/
 
 static int32_t _rendererCnt = -1;
-#ifdef __STDCPP_THREADS__
-static mutex _rendererMtx;
-#else
-static struct { void lock() {} void unlock() {} } _rendererMtx;
-#endif
+static StrictKey _rendererMtx;
 
 struct SwTask : Task
 {

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -36,11 +36,7 @@
 #define NOISE_LEVEL 0.5f
 
 static int32_t _rendererCnt = -1;
-#ifdef __STDCPP_THREADS__
-static mutex _rendererMtx;
-#else
-static struct { void lock() {} void unlock() {} } _rendererMtx;
-#endif
+static StrictKey _rendererMtx;
 
 static constexpr float IDENTITY_VERTEX[] = {-1.f, 1.f, -1.f, -1.f, 1.f, 1.f, 1.f, -1.f};
 static constexpr uint32_t RECT_INDEX[] = {0, 1, 2, 2, 1, 3};

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -28,12 +28,7 @@
 /************************************************************************/
 
 static int32_t _rendererCnt = -1;
-#ifdef __STDCPP_THREADS__
-static mutex _rendererMtx;
-#else
-static struct { void lock() {} void unlock() {} } _rendererMtx;
-#endif
-
+static StrictKey _rendererMtx;
 
 void WgRenderer::release()
 {

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -23,6 +23,7 @@
 #ifndef _TVG_WG_RENDERER_H_
 #define _TVG_WG_RENDERER_H_
 
+#include "tvgRender.h"
 #include "tvgWgRenderTask.h"
 #include "tvgWgTextureMgr.h"
 


### PR DESCRIPTION
Still there were mutex usages in sw engine (mempool) this revised the tvg Lock for mutex portability

- StrictLock enables the mutex only if __STDCPP_THREADS__
- Replaced invidual mutex usage with StrictLock in engines