### PR TITLE
wg_engine: improve convex solid fill performance

### DIFF
--- a/src/renderer/gpu_engine/wg/meson.build
+++ b/src/renderer/gpu_engine/wg/meson.build
@@ -10,6 +10,7 @@ source_file = [
     'tvgWgRenderTask.h',
     'tvgWgShaderSrc.h',
     'tvgWgShaderTypes.h',
+    'tvgWgSolidBatch.h',
     'tvgWgTextureMgr.h',
     'tvgWgTessellator.h',
     'tvgWgBindGroups.cpp',
@@ -23,6 +24,7 @@ source_file = [
     'tvgWgRenderTask.cpp',
     'tvgWgShaderSrc.cpp',
     'tvgWgShaderTypes.cpp',
+    'tvgWgSolidBatch.cpp',
     'tvgWgTextureMgr.cpp',
     'tvgWgTessellator.cpp'
 ]

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
@@ -178,8 +178,7 @@ bool WgContext::allocateBufferUniform(WGPUBuffer& buffer, const void* data, uint
     return false;
 }
 
-
-bool WgContext::allocateBufferVertex(WGPUBuffer& buffer, const float* data, uint64_t size)
+bool WgContext::allocateBufferVertex(WGPUBuffer& buffer, const void* data, uint64_t size)
 {
     if ((buffer) && (wgpuBufferGetSize(buffer) >= size))
         wgpuQueueWriteBuffer(queue, buffer, 0, data, size);

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.h
@@ -59,7 +59,7 @@ struct WgContext {
 
     // create buffer objects (return true, if buffer handle was changed)
     bool allocateBufferUniform(WGPUBuffer& buffer, const void* data, uint64_t size);
-    bool allocateBufferVertex(WGPUBuffer& buffer, const float* data, uint64_t size);
+    bool allocateBufferVertex(WGPUBuffer& buffer, const void* data, uint64_t size);
     bool allocateBufferIndex(WGPUBuffer& buffer, const uint32_t* data, uint64_t size);
 
     // release buffer objects

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -257,7 +257,8 @@ void WgCompositor::requestShape(WgRenderDataShape* renderData)
     stageBufferGeometry.append(renderData);
 
     auto& shapeSettings = renderData->renderSettingsShape;
-    if (shapeSettings.fillType == WgRenderSettingsType::Solid) shapeSettings.solidColorInd = stageBufferSolidColor.append(shapeSettings.settings.color);
+    auto& shapeSolid = renderData->solidShape;
+    if (shapeSettings.fillType == WgRenderSettingsType::Solid) shapeSolid.colorInd = stageBufferSolidColor.append(shapeSolid.packedColor());
     else shapeSettings.bindGroupInd = stageBufferPaint.append(shapeSettings.settings);
 
     if (renderData->meshStrokes.vbuffer.count > 0) {
@@ -268,7 +269,8 @@ void WgCompositor::requestShape(WgRenderDataShape* renderData)
 
     if (!renderData->renderSettingsStroke.skip && renderData->meshStrokes.vbuffer.count > 0) {
         auto& strokeSettings = renderData->renderSettingsStroke;
-        if (strokeSettings.fillType == WgRenderSettingsType::Solid) strokeSettings.solidColorInd = stageBufferSolidColor.append(strokeSettings.settings.color);
+        auto& strokeSolid = renderData->solidStroke;
+        if (strokeSettings.fillType == WgRenderSettingsType::Solid) strokeSolid.colorInd = stageBufferSolidColor.append(strokeSolid.packedColor());
         else strokeSettings.bindGroupInd = stageBufferPaint.append(strokeSettings.settings);
     }
     ARRAY_FOREACH(p, renderData->clips)
@@ -284,6 +286,11 @@ void WgCompositor::requestImage(WgRenderDataPicture* renderData)
         requestShape((WgRenderDataShape*)(*p));
 }
 
+void WgCompositor::requestSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgSolidBatchRange& range)
+{
+    stageBufferGeometry.appendSolidBatch(renderDataShapes, stageBufferSolidColor, range);
+    range.viewport = renderDataShapes[0]->viewport;
+}
 
 void WgCompositor::renderShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod)
 {
@@ -321,6 +328,23 @@ void WgCompositor::renderShape(WgContext& context, WgRenderDataShape* renderData
     }
 }
 
+void WgCompositor::renderSolidBatch(const WgSolidBatchRange& range)
+{
+    assert(renderPassEncoder);
+
+    const uint64_t vertexSize = static_cast<uint64_t>(range.vertexCount) * sizeof(Point);
+    const uint64_t colorSize = static_cast<uint64_t>(range.vertexCount) * sizeof(RenderColor);
+    const uint64_t indexSize = static_cast<uint64_t>(range.indexCount) * sizeof(uint32_t);
+
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, range.viewport.x(), range.viewport.y(), range.viewport.w(), range.viewport.h());
+    wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_batch);
+    wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 0, stageBufferGeometry.vbuffer_gpu, range.vertexOffset, vertexSize);
+    wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 1, stageBufferSolidColor.vbuffer_gpu, range.colorOffset, colorSize);
+    wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, stageBufferGeometry.ibuffer_gpu, WGPUIndexFormat_Uint32, range.indexOffset, indexSize);
+    wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.indexCount, 1, 0, 0, 0);
+}
 
 void WgCompositor::renderImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod)
 {
@@ -412,8 +436,7 @@ void WgCompositor::drawMeshSolid(WgContext& context, WgMeshData* meshData, uint3
     const uint64_t icount = meshData->ibuffer.count;
     const uint64_t vsize = meshData->vbuffer.count * sizeof(Point);
     const uint64_t isize = icount * sizeof(uint32_t);
-    const uint64_t csize = sizeof(WgShaderTypeVec4f);
-    // One instance (instanceCount = 1): select this draw's single vec4 solid color by offset.
+    const uint64_t csize = sizeof(RenderColor);
     const uint64_t coffset = solidColorInd * csize;
     wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 0, stageBufferGeometry.vbuffer_gpu, meshData->voffset, vsize);
     wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 1, stageBufferSolidColor.vbuffer_gpu, coffset, csize);
