### PR TITLE
renderer: detect non-support formats accurately

### DIFF
--- a/src/common/tvgCommon.h
+++ b/src/common/tvgCommon.h
@@ -70,12 +70,12 @@ namespace tvg
 {
     enum class FileType
     {
-        Png = 0,
-        Jpg,
-        Webp,
-        Svg,
+        Svg = 0,
         Lot,
         Sfnt,
+        Png,
+        Jpg,
+        Webp,
         Raw,
         Gif,
         Unknown

--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -69,104 +69,60 @@ static Inlist<tvg::Loader> _activeLoaders;
 static tvg::Loader* _find(FileType type)
 {
     switch (type) {
-        case FileType::Png: {
-#ifdef THORVG_PNG_LOADER_SUPPORT
-            return new PngLoader;
-#endif
-            break;
-        }
-        case FileType::Jpg: {
-#ifdef THORVG_JPG_LOADER_SUPPORT
-            return new JpgLoader;
-#endif
-            break;
-        }
-        case FileType::Webp: {
-#ifdef THORVG_WEBP_LOADER_SUPPORT
-            return new WebpLoader;
-#endif
-            break;
-        }
-        case FileType::Svg: {
 #ifdef THORVG_SVG_LOADER_SUPPORT
-            return new SvgLoader;
+        case FileType::Svg: return new SvgLoader;
 #endif
-            break;
-        }
-        case FileType::Sfnt: {
-#ifdef THORVG_SFNT_LOADER_SUPPORT
-            return new SfntLoader;
-#endif
-            break;
-        }
-        case FileType::Lot: {
 #ifdef THORVG_LOTTIE_LOADER_SUPPORT
-            return new LottieLoader;
+        case FileType::Lot: return new LottieLoader;
 #endif
-            break;
-        }
-        case FileType::Raw: {
-            return new RawLoader;
-            break;
-        }
-        default: {
-            break;
-        }
+#ifdef THORVG_SFNT_LOADER_SUPPORT
+        case FileType::Sfnt: return new SfntLoader;
+#endif
+#ifdef THORVG_PNG_LOADER_SUPPORT
+        case FileType::Png: return new PngLoader;
+#endif
+#ifdef THORVG_JPG_LOADER_SUPPORT
+        case FileType::Jpg: return new JpgLoader;
+#endif
+#ifdef THORVG_WEBP_LOADER_SUPPORT
+        case FileType::Webp: return new WebpLoader;
+#endif
+        case FileType::Raw: return new RawLoader;
+        default: break;
     }
 
 #ifdef THORVG_LOG_ENABLED
-    const char* format;
-    switch (type) {
-        case FileType::Svg: {
-            format = "SVG";
-            break;
+    auto toString = [](FileType type) {
+        switch (type) {
+            case FileType::Svg:  return "SVG";
+            case FileType::Lot:  return "LOT";
+            case FileType::Sfnt: return "SFNT";
+            case FileType::Png:  return "PNG";
+            case FileType::Jpg:  return "JPG";
+            case FileType::Webp: return "WEBP";
+            case FileType::Raw:  return "RAW";
+            case FileType::Gif:  return "GIF";
+            default:             return "???";
         }
-        case FileType::Sfnt: {
-            format = "SFNT";
-            break;
-        }
-        case FileType::Lot: {
-            format = "LOT";
-            break;
-        }
-        case FileType::Raw: {
-            format = "RAW";
-            break;
-        }
-        case FileType::Png: {
-            format = "PNG";
-            break;
-        }
-        case FileType::Jpg: {
-            format = "JPG";
-            break;
-        }
-        case FileType::Webp: {
-            format = "WEBP";
-            break;
-        }
-        default: {
-            format = "???";
-            break;
-        }
-    }
-    TVGLOG("RENDERER", "%s format is not supported", format);
+    };
+    TVGLOG("RENDERER", "%s format is not supported", toString(type));
 #endif
     return nullptr;
 }
 
 #ifdef THORVG_FILE_IO_SUPPORT
-static tvg::Loader* _findByPath(const char* filename)
+static tvg::Loader* _findByPath(const char* filename, bool& invalid)
 {
     auto ext = fileext(filename);
-    if (!ext) return nullptr;
-
-    if (!strcmp(ext, "svg")) return _find(FileType::Svg);
-    if (!strcmp(ext, "lot") || !strcmp(ext, "json")) return _find(FileType::Lot);
-    if (!strcmp(ext, "png")) return _find(FileType::Png);
-    if (!strcmp(ext, "jpg")) return _find(FileType::Jpg);
-    if (!strcmp(ext, "webp")) return _find(FileType::Webp);
-    if (!strcmp(ext, "ttf") || !strcmp(ext, "ttc") || !strcmp(ext, "otf") || !strcmp(ext, "otc")) return _find(FileType::Sfnt);
+    if (ext) {
+        if (!strcmp(ext, "svg")) return _find(FileType::Svg);
+        if (!strcmp(ext, "lot") || !strcmp(ext, "json")) return _find(FileType::Lot);
+        if (!strcmp(ext, "png")) return _find(FileType::Png);
+        if (!strcmp(ext, "jpg")) return _find(FileType::Jpg);
+        if (!strcmp(ext, "webp")) return _find(FileType::Webp);
+        if (!strcmp(ext, "ttf") || !strcmp(ext, "ttc") || !strcmp(ext, "otf") || !strcmp(ext, "otc")) return _find(FileType::Sfnt);
+    }
+    invalid = true;  // invalid file path outside ThorVG's scope.
     return nullptr;
 }
 #endif
@@ -178,12 +134,12 @@ static FileType _convert(const char* mimeType)
     auto type = FileType::Unknown;
 
     if (!strcmp(mimeType, "svg") || !strcmp(mimeType, "svg+xml")) type = FileType::Svg;
-    else if (!strcmp(mimeType, "ttf") || !strcmp(mimeType, "otf")) type = FileType::Sfnt;
     else if (!strcmp(mimeType, "lot") || !strcmp(mimeType, "lottie+json")) type = FileType::Lot;
-    else if (!strcmp(mimeType, "raw")) type = FileType::Raw;
+    else if (!strcmp(mimeType, "ttf") || !strcmp(mimeType, "otf")) type = FileType::Sfnt;
     else if (!strcmp(mimeType, "png")) type = FileType::Png;
     else if (!strcmp(mimeType, "jpg") || !strcmp(mimeType, "jpeg")) type = FileType::Jpg;
     else if (!strcmp(mimeType, "webp")) type = FileType::Webp;
+    else if (!strcmp(mimeType, "raw")) type = FileType::Raw;
     else TVGLOG("RENDERER", "Given mimetype is unknown = \"%s\".", mimeType);
 
     return type;
@@ -255,14 +211,12 @@ bool LoaderMgr::retrieve(Loader* loader)
     return true;
 }
 
-tvg::Loader* LoaderMgr::loader(const char* filename, const LoaderOps* ops, bool* invalid)
+tvg::Loader* LoaderMgr::loader(const char* filename, const LoaderOps* ops, bool& invalid)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    *invalid = false;
-
     if (auto loader = _findFromCache(filename)) return loader;
 
-    if (auto loader = _findByPath(filename)) {
+    if (auto loader = _findByPath(filename, invalid)) {
         if (loader->open(filename, ops)) {
             if (loader->cache(filename)) {
                 ScopedLock lock(_key);
@@ -270,6 +224,7 @@ tvg::Loader* LoaderMgr::loader(const char* filename, const LoaderOps* ops, bool*
             }
             return loader;
         }
+        invalid = true;
         delete (loader);
     }
     // Unknown MimeType. Try with the candidates in the order
@@ -285,7 +240,6 @@ tvg::Loader* LoaderMgr::loader(const char* filename, const LoaderOps* ops, bool*
             delete (loader);
         }
     }
-    *invalid = true;
 #endif
     return nullptr;
 }

--- a/src/renderer/tvgLoaderMgr.h
+++ b/src/renderer/tvgLoaderMgr.h
@@ -32,7 +32,7 @@ struct LoaderMgr
 {
     static bool init();
     static bool term();
-    static Loader* loader(const char* filename, const LoaderOps* ops, bool* invalid);
+    static Loader* loader(const char* filename, const LoaderOps* ops, bool& invalid);
     static Loader* loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy);
     static Loader* loader(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy);
     static Loader* loader(const char* name, const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy);

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -136,11 +136,12 @@ struct PictureImpl : Picture
     {
         if (vector || bitmap) return Result::InsufficientCondition;
 
-        bool invalid;  //Invalid Path
         PictureOps ops = {resolver, nullptr, accessible};
-        auto loader = LoaderMgr::loader(filename, &ops, &invalid);
+        auto invalid = false;  // invalid path
+        auto loader = LoaderMgr::loader(filename, &ops, invalid);
+        if (loader) return load(loader);
         if (invalid) return Result::InvalidArguments;
-        return load(loader);
+        return Result::NonSupport;
     }
 
     Result load(const char* data, uint32_t size, const char* mimeType, const char* rpath, bool copy)

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -48,9 +48,9 @@ Result Text::size(float size) noexcept
 Result Text::load(const char* filename) noexcept
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    bool invalid; //invalid path
     LoaderOps ops = {Type::Text};
-    auto loader = LoaderMgr::loader(filename, &ops, &invalid);
+    auto invalid = false;   // invalid path
+    auto loader = LoaderMgr::loader(filename, &ops, invalid);
     if (loader) return Result::Success;
     if (invalid) return Result::InvalidArguments;
     else return Result::NonSupport;


### PR DESCRIPTION
- distinguish invalid paths from unsupported formats
- this includes filetype re-order and neat code plus