### PR TITLE
wg_engine: improve stencil fill performance

### DIFF
--- a/src/renderer/gpu_engine/wg/meson.build
+++ b/src/renderer/gpu_engine/wg/meson.build
@@ -11,6 +11,7 @@ source_file = [
     'tvgWgShaderSrc.h',
     'tvgWgShaderTypes.h',
     'tvgWgSolidBatch.h',
+    'tvgWgStencilBatch.h',
     'tvgWgTextureMgr.h',
     'tvgWgTessellator.h',
     'tvgWgBindGroups.cpp',
@@ -25,6 +26,7 @@ source_file = [
     'tvgWgShaderSrc.cpp',
     'tvgWgShaderTypes.cpp',
     'tvgWgSolidBatch.cpp',
+    'tvgWgStencilBatch.cpp',
     'tvgWgTextureMgr.cpp',
     'tvgWgTessellator.cpp'
 ]

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -292,6 +292,44 @@ void WgCompositor::requestSolidBatch(const Array<WgRenderDataShape*>& renderData
     range.viewport = renderDataShapes[0]->viewport;
 }
 
+void WgCompositor::requestStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range)
+{
+    assert(renderDataShapes.count > 1);
+    stageBufferGeometry.appendStencilBatch(renderDataShapes, range);
+    range.viewport = renderDataShapes[0]->viewport;
+    range.fillRule = renderDataShapes[0]->fillRule;
+    range.solidOnly = true;
+
+    bool colorsStarted = false;
+    uint32_t pendingColorCount = 0;
+    ARRAY_FOREACH(p, renderDataShapes) {
+        auto renderData = *p;
+        assert(!renderData->convex);
+        assert(renderData->fillRule == range.fillRule);
+        auto& settings = renderData->renderSettingsShape;
+        const auto count = renderData->meshBBox.vbuffer.count;
+
+        if (settings.fillType == WgRenderSettingsType::Solid) {
+            if (!colorsStarted) {
+                range.colorOffset = static_cast<size_t>(stageBufferSolidColor.vbuffer.count) * sizeof(RenderColor);
+                if (pendingColorCount) {
+                    stageBufferSolidColor.appendRepeated({}, pendingColorCount);
+                }
+                colorsStarted = true;
+            }
+            stageBufferSolidColor.appendRepeated(renderData->solidShape.packedColor(), count);
+        } else {
+            assert(settings.fillType == WgRenderSettingsType::Linear || settings.fillType == WgRenderSettingsType::Radial);
+            range.solidOnly = false;
+            settings.bindGroupInd = stageBufferPaint.append(settings.settings);
+            if (colorsStarted) {
+                stageBufferSolidColor.appendRepeated({}, count);
+            } else pendingColorCount += count;
+        }
+    }
+}
+
+
 void WgCompositor::renderShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod)
 {
     assert(renderData);
@@ -345,6 +383,77 @@ void WgCompositor::renderSolidBatch(const WgSolidBatchRange& range)
     wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, stageBufferGeometry.ibuffer_gpu, WGPUIndexFormat_Uint32, range.indexOffset, indexSize);
     wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.indexCount, 1, 0, 0, 0);
 }
+
+void WgCompositor::renderStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, const WgStencilBatchRange& range)
+{
+    assert(renderPassEncoder);
+    assert(renderDataShapes.count > 1);
+    assert(range.stencil.vertexCount > 0 && range.stencil.indexCount > 0);
+    assert(range.cover.vertexCount > 0 && range.cover.indexCount > 0);
+
+    const uint64_t stencilVertexSize = static_cast<uint64_t>(range.stencil.vertexCount) * sizeof(Point);
+    const uint64_t stencilIndexSize = static_cast<uint64_t>(range.stencil.indexCount) * sizeof(uint32_t);
+    const uint64_t coverVertexSize = static_cast<uint64_t>(range.cover.vertexCount) * sizeof(Point);
+    const uint64_t coverIndexSize = static_cast<uint64_t>(range.cover.indexCount) * sizeof(uint32_t);
+
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, range.viewport.x(), range.viewport.y(), range.viewport.w(), range.viewport.h());
+    wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, range.fillRule == FillRule::NonZero ? pipelines.nonzero : pipelines.evenodd);
+    wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 0, stageBufferGeometry.vbuffer_gpu, range.stencil.vertexOffset, stencilVertexSize);
+    wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, stageBufferGeometry.ibuffer_gpu, WGPUIndexFormat_Uint32, range.stencil.indexOffset, stencilIndexSize);
+    wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.stencil.indexCount, 1, 0, 0, 0);
+
+    wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 0, stageBufferGeometry.vbuffer_gpu, range.cover.vertexOffset, coverVertexSize);
+    wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, stageBufferGeometry.ibuffer_gpu, WGPUIndexFormat_Uint32, range.cover.indexOffset, coverIndexSize);
+
+    // Keep the common all-solid case identical to the original two-draw path.
+    if (range.solidOnly) {
+        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_stencil_batch);
+        wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 1, stageBufferSolidColor.vbuffer_gpu, range.colorOffset, static_cast<uint64_t>(range.cover.vertexCount) * sizeof(RenderColor));
+        wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.cover.indexCount, 1, 0, 0, 0);
+        return;
+    }
+
+    uint32_t firstIndex = 0;
+    bool colorsBound = false;
+
+    auto p = renderDataShapes.begin();
+    const auto end = renderDataShapes.end();
+    while (p < end) {
+        auto renderData = *p;
+        auto& settings = renderData->renderSettingsShape;
+        const auto batchFirstIndex = firstIndex;
+
+        do {
+            const auto indexCount = renderData->meshBBox.ibuffer.count;
+            const uint64_t nextIndex = static_cast<uint64_t>(firstIndex) + indexCount;
+            assert(indexCount > 0 && firstIndex <= range.cover.indexCount && nextIndex <= range.cover.indexCount);
+            firstIndex = static_cast<uint32_t>(nextIndex);
+            if (++p == end || settings.fillType != WgRenderSettingsType::Solid) break;
+            renderData = *p;
+        } while (renderData->renderSettingsShape.fillType == WgRenderSettingsType::Solid);
+
+        if (settings.fillType == WgRenderSettingsType::Solid) {
+            if (!colorsBound) {
+                wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 1, stageBufferSolidColor.vbuffer_gpu, range.colorOffset, static_cast<uint64_t>(range.cover.vertexCount) * sizeof(RenderColor));
+                colorsBound = true;
+            }
+            wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_stencil_batch);
+        } else {
+            assert(settings.fillType == WgRenderSettingsType::Linear || settings.fillType == WgRenderSettingsType::Radial);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
+            wgpuRenderPassEncoderSetPipeline(renderPassEncoder, settings.fillType == WgRenderSettingsType::Linear ? pipelines.linear : pipelines.radial);
+        }
+        wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, firstIndex - batchFirstIndex, 1, batchFirstIndex, 0, 0);
+    }
+
+    assert(firstIndex == range.cover.indexCount);
+}
+
 
 void WgCompositor::renderImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod)
 {

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -292,6 +292,41 @@ void WgCompositor::requestSolidBatch(const Array<WgRenderDataShape*>& renderData
     range.viewport = renderDataShapes[0]->viewport;
 }
 
+void WgCompositor::requestStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range)
+{
+    assert(renderDataShapes.count > 1);
+    stageBufferGeometry.appendStencilBatch(renderDataShapes, range);
+    range.viewport = renderDataShapes[0]->viewport;
+    range.fillRule = renderDataShapes[0]->fillRule;
+    range.solidOnly = true;
+
+    uint32_t pendingColorCount = 0;
+    auto colorsStarted = false;
+
+    ARRAY_FOREACH(p, renderDataShapes) {
+        auto renderData = *p;
+        assert(!renderData->convex);
+        assert(renderData->fillRule == range.fillRule);
+        auto& settings = renderData->renderSettingsShape;
+        const auto count = renderData->meshBBox.vbuffer.count;
+
+        if (settings.fillType == WgRenderSettingsType::Solid) {
+            if (!colorsStarted) {
+                range.colorOffset = static_cast<size_t>(stageBufferSolidColor.vbuffer.count) * sizeof(RenderColor);
+                if (pendingColorCount) stageBufferSolidColor.appendRepeated({}, pendingColorCount);
+                colorsStarted = true;
+            }
+            stageBufferSolidColor.appendRepeated(renderData->solidShape.packedColor(), count);
+        } else {
+            assert(settings.fillType == WgRenderSettingsType::Linear || settings.fillType == WgRenderSettingsType::Radial);
+            range.solidOnly = false;
+            settings.bindGroupInd = stageBufferPaint.append(settings.settings);
+            if (colorsStarted) stageBufferSolidColor.appendRepeated({}, count);
+            else pendingColorCount += count;
+        }
+    }
+}
+
 void WgCompositor::renderShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod)
 {
     assert(renderData);
@@ -344,6 +379,76 @@ void WgCompositor::renderSolidBatch(const WgSolidBatchRange& range)
     wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 1, stageBufferSolidColor.vbuffer_gpu, range.colorOffset, colorSize);
     wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, stageBufferGeometry.ibuffer_gpu, WGPUIndexFormat_Uint32, range.indexOffset, indexSize);
     wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.indexCount, 1, 0, 0, 0);
