### PR TITLE
lottie/slot: correctly resolve image on overriding

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -834,7 +834,7 @@ struct LottieImage : LottieObject
     LottieProperty* override(LottieProperty* prop, bool release) override
     {
         LottieProperty* backup = nullptr;
-        OVERRIDE(bitmap);
+        if (OVERRIDE(bitmap)) resolved = bitmap.picture && bitmap.picture->size(nullptr, nullptr) == Result::Success;
         return backup;
     }
 

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -959,6 +959,8 @@ struct LottieBitmap : LottieProperty, AssetSrc
             picture->unref();
             picture = nullptr;
         }
+
+        size = 0;
     }
 
     uint32_t frameCnt() override { return 0; }
@@ -979,6 +981,14 @@ struct LottieBitmap : LottieProperty, AssetSrc
 
         width = rhs.width;
         height = rhs.height;
+
+        if (shallow) {
+            data = rhs.data;
+            mimeType = rhs.mimeType;
+            size = rhs.size;
+            rhs.data = nullptr;
+            rhs.mimeType = nullptr;
+        } else if (rhs.size == 0 && rhs.path) path = tvg::duplicate(rhs.path);
     }
 };
 


### PR DESCRIPTION
LottieImage::override() never refreshed the resolved flag, so after a slot swap the asset resolver was skipped and a path-based bitmap with nothing loaded rendered blank.

Moreover LottieBitmap::copy() also carried only picture/width/height, so even with the flag refreshed the resolver would be handed a null source. Move the source on a shallow copy and duplicate the path on a deep one.

issue: https://github.com/thorvg/thorvg/issues/4606

> Originally commited by @theashraf in https://github.com/thorvg/thorvg/pull/4565/changes/23f65ab9daeb81c0179457e4a8448e778148c2ee


### Reproduction

- full source : [LottieSlotResolverSource.cpp](https://github.com/user-attachments/files/30422659/LottieSlotResolverSource.cpp)
- anim file : [anim.json](https://github.com/user-attachments/files/30424900/slotresolver.json)



```cpp
auto animation = tvg::LottieAnimation::gen();
auto picture = animation->picture();

picture->resolver([](tvg::Paint* p, const char* src, void*) {
    auto assetPath = string(src).replace(0, sizeof(EXAMPLE_DIR"/lottie/extensions/") - 1, EXAMPLE_DIR"/");
    return tvgexam::verify(static_cast<tvg::Picture*>(p)->load(assetPath.c_str()));
}, nullptr);

//assets: {"sid":"path_img","u":"image/","p":"logo.png","e":0,"w":300,"h":300}
picture->load("anim.json");

/* animation plays frame by frame */

auto id = animation->gen(R"({"path_img":{"p":{"id":"image_0","w":300,"h":300,"u":"image/","p":"clouds.png","e":0}}})");
animation->apply(id);

//before: the resolver is never called, the layer goes blank
//after: resolve `clouds.png`
```

| Before | After |
|---------|---------|
| <img height="500" alt="CleanShot 2026-07-28 at 00 00 57@2x" src="https://github.com/user-attachments/assets/c7083040-d6fc-45dd-9acc-f4593555df72" /> | <img height="500" alt="CleanShot 2026-07-28 at 00 01 14@2x" src="https://github.com/user-attachments/assets/655a5678-0f83-4154-b791-76f502a44d9e" /> |
