### PR TITLE
svg/parser: Prevent a crash in font-face declarations

### DIFF
--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -438,7 +438,7 @@ bool xmlParseW3CAttribute(const char* buf, unsigned bufLength, xmlAttributeCb fu
         auto next = (char*)strchr(buf, ';');
 
         if (auto src = strstr(buf, "src")) {//src tag from css font-face contains extra semicolon
-            if (src < sep) {
+            if (next && src < sep) {
                 if (next + 1 < end) next = (char*)strchr(next + 1, ';');
                 else break;
             }


### PR DESCRIPTION
## Problem

Loading an SVG containing an `font-face` `src` descriptor without a trailing semicolon caused an access violation.

When no semicolon followed the declaration, `strchr()` returned `nullptr`. The font-face-specific path incremented that pointer before searching for another semicolon.

Fixes #4605

## Solution

Check that the initial semicolon exists before searching for the next one.

## Test Resource

The manual verification uses the minimal SVG reported in #4605.

For visual before-and-after verification, a white background, text alignment, and text color were added for visibility. The `font-face` declaration that triggers the issue was unchanged.

```xml
<svg xmlns="http://www.w3.org/2000/svg" width="160" height="90">
  <style>
    @font-face {
      font-family: Ext;
      src: url('missing.svg#Font')
    }
  </style>
  <rect width="160" height="90" fill="white"/>
  <text x="80" y="45"
        text-anchor="middle"
        font-family="Ext"
        font-size="20"
        fill="black">Hello</text>
</svg>
```

The missing external font is intentional. The SVG should load without crashing and may use the fallback font.

## Verification

### Manual Reproduction

- Before the fix: access violation (`0xC0000005`)
- After the fix: loaded without crashing

### Picture Tests

- 8 test cases passed
- 57 assertions passed

### Full Unit Tests

Tested on Windows with MSVC.

- Ok: 1
- Fail: 0

### GitHub CI

- 23 checks passed

### thorvg.example

Manually verified the same SVG using the `PictureSvg` example.

- Before the fix: access violation (`0xC0000005`)
- After the fix: loaded and rendered using the fallback font

## Screenshots

### Before Fix

The `PictureSvg` example terminates with an access violation.

<img width="923" height="152" alt="image" src="https://github.com/user-attachments/assets/ff1136d8-95bc-432f-81d4-d704171050f9" />

### After Fix

The same SVG is loaded and rendered without crashing.

<img width="987" height="1011" alt="image" src="https://github.com/user-attachments/assets/9a85af00-a251-4403-8743-6a49ce273da8" />

### Unit Tests

The full Windows unit test suite passes without failures.

<img width="957" height="275" alt="image" src="https://github.com/user-attachments/assets/917c5c61-b306-4483-ae26-077b53399a71" />