+}
+
+void WgCompositor::renderStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, const WgStencilBatchRange& range)
+{
+    assert(renderPassEncoder);
+    assert(renderDataShapes.count > 1);
+    assert(range.stencil.vertexCount > 0 && range.stencil.indexCount > 0);
+    assert(range.cover.vertexCount > 0 && range.cover.indexCount > 0);
+
+    const uint64_t stencilVertexSize = static_cast<uint64_t>(range.stencil.vertexCount) * sizeof(Point);
+    const uint64_t stencilIndexSize = static_cast<uint64_t>(range.stencil.indexCount) * sizeof(uint32_t);
+    const uint64_t coverVertexSize = static_cast<uint64_t>(range.cover.vertexCount) * sizeof(Point);
+    const uint64_t coverIndexSize = static_cast<uint64_t>(range.cover.indexCount) * sizeof(uint32_t);
+
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, range.viewport.x(), range.viewport.y(), range.viewport.w(), range.viewport.h());
+    wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, range.fillRule == FillRule::NonZero ? pipelines.nonzero : pipelines.evenodd);
+    wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 0, stageBufferGeometry.vbuffer_gpu, range.stencil.vertexOffset, stencilVertexSize);
+    wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, stageBufferGeometry.ibuffer_gpu, WGPUIndexFormat_Uint32, range.stencil.indexOffset, stencilIndexSize);
+    wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.stencil.indexCount, 1, 0, 0, 0);
+
+    wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 0, stageBufferGeometry.vbuffer_gpu, range.cover.vertexOffset, coverVertexSize);
+    wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, stageBufferGeometry.ibuffer_gpu, WGPUIndexFormat_Uint32, range.cover.indexOffset, coverIndexSize);
+
+    // Keep the common all-solid case identical to the original two-draw path.
+    if (range.solidOnly) {
+        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_stencil_batch);
+        wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 1, stageBufferSolidColor.vbuffer_gpu, range.colorOffset, static_cast<uint64_t>(range.cover.vertexCount) * sizeof(RenderColor));
+        wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.cover.indexCount, 1, 0, 0, 0);
+        return;
+    }
+
+    uint32_t firstIndex = 0;
+    bool colorsBound = false;
+
+    auto p = renderDataShapes.begin();
+    const auto end = renderDataShapes.end();
+    while (p < end) {
+        auto renderData = *p;
+        auto& settings = renderData->renderSettingsShape;
+        const auto batchFirstIndex = firstIndex;
+
+        do {
+            const auto indexCount = renderData->meshBBox.ibuffer.count;
+            const uint64_t nextIndex = static_cast<uint64_t>(firstIndex) + indexCount;
+            assert(indexCount > 0 && firstIndex <= range.cover.indexCount && nextIndex <= range.cover.indexCount);
+            firstIndex = static_cast<uint32_t>(nextIndex);
+            if (++p == end || settings.fillType != WgRenderSettingsType::Solid) break;
+            renderData = *p;
+        } while (renderData->renderSettingsShape.fillType == WgRenderSettingsType::Solid);
+
+        if (settings.fillType == WgRenderSettingsType::Solid) {
+            if (!colorsBound) {
+                wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 1, stageBufferSolidColor.vbuffer_gpu, range.colorOffset, static_cast<uint64_t>(range.cover.vertexCount) * sizeof(RenderColor));
+                colorsBound = true;
+            }
+            wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_stencil_batch);
+        } else {
+            assert(settings.fillType == WgRenderSettingsType::Linear || settings.fillType == WgRenderSettingsType::Radial);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
+            wgpuRenderPassEncoderSetPipeline(renderPassEncoder, settings.fillType == WgRenderSettingsType::Linear ? pipelines.linear : pipelines.radial);
+        }
+        wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, firstIndex - batchFirstIndex, 1, batchFirstIndex, 0, 0);
+    }
+
+    assert(firstIndex == range.cover.indexCount);
 }
 
 void WgCompositor::renderImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod)

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.h
@@ -125,10 +125,12 @@ public:
     void requestShape(WgRenderDataShape* renderData);
     void requestImage(WgRenderDataPicture* renderData);
     void requestSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgSolidBatchRange& range);
