### PR TITLE
loader: fix a font sharing count leak on cached data loading

### DIFF
--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -235,12 +235,11 @@ bool LoaderMgr::init()
 
 bool LoaderMgr::term()
 {
-    // clean up the remained font loaders which is globally used.
+    // force clean up the font loaders which is globally used.
     INLIST_SAFE_FOREACH(_activeLoaders, loader) {
         if (loader->type != FileType::Sfnt) continue;
-        auto ret = loader->close();
         _activeLoaders.remove(loader);
-        if (ret) delete (loader);
+        delete (loader);
     }
     return true;
 }
@@ -250,9 +249,7 @@ bool LoaderMgr::retrieve(Loader* loader)
     if (!loader) return false;
 
     if (loader->close()) {
-        if (loader->cached) {
-            _activeLoaders.remove(loader);
-        }
+        if (loader->cached) _activeLoaders.remove(loader);
         delete (loader);
     }
     return true;

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -51,10 +51,7 @@ Result Text::load(const char* filename) noexcept
     bool invalid; //invalid path
     LoaderOps ops = {Type::Text};
     auto loader = LoaderMgr::loader(filename, &ops, &invalid);
-    if (loader) {
-        if (loader->sharing > 0) --loader->sharing;   //font loading doesn't mean sharing.
-        return Result::Success;
-    }
+    if (loader) return Result::Success;
     if (invalid) return Result::InvalidArguments;
     else return Result::NonSupport;
 #else


### PR DESCRIPTION
LoaderMgr::loader(name, data, ...) returns early
when the font is already cached, but font() increments the sharing count on that hit and the caller (Text::load) discards the result, so the count was never balanced and the loader leaked at unload. Loading the same font data twice (e.g. a lottie with an embedded font, loaded twice) strands the loader past Initializer::term().

Now, properly account for shared fonts by forcefully clearing the font cache during termination.