### PR TITLE
renderer: fix scene opacity loss in post-processing composition

### DIFF
--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -133,7 +133,7 @@ struct SceneImpl : Scene
 
         RenderCompositor* cmp = nullptr;
         // its parent is already in composition mode, maybe parasitize its surface
-        auto incomposite = (uint8_t(CompositionFlag::PostProcessing) & uint8_t(flag)) && !effects;
+        auto incomposite = (uint8_t(CompositionFlag::PostProcessing) & uint8_t(flag)) && !effects && impl.cmpFlag == CompositionFlag::Blending;
         auto ret = true;
 
         renderer->blend(impl.blendMethod);


### PR DESCRIPTION
In a direct composition path, it doesn't
examine the child's own composition purpose.

Therefore, children requiring Opacity
composition also skipped.

related: https://github.com/thorvg/thorvg/issues/4520

---

```cpp
auto inner = tvg::Scene::gen();
auto shape = tvg::Shape::gen();
shape->appendRect(20, 50, 100, 100);
shape->fill(255, 0, 0);
inner->add(shape);

auto scene = tvg::Scene::gen();
scene->add(inner);
scene->opacity(128);

auto parent = tvg::Scene::gen();
parent->add(scene);
parent->add(tvg::SceneEffect::GaussianBlur, 3.0, 0, 0, 100);
canvas->add(parent);
```

- Expected : 50% red
- Actual : 100% red (opacity ignored)


| Before | After |
|---------|---------|
| <img height="500" alt="CleanShot 2026-07-24 at 20 23 50@2x" src="https://github.com/user-attachments/assets/81708602-5949-4e55-8721-ac5f3555aa43" /> | <img height="500" alt="CleanShot 2026-07-24 at 20 24 10@2x" src="https://github.com/user-attachments/assets/b9a6c9e5-c1fb-448a-b489-c861ea500b75" /> |