+    void requestStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range);
 
     // render shapes, images and scenes
     void renderShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
     void renderSolidBatch(const WgSolidBatchRange& range);
+    void renderStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, const WgStencilBatchRange& range);
     void renderImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod);
     void renderScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose);
     void composeScene(WgContext& context, WgRenderTarget* src, WgRenderTarget* mask, WgCompose* compose);

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
@@ -349,6 +349,13 @@ void WgPipelines::initialize(WgContext& context)
         layout_solid, vertexBufferLayoutsSolidBatch, 2,
         WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
         depthStencilStateScene, multisampleState);
+    // render pipeline solid stencil batch cover (per-vertex color)
+    solid_stencil_batch = createRenderPipeline(
+        context.device, "The render pipeline solid stencil batch cover",
+        shader_solid, "vs_main", "fs_main",
+        layout_solid, vertexBufferLayoutsSolidBatch, 2,
+        WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
+        depthStencilStateShape, multisampleState);
     // render pipeline radial (no stencil)
     radial_conv = createRenderPipeline(
         context.device, "The render pipeline radial",
@@ -568,6 +575,7 @@ void WgPipelines::releaseGraphicHandles(WgContext& context)
     releaseRenderPipeline(image);
     releaseRenderPipeline(linear_conv);
     releaseRenderPipeline(radial_conv);
+    releaseRenderPipeline(solid_stencil_batch);
     releaseRenderPipeline(solid_batch);
     releaseRenderPipeline(solid_conv);
     releaseRenderPipeline(linear);

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.h
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.h
@@ -87,6 +87,7 @@ public:
     WGPURenderPipeline linear{};
     WGPURenderPipeline solid_conv{};  // convex geometry (no stencil)
     WGPURenderPipeline solid_batch{};  // batched convex geometry (no stencil)
+    WGPURenderPipeline solid_stencil_batch{}; // batched complex geometry cover
     WGPURenderPipeline radial_conv{}; // convex geometry (no stencil)
     WGPURenderPipeline linear_conv{}; // convex geometry (no stencil)
     WGPURenderPipeline image{};

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.h
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.h
@@ -87,6 +87,7 @@ public:
     WGPURenderPipeline linear{};
     WGPURenderPipeline solid_conv{};  // convex geometry (no stencil)
     WGPURenderPipeline solid_batch{};  // batched convex geometry (no stencil)
+    WGPURenderPipeline solid_stencil_batch{};  // batched complex geometry cover
     WGPURenderPipeline radial_conv{}; // convex geometry (no stencil)
     WGPURenderPipeline linear_conv{}; // convex geometry (no stencil)
     WGPURenderPipeline image{};

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -519,11 +519,25 @@ void WgStageBufferGeometry::append(WgRenderDataPicture* renderDataPicture)
 
 void WgStageBufferGeometry::appendSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range)
 {
-    uint32_t vertexCount = 0;
-    uint32_t indexCount = 0;
+    appendBatch(renderDataShapes, range, &WgRenderDataShape::meshShape);
+    if (colors.vbuffer.reserved < colors.vbuffer.count + range.vertexCount)
+        colors.vbuffer.grow(std::max(range.vertexCount, colors.vbuffer.reserved));
+    range.colorOffset = colors.vbuffer.count * sizeof(RenderColor);
 
     ARRAY_FOREACH(shape, renderDataShapes) {
         const auto& mesh = (*shape)->meshShape;
+        colors.appendRepeated((*shape)->solidShape.packedColor(), mesh.vbuffer.count);
+    }
+}
+
+void WgStageBufferGeometry::appendBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgGeometryRange& range, WgMeshData WgRenderDataShape::*meshMember)
+{
+    assert(renderDataShapes.count > 1);
+
+    uint32_t vertexCount = 0;
+    uint32_t indexCount = 0;
+    ARRAY_FOREACH(p, renderDataShapes) {
+        const auto& mesh = (*p)->*meshMember;
         vertexCount += mesh.vbuffer.count;
         indexCount += mesh.ibuffer.count;
     }
@@ -535,21 +549,17 @@ void WgStageBufferGeometry::appendSolidBatch(const Array<WgRenderDataShape*>& re
         vbuffer.grow(std::max(vertexBytes, vbuffer.reserved));
     if (ibuffer.reserved < ibuffer.count + indexBytes)
         ibuffer.grow(std::max(indexBytes, ibuffer.reserved));
-    if (colors.vbuffer.reserved < colors.vbuffer.count + vertexCount)
-        colors.vbuffer.grow(std::max(vertexCount, colors.vbuffer.reserved));
 
     range.vertexOffset = vbuffer.count;
     range.indexOffset = ibuffer.count;
-    range.colorOffset = colors.vbuffer.count * sizeof(RenderColor);
     range.vertexCount = vertexCount;
     range.indexCount = indexCount;
 
     uint32_t baseVertex = 0;
     auto vertexDst = vbuffer.data + vbuffer.count;
     auto indexDst = ibuffer.data + ibuffer.count;
-
-    ARRAY_FOREACH(shape, renderDataShapes) {
-        const auto& mesh = (*shape)->meshShape;
+    ARRAY_FOREACH(p, renderDataShapes) {
+        const auto& mesh = (*p)->*meshMember;
         const uint32_t meshVertexBytes = mesh.vbuffer.count * sizeof(Point);
         memcpy(vertexDst, mesh.vbuffer.data, meshVertexBytes);
         vertexDst += meshVertexBytes;
@@ -561,10 +571,15 @@ void WgStageBufferGeometry::appendSolidBatch(const Array<WgRenderDataShape*>& re
         }
 
         baseVertex += mesh.vbuffer.count;
-        colors.appendRepeated((*shape)->solidShape.packedColor(), mesh.vbuffer.count);
     }
     vbuffer.count += vertexBytes;
     ibuffer.count += indexBytes;
+}
+
+void WgStageBufferGeometry::appendStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range)
+{
+    appendBatch(renderDataShapes, range.stencil, &WgRenderDataShape::meshShape);
+    appendBatch(renderDataShapes, range.cover, &WgRenderDataShape::meshBBox);
 }
 
 void WgStageBufferGeometry::release(WgContext& context)
@@ -616,8 +631,7 @@ void WgStageBufferSolidColor::appendRepeated(const RenderColor& value, uint32_t 
 
 void WgStageBufferSolidColor::flush(WgContext& context)
 {
-    if (vbuffer.count > 0)
-        context.allocateBufferVertex(vbuffer_gpu, vbuffer.data, vbuffer.count * sizeof(RenderColor));
+    if (vbuffer.count > 0) context.allocateBufferVertex(vbuffer_gpu, vbuffer.data, vbuffer.count * sizeof(RenderColor));
 }
 
 //***********************************************************************

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -519,11 +519,25 @@ void WgStageBufferGeometry::append(WgRenderDataPicture* renderDataPicture)
 
 void WgStageBufferGeometry::appendSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range)
 {
-    uint32_t vertexCount = 0;
-    uint32_t indexCount = 0;
+    appendBatch(renderDataShapes, range, &WgRenderDataShape::meshShape);
+    if (colors.vbuffer.reserved < colors.vbuffer.count + range.vertexCount)
+        colors.vbuffer.grow(std::max(range.vertexCount, colors.vbuffer.reserved));
+    range.colorOffset = colors.vbuffer.count * sizeof(RenderColor);
 
     ARRAY_FOREACH(shape, renderDataShapes) {
         const auto& mesh = (*shape)->meshShape;
+        colors.appendRepeated((*shape)->solidShape.packedColor(), mesh.vbuffer.count);
+    }
+}
+
+void WgStageBufferGeometry::appendBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgGeometryRange& range, WgMeshData WgRenderDataShape::* meshMember)
+{
+    assert(renderDataShapes.count > 1);
+
+    uint32_t vertexCount = 0;
+    uint32_t indexCount = 0;
+    ARRAY_FOREACH(p, renderDataShapes) {
+        const auto& mesh = (*p)->*meshMember;
         vertexCount += mesh.vbuffer.count;
         indexCount += mesh.ibuffer.count;
     }
@@ -535,21 +549,17 @@ void WgStageBufferGeometry::appendSolidBatch(const Array<WgRenderDataShape*>& re
         vbuffer.grow(std::max(vertexBytes, vbuffer.reserved));
     if (ibuffer.reserved < ibuffer.count + indexBytes)
         ibuffer.grow(std::max(indexBytes, ibuffer.reserved));
-    if (colors.vbuffer.reserved < colors.vbuffer.count + vertexCount)
-        colors.vbuffer.grow(std::max(vertexCount, colors.vbuffer.reserved));
 
     range.vertexOffset = vbuffer.count;
     range.indexOffset = ibuffer.count;
-    range.colorOffset = colors.vbuffer.count * sizeof(RenderColor);
     range.vertexCount = vertexCount;
     range.indexCount = indexCount;
 
     uint32_t baseVertex = 0;
     auto vertexDst = vbuffer.data + vbuffer.count;
     auto indexDst = ibuffer.data + ibuffer.count;
-
-    ARRAY_FOREACH(shape, renderDataShapes) {
-        const auto& mesh = (*shape)->meshShape;
+    ARRAY_FOREACH(p, renderDataShapes) {
+        const auto& mesh = (*p)->*meshMember;
         const uint32_t meshVertexBytes = mesh.vbuffer.count * sizeof(Point);
         memcpy(vertexDst, mesh.vbuffer.data, meshVertexBytes);
         vertexDst += meshVertexBytes;
@@ -561,11 +571,18 @@ void WgStageBufferGeometry::appendSolidBatch(const Array<WgRenderDataShape*>& re
         }
 
         baseVertex += mesh.vbuffer.count;
-        colors.appendRepeated((*shape)->solidShape.packedColor(), mesh.vbuffer.count);
     }
     vbuffer.count += vertexBytes;
     ibuffer.count += indexBytes;
 }
+
+
+void WgStageBufferGeometry::appendStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range)
+{
+    appendBatch(renderDataShapes, range.stencil, &WgRenderDataShape::meshShape);
+    appendBatch(renderDataShapes, range.cover, &WgRenderDataShape::meshBBox);
+}
+
 
 void WgStageBufferGeometry::release(WgContext& context)
 {

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.h
@@ -29,7 +29,8 @@
 
 struct WgTextureMgr;
 
-struct WgImageData {
+struct WgImageData
+{
     WGPUTexture texture{};
     WGPUTextureView textureView{};
     WGPUBindGroup bindGroup{};
@@ -144,14 +145,28 @@ public:
     void release(WgContext& context);
 };
 
-struct WgSolidBatchRange
+struct WgGeometryRange
 {
     size_t vertexOffset{};
     size_t indexOffset{};
-    size_t colorOffset{};
     uint32_t vertexCount{};
     uint32_t indexCount{};
+};
+
+struct WgSolidBatchRange : WgGeometryRange
+{
+    size_t colorOffset{};
     RenderRegion viewport{};
+};
+
+struct WgStencilBatchRange
+{
+    WgGeometryRange stencil{};
+    WgGeometryRange cover{};
+    size_t colorOffset{};
+    RenderRegion viewport{};
+    FillRule fillRule{};
+    bool solidOnly{};
 };
 
 // gaussian blur, drop shadow, fill, tint, tritone
@@ -192,6 +207,8 @@ class WgStageBufferGeometry {
 private:
     Array<uint8_t> vbuffer;
     Array<uint8_t> ibuffer;
+    void appendBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgGeometryRange& range, WgMeshData WgRenderDataShape::*meshMember);
+
 public:
     WGPUBuffer vbuffer_gpu{};
     WGPUBuffer ibuffer_gpu{};
@@ -200,6 +217,7 @@ public:
     void append(WgRenderDataShape* renderDataShape);
     void append(WgRenderDataPicture* renderDataPicture);
     void appendSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range);
+    void appendStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range);
     void initialize(WgContext& context){};
     void release(WgContext& context);
     void clear();

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.h
@@ -144,14 +144,28 @@ public:
     void release(WgContext& context);
 };
 
