### PR TITLE
infra: enable the wg engine in the binary size workflow

### DIFF
--- a/.github/workflows/binary_size.yml
+++ b/.github/workflows/binary_size.yml
@@ -21,6 +21,7 @@ jobs:
             key: x86_64-gcc
             runs_on: ubuntu-24.04
             extra_packages: 'libturbojpeg0-dev libpng-dev libwebp-dev libgles-dev'
+            engines: 'all'
             cc: gcc
             cxx: g++
             c_args: ''
@@ -32,6 +33,7 @@ jobs:
             key: x86_64-clang
             runs_on: ubuntu-24.04
             extra_packages: 'clang lld libomp-dev libturbojpeg0-dev libpng-dev libwebp-dev libgles-dev'
+            engines: 'all'
             cc: clang
             cxx: clang++
             c_args: ''
@@ -40,10 +42,13 @@ jobs:
             cpp_link_args: ''
 
           # x86 32-bit 
+          # wgpu-native currently does not ship a 32-bit Linux build,
+          # so the wg engine is excluded from this config.
           - label: x86 gcc (32-bit)
             key: x86-gcc
             runs_on: ubuntu-24.04
             extra_packages: 'gcc-multilib g++-multilib'
+            engines: 'cpu, gl'
             cc: gcc
             cxx: g++
             c_args: '-m32'
@@ -56,6 +61,7 @@ jobs:
             key: arm64-clang
             runs_on: ubuntu-24.04-arm
             extra_packages: 'clang lld libomp-dev libturbojpeg0-dev libpng-dev libwebp-dev libgles-dev'
+            engines: 'all'
             cc: clang
             cxx: clang++
             c_args: ''
@@ -112,9 +118,15 @@ jobs:
 
         sudo chown -R "$USER:$USER" "$APT_CACHE_DIR"
 
+    - name: Install wgpu_native
+      if: contains(matrix.engines, 'all') || contains(matrix.engines, 'wg')
+      run: |
+        bash .github/workflows/install_wgpu_native.sh
+
     # Build both revisions, strip, and collect report files per matrix entry.
     - name: Build and collect sizes
       env:
+        ENGINES: ${{ matrix.engines }}
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
         C_ARGS: ${{ matrix.c_args }}
@@ -130,7 +142,7 @@ jobs:
           local src_dir="$1" build_dir="$2"
           local meson_args=(
             -Dloaders="all"
-            -Dengines="cpu, gl"
+            -Dengines="$ENGINES"
             -Dsavers="all"
             -Dbindings="capi"
             -Dstatic=true


### PR DESCRIPTION
The workflow built with -Dengines="cpu, gl", so wg engine changes were never compiled into the measured library and the report always showed a zero delta for them.

- add a per-config engines field to the build matrix
- install wgpu_native for the configs that request wg
- keep "cpu, gl" for x86 32-bit, as wgpu-native does not ship a 32-bit Linux build

Verified locally with [act](https://github.com/nektos/act) by adding a 4 KB probe symbol to
`src/renderer/gpu_engine/wg/tvgWgRenderer.cpp`:

| Config | base text | base data | probe text | probe data | Delta |
|--------|----------:|----------:|-----------:|-----------:|------:|
| arm64-clang | 960,799 | 25,216 | 964,895 | 25,216 | +4096 (+0.42%) |
| x86-gcc | 899,065 | 11,620 | 899,065 | 11,620 | 0 (0.00%) |
| x86_64-clang | 975,686 | 23,568 | 979,798 | 23,568 | +4112 (+0.41%) |
| x86_64-gcc | 982,463 | 23,432 | 986,591 | 23,432 | +4128 (+0.41%) |

(arm64 measure under QEMU emulation)

issue: #4547