@@ -463,7 +486,7 @@ void WgCompositor::drawShape(WgContext& context, WgRenderDataShape* renderData)
 
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, convex ? pipelines.solid_conv : pipelines.solid);
-        drawMeshSolid(context, mesh, settings.solidColorInd);
+        drawMeshSolid(context, mesh, renderData->solidShape.colorInd);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
@@ -505,7 +528,7 @@ void WgCompositor::blendShape(WgContext& context, WgRenderDataShape* renderData,
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_blend[blendMethodInd]);
-        drawMeshSolid(context, &renderData->meshBBox, settings.solidColorInd);
+        drawMeshSolid(context, &renderData->meshBBox, renderData->solidShape.colorInd);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
@@ -546,7 +569,7 @@ void WgCompositor::clipShape(WgContext& context, WgRenderDataShape* renderData)
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
-        drawMeshSolid(context, &renderData->meshBBox, settings.solidColorInd);
+        drawMeshSolid(context, &renderData->meshBBox, renderData->solidShape.colorInd);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
@@ -581,7 +604,7 @@ void WgCompositor::drawStrokes(WgContext& context, WgRenderDataShape* renderData
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
-        drawMeshSolid(context, &renderData->meshStrokesBBox, settings.solidColorInd);
+        drawMeshSolid(context, &renderData->meshStrokesBBox, renderData->solidStroke.colorInd);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
@@ -623,7 +646,7 @@ void WgCompositor::blendStrokes(WgContext& context, WgRenderDataShape* renderDat
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_blend[blendMethodInd]);
-        drawMeshSolid(context, &renderData->meshStrokesBBox, settings.solidColorInd);
+        drawMeshSolid(context, &renderData->meshStrokesBBox, renderData->solidStroke.colorInd);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
@@ -666,7 +689,7 @@ void WgCompositor::clipStrokes(WgContext& context, WgRenderDataShape* renderData
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
-        drawMeshSolid(context, &renderData->meshStrokesBBox, settings.solidColorInd);
+        drawMeshSolid(context, &renderData->meshStrokesBBox, renderData->solidStroke.colorInd);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.h
@@ -124,9 +124,11 @@ public:
     // request shapes for drawing (staging)
     void requestShape(WgRenderDataShape* renderData);
     void requestImage(WgRenderDataPicture* renderData);
+    void requestSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgSolidBatchRange& range);
 
     // render shapes, images and scenes
     void renderShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
+    void renderSolidBatch(const WgSolidBatchRange& range);
     void renderImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod);
     void renderScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose);
     void composeScene(WgContext& context, WgRenderTarget* src, WgRenderTarget* mask, WgCompose* compose);

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
@@ -152,16 +152,18 @@ void WgPipelines::initialize(WgContext& context)
 {
     // common pipeline settings
     const WGPUVertexAttribute vertexAttributePos { .format = WGPUVertexFormat_Float32x2, .offset = 0, .shaderLocation = 0 };
-    const WGPUVertexAttribute vertexAttributeColor { .format = WGPUVertexFormat_Float32x4, .offset = 0, .shaderLocation = 1 };
+    const WGPUVertexAttribute vertexAttributeColor{.format = WGPUVertexFormat_Unorm8x4, .offset = 0, .shaderLocation = 1};
     const WGPUVertexAttribute vertexAttributeTex { .format = WGPUVertexFormat_Float32x2, .offset = 0, .shaderLocation = 1 };
     const WGPUVertexAttribute vertexAttributesPos[] { vertexAttributePos };
     const WGPUVertexAttribute vertexAttributesColor[] { vertexAttributeColor };
     const WGPUVertexAttribute vertexAttributesTex[] { vertexAttributeTex };
     const WGPUVertexBufferLayout vertexBufferLayoutPos { .stepMode = WGPUVertexStepMode_Vertex, .arrayStride = 8, .attributeCount = 1, .attributes = vertexAttributesPos };
-    // Solid path: one vec4 color per draw from an instance-rate aux vertex slot.
-    const WGPUVertexBufferLayout vertexBufferLayoutColor { .stepMode = WGPUVertexStepMode_Instance, .arrayStride = 16, .attributeCount = 1, .attributes = vertexAttributesColor };
+    // Solid colors advance per instance for single draws and per vertex for batches.
+    const WGPUVertexBufferLayout vertexBufferLayoutColor{.stepMode = WGPUVertexStepMode_Instance, .arrayStride = sizeof(RenderColor), .attributeCount = 1, .attributes = vertexAttributesColor};
+    const WGPUVertexBufferLayout vertexBufferLayoutColorBatch{.stepMode = WGPUVertexStepMode_Vertex, .arrayStride = sizeof(RenderColor), .attributeCount = 1, .attributes = vertexAttributesColor};
     const WGPUVertexBufferLayout vertexBufferLayoutTex { .stepMode = WGPUVertexStepMode_Vertex, .arrayStride = 8, .attributeCount = 1, .attributes = vertexAttributesTex };
     const WGPUVertexBufferLayout vertexBufferLayoutsSolid[] { vertexBufferLayoutPos, vertexBufferLayoutColor };
+    const WGPUVertexBufferLayout vertexBufferLayoutsSolidBatch[]{vertexBufferLayoutPos, vertexBufferLayoutColorBatch};
     const WGPUVertexBufferLayout vertexBufferLayoutsShape[] { vertexBufferLayoutPos };
     const WGPUVertexBufferLayout vertexBufferLayoutsImage[] { vertexBufferLayoutPos, vertexBufferLayoutTex };
     const WGPUMultisampleState multisampleState   { .count = 4, .mask = 0xFFFFFFFF, .alphaToCoverageEnabled = false };
@@ -338,6 +340,13 @@ void WgPipelines::initialize(WgContext& context)
         context.device, "The render pipeline solid",
         shader_solid, "vs_main", "fs_main",
         layout_solid, vertexBufferLayoutsSolid, 2,
+        WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
+        depthStencilStateScene, multisampleState);
+    // render pipeline solid batch (no stencil, per-vertex color)
+    solid_batch = createRenderPipeline(
+        context.device, "The render pipeline solid batch",
+        shader_solid, "vs_main", "fs_main",
+        layout_solid, vertexBufferLayoutsSolidBatch, 2,
         WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
         depthStencilStateScene, multisampleState);
     // render pipeline radial (no stencil)
