### PR TITLE
svg_loader: fix an out-of-bounds read on a malformed opening tag

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3280,22 +3280,13 @@ static void _svgLoaderParserXmlOpen(SvgParserContext* ctx, const char* content, 
     SvgNode *node = nullptr, *parent = nullptr;
     attrs = xmlFindAttributesTag(content, length);
 
-    if (!attrs) {
-        //Parse the empty tag
-        attrs = content;
-        while ((attrs != nullptr) && *attrs != '>') attrs++;
-        if (empty) attrs--;
-    }
-
-    if (attrs) {
-        //Find out the tag name starting from content till sz length
-        sz = attrs - content;
-        while ((sz > 0) && (isspace(content[sz - 1]))) sz--;
-        if ((unsigned)sz >= sizeof(tagName)) return;
-        strncpy(tagName, content, sz);
-        tagName[sz] = '\0';
-        attrsLength = length - sz;
-    }
+    //Find out the tag name starting from content till sz length
+    sz = attrs - content;
+    while ((sz > 0) && (isspace((unsigned char)content[sz - 1]))) sz--;
+    if ((unsigned)sz >= sizeof(tagName)) return;
+    strncpy(tagName, content, sz);
+    tagName[sz] = '\0';
+    attrsLength = length - sz;
 
     if (ctx->gradientStack.count > 0 && !ctx->gradientStack.last()) {
         if (!empty) ctx->gradientStack.push(nullptr);
@@ -3789,20 +3780,12 @@ static bool _svgLoaderParserForValidCheckXmlOpen(SvgParserContext* ctx, const ch
     int attrsLength = 0;
     attrs = xmlFindAttributesTag(content, length);
 
-    if (!attrs) {
-        //Parse the empty tag
-        attrs = content;
-        while ((attrs != nullptr) && *attrs != '>') attrs++;
-    }
-
-    if (attrs) {
-        sz = attrs - content;
-        while ((sz > 0) && (isspace((unsigned char)content[sz - 1]))) sz--;
-        if ((unsigned)sz >= sizeof(tagName)) return false;
-        strncpy(tagName, content, sz);
-        tagName[sz] = '\0';
-        attrsLength = length - sz;
-    }
+    sz = attrs - content;
+    while ((sz > 0) && (isspace((unsigned char)content[sz - 1]))) sz--;
+    if ((unsigned)sz >= sizeof(tagName)) return false;
+    strncpy(tagName, content, sz);
+    tagName[sz] = '\0';
+    attrsLength = length - sz;
 
     if ((method = _findGroupFactory(tagName))) {
         if (!ctx->doc) {

--- a/src/loaders/svg/tvgXmlParser.cpp
+++ b/src/loaders/svg/tvgXmlParser.cpp
@@ -543,5 +543,5 @@ const char* xmlFindAttributesTag(const char* buf, unsigned bufLength)
         }
     }
 
-    return nullptr;
+    return itrEnd;
 }


### PR DESCRIPTION
An opening tag with no whitespace and no '=' carries no attributes, and xmlFindAttributesTag() signalled that with nullptr. Both XML open handlers then scanned forward for '>', which lies outside the content they were given, so the scan could stop past its end. The tag name then came out longer than the content and 'attrsLength = length - sz' underflowed, letting xmlParseAttributes() read past the end of the buffer.

Report the end of the content instead of nullptr. The tag name then always stays inside the content, and the result can no longer be null - the function returns buf, a position inside buf, or its end - so the callers need no separate handling for it.

Cases fixed:
 - `<svg\0/>, <svg\0 />, <svg\0\0/>`
 the NUL keeps the tag name matching "svg" while the length goes negative, so xmlParseAttributes() reads past the end of the buffer
 - `<svg/>`
 rejected as an invalid document, because the tag name came out as "svg/"

issues
https://github.com/thorvg/thorvg/security/advisories/GHSA-c2qc-59qf-xpr9
https://github.com/thorvg/thorvg/security/advisories/GHSA-7c8w-36jw-m7hj