### PR TITLE
lottie/text: stop refiring the asset resolver for URL fonts

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -994,7 +994,7 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
     if (paint->font(doc.name) != Result::Success) {
         char* src;
         bool free = false;
-        if (text->font && text->font->path) src = text->font->path;
+        if (text->font && text->font->path && tvg::equal(doc.name, text->font->name)) src = text->font->path;
         else {
             auto len = (strlen(doc.name) + 6);
             src = tvg::malloc<char>(sizeof(char) * len);
@@ -1003,7 +1003,7 @@ void LottieBuilder::updateURLFont(LottieLayer* layer, float frameNo, LottieText*
         }
         if (!resolver || !resolver->func(paint, src, resolver->data)) {
             paint->font(nullptr);  //fallback to any available font
-        }
+        } else LoaderMgr::aliasing(to<TextImpl>(paint)->loader, doc.name);
         if (free) tvg::free(src);
     }
 

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -208,8 +208,11 @@ struct FontLoader : Loader
     static constexpr const float DPI = 96.0f / 72.0f;  // dpi base?
 
     char* name = nullptr;
+    char* alias = nullptr;
 
     FontLoader(FileType type) : Loader(type) {}
+
+    virtual ~FontLoader() { tvg::free(alias); }
 
     using Loader::read;
 

--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -337,13 +337,25 @@ tvg::Loader* LoaderMgr::font(const char* name)
 {
     ScopedLock lock(_key);
     INLIST_FOREACH(_activeLoaders, loader) {
-        if (loader->type != FileType::Sfnt) continue;
-        if (loader->cached && tvg::equal(name, static_cast<FontLoader*>(loader)->name)) {
+        if (loader->type != FileType::Sfnt || !loader->cached) continue;
+        auto font = static_cast<FontLoader*>(loader);
+        if (tvg::equal(name, font->name) || (font->alias && tvg::equal(name, font->alias))) {
             ++loader->sharing;
             return loader;
         }
     }
     return nullptr;
+}
+
+void LoaderMgr::aliasing(Loader* loader, const char* name)
+{
+    if (!loader || !name || loader->type != FileType::Sfnt) return;
+
+    ScopedLock lock(_key);
+    auto font = static_cast<FontLoader*>(loader);
+    if (tvg::equal(name, font->name)) return;
+    tvg::free(font->alias);
+    font->alias = tvg::duplicate(name);
 }
 
 tvg::Loader* LoaderMgr::anyfont()

--- a/src/renderer/tvgLoaderMgr.h
+++ b/src/renderer/tvgLoaderMgr.h
@@ -38,6 +38,7 @@ struct LoaderMgr
     static Loader* loader(const char* name, const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy);
     static Loader* font(const char* name);
     static Loader* anyfont();
+    static void aliasing(Loader* loader, const char* name);
     static bool retrieve(const char* filename);
     static bool retrieve(Loader* loader);
 };


### PR DESCRIPTION
The font asset resolver lets users resolve an arbitrary font under an arbitrary name based on src. However, when the resolved font is registered under a name that is not defined in the lottie asset (fName), updateURLFont() always treats it as a font load failure, so the already resolved and rendered font is re-resolved every frame, and the callback is invoked every frame as well.

Until now this forced the user side to parse the fName registered in the JSON separately and match it. With this patch, resolving with a new font name no longer causes that problem.

issue: https://github.com/thorvg/thorvg/issues/4604

# Note

Implements an alias on the font loader so a resolver can supply the new font it matches by src, correcting font stays loaded.

<img width="500" alt="CleanShot 2026-07-30 at 03 12 16@2x" src="https://github.com/user-attachments/assets/59170595-9d65-4dde-9936-b01a8338f9eb" />


When the asset resolver maps a font onto the text paint, the loader is aliased to the font name the lottie document currently sets. A font that has already been resolved is therefore found on the following frames, and the resolver is no longer fired every frame for it.

The lottie-declared name is not overwritten by the name the user registered, so when the font name changes dynamically(_such as keyframes, expressions or slots_), the lookup misses again and the callback is fired for the new request.

> FYI that the alias is currently used only for the resolver case.
Aliasing is common in font management, though it is usually designed as a 1:N relation. this could be revised if the extensibility is needed.