@@ -559,6 +568,7 @@ void WgPipelines::releaseGraphicHandles(WgContext& context)
     releaseRenderPipeline(image);
     releaseRenderPipeline(linear_conv);
     releaseRenderPipeline(radial_conv);
+    releaseRenderPipeline(solid_batch);
     releaseRenderPipeline(solid_conv);
     releaseRenderPipeline(linear);
     releaseRenderPipeline(radial);

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.h
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.h
@@ -86,6 +86,7 @@ public:
     WGPURenderPipeline radial{};
     WGPURenderPipeline linear{};
     WGPURenderPipeline solid_conv{};  // convex geometry (no stencil)
+    WGPURenderPipeline solid_batch{};  // batched convex geometry (no stencil)
     WGPURenderPipeline radial_conv{}; // convex geometry (no stencil)
     WGPURenderPipeline linear_conv{}; // convex geometry (no stencil)
     WGPURenderPipeline image{};

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -83,21 +83,11 @@ void WgImageData::release(WgContext& context)
 // WgRenderSettings
 //***********************************************************************
 
-void WgRenderSettings::bakeSolidColor()
+uint8_t WgRenderSettings::updateOpacity(tvg::ColorSpace cs, uint8_t opacity)
 {
-    if (fillType != WgRenderSettingsType::Solid) return;
-    settings.color = solidColor;
-    settings.color.vec[3] *= opacity;
-    settings.options.vec[3] = 1.0f;
-}
-
-
-void WgRenderSettings::update(TVG_UNUSED WgContext& context, tvg::ColorSpace cs, uint8_t opacity)
-{
-    //TODO: Update separately according to the RenderUpdateFlag
-    settings.options.update(cs, opacity * opacityMultiplier);
-    this->opacity = settings.options.vec[3];
-    bakeSolidColor();
+    auto effectiveOpacity = static_cast<uint8_t>(opacity * opacityMultiplier);
+    settings.options.update(cs, effectiveOpacity);
+    return effectiveOpacity;
 }
 
 void WgRenderSettings::update(WgContext& context, const Fill* fill, const Matrix* modelTransform, bool updateColorRamp)
@@ -105,23 +95,10 @@ void WgRenderSettings::update(WgContext& context, const Fill* fill, const Matrix
     assert(fill);
     settings.gradient.update(fill, modelTransform);
     if (updateColorRamp) gradientData.update(context, fill);
-    // get gradient rasterisation settings
-    rasterType = WgRenderRasterType::Gradient;
     if (fill->type() == Type::LinearGradient)
         fillType = WgRenderSettingsType::Linear;
     else if (fill->type() == Type::RadialGradient)
         fillType = WgRenderSettingsType::Radial;
-    settings.options.vec[3] = opacity;
-};
-
-
-void WgRenderSettings::update(TVG_UNUSED WgContext& context, const RenderColor& c)
-{
-    solidColor.update(c);
-    settings.color = solidColor;
-    rasterType = WgRenderRasterType::Solid;
-    fillType = WgRenderSettingsType::Solid;
-    bakeSolidColor();
 };
 
 
@@ -540,6 +517,55 @@ void WgStageBufferGeometry::append(WgRenderDataPicture* renderDataPicture)
     append(&renderDataPicture->meshData);
 }
 