-struct WgSolidBatchRange
+struct WgGeometryRange
 {
     size_t vertexOffset{};
     size_t indexOffset{};
-    size_t colorOffset{};
     uint32_t vertexCount{};
     uint32_t indexCount{};
+};
+
+struct WgSolidBatchRange : WgGeometryRange
+{
+    size_t colorOffset{};
     RenderRegion viewport{};
+};
+
+struct WgStencilBatchRange
+{
+    WgGeometryRange stencil{};
+    WgGeometryRange cover{};
+    size_t colorOffset{};
+    RenderRegion viewport{};
+    FillRule fillRule{};
+    bool solidOnly{};
 };
 
 // gaussian blur, drop shadow, fill, tint, tritone
@@ -192,6 +206,7 @@ class WgStageBufferGeometry {
 private:
     Array<uint8_t> vbuffer;
     Array<uint8_t> ibuffer;
+    void appendBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgGeometryRange& range, WgMeshData WgRenderDataShape::* meshMember);
 public:
     WGPUBuffer vbuffer_gpu{};
     WGPUBuffer ibuffer_gpu{};
@@ -200,6 +215,7 @@ public:
     void append(WgRenderDataShape* renderDataShape);
     void append(WgRenderDataPicture* renderDataPicture);
     void appendSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range);
