### PR TITLE
cpu_engine: fix a crash in stroke bounds of an unprepared shape

### DIFF
--- a/src/renderer/cpu_engine/tvgSwShape.cpp
+++ b/src/renderer/cpu_engine/tvgSwShape.cpp
@@ -539,11 +539,12 @@ void shapeDelFill(SwShape& shape)
 
 bool shapeStrokeBBox(SwShape& shape, const RenderShape* rshape, Point* pt4, const Matrix& m, SwMpool* mpool)
 {
+    // TODO: We can skip generation here if the stroke hasn't been updated.
     if (rshape->strokeWidth() > 0.0f) {
         auto outline = _genOutline(rshape, mpool, 0, rshape->trimpath());
         if (!outline) return false;
 
-        strokeReset(shape.stroke, rshape, m, mpool, 0);
+        shapeResetStroke(shape, rshape, m, mpool, 0);
         strokeParseOutline(shape.stroke, *outline, mpool, 0);
 
         auto func = [](SwStrokeBorder* border, const Matrix& m, Point& min, Point& max) {


### PR DESCRIPTION
shapeStrokeBBox() enters the stroking path on the authored stroke width alone and dereferences shape.stroke, but the raster pass may have left it null: a zero-opacity paint's task is marked ready without running (prepareCommon), and a zero-alpha solid stroke is discarded by shapeDelStroke (validStrokeWidth). Querying such a shape's bounds (e.g. Paint::bounds / tvg_paint_get_aabb) then crashed on the null stroke.

Allocate the stroke lazily before resetting it, matching shapeResetStroke().