+void WgStageBufferGeometry::appendSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range)
+{
+    uint32_t vertexCount = 0;
+    uint32_t indexCount = 0;
+
+    ARRAY_FOREACH(shape, renderDataShapes) {
+        const auto& mesh = (*shape)->meshShape;
+        vertexCount += mesh.vbuffer.count;
+        indexCount += mesh.ibuffer.count;
+    }
+
+    const uint32_t vertexBytes = vertexCount * sizeof(Point);
+    const uint32_t indexBytes = indexCount * sizeof(uint32_t);
+
+    if (vbuffer.reserved < vbuffer.count + vertexBytes)
+        vbuffer.grow(std::max(vertexBytes, vbuffer.reserved));
+    if (ibuffer.reserved < ibuffer.count + indexBytes)
+        ibuffer.grow(std::max(indexBytes, ibuffer.reserved));
+    if (colors.vbuffer.reserved < colors.vbuffer.count + vertexCount)
+        colors.vbuffer.grow(std::max(vertexCount, colors.vbuffer.reserved));
+
+    range.vertexOffset = vbuffer.count;
+    range.indexOffset = ibuffer.count;
+    range.colorOffset = colors.vbuffer.count * sizeof(RenderColor);
+    range.vertexCount = vertexCount;
+    range.indexCount = indexCount;
+
+    uint32_t baseVertex = 0;
+    auto vertexDst = vbuffer.data + vbuffer.count;
+    auto indexDst = ibuffer.data + ibuffer.count;
+
+    ARRAY_FOREACH(shape, renderDataShapes) {
+        const auto& mesh = (*shape)->meshShape;
+        const uint32_t meshVertexBytes = mesh.vbuffer.count * sizeof(Point);
+        memcpy(vertexDst, mesh.vbuffer.data, meshVertexBytes);
+        vertexDst += meshVertexBytes;
+
+        for (uint32_t i = 0; i < mesh.ibuffer.count; ++i) {
+            const auto index = mesh.ibuffer[i] + baseVertex;
+            memcpy(indexDst, &index, sizeof(index));
+            indexDst += sizeof(index);
+        }
+
+        baseVertex += mesh.vbuffer.count;
+        colors.appendRepeated((*shape)->solidShape.packedColor(), mesh.vbuffer.count);
+    }
+    vbuffer.count += vertexBytes;
+    ibuffer.count += indexBytes;
+}
 
 void WgStageBufferGeometry::release(WgContext& context)
 {
@@ -557,7 +583,7 @@ void WgStageBufferGeometry::clear()
 
 void WgStageBufferGeometry::flush(WgContext& context) 
 {
-    context.allocateBufferVertex(vbuffer_gpu, (float *)vbuffer.data, vbuffer.count);
+    context.allocateBufferVertex(vbuffer_gpu, vbuffer.data, vbuffer.count);
     context.allocateBufferIndex(ibuffer_gpu, (uint32_t *)ibuffer.data, ibuffer.count);
 }
 
@@ -576,11 +602,22 @@ void WgStageBufferSolidColor::clear()
     vbuffer.clear();
 }
 
+void WgStageBufferSolidColor::appendRepeated(const RenderColor& value, uint32_t count)
+{
+    if (vbuffer.reserved < vbuffer.count + count) {
+        vbuffer.grow(std::max(count, vbuffer.reserved));
+    }
+    auto dst = vbuffer.data + vbuffer.count;
+    for (uint32_t i = 0; i < count; ++i) {
+        dst[i] = value;
+    }
+    vbuffer.count += count;
+}
 
 void WgStageBufferSolidColor::flush(WgContext& context)
 {
     if (vbuffer.count > 0)
-        context.allocateBufferVertex(vbuffer_gpu, (float*)vbuffer.data, vbuffer.count * sizeof(WgShaderTypeVec4f));
+        context.allocateBufferVertex(vbuffer_gpu, vbuffer.data, vbuffer.count * sizeof(RenderColor));
 }
 
 //***********************************************************************

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.h
@@ -40,26 +40,29 @@ struct WgImageData {
 };
 
 enum class WgRenderSettingsType { None = 0, Solid = 1, Linear = 2, Radial = 3 };
-enum class WgRenderRasterType { Solid = 0, Gradient, Image };
+
+static_assert(sizeof(RenderColor) == 4, "Solid color vertex data must remain tightly packed RGBA8");
+
+struct WgSolidData
+{
+    uint32_t colorInd{};
+    RenderColor color{};
+    uint8_t opacity = 255;
+
+    RenderColor packedColor() const { return {color.r, color.g, color.b, MULTIPLY(color.a, opacity)}; }
+};
 
 struct WgRenderSettings
 {
     uint32_t bindGroupInd{};
-    // Solid path: per-draw index into the instance-rate vec4 color stream.
-    uint32_t solidColorInd{};
     WgShaderTypePaintSettings settings;
-    WgShaderTypeVec4f solidColor;
     WgImageData gradientData;
     WgRenderSettingsType fillType{};
-    WgRenderRasterType rasterType{};
     float opacityMultiplier = 1.0f;
-    float opacity = 1.0f;
     bool skip{};
 
-    void bakeSolidColor();
-    void update(WgContext& context, tvg::ColorSpace cs, uint8_t opacity);
+    uint8_t updateOpacity(tvg::ColorSpace cs, uint8_t opacity);
     void update(WgContext& context, const Fill* fill, const Matrix* modelTransform, bool updateColorRamp);
-    void update(WgContext& context, const RenderColor& c);
     void release(WgContext& context);
 };
 
