### PR TITLE
svg_loader: decode XML entities

### DIFF
--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -68,19 +68,38 @@ static const char* _xmlFindWhiteSpace(const char* itr, const char* itrEnd)
     return itr;
 }
 
+struct XmlEntity
+{
+    const char* name;
+    uint8_t length;
+};
+
+static constexpr XmlEntity xmlEntities[] = {
+    {"&#10;", 5},
+    {"&quot;", 6},
+    {"&nbsp;", 6},
+    {"&apos;", 6},
+    {"&amp;", 5},
+    {"&lt;", 4},
+    {"&gt;", 4},
+    {"&#035;", 6},
+    {"&#039;", 6},
+};
+
+static const XmlEntity* _xmlFindEntity(const char* itr, const char* itrEnd)
+{
+    for (auto& entity : xmlEntities) {
+        if (itrEnd - itr >= entity.length && !memcmp(itr, entity.name, entity.length)) return &entity;
+    }
+    return nullptr;
+}
 
 static const char* _xmlSkipXmlEntities(const char* itr, const char* itrEnd)
 {
-    auto p = itr;
     while (itr < itrEnd && *itr == '&') {
-        for (int i = 0; i < NUMBER_OF_XML_ENTITIES; ++i) {
-            if (strncmp(itr, xmlEntity[i], xmlEntityLength[i]) == 0) {
-                itr += xmlEntityLength[i];
-                break;
-            }
-        }
-        if (itr == p) break;
-        p = itr;
+        auto entity = _xmlFindEntity(itr, itrEnd);
+        if (!entity) break;
+        itr += entity->length;
     }
     return itr;
 }
