### PR TITLE
doc: fix incorrect current point description in appendRect()

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1259,8 +1259,8 @@ struct TVG_API Shape : Paint
      *
      * The rectangle is treated as a new sub-path - it is not connected with the previous sub-path.
      *
-     * The value of the current point is set to (@p x + @p rx, @p y) - in case @p rx is greater
-     * than @p w/2 the current point is set to (@p x + @p w/2, @p y)
+     * The value of the current point is set to (@p x + @p w, @p y + @p ry) - in case @p ry is greater
+     * than @p h/2 the current point is set to (@p x + @p w, @p y + @p h/2).
      *
      * @param[in] x The horizontal coordinate of the upper-left corner of the rectangle.
      * @param[in] y The vertical coordinate of the upper-left corner of the rectangle.

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -1387,8 +1387,8 @@ TVG_API Tvg_Result tvg_shape_close(Tvg_Paint paint);
  *
  * The rectangle is treated as a new sub-path - it is not connected with the previous sub-path.
  *
- * The value of the current point is set to (@p x + @p rx, @p y) - in case @p rx is greater
- * than @p w/2 the current point is set to (@p x + @p w/2, @p y)
+ * The value of the current point is set to (@p x + @p w, @p y + @p ry) - in case @p ry is greater
+ * than @p h/2 the current point is set to (@p x + @p w, @p y + @p h/2).
  *
  * @param[in] paint The shape object.
  * @param[in] x The horizontal coordinate of the upper-left corner of the rectangle.


### PR DESCRIPTION
`Shape::appendRect()` and its CAPI binding `tvg_shape_append_rect()` document that the **current point** after the call is set to `(x + rx, y)`, clamped to `(x + w/2, y)` when `rx` exceeds `w/2`.

But actual implementation (`RenderPath::addRect()`) closes path at `(x + w, y + ry)`, clamped to `(x + w, y + h/2)` when `ry` exceeds `h/2`.

Update descriptions to match the implementation.
