### PR TITLE
lottie: clamp opacity/color to the valid range on parsing

### DIFF
--- a/src/loaders/lottie/tvgLottieCommon.h
+++ b/src/loaders/lottie/tvgLottieCommon.h
@@ -98,7 +98,7 @@ struct TextDocument
 
 static inline int32_t REMAP255(float val)
 {
-    return (int32_t)nearbyintf(val * 255.0f);
+    return (int32_t)nearbyintf(tvg::clamp(val, 0.0f, 1.0f) * 255.0f);
 }
 
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -272,11 +272,11 @@ bool LottieParser::getValue(uint8_t& val)
 {
     if (peekType() == kArrayType) {
         enterArray();
-        if (nextArrayValue()) val = (uint8_t)(getFloat() * 2.55f);
+        if (nextArrayValue()) val = (uint8_t)REMAP255(getFloat() * 0.01f);
         //discard rest
         while (nextArrayValue()) getFloat();
     } else {
-        val = (uint8_t)(getFloat() * 2.55f);
+        val = (uint8_t)REMAP255(getFloat() * 0.01f);
     }
     return false;
 }


### PR DESCRIPTION
Opacity (0 ~ 100) and color channels (0 ~ 1)
are stored as uint8, but the Lottie spec defines
them as unbounded numbers.

Clamp inside REMAP255 so every value narrowed
to an 8-bit channel.

issue: https://github.com/thorvg/thorvg/issues/4551

test file: [opacity.json](https://github.com/user-attachments/files/30333776/opacity.json)

| Before | After |
|---------|---------|
| <img height="500" alt="CleanShot 2026-07-24 at 14 43 03@2x" src="https://github.com/user-attachments/assets/eff1d334-bf02-4f99-9969-5a5cbf13b9cc" /> | <img height="500" alt="CleanShot 2026-07-24 at 14 42 46@2x" src="https://github.com/user-attachments/assets/8114000a-5366-4229-b4fc-22481accae1a" /> |