@@ -90,10 +109,9 @@ static const char* _xmlUnskipXmlEntities(const char* itr, const char* itrStart)
 {
     auto p = itr;
     while (itr > itrStart && *(itr - 1) == ';') {
-        for (int i = 0; i < NUMBER_OF_XML_ENTITIES; ++i) {
-            if (itr - xmlEntityLength[i] > itrStart &&
-                strncmp(itr - xmlEntityLength[i], xmlEntity[i], xmlEntityLength[i]) == 0) {
-                itr -= xmlEntityLength[i];
+        for (auto& entity : xmlEntities) {
+            if (itr - itrStart > entity.length && !memcmp(itr - entity.length, entity.name, entity.length)) {
+                itr -= entity.length;
                 break;
             }
         }
@@ -130,7 +148,6 @@ static const char* _unskipWhiteSpacesAndXmlEntities(const char* itr, const char*
     }
     return itr;
 }
-
 
 static const char* _xmlFindStartTag(const char* itr, const char* itrEnd)
 {

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -72,18 +72,19 @@ struct XmlEntity
 {
     const char* name;
     uint8_t length;
+    char decoded;
 };
 
 static constexpr XmlEntity xmlEntities[] = {
-    {"&#10;", 5},
-    {"&quot;", 6},
-    {"&nbsp;", 6},
-    {"&apos;", 6},
-    {"&amp;", 5},
-    {"&lt;", 4},
-    {"&gt;", 4},
-    {"&#035;", 6},
-    {"&#039;", 6},
+    {"&#10;", 5, '\n'},
+    {"&#035;", 6, '#'},
+    {"&#039;", 6, '\''},
+    {"&quot;", 6, '"'},
+    {"&nbsp;", 6, ' '},
+    {"&apos;", 6, '\''},
+    {"&amp;", 5, '&'},
+    {"&lt;", 4, '<'},
+    {"&gt;", 4, '>'},
 };
 
 static const XmlEntity* _xmlFindEntity(const char* itr, const char* itrEnd)
@@ -94,66 +95,25 @@ static const XmlEntity* _xmlFindEntity(const char* itr, const char* itrEnd)
     return nullptr;
 }
 
-static const char* _xmlSkipXmlEntities(const char* itr, const char* itrEnd)
+static unsigned _xmlDecodeEntities(const char* itr, const char* itrEnd, char* decoded)
 {
-    while (itr < itrEnd && *itr == '&') {
-        auto entity = _xmlFindEntity(itr, itrEnd);
-        if (!entity) break;
-        itr += entity->length;
-    }
-    return itr;
-}
-
-
-static const char* _xmlUnskipXmlEntities(const char* itr, const char* itrStart)
-{
-    auto p = itr;
-    while (itr > itrStart && *(itr - 1) == ';') {
-        for (auto& entity : xmlEntities) {
-            if (itr - itrStart > entity.length && !memcmp(itr - entity.length, entity.name, entity.length)) {
-                itr -= entity.length;
-                break;
-            }
+    auto dst = decoded;
+    while (itr < itrEnd) {
+        auto entity = (*itr == '&') ? _xmlFindEntity(itr, itrEnd) : nullptr;
+        if (!entity) *dst++ = *itr++;
+        else {
+            *dst++ = entity->decoded;
+            itr += entity->length;
         }
-        if (itr == p) break;
-        p = itr;
     }
-    return itr;
-}
-
-
-static const char* _skipWhiteSpacesAndXmlEntities(const char* itr, const char* itrEnd)
-{
-    itr = svgUtilSkipWhiteSpace(itr, itrEnd);
-    auto p = itr;
-    while (true) {
-        if (p != (itr = _xmlSkipXmlEntities(itr, itrEnd))) p = itr;
-        else break;
-        if (p != (itr = svgUtilSkipWhiteSpace(itr, itrEnd))) p = itr;
-        else break;
-    }
-    return itr;
-}
-
-
-static const char* _unskipWhiteSpacesAndXmlEntities(const char* itr, const char* itrStart)
-{
-    itr = svgUtilUnskipWhiteSpace(itr, itrStart);
-    auto p = itr;
-    while (true) {
-        if (p != (itr = _xmlUnskipXmlEntities(itr, itrStart))) p = itr;
-        else break;
-        if (p != (itr = svgUtilUnskipWhiteSpace(itr, itrStart))) p = itr;
-        else break;
-    }
-    return itr;
+    *dst = '\0';
+    return dst - decoded;
 }
 
 static const char* _xmlFindStartTag(const char* itr, const char* itrEnd)
 {
     return (const char*)memchr(itr, '<', itrEnd - itr);
 }
-
 
 static const char* _xmlFindEndTag(const char* itr, const char* itrEnd)
 {
@@ -286,13 +246,15 @@ bool isIgnoreUnsupportedLogElements(TVG_UNUSED const char* tagName)
 
 bool xmlParseAttributes(const char* buf, unsigned bufLength, xmlAttributeCb func, const void* data)
 {
+    if (!buf || !func) return false;
+
     const char *itr = buf, *itrEnd = buf + bufLength;
     char* tmpBuf = tvg::malloc<char>(bufLength + 1);
 
-    if (!buf || !func || !tmpBuf) goto error;
+    if (!tmpBuf) return false;
 
     while (itr < itrEnd) {
-        const char* p = _skipWhiteSpacesAndXmlEntities(itr, itrEnd);
+        const char* p = svgUtilSkipWhiteSpace(itr, itrEnd);
         const char *key, *keyEnd, *value, *valueEnd;
         char* tval;
 
@@ -314,35 +276,32 @@ bool xmlParseAttributes(const char* buf, unsigned bufLength, xmlAttributeCb func
             if (!value) goto error;
             value++;
         }
-        keyEnd = _xmlUnskipXmlEntities(keyEnd, key);
-
-        value = _skipWhiteSpacesAndXmlEntities(value, itrEnd);
+        value = svgUtilSkipWhiteSpace(value, itrEnd);
         if (value == itrEnd) goto error;
 
         if ((*value == '"') || (*value == '\'')) {
-            valueEnd = (const char*)memchr(value + 1, *value, itrEnd - value);
+            valueEnd = (const char*)memchr(value + 1, *value, itrEnd - value - 1);
             if (!valueEnd) goto error;
             value++;
         } else {
             valueEnd = _xmlFindWhiteSpace(value, itrEnd);
         }
 
-        itr = valueEnd + 1;
+        itr = (valueEnd < itrEnd) ? valueEnd + 1 : valueEnd;
 
-        value = _skipWhiteSpacesAndXmlEntities(value, itrEnd);
-        valueEnd = _unskipWhiteSpacesAndXmlEntities(valueEnd, value);
+        value = svgUtilSkipWhiteSpace(value, valueEnd);
+        if (value < valueEnd) valueEnd = svgUtilUnskipWhiteSpace(valueEnd, value);
 
         memcpy(tmpBuf, key, keyEnd - key);
         tmpBuf[keyEnd - key] = '\0';
 
         tval = tmpBuf + (keyEnd - key) + 1;
-        int i = 0;
-        while (value < valueEnd) {
-            value = _xmlSkipXmlEntities(value, valueEnd);
-            tval[i++] = *value;
-            value++;
+        auto decodedLength = _xmlDecodeEntities(value, valueEnd, tval);
+        if (decodedLength) {
+            auto decodedEnd = svgUtilUnskipWhiteSpace(tval + decodedLength, tval);
+            *const_cast<char*>(decodedEnd) = '\0';
+            tval = const_cast<char*>(svgUtilSkipWhiteSpace(tval, decodedEnd));
         }
-        tval[i] = '\0';
 
         if (!func((void*)data, tmpBuf, tval)) {
             if (_unsupported(tmpBuf, tval)) {
@@ -413,8 +372,8 @@ bool xmlParse(const char* buf, unsigned bufLength, bool strip, xmlCb func, const
                 }
 
                 if (strip && (type != XMLType::CData)) {
-                    start = _skipWhiteSpacesAndXmlEntities(start, end);
-                    end = _unskipWhiteSpacesAndXmlEntities(end, start);
+                    start = svgUtilSkipWhiteSpace(start, end);
+                    end = svgUtilUnskipWhiteSpace(end, start);
                 }
 
                 if (!func((void*)data, type, start, (unsigned int)(end - start))) return false;
@@ -428,8 +387,8 @@ bool xmlParse(const char* buf, unsigned bufLength, bool strip, xmlCb func, const
 
             if (strip && ((SvgParserContext*)data)->openedTag != OpenedTagType::Text) {
                 p = itr;
-                p = _skipWhiteSpacesAndXmlEntities(p, itrEnd);
-                if (p) {
+                p = svgUtilSkipWhiteSpace(p, itrEnd);
+                if (p != itr) {
                     if (!func((void*)data, XMLType::Ignored, itr, (unsigned int)(p - itr))) return false;
                     itr = p;
                 }
@@ -439,9 +398,19 @@ bool xmlParse(const char* buf, unsigned bufLength, bool strip, xmlCb func, const
             if (!p) p = itrEnd;
 
             end = p;
-            if (strip && ((SvgParserContext*)data)->openedTag != OpenedTagType::Text) end = _unskipWhiteSpacesAndXmlEntities(end, itr);
+            if (strip && ((SvgParserContext*)data)->openedTag != OpenedTagType::Text) end = svgUtilUnskipWhiteSpace(end, itr);
 
-            if (itr != end && !func((void*)data, XMLType::Data, itr, (unsigned int)(end - itr))) return false;
+            if (itr != end) {
+                auto length = (unsigned int)(end - itr);
+                if (memchr(itr, '&', length)) {
+                    auto decoded = tvg::malloc<char>(length + 1);
+                    if (!decoded) return false;
+                    auto decodedLength = _xmlDecodeEntities(itr, end, decoded);
+                    auto result = func((void*)data, XMLType::Data, decoded, decodedLength);
+                    tvg::free(decoded);
+                    if (!result) return false;
+                } else if (!func((void*)data, XMLType::Data, itr, length)) return false;
+            }
 
             if (strip && (end < p) && !func((void*)data, XMLType::Ignored, end, (unsigned int)(p - end))) return false;
 
@@ -570,8 +539,6 @@ const char* xmlFindAttributesTag(const char* buf, unsigned bufLength)
             //User skip tagname and already gave it the attributes.
             if (*itr == '=') return buf;
         } else {
-            itr = _xmlUnskipXmlEntities(itr, buf);
-            if (itr == itrEnd) return nullptr;
             return itr;
         }
     }

--- a/src/loaders/svg/tvgXmlParser.h
+++ b/src/loaders/svg/tvgXmlParser.h
@@ -25,10 +25,6 @@
 
 #include "tvgSvgCommon.h"
 
-#define NUMBER_OF_XML_ENTITIES 9
-const char* const xmlEntity[] = {"&#10;", "&quot;", "&nbsp;", "&apos;", "&amp;", "&lt;", "&gt;", "&#035;", "&#039;"};
-const int xmlEntityLength[] = {5, 6, 6, 6, 5, 4, 4, 6, 6};
-
 enum class XMLType
 {
     Open = 0,     //!< \<tag attribute="value"\>


### PR DESCRIPTION
Decode XML entities before forwarding XML data to the SVG parser callback: the five predefined XML entities, plus the numeric character  references (&#10;, &#035;, &#039;) and &nbsp; that the previous entity table already recognized.
Reuse the same decoder for attribute  values and treat only actual whitespace as ignorable.


issue: #4584