+    void appendStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range);
     void initialize(WgContext& context){};
     void release(WgContext& context);
     void clear();

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
@@ -23,6 +23,24 @@
 #include "tvgWgRenderTask.h"
 #include <iostream>
 
+WgBatchTask::WgBatchTask(WgRenderDataShape* first, WgRenderDataShape* second, bool stencilBatch) : shapes{2}, stencilBatch(stencilBatch)
+{
+    shapes.push(first);
+    shapes.push(second);
+}
+
+void WgBatchTask::stage(WgCompositor& compositor)
+{
+    if (stencilBatch) compositor.requestStencilBatch(shapes, stencilRange);
+    else compositor.requestSolidBatch(shapes, solidRange);
+}
+
+void WgBatchTask::run(WgContext&, WgCompositor& compositor, WGPUCommandEncoder)
+{
+    if (stencilBatch) compositor.renderStencilBatch(shapes, stencilRange);
+    else compositor.renderSolidBatch(solidRange);
+}
+
 //***********************************************************************
 // WgPaintTask
 //***********************************************************************

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
@@ -23,6 +23,25 @@
 #include "tvgWgRenderTask.h"
 #include <iostream>
 
+WgBatchTask::WgBatchTask(WgRenderDataShape* first, WgRenderDataShape* second, bool stencilBatch) :
+    shapes{2}, stencilBatch(stencilBatch)
+{
+    shapes.push(first);
+    shapes.push(second);
+}
+
+void WgBatchTask::stage(WgCompositor& compositor)
+{
+    if (stencilBatch) compositor.requestStencilBatch(shapes, stencilRange);
+    else compositor.requestSolidBatch(shapes, solidRange);
+}
+
+void WgBatchTask::run(WgContext&, WgCompositor& compositor, WGPUCommandEncoder)
+{
+    if (stencilBatch) compositor.renderStencilBatch(shapes, stencilRange);
+    else compositor.renderSolidBatch(solidRange);
+}
+
 //***********************************************************************
 // WgPaintTask
 //***********************************************************************

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
@@ -46,6 +46,17 @@ struct WgPaintTask: public WgRenderTask {
     void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
 };
 
