### PR TITLE
api: add origin reference point API for Paint

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -322,6 +322,18 @@ enum struct Type : uint8_t
     RadialGradient         ///< RadialGradient class
 };
 
+/**
+ * @brief Enumeration specifying the origin reference point of a paint's coordinate system.
+ * 
+ * @see Paint::origin()
+ * 
+ * @since 1.2
+ */
+enum struct Origin : uint8_t
+{
+    TopLeft = 0, ///< Default. Origin at the top-left corner, with the horizontal and vertical axes pointing right and down.
+    BottomLeft  ///< Origin at the bottom-left corner, with the vertical axis pointing up.
+};
 
 /**
  * @brief A data structure representing a point in two-dimensional space.
@@ -777,6 +789,21 @@ struct TVG_API Paint
      * @since 1.0
      */
     static void rel(Paint* paint) noexcept;
+
+    /**
+     * @brief Sets the origin reference point for the paint's coordinate system.
+     *
+     * By default, the origin is at the top-left corner of the paint,
+     * with the horizontal and vertical axes pointing right and down.
+     *
+     * @param[in] position The origin position to apply. The default is @c Origin::TopLeft.
+     *
+     * @retval Result::InsufficientCondition in case a custom transform is applied.
+     * @see Paint::transform()
+     *
+     * @since 1.2
+     */
+    Result origin(Origin position) noexcept;
 
 protected:
     virtual ~Paint();

--- a/src/renderer/tvgPaint.cpp
+++ b/src/renderer/tvgPaint.cpp
@@ -472,3 +472,18 @@ bool Paint::visible() const noexcept
 {
     return !pImpl->hidden;
 }
+
+Result Paint::origin(Origin position) noexcept
+{
+    auto offset = 0.0f;
+
+    if (position == Origin::BottomLeft) {
+        Point pt4[4];
+        auto pm = tvg::identity();
+        if (!pImpl->bounds(pt4, &pm, false)) return Result::InsufficientCondition;
+        offset = pt4[3].y - pt4[0].y;  //local height (top-left → bottom-left)
+    }
+
+    if (pImpl->origin(position, offset)) return Result::Success;
+    return Result::InsufficientCondition;
+}

--- a/src/renderer/tvgPaint.h
+++ b/src/renderer/tvgPaint.h
@@ -54,6 +54,9 @@ struct Paint::Impl
         Matrix m;                 //input matrix
         float degree;             //rotation degree
         float scale;              //scale factor
+        float tx = 0.0f, ty = 0.0f;      //user-requested translate (raw, independent of origin)
+        float originOffset = 0.0f;       //extra offset applied when origin != TopLeft (e.g. local height for BottomLeft)
+        Origin origin = Origin::TopLeft; //origin reference point
         bool overriding;          //user transform?
 
         void update()
@@ -68,6 +71,15 @@ struct Paint::Impl
             m.e33 = 1.0f;
             tvg::scale(&m, {scale, scale});
             tvg::rotate(&m, degree);
+
+            //flip the linear (rotate/scale) block for a bottom-left origin
+            if (origin == Origin::BottomLeft) {
+                m.e21 = -m.e21;
+                m.e22 = -m.e22;
+            }
+
+            m.e13 = tx;
+            m.e23 = ty + originOffset;
         }
     } tr;
     RenderUpdateFlag renderFlag = RenderUpdateFlag::None;
@@ -240,6 +252,10 @@ struct Paint::Impl
         tvg::identity(&tr.m);
         tr.degree = 0.0f;
         tr.scale = 1.0f;
+        tr.tx = 0.0f;
+        tr.ty = 0.0f;
+        tr.origin = Origin::TopLeft;
+        tr.originOffset = 0.0f;
         tr.overriding = false;
 
         parent = nullptr;
@@ -273,9 +289,20 @@ struct Paint::Impl
     bool translate(float x, float y)
     {
         if (tr.overriding) return false;
-        if (tvg::equal(x, tr.m.e13) && tvg::equal(y, tr.m.e23)) return true;
-        tr.m.e13 = x;
-        tr.m.e23 = y;
+        if (tvg::equal(x, tr.tx) && tvg::equal(y, tr.ty)) return true;
+        tr.tx = x;
+        tr.ty = y;
+        mark(RenderUpdateFlag::Transform);
+
+        return true;
+    }
+
+    bool origin(Origin position, float offset)
+    {
+        if (tr.overriding) return false;
+        if (tr.origin == position && tvg::equal(offset, tr.originOffset)) return true;
+        tr.origin = position;
+        tr.originOffset = offset;
         mark(RenderUpdateFlag::Transform);
 
         return true;


### PR DESCRIPTION
### Summary
Answers #4047 — is it possible to set the canvas/paint origin (e.g. bottom-left instead of top-left)?

There was no way to do this directly. Paint::translate()'s coordinate system is hardcoded to top-left with the vertical axis pointing down. This PR adds Paint::origin(Origin position), letting a paint's local coordinate system reference the bottom-left corner instead, with the vertical axis pointing up.

```
enum struct Origin : uint8_t
{
    TopLeft = 0,  //default
    BottomLeft
};

Result origin(Origin position) noexcept;
```

### Design notes
Scoped to TopLeft/BottomLeft only, matching what the issue actually asked for. Since enum values are purely additive, TopRight/BottomRight/Center can be added later without breaking compatibility.

Placed on Paint (not Scene/Canvas), since it's conceptually the same category of feature as translate()/rotate()/scale(), which already live there and apply uniformly to any paint type (Shape/Scene/Picture/Text).

Like other Paint transform setters, returns Result::InsufficientCondition if a custom transform() matrix has already been applied.

### Implementation

My first attempt implemented origin() on top of the existing transform(Matrix) override mechanism, but that turned out to conflict with translate(): setting a custom matrix flips on overriding, which silently blocks any translate() call made afterward, and rebuilding the matrix from scratch also discarded any translate() set beforehand.

Instead, origin() now stores its state (Origin, offset) independently from the existing translate()/rotate()/scale() values in Paint::Impl::tr, and both are only combined into the final matrix inside tr.update() (called lazily whenever the transform is queried). This mirrors how translate/rotate/scale already coexist via separate stored primitives (tx, ty, degree, scale) rather than each mutating a shared matrix directly. As a result, origin() and translate() can be called in either order.

The bottom-left offset is computed once (at origin() call time) from the paint's current local bounds (Paint::Impl::bounds() with an identity matrix), so it reflects the paint's own geometry rather than a hardcoded value.

### Testing
```
struct UserExample : tvgexam::Example
{
    bool content(tvg::Canvas* canvas, uint32_t w, uint32_t h) override
    {
        auto shape = tvg::Shape::gen();
        shape->moveTo(50, 0);
        shape->lineTo(0, 100);
        shape->lineTo(100, 100);
        shape->close();
        shape->fill(255, 0, 0);         //빨강: 원래(TopLeft)
        shape->translate(50, 50);
        canvas->add(shape);

        auto flipped = tvg::Shape::gen();
        flipped->moveTo(50, 0);
        flipped->lineTo(0, 100);
        flipped->lineTo(100, 100);
        flipped->close();
        flipped->fill(0, 0, 255);       //파랑: origin(BottomLeft)
        flipped->origin(tvg::Origin::BottomLeft);
        flipped->translate(200, 50);
        canvas->add(flipped);

        return true;
    }
};
```
<img width="297" height="172" alt="image" src="https://github.com/user-attachments/assets/751f2461-b9fb-410c-b489-d3db6ea568e3" />

