### PR TITLE
cpu_engine: fix a crash in stroke bounds of an unprepared shape

### DIFF
--- a/src/renderer/cpu_engine/tvgSwShape.cpp
+++ b/src/renderer/cpu_engine/tvgSwShape.cpp
@@ -543,6 +543,7 @@ bool shapeStrokeBBox(SwShape& shape, const RenderShape* rshape, Point* pt4, cons
         auto outline = _genOutline(rshape, mpool, 0, rshape->trimpath());
         if (!outline) return false;
 
+        if (!shape.stroke) shape.stroke = tvg::calloc<SwStroke>(1, sizeof(SwStroke));
         strokeReset(shape.stroke, rshape, m, mpool, 0);
         strokeParseOutline(shape.stroke, *outline, mpool, 0);
 


### PR DESCRIPTION
shapeStrokeBBox() enters the stroking path on the authored stroke width alone and dereferences shape.stroke, but the raster pass may have left it null: a zero-opacity paint's task is marked ready without running (prepareCommon), and a zero-alpha solid stroke is discarded by shapeDelStroke (validStrokeWidth). Querying such a shape's bounds (e.g. Paint::bounds / tvg_paint_get_aabb) then crashed on the null stroke.

Allocate the stroke lazily before resetting it, matching shapeResetStroke().