+struct WgBatchTask: public WgRenderTask {
+    Array<WgRenderDataShape*> shapes;
+    WgSolidBatchRange solidRange;
+    WgStencilBatchRange stencilRange;
+    bool stencilBatch{};
+
+    WgBatchTask(WgRenderDataShape* first, WgRenderDataShape* second, bool stencilBatch);
+    void stage(WgCompositor& compositor) override;
+    void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
+};
+
 // task for scene rendering with blending, composition and effect
 struct WgSceneTask: public WgRenderTask {
 public:

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
@@ -25,15 +25,17 @@
  
 #include "tvgWgCompositor.h"
 
-// base class for any renderable objects 
-struct WgRenderTask {
+// base class for any renderable objects
+struct WgRenderTask
+{
     virtual ~WgRenderTask() {}
     virtual void stage(WgCompositor& compositor) = 0;
     virtual void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) = 0;
 };
 
 // task for single shape rendering
-struct WgPaintTask: public WgRenderTask {
+struct WgPaintTask : WgRenderTask
+{
     // shape render properties
     WgRenderDataPaint* renderData{};
     BlendMethod blendMethod{};
@@ -46,9 +48,21 @@ struct WgPaintTask: public WgRenderTask {
     void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
 };
 
+struct WgBatchTask : WgRenderTask
+{
+    Array<WgRenderDataShape*> shapes;
+    WgSolidBatchRange solidRange;
+    WgStencilBatchRange stencilRange;
+    bool stencilBatch{};
+
+    WgBatchTask(WgRenderDataShape* first, WgRenderDataShape* second, bool stencilBatch);
+    void stage(WgCompositor& compositor) override;
+    void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
+};
+
 // task for scene rendering with blending, composition and effect
-struct WgSceneTask: public WgRenderTask {
-public:
+struct WgSceneTask : WgRenderTask
+{
     // parent scene (nullptr for root scene)
     WgSceneTask* parent{};
     // children can be shapes or scenes tasks
@@ -68,7 +82,7 @@ public:
     void stage(WgCompositor& compositor) override;
     // run all, including all shapes drawing, blending, composition and effect
     void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
-private:
+
     void runChildren(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder);
     void runEffect(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder);
 };

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -227,6 +227,7 @@ bool WgRenderer::preRender()
     if (mContext.invalid()) return false;
 
     mSolidBatch = {};
+    mStencilBatch = {};
     mCompositor.reset(mContext);
 
     assert(mRenderTargetStack.count == 0);
@@ -254,6 +255,7 @@ bool WgRenderer::renderShape(RenderData data)
     WgSceneTask* sceneTask = mSceneTaskStack.last();
 
     if (mSolidBatch.draw(sceneTask, renderData, mBlendMethod, mRenderTaskList)) return true;
+    if (mStencilBatch.draw(sceneTask, renderData, mBlendMethod, mRenderTaskList)) return true;
 
     WgPaintTask* paintTask = new WgPaintTask(renderData, mBlendMethod);
     sceneTask->children.push(paintTask);

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -25,6 +25,7 @@
 
 #include "tvgRender.h"
 #include "tvgWgSolidBatch.h"
+#include "tvgWgStencilBatch.h"
 #include "tvgWgTextureMgr.h"
 
 struct WgRenderer : RenderMethod
@@ -84,6 +85,7 @@ private:
     Array<WgSceneTask*> mSceneTaskStack;
     Array<WgRenderTask*> mRenderTaskList;
     WgSolidBatch mSolidBatch;
+    WgStencilBatch mStencilBatch;
 
     // render target pool
     WgRenderTargetPool mRenderTargetPool;

--- a/src/renderer/gpu_engine/wg/tvgWgSolidBatch.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgSolidBatch.cpp
@@ -22,28 +22,6 @@
 
 #include "tvgWgSolidBatch.h"
 
-struct WgSolidBatchTask : WgRenderTask
-{
-    Array<WgRenderDataShape*> shapes;
-    WgSolidBatchRange range{};
-
-    WgSolidBatchTask(WgRenderDataShape* first, WgRenderDataShape* second) : shapes{2}
-    {
-        shapes.push(first);
-        shapes.push(second);
-    }
-
-    void stage(WgCompositor& compositor) override
-    {
-        compositor.requestSolidBatch(shapes, range);
-    }
-
-    void run(WgContext&, WgCompositor& compositor, WGPUCommandEncoder) override
-    {
-        compositor.renderSolidBatch(range);
-    }
-};
-
 static inline bool eligible(const WgRenderDataShape* renderData, BlendMethod blendMethod)
 {
     if (blendMethod != BlendMethod::Normal) return false;
@@ -75,7 +53,7 @@ static inline WgRenderTask* emitSingle(WgSceneTask* sceneTask, WgRenderDataShape
 static inline WgRenderTask* promote(WgSceneTask* sceneTask, WgRenderTask* task, WgRenderDataShape* first, WgRenderDataShape* renderData, Array<WgRenderTask*>& renderTaskList)
 {
     // Tasks are staged only after the tree is complete, so replacing its tail is safe.
-    auto batchTask = new WgSolidBatchTask(first, renderData);
+    auto batchTask = new WgBatchTask(first, renderData, false);
     sceneTask->children.last() = batchTask;
     renderTaskList.last() = batchTask;
     delete task;
@@ -85,7 +63,7 @@ static inline WgRenderTask* promote(WgSceneTask* sceneTask, WgRenderTask* task, 
 
 static inline void append(WgRenderTask* task, WgRenderDataShape* renderData)
 {
-    static_cast<WgSolidBatchTask*>(task)->shapes.push(renderData);
+    static_cast<WgBatchTask*>(task)->shapes.push(renderData);
 }
 
 bool WgSolidBatch::draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)

--- a/src/renderer/gpu_engine/wg/tvgWgStencilBatch.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgStencilBatch.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgMath.h"
+#include "tvgWgStencilBatch.h"
+
+static inline bool eligible(const WgRenderDataShape* renderData, BlendMethod blendMethod, RenderRegion& bounds)
+{
+    if (blendMethod != BlendMethod::Normal) return false;
+    if (renderData->renderSettingsShape.skip) return false;
+    const auto fillType = renderData->renderSettingsShape.fillType;
+    if (fillType != WgRenderSettingsType::Solid && fillType != WgRenderSettingsType::Linear && fillType != WgRenderSettingsType::Radial) return false;
+    if (renderData->convex || renderData->viewport.invalid() || !renderData->clips.empty()) return false;
+    if (renderData->meshShape.vbuffer.empty() || renderData->meshShape.ibuffer.empty() || renderData->meshBBox.vbuffer.empty() || renderData->meshBBox.ibuffer.empty()) return false;
+    if (!renderData->renderSettingsStroke.skip && !renderData->meshStrokes.ibuffer.empty()) return false;
+
+    // Clip finite geometry bounds to the viewport before rounding to the integer overlap region.
+    const auto& aabb = renderData->aabb;
+    if (!std::isfinite(aabb.min.x) || !std::isfinite(aabb.min.y) || !std::isfinite(aabb.max.x) || !std::isfinite(aabb.max.y)) return false;
+    const auto minX = tvg::clamp(static_cast<double>(aabb.min.x), static_cast<double>(renderData->viewport.min.x), static_cast<double>(renderData->viewport.max.x));
+    const auto minY = tvg::clamp(static_cast<double>(aabb.min.y), static_cast<double>(renderData->viewport.min.y), static_cast<double>(renderData->viewport.max.y));
+    const auto maxX = tvg::clamp(static_cast<double>(aabb.max.x), static_cast<double>(renderData->viewport.min.x), static_cast<double>(renderData->viewport.max.x));
+    const auto maxY = tvg::clamp(static_cast<double>(aabb.max.y), static_cast<double>(renderData->viewport.min.y), static_cast<double>(renderData->viewport.max.y));
+    if (maxX <= minX || maxY <= minY) return false;
+    bounds = {{static_cast<int32_t>(std::floor(minX)), static_cast<int32_t>(std::floor(minY))},
+              {static_cast<int32_t>(std::ceil(maxX)), static_cast<int32_t>(std::ceil(maxY))}};
+
+    return true;
+}
+
+
+static inline bool intersects(const WgStencilBatch& batch, const RenderRegion& bounds)
+{
+    const auto min = batch.ySorted ? bounds.min.y : bounds.min.x;
+    const auto max = batch.ySorted ? bounds.max.y : bounds.max.x;
+    ARRAY_FOREACH(p, batch.bounds) {
+        const auto pMin = batch.ySorted ? (*p).min.y : (*p).min.x;
+        if ((batch.ySorted ? (*p).max.y : (*p).max.x) <= min) continue;
+        if (pMin >= max) break;
+        if ((*p).intersected(bounds)) return true;
+    }
+    return false;
+}
+
+
+static inline void addBounds(WgStencilBatch& batch, const RenderRegion& bounds)
+{
+    auto p = batch.bounds.count;
+    const auto min = batch.ySorted ? bounds.min.y : bounds.min.x;
+    batch.bounds.push(bounds);
+    while (p > 0 && (batch.ySorted ? batch.bounds[p - 1].min.y : batch.bounds[p - 1].min.x) > min) {
+        batch.bounds[p] = batch.bounds[p - 1];
+        --p;
+    }
+    batch.bounds[p] = bounds;
+}
+
+
+static inline bool appendable(const WgStencilBatch& batch, WgSceneTask* sceneTask, WgRenderDataShape* renderData, const RenderRegion& bounds, const Array<WgRenderTask*>& renderTaskList)
+{
+    if (batch.sceneTask != sceneTask) return false;
+    if (sceneTask->children.last() != batch.task) return false;
+    if (renderTaskList.last() != batch.task) return false;
+    if (!(batch.viewport == renderData->viewport) || batch.fillRule != renderData->fillRule) return false;
+    return !intersects(batch, bounds);
+}
+
+
+static inline void emitSingle(WgStencilBatch& batch, WgSceneTask* sceneTask, WgRenderDataShape* renderData, const RenderRegion& bounds, Array<WgRenderTask*>& renderTaskList)
+{
+    auto task = new WgPaintTask(renderData, BlendMethod::Normal);
+    sceneTask->children.push(task);
+    renderTaskList.push(task);
+
+    batch.sceneTask = sceneTask;
+    batch.task = task;
+    batch.first = renderData;
+    batch.viewport = renderData->viewport;
+    batch.fillRule = renderData->fillRule;
+    batch.ySorted = batch.viewport.sh() > batch.viewport.sw();
+    batch.bounds.clear();
+    addBounds(batch, bounds);
+}
+
+
+static inline void promote(WgStencilBatch& batch, WgRenderDataShape* renderData, const RenderRegion& bounds, Array<WgRenderTask*>& renderTaskList)
+{
+    assert(batch.sceneTask && batch.first && batch.task);
+    assert(batch.sceneTask->children.last() == batch.task && renderTaskList.last() == batch.task);
+
+    auto batchTask = new WgBatchTask(batch.first, renderData, true);
+    batch.sceneTask->children.last() = batchTask;
+    renderTaskList.last() = batchTask;
+    delete batch.task;
+
+    batch.task = batchTask;
+    batch.first = nullptr;
+    addBounds(batch, bounds);
+}
+
+
+static inline void append(WgStencilBatch& batch, WgRenderDataShape* renderData, const RenderRegion& bounds)
+{
+    assert(batch.sceneTask && !batch.first && batch.task);
+    static_cast<WgBatchTask*>(batch.task)->shapes.push(renderData);
+    addBounds(batch, bounds);
+}
+
+
+bool WgStencilBatch::draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)
+{
+    RenderRegion bounds{};
+    if (!eligible(renderData, blendMethod, bounds)) return false;
+
+    if (!appendable(*this, sceneTask, renderData, bounds, renderTaskList)) {
+        emitSingle(*this, sceneTask, renderData, bounds, renderTaskList);
+        return true;
+    }
+
+    if (first) promote(*this, renderData, bounds, renderTaskList);
+    else append(*this, renderData, bounds);
+    return true;
+}

--- a/src/renderer/gpu_engine/wg/tvgWgStencilBatch.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgStencilBatch.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "tvgMath.h"
+#include "tvgWgStencilBatch.h"
+
+static bool eligible(const WgRenderDataShape* renderData, BlendMethod blendMethod, RenderRegion& bounds)
+{
+    if (blendMethod != BlendMethod::Normal || renderData->renderSettingsShape.skip) return false;
+
+    const auto fillType = renderData->renderSettingsShape.fillType;
+    if (fillType != WgRenderSettingsType::Solid && fillType != WgRenderSettingsType::Linear && fillType != WgRenderSettingsType::Radial) return false;
+
+    if (renderData->convex || renderData->viewport.invalid() || !renderData->clips.empty()) return false;
+    if (renderData->meshShape.vbuffer.empty() || renderData->meshShape.ibuffer.empty() || renderData->meshBBox.vbuffer.empty() || renderData->meshBBox.ibuffer.empty()) return false;
+    if (!renderData->renderSettingsStroke.skip && !renderData->meshStrokes.ibuffer.empty()) return false;
+
+    // Clip finite geometry bounds to the viewport before rounding to the integer overlap region.
+    const auto& aabb = renderData->aabb;
+    if (!std::isfinite(aabb.min.x) || !std::isfinite(aabb.min.y) || !std::isfinite(aabb.max.x) || !std::isfinite(aabb.max.y)) return false;
+
+    const auto minX = tvg::clamp(static_cast<double>(aabb.min.x), static_cast<double>(renderData->viewport.min.x), static_cast<double>(renderData->viewport.max.x));
+    const auto minY = tvg::clamp(static_cast<double>(aabb.min.y), static_cast<double>(renderData->viewport.min.y), static_cast<double>(renderData->viewport.max.y));
+    const auto maxX = tvg::clamp(static_cast<double>(aabb.max.x), static_cast<double>(renderData->viewport.min.x), static_cast<double>(renderData->viewport.max.x));
+    const auto maxY = tvg::clamp(static_cast<double>(aabb.max.y), static_cast<double>(renderData->viewport.min.y), static_cast<double>(renderData->viewport.max.y));
+    if (maxX <= minX || maxY <= minY) return false;
+
+    bounds = {{static_cast<int32_t>(std::floor(minX)), static_cast<int32_t>(std::floor(minY))}, {static_cast<int32_t>(std::ceil(maxX)), static_cast<int32_t>(std::ceil(maxY))}};
+
+    return true;
+}
+
+static bool intersects(const WgStencilBatch& batch, const RenderRegion& bounds)
+{
+    const auto min = batch.ySorted ? bounds.min.y : bounds.min.x;
+    const auto max = batch.ySorted ? bounds.max.y : bounds.max.x;
+    ARRAY_FOREACH(p, batch.bounds) {
+        const auto pMin = batch.ySorted ? (*p).min.y : (*p).min.x;
+        if ((batch.ySorted ? (*p).max.y : (*p).max.x) <= min) continue;
+        if (pMin >= max) break;
+        if ((*p).intersected(bounds)) return true;
+    }
+    return false;
+}
+
+static void addBounds(WgStencilBatch& batch, const RenderRegion& bounds)
+{
+    auto p = batch.bounds.count;
+    const auto min = batch.ySorted ? bounds.min.y : bounds.min.x;
+    batch.bounds.push(bounds);
+    while (p > 0 && (batch.ySorted ? batch.bounds[p - 1].min.y : batch.bounds[p - 1].min.x) > min) {
+        batch.bounds[p] = batch.bounds[p - 1];
+        --p;
+    }
+    batch.bounds[p] = bounds;
+}
+
+static bool appendable(const WgStencilBatch& batch, WgSceneTask* sceneTask, WgRenderDataShape* renderData, const RenderRegion& bounds, const Array<WgRenderTask*>& renderTaskList)
+{
+    if (batch.sceneTask != sceneTask || sceneTask->children.last() != batch.task || renderTaskList.last() != batch.task) return false;
+    if (!(batch.viewport == renderData->viewport) || batch.fillRule != renderData->fillRule) return false;
+    return !intersects(batch, bounds);
+}
+
+static void emitSingle(WgStencilBatch& batch, WgSceneTask* sceneTask, WgRenderDataShape* renderData, const RenderRegion& bounds, Array<WgRenderTask*>& renderTaskList)
+{
+    auto task = new WgPaintTask(renderData, BlendMethod::Normal);
+    sceneTask->children.push(task);
+    renderTaskList.push(task);
+
+    batch.sceneTask = sceneTask;
+    batch.task = task;
+    batch.first = renderData;
+    batch.viewport = renderData->viewport;
+    batch.fillRule = renderData->fillRule;
+    batch.ySorted = batch.viewport.sh() > batch.viewport.sw();
+    batch.bounds.clear();
+
+    addBounds(batch, bounds);
+}
+
+static void promote(WgStencilBatch& batch, WgRenderDataShape* renderData, const RenderRegion& bounds, Array<WgRenderTask*>& renderTaskList)
+{
+    assert(batch.sceneTask && batch.first && batch.task);
+    assert(batch.sceneTask->children.last() == batch.task && renderTaskList.last() == batch.task);
+
+    auto batchTask = new WgBatchTask(batch.first, renderData, true);
+    batch.sceneTask->children.last() = batchTask;
+    renderTaskList.last() = batchTask;
+    delete (batch.task);
+
+    batch.task = batchTask;
+    batch.first = nullptr;
+    addBounds(batch, bounds);
+}
+
+static void append(WgStencilBatch& batch, WgRenderDataShape* renderData, const RenderRegion& bounds)
+{
+    assert(batch.sceneTask && !batch.first && batch.task);
+    static_cast<WgBatchTask*>(batch.task)->shapes.push(renderData);
+    addBounds(batch, bounds);
+}
+
+bool WgStencilBatch::draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)
+{
+    RenderRegion bounds;
+    if (!eligible(renderData, blendMethod, bounds)) return false;
+
+    if (!appendable(*this, sceneTask, renderData, bounds, renderTaskList)) {
+        emitSingle(*this, sceneTask, renderData, bounds, renderTaskList);
+        return true;
+    }
+
+    if (first) promote(*this, renderData, bounds, renderTaskList);
+    else append(*this, renderData, bounds);
+    return true;
+}

--- a/src/renderer/gpu_engine/wg/tvgWgStencilBatch.h
+++ b/src/renderer/gpu_engine/wg/tvgWgStencilBatch.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_STENCIL_BATCH_H_
+#define _TVG_WG_STENCIL_BATCH_H_
+
+#include "tvgWgRenderTask.h"
+
+struct WgStencilBatch
+{
+    bool draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList);
+
+    WgSceneTask* sceneTask{};
+    WgRenderTask* task{};
+    WgRenderDataShape* first{};
+    Array<RenderRegion> bounds;
+    RenderRegion viewport{};
+    FillRule fillRule{};
+    bool ySorted{};
+};
+
+#endif  // _TVG_WG_STENCIL_BATCH_H_

--- a/src/renderer/gpu_engine/wg/tvgWgStencilBatch.h
+++ b/src/renderer/gpu_engine/wg/tvgWgStencilBatch.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 ThorVG project. All rights reserved.
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _TVG_WG_STENCIL_BATCH_H_
+#define _TVG_WG_STENCIL_BATCH_H_
+
+#include "tvgWgRenderTask.h"
+
+struct WgStencilBatch
+{
+    bool draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList);
+
+    WgSceneTask* sceneTask{};
+    WgRenderTask* task{};
+    WgRenderDataShape* first{};
+    Array<RenderRegion> bounds;
+    RenderRegion viewport{};
+    FillRule fillRule{};
+    bool ySorted{};
+};
+
+#endif // _TVG_WG_STENCIL_BATCH_H_


### PR DESCRIPTION
Depends on #4582, which batches consecutive convex solid fills.

Non-convex fills still require a stencil pass followed by a cover pass for each shape. Repeating that sequence creates unnecessary submissions when consecutive shapes use compatible render state and do not overlap.

This PR batches that stencil-and-cover path. Compatible non-overlapping solid and gradient fills share staged geometry and one stencil draw. Adjacent solid covers are coalesced, while gradient covers remain in source order.

Overlaps, fill-rule or viewport changes, clips, visible strokes, blending, and intervening tasks remain ordering boundaries. Staging grows geometrically and uses overflow-safe byte limits instead of artificial chunk caps.

### On Apple M1/Metal, using disjoint concave solid fills:

| Shapes | Submission | Queue-complete |
| -- | --: | --: |
| 64 | 1.81× | 1.04× |
| 256 | 2.59× | 1.28× |
| 576 | 3.20× | 2.24× |
| 1,024 | 2.87× | 2.57× |
| 1,600 | 2.39× | 2.24× |
| 4,096 | 1.31× | 1.33× |

https://github.com/user-attachments/assets/36032fcf-f4f4-4b57-99aa-9605be237c0c