@@ -80,7 +83,9 @@ struct WgRenderDataPaint
 struct WgRenderDataShape: public WgRenderDataPaint
 {
     WgRenderSettings renderSettingsShape{};
+    WgSolidData solidShape{};
     WgRenderSettings renderSettingsStroke{};
+    WgSolidData solidStroke{};
     WgMeshData meshBBox{};
     WgMeshData meshShape{};
     WgMeshData meshShapeBBox{};
@@ -139,6 +144,16 @@ public:
     void release(WgContext& context);
 };
 
+struct WgSolidBatchRange
+{
+    size_t vertexOffset{};
+    size_t indexOffset{};
+    size_t colorOffset{};
+    uint32_t vertexCount{};
+    uint32_t indexCount{};
+    RenderRegion viewport{};
+};
+
 // gaussian blur, drop shadow, fill, tint, tritone
 #define WG_GAUSSIAN_MAX_LEVEL 3
 struct WgRenderDataEffectParams
@@ -171,6 +186,8 @@ public:
     void release(WgContext& context);
 };
 
+class WgStageBufferSolidColor;
+
 class WgStageBufferGeometry {
 private:
     Array<uint8_t> vbuffer;
@@ -182,23 +199,24 @@ public:
     void append(WgMeshData* meshData);
     void append(WgRenderDataShape* renderDataShape);
     void append(WgRenderDataPicture* renderDataPicture);
+    void appendSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range);
     void initialize(WgContext& context){};
     void release(WgContext& context);
     void clear();
     void flush(WgContext& context);
 };
 
-class WgStageBufferSolidColor {
-private:
-    Array<WgShaderTypeVec4f> vbuffer;
-public:
+struct WgStageBufferSolidColor
+{
+    Array<RenderColor> vbuffer;
     WGPUBuffer vbuffer_gpu{};
 
-    uint32_t append(const WgShaderTypeVec4f& value) {
+    uint32_t append(const RenderColor& value)
+    {
         vbuffer.push(value);
         return vbuffer.count - 1;
     }
-
+    void appendRepeated(const RenderColor& value, uint32_t count);
     void release(WgContext& context);
     void clear();
     void flush(WgContext& context);

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
@@ -27,6 +27,12 @@
 // WgPaintTask
 //***********************************************************************
 
+void WgPaintTask::stage(WgCompositor& compositor)
+{
+    if (renderData->type() == tvg::Type::Shape) compositor.requestShape((WgRenderDataShape*)renderData);
+    else if (renderData->type() == tvg::Type::Picture) compositor.requestImage((WgRenderDataPicture*)renderData);
+}
+
 void WgPaintTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
 {
     if (renderData->type() == tvg::Type::Shape)
@@ -39,6 +45,13 @@ void WgPaintTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandE
 //***********************************************************************
 // WgSceneTask
 //***********************************************************************
+
+void WgSceneTask::stage(WgCompositor& compositor)
+{
+    ARRAY_FOREACH(task, children) {
+        (*task)->stage(compositor);
+    }
+}
 
 void WgSceneTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
 {

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
@@ -28,6 +28,7 @@
 // base class for any renderable objects 
 struct WgRenderTask {
     virtual ~WgRenderTask() {}
+    virtual void stage(WgCompositor& compositor) = 0;
     virtual void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) = 0;
 };
 
@@ -39,6 +40,8 @@ struct WgPaintTask: public WgRenderTask {
 
     WgPaintTask(WgRenderDataPaint* renderData, BlendMethod blendMethod) : 
         renderData(renderData), blendMethod(blendMethod) {}
+    // stage all resources used by this paint
+    void stage(WgCompositor& compositor) override;
     // apply shape execution, including custom blending and clipping
     void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
 };
@@ -61,12 +64,13 @@ public:
 
     WgSceneTask(WgRenderTarget* renderTarget, WgCompose* compose, WgSceneTask* parent) :
         parent(parent), renderTarget(renderTarget), compose(compose) {}
+    // stage all resources used by the scene tree
+    void stage(WgCompositor& compositor) override;
     // run all, including all shapes drawing, blending, composition and effect
     void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
 private:
     void runChildren(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder);
     void runEffect(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder);
 };
- 
- #endif // _TVG_WG_RENDER_TASK_H_
- 
+
+#endif  // _TVG_WG_RENDER_TASK_H_

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -160,8 +160,8 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
     // update paint settings
     if ((!data) || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Blend | RenderUpdateFlag::Color))) {
-        rds->renderSettingsShape.update(mContext, mTargetSurface.cs, opacity);
-        rds->renderSettingsStroke.update(mContext, mTargetSurface.cs, opacity);
+        rds->solidShape.opacity = rds->renderSettingsShape.updateOpacity(mTargetSurface.cs, opacity);
+        rds->solidStroke.opacity = rds->renderSettingsStroke.updateOpacity(mTargetSurface.cs, opacity);
         rds->fillRule = rshape.rule;
     }
 
@@ -173,8 +173,9 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
         if (rshape.fill && (!data || (flags & (RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform)))) {
             bool updateColorRamp = !data || ((flags & RenderUpdateFlag::Gradient) != RenderUpdateFlag::None);
             rds->renderSettingsShape.update(mContext, rshape.fill, &transform, updateColorRamp);
-        } else if (!data || (flags & RenderUpdateFlag::Color)) {
-            rds->renderSettingsShape.update(mContext, rshape.color);
+        } else if (!data || (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient))) {
+            rds->solidShape.color = rshape.color;
+            rds->renderSettingsShape.fillType = WgRenderSettingsType::Solid;
         }
     }
     // update strokes render settings
