### PR TITLE
lottie/text: fix point text vertical alignment (backport #4571 to v1.0.x)

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1034,14 +1034,14 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     if (text->font && text->font->style && strstr(text->font->style, "Italic")) paint->italic();
     paint->text(buf);
     paint->layout(doc.bbox.size.x, doc.bbox.size.y);
-    paint->translate(doc.bbox.pos.x, doc.bbox.pos.y);
     if (doc.bbox.size.x > 0.0f) paint->wrap(TextWrap::Smart);
 
     //align the text to the base line, or top within the box
     TextMetrics metrics;
     paint->metrics(metrics);
-    auto valign = (doc.bbox.size.y > 0.0f) ? 0.0f : metrics.ascent / (metrics.ascent - metrics.descent);
-    paint->align(doc.justify, valign);
+    auto vpos = doc.bbox.pos.y - (doc.bbox.size.y > 0.0f ? 0.0f : metrics.ascent);
+    paint->translate(doc.bbox.pos.x, vpos);
+    paint->align(doc.justify, 0.0f);
 
     //apply spacing
     auto hspacing = 1.0f + doc.tracking * doc.size / metrics.ascent;


### PR DESCRIPTION
Backport of #4571 to the `v1.0.x` release branch.

#4571 fixed the **point text** case of #4334 on `main`. This cherry-picks it onto `v1.0.x` so it can be consumed without waiting for the next release tag.

## Why the release branch

Downstream runtimes pin `v1.0.x` lineage rather than `main`. [`dotlottie-rs`](https://github.com/LottieFiles/dotlottie-rs) currently pins v1.0.6, and every one of its historical bumps has tracked a `v1.0.x` tag. Picking up the fix from `main` would mean pulling 314 commits into the runtime behind every dotLottie player; this backport is 3 lines on top of a branch that already carries v1.0.7.

## The change

Identical in substance to #4571. For point text (`bbox.size.y <= 0`), cancel the sfnt loader's baked-in `hhea.ascent` offset by translating up one ascent, and use `valign 0` — so the first baseline lands on the layer origin, matching lottie-web and After Effects.

Note this supersedes the conditional `valign` introduced for box text in #4462 (already on this branch via v1.0.7): the `size.y > 0` box path still resolves to `valign 0` with an unchanged y translate, so **box text behaviour is untouched**.

## Verification

- Cherry-picks cleanly onto `v1.0.x` (auto-merge, 3 insertions / 3 deletions, one file). The pre-image here is already the #4462 form, so the two fixes compose as intended.
- `src/loaders/lottie/tvgLottieBuilder.cpp` compiles clean on this branch.
- Rendering behaviour was verified live on `main` in #4571 against lottie-web 5.12.2 as reference: first-baseline Y within ~1px on every line (141/218/293/368), top line no longer clipped.

Scope is unchanged from #4571 — the `updateURLFont` (URL / data-URI font, empty `chars`) path. The embedded-`chars` glyph path likely needs the same treatment, and #4334 stays open for its remaining sub-cases.
