### PR TITLE
infra: Require OpenMP dependency when enabled

### DIFF
--- a/src/renderer/cpu_engine/meson.build
+++ b/src/renderer/cpu_engine/meson.build
@@ -21,7 +21,7 @@ source_file = [
 omp_dep = []
 
 if openmp
-    omp_dep = dependency('openmp', required: false)
+    omp_dep = dependency('openmp')
 endif
 
 engine_dep += [declare_dependency(


### PR DESCRIPTION
When OpenMP is enabled but unavailable, the build fails during compilation because omp.h cannot be found.
Require the OpenMP dependency so the failure is reported during Meson setup.

Issue: #4581 