@@ -182,8 +183,9 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
         if (rshape.stroke->fill && (!data || (flags & (RenderUpdateFlag::GradientStroke | RenderUpdateFlag::Transform)))) {
             bool updateColorRamp = !data || ((flags & RenderUpdateFlag::GradientStroke) != RenderUpdateFlag::None);
             rds->renderSettingsStroke.update(mContext, rshape.stroke->fill, nullptr, updateColorRamp);
-        } else if (!data || (flags & RenderUpdateFlag::Stroke)) {
-            rds->renderSettingsStroke.update(mContext, rshape.stroke->color);
+        } else if (!data || (flags & (RenderUpdateFlag::Stroke | RenderUpdateFlag::GradientStroke))) {
+            rds->solidStroke.color = rshape.stroke->color;
+            rds->renderSettingsStroke.fillType = WgRenderSettingsType::Solid;
         }
     }
 
@@ -199,7 +201,7 @@ RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
     // update paint settings
     rdp->viewport = vport;
     rdp->transform = transform;
-    if (!data || (flags & (RenderUpdateFlag::Blend | RenderUpdateFlag::Color))) rdp->renderSettings.update(mContext, surface->cs, opacity);
+    if (!data || (flags & (RenderUpdateFlag::Blend | RenderUpdateFlag::Color))) rdp->renderSettings.updateOpacity(surface->cs, opacity);
 
     auto updateSurface = !data || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path | RenderUpdateFlag::Image));
     if (updateSurface) rdp->updateSurface(surface, transform);
@@ -224,6 +226,7 @@ bool WgRenderer::preRender()
 {
     if (mContext.invalid()) return false;
 
+    mSolidBatch = {};
     mCompositor.reset(mContext);
 
     assert(mRenderTargetStack.count == 0);
@@ -247,11 +250,14 @@ bool WgRenderer::preRender()
 
 bool WgRenderer::renderShape(RenderData data)
 {
-    WgPaintTask* paintTask = new WgPaintTask((WgRenderDataPaint*)data, mBlendMethod);
+    auto renderData = (WgRenderDataShape*)data;
     WgSceneTask* sceneTask = mSceneTaskStack.last();
+
+    if (mSolidBatch.draw(sceneTask, renderData, mBlendMethod, mRenderTaskList)) return true;
+
+    WgPaintTask* paintTask = new WgPaintTask(renderData, mBlendMethod);
     sceneTask->children.push(paintTask);
     mRenderTaskList.push(paintTask);
-    mCompositor.requestShape((WgRenderDataShape*)data);
     return true;
 }
 
@@ -262,13 +268,15 @@ bool WgRenderer::renderImage(RenderData data)
     WgSceneTask* sceneTask = mSceneTaskStack.last();
     sceneTask->children.push(paintTask);
     mRenderTaskList.push(paintTask);
-    mCompositor.requestImage((WgRenderDataPicture*)data);
     return true;
 }
 
 
 bool WgRenderer::postRender()
 {
+    WgSceneTask* sceneTaskRoot = mSceneTaskStack.last();
+    sceneTaskRoot->stage(mCompositor);
+
     // flush stage data to gpu
     mCompositor.flush(mContext);
 
@@ -276,7 +284,6 @@ bool WgRenderer::postRender()
     WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
 
     // run rendering (all the fun is here)
-    WgSceneTask* sceneTaskRoot = mSceneTaskStack.last();
     sceneTaskRoot->run(mContext, mCompositor, commandEncoder);
 
     // execute and release command encoder
@@ -585,7 +592,8 @@ bool WgRenderer::region(RenderEffect* effect)
 
 bool WgRenderer::render(RenderCompositor* cmp, const RenderEffect* effect, TVG_UNUSED bool direct)
 {
-    mSceneTaskStack.last()->effect = effect;
+    auto sceneTask = mSceneTaskStack.last();
+    sceneTask->effect = effect;
     return true;
 }
 

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -24,7 +24,7 @@
 #define _TVG_WG_RENDERER_H_
 
 #include "tvgRender.h"
-#include "tvgWgRenderTask.h"
+#include "tvgWgSolidBatch.h"
 #include "tvgWgTextureMgr.h"
 
 struct WgRenderer : RenderMethod
@@ -83,6 +83,7 @@ private:
     Array<WgRenderTarget*> mRenderTargetStack;
     Array<WgSceneTask*> mSceneTaskStack;
     Array<WgRenderTask*> mRenderTaskList;
+    WgSolidBatch mSolidBatch;
 
     // render target pool
     WgRenderTargetPool mRenderTargetPool;

--- a/src/renderer/gpu_engine/wg/tvgWgShaderSrc.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgShaderSrc.cpp
@@ -105,7 +105,7 @@ const char* cShaderSrc_Linear = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position : vec4f, @location(0) vGradCoord : vec4f };
 struct GradSettings  { transform: mat4x4f, coords: vec4f, focal: vec4f };
-struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
+struct PaintSettings { options: vec4f, gradient: GradSettings };
 
 // uniforms
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
@@ -142,7 +142,7 @@ const char* cShaderSrc_Radial = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position : vec4f, @location(0) vGradCoord : vec4f };
 struct GradSettings  { transform: mat4x4f, coords: vec4f, focal: vec4f };
-struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
+struct PaintSettings { options: vec4f, gradient: GradSettings };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
 @group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
@@ -280,7 +280,7 @@ const char* cShaderSrc_Linear_Blend = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position: vec4f, @location(0) vGradCoord : vec4f, @location(1) vScrCoord: vec2f };
 struct GradSettings  { transform: mat4x4f, coords: vec4f, focal: vec4f };
-struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
+struct PaintSettings { options: vec4f, gradient: GradSettings };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
 @group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;
@@ -328,7 +328,7 @@ const char* cShaderSrc_Radial_Blend = R"(
 struct VertexInput { @location(0) position: vec2f };
 struct VertexOutput { @builtin(position) position: vec4f, @location(0) vGradCoord : vec4f, @location(1) vScrCoord: vec2f };
 struct GradSettings  { transform: mat4x4f, coords: vec4f, focal: vec4f };
-struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
+struct PaintSettings { options: vec4f, gradient: GradSettings };
 
 @group(0) @binding(0) var<uniform> uViewMat : mat4x4f;
 @group(1) @binding(0) var<uniform> uPaintSettings : PaintSettings;

--- a/src/renderer/gpu_engine/wg/tvgWgShaderTypes.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgShaderTypes.cpp
@@ -96,26 +96,12 @@ WgShaderTypeVec4f::WgShaderTypeVec4f(const ColorSpace colorSpace, uint8_t o)
 }
 
 
-WgShaderTypeVec4f::WgShaderTypeVec4f(const RenderColor& c)
-{
-    update(c);
-}
-
-
 void WgShaderTypeVec4f::update(const ColorSpace colorSpace, uint8_t o)
 {
     vec[0] = (uint32_t)colorSpace;
     vec[3] = o / 255.0f;
 }
 
-
-void WgShaderTypeVec4f::update(const RenderColor& c)
-{
-    vec[0] = c.r / 255.0f; // red
-    vec[1] = c.g / 255.0f; // green
-    vec[2] = c.b / 255.0f; // blue
-    vec[3] = c.a / 255.0f; // alpha
-}
 
 void WgShaderTypeVec4f::update(const RenderRegion& r)
 {

--- a/src/renderer/gpu_engine/wg/tvgWgShaderTypes.h
+++ b/src/renderer/gpu_engine/wg/tvgWgShaderTypes.h
@@ -55,9 +55,7 @@ struct WgShaderTypeVec4f
 
     WgShaderTypeVec4f() {};
     WgShaderTypeVec4f(const ColorSpace colorSpace, uint8_t o);
-    WgShaderTypeVec4f(const RenderColor& c);
     void update(const ColorSpace colorSpace, uint8_t o);
-    void update(const RenderColor& c);
     void update(const RenderRegion& r);
 };
 
@@ -75,17 +73,15 @@ struct WgShaderTypeGradSettings
     void update(const Fill* fill, const Matrix* modelTransform);
 };
 
-// WGSL: struct PaintSettings { options: vec4f, color: vec4f, gradient: GradSettings };
+// WGSL: struct PaintSettings { options: vec4f, gradient: GradSettings };
 struct WgShaderTypePaintSettings
 {
     // [0] - color space, [3] - opacity
     WgShaderTypeVec4f options;
-    // solid color
-    WgShaderTypeVec4f color;
     // gradient settings (linear/radial)
     WgShaderTypeGradSettings gradient;
     // align to 256 bytes (see webgpu spec: minUniformBufferOffsetAlignment)
-    uint8_t _padding[256 - sizeof(options) - sizeof(color) - sizeof(gradient)];
+    uint8_t _padding[256 - sizeof(options) - sizeof(gradient)];
 };
 // see webgpu spec: 3.6.2. Limits - minUniformBufferOffsetAlignment (256)
 static_assert(sizeof(WgShaderTypePaintSettings) == 256, "Uniform shader data type size must be aligned to 256 bytes");

