### PR TITLE
engines: draw a cap dot for degenerate closed subpaths (M x y Z)

### DIFF
--- a/src/renderer/cpu_engine/tvgSwStroke.cpp
+++ b/src/renderer/cpu_engine/tvgSwStroke.cpp
@@ -666,7 +666,12 @@ static void _beginSubPath(SwStroke& stroke, const Point& to, bool closed)
 
 static void _endSubPath(SwStroke& stroke)
 {
-    if (stroke.closedSubPath) {
+    //a degenerate (zero-length) subpath has no real direction to close a loop with.
+    //treat it the same as an open path so round/square caps still render as a dot,
+    //even though it was technically closed (e.g. moveTo(x,y); close();).
+    auto degenerate = tvg::zero(stroke.subPathLength) && stroke.center == stroke.subPathStart;
+
+    if (stroke.closedSubPath && !degenerate) {
         //close the path if needed
         if (stroke.center != stroke.subPathStart) _lineTo(stroke, stroke.subPathStart);
 

--- a/src/renderer/gpu_engine/gl/tvgGlTessellator.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlTessellator.cpp
@@ -180,10 +180,15 @@ void Stroker::close()
 {
     if (length(mState.prevPt - mState.firstPt) > 0.015625f) {
         lineTo(mState.firstPt);
+        join(mState.firstPtDir);
+    } else if (mState.firstPtDir.x == 0.f && mState.firstPtDir.y == 0.f) {
+        // moveTo + close with nothing actually drawn in between (degenerate subpath):
+        // draw a cap dot instead of joining, matching the sw_engine's zero-length behavior.
+        cap();
+    } else {
+        // join firstPt with prevPt
+        join(mState.firstPtDir);
     }
-
-    // join firstPt with prevPt
-    join(mState.firstPtDir);
 }
 
 

--- a/src/renderer/gpu_engine/wg/tvgWgTessellator.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgTessellator.cpp
@@ -178,10 +178,15 @@ void WgStroker::close()
 {
     if (length(mState.prevPt - mState.firstPt) > 0.015625f) {
         lineTo(mState.firstPt);
+        join(mState.firstPtDir);
+    } else if (mState.firstPtDir.x == 0.f && mState.firstPtDir.y == 0.f) {
+        // moveTo + close with nothing actually drawn in between (degenerate subpath):
+        // draw a cap dot instead of joining, matching the sw_engine's zero-length behavior.
+        cap();
+    } else {
+        // join firstPt with prevPt
+        join(mState.firstPtDir);
     }
-
-    // join firstPt with prevPt
-    join(mState.firstPtDir);
 }
 
 


### PR DESCRIPTION
### Summary

A subpath that consists only of moveTo() followed by close() (e.g. M 100 100 Z) has zero length, but was not rendering a round/square stroke cap as a dot on any engine — unlike an explicit zero-length lineTo (e.g. M 100 100 L 100 100), which cpu_engine already handles correctly (#3066).

This PR makes all three engines (cpu / gl / wg) consistently draw a cap dot for this degenerate case, matching the reference behavior seen in Adobe After Effects and lottie-web.

Fixes #3251

### Root cause

**cpu_engine** (tvgSwStroke.cpp)
_endSubPath() only draws a cap dot (_addCap()) in its "open subpath" branch. A moveTo + close() subpath is technically closed (closedSubPath == true), so it always took the "closed subpath" branch instead, which only handles corner joins — and a degenerate zero-length subpath has no real corner to join, so nothing was drawn.

**gl_engine / wg_engine** (tvgGlTessellator.cpp / tvgWgTessellator.cpp)
Stroker::close() / WgStroker::close() only ever called join(), never cap(). A degenerate subpath (nothing drawn between moveTo and close) needs a cap dot instead of a join, but the code path to draw one (cap()) was never reached from close().

### Changes
cpu_engine: _endSubPath() now treats a subpath as "open" (taking the cap-drawing branch) whenever it's degenerate (subPathLength == 0 and center == subPathStart), regardless of whether close() was actually called — since a zero-length path has no meaningful direction to join.
gl_engine / wg_engine: close() now calls cap() instead of join() when nothing was actually drawn in the subpath (firstPtDir is still (0,0)).
**Verification**
cpu: confirmed locally — the repro from #3251 now renders the dot with the default (software) backend.
gl: confirmed locally — the repro now renders the dot with the gl backend.
wg: WgStroker is structurally identical to gl_engine's Stroker (same fix applied 1:1), but I wasn't able to verify this locally due to the WebGPU (wgpu-native) setup on Windows/MSYS2. Would appreciate a check from someone who can run the wg backend, or I'm happy to investigate further if needed.


Repro used
`cpp
auto shape = tvg::Shape::gen();
shape->moveTo(200, 200);
shape->close();
shape->strokeFill(255, 0, 0);
shape->strokeCap(tvg::StrokeCap::Round);
shape->strokeWidth(10);
canvas->add(shape);`