### PR TITLE
common/lock: use StrictKey::lock()/unlock() in ScopedLock

### DIFF
--- a/src/common/tvgLock.h
+++ b/src/common/tvgLock.h
@@ -103,17 +103,16 @@ namespace tvg
 
         ScopedLock(StrictKey& k)
         {
-            k.mtx.lock();
+            k.lock();
             key = &k;
         }
 
         ~ScopedLock()
         {
-            if (key) key->mtx.unlock();
+            if (key) key->unlock();
         }
     };
 #endif //THORVG_THREAD_SUPPORT
 }
 
 #endif //_TVG_LOCK_H_
-


### PR DESCRIPTION
Replace direct mutex access (k.mtx.lock/unlock) with StrictKey's lock()/unlock() calls in ScopedLock within src/common/tvgLock.h. This improves encapsulation and lets StrictKey control locking behavior/platform specifics. No functional change expected; just avoids touching the mutex member directly.