--- a/src/renderer/gpu_engine/wg/tvgWgSolidBatch.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgSolidBatch.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgWgSolidBatch.h"
+
+struct WgSolidBatchTask : WgRenderTask
+{
+    Array<WgRenderDataShape*> shapes;
+    WgSolidBatchRange range{};
+
+    WgSolidBatchTask(WgRenderDataShape* first, WgRenderDataShape* second) : shapes{2}
+    {
+        shapes.push(first);
+        shapes.push(second);
+    }
+
+    void stage(WgCompositor& compositor) override
+    {
+        compositor.requestSolidBatch(shapes, range);
+    }
+
+    void run(WgContext&, WgCompositor& compositor, WGPUCommandEncoder) override
+    {
+        compositor.renderSolidBatch(range);
+    }
+};
+
+static inline bool eligible(const WgRenderDataShape* renderData, BlendMethod blendMethod)
+{
+    if (blendMethod != BlendMethod::Normal) return false;
+    if (renderData->renderSettingsShape.skip || renderData->renderSettingsShape.fillType != WgRenderSettingsType::Solid) return false;
+    if (!renderData->convex || renderData->viewport.invalid() || !renderData->clips.empty()) return false;
+    if (renderData->meshShape.vbuffer.empty() || renderData->meshShape.ibuffer.empty()) return false;
+    if (!renderData->renderSettingsStroke.skip && !renderData->meshStrokes.ibuffer.empty()) return false;
+    return true;
+}
+
+static inline bool appendable(WgSceneTask* batchSceneTask, WgRenderTask* batchTask, const RenderRegion& batchViewport, WgSceneTask* sceneTask, const WgRenderDataShape* renderData, const Array<WgRenderTask*>& renderTaskList)
+{
+    // Any task submitted after the candidate is an implicit batch boundary.
+    if (batchSceneTask != sceneTask) return false;
+    if (sceneTask->children.last() != batchTask) return false;
+    if (renderTaskList.last() != batchTask) return false;
+    if (!(batchViewport == renderData->viewport)) return false;
+    return true;
+}
+
+static inline WgRenderTask* emitSingle(WgSceneTask* sceneTask, WgRenderDataShape* renderData, Array<WgRenderTask*>& renderTaskList)
+{
+    auto task = new WgPaintTask(renderData, BlendMethod::Normal);
+    sceneTask->children.push(task);
+    renderTaskList.push(task);
+    return task;
+}
+
+static inline WgRenderTask* promote(WgSceneTask* sceneTask, WgRenderTask* task, WgRenderDataShape* first, WgRenderDataShape* renderData, Array<WgRenderTask*>& renderTaskList)
+{
+    // Tasks are staged only after the tree is complete, so replacing its tail is safe.
+    auto batchTask = new WgSolidBatchTask(first, renderData);
+    sceneTask->children.last() = batchTask;
+    renderTaskList.last() = batchTask;
+    delete task;
+
+    return batchTask;
+}
+
+static inline void append(WgRenderTask* task, WgRenderDataShape* renderData)
+{
+    static_cast<WgSolidBatchTask*>(task)->shapes.push(renderData);
+}
+
+bool WgSolidBatch::draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)
+{
+    if (!eligible(renderData, blendMethod)) return false;
+
+    if (!appendable(this->sceneTask, task, viewport, sceneTask, renderData, renderTaskList)) {
+        task = emitSingle(sceneTask, renderData, renderTaskList);
+        this->sceneTask = sceneTask;
+        first = renderData;
+        viewport = renderData->viewport;
+        return true;
+    }
+
+    if (first) {
+        task = promote(this->sceneTask, task, first, renderData, renderTaskList);
+        first = nullptr;
+    } else append(task, renderData);
+    return true;
+}

--- a/src/renderer/gpu_engine/wg/tvgWgSolidBatch.h
+++ b/src/renderer/gpu_engine/wg/tvgWgSolidBatch.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_SOLID_BATCH_H_
+#define _TVG_WG_SOLID_BATCH_H_
+
+#include "tvgWgRenderTask.h"
+
+struct WgSolidBatch
+{
+    bool draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList);
+
+    WgSceneTask* sceneTask{};
+    WgRenderTask* task{};
+    WgRenderDataShape* first{};
+    RenderRegion viewport{};
+};
+
+#endif  // _TVG_WG_SOLID_BATCH_H_


### PR DESCRIPTION
Reduce draw-call overhead for consecutive convex solid fills by staging their geometry and baked colors into one indexed draw. Keep singleton fills on the existing instance-rate path.


### Performance

Compared current `main` (`465b85c1`) with this PR’s current merge revision (`d1c157cc`, head `c7ca96e3`) on Apple M1 using WebGPU.

| Source | Workload | FPS change ±95% | Result |
|---|---|---:|---|
| `benchmark` | Rectangle / default | **+4.25% ± 1.87%** | Faster |
| `benchmark` | Rectangle / rotation | +2.43% ± 3.28% | Neutral |
| `benchmark` | Circle / default | **+15.10% ± 1.29%** | Faster |
| `benchmark` | Circle / rotation | **+15.65% ± 2.63%** | Faster |
| `thorvg.example` | `ManyRects` | −1.26% ± 2.09% | Neutral |
| `thorvg.example` | `SmartRender` | +4.09% ± 5.34% | Neutral |

The strongest reproducible improvement is approximately **15–16% higher FPS for Circle workloads**. No confirmed regression was found in the targeted examples.

Method: five order-balanced pairs per workload and 1,000 measured frames per process. Benchmarks used 120 warmup frames; examples used 30. Changes are paired means with unadjusted 95% Student-t intervals. “Neutral” means the interval includes zero. Timing covers `update + draw/sync + present` without explicitly waiting for completed GPU work.