### PR TITLE
svg_loader: fix memory errors on malformed elements

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1061,6 +1061,7 @@ static void _handleFilterAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* node, c
 
 static void _handleMaskTypeAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* node, const char* value)
 {
+    if (node->type != SvgNodeType::Mask) return;
     node->node.mask.type = _toMaskType(value);
 }
 
@@ -3395,6 +3396,8 @@ static void _svgLoaderParserText(SvgParserContext* ctx, const char* content, uns
 {
     auto node = ctx->parser->node;
 
+    if (node->type != SvgNodeType::Text && node->type != SvgNodeType::Tspan) return;
+
     if (_hasTspanChild(node)) {
         auto run = _createNode(node, SvgNodeType::Tspan);
         run->node.text.x = FLT_MAX;
@@ -3576,8 +3579,8 @@ static bool _cssApplyClass(SvgNode* node, const char* classString, SvgNode* styl
 static void _cssApplyStyleToPostponeds(Array<SvgNodeIdPair>& postponeds, SvgNode* style)
 {
     ARRAY_FOREACH(p, postponeds) {
-        auto nodeIdPair = *p;
-        _cssApplyClass(nodeIdPair.node, nodeIdPair.id, style);
+        auto node = p->node;
+        _cssApplyClass(node, node->style->cssClass, style);
     }
 }
 


### PR DESCRIPTION
mask-type and character data are written into the node union without checking which element they land on, and a postponed CSS class keeps a pointer that a repeated class attribute frees. Check the node type before writing to the union, and read the class back from the node.

Cases fixed:
 - `<image href="data:image/svg+xml;base64,..." mask-type="Alpha"/>`
mask-type is handled through the generic style attribute table, so it wrote node->node.mask.type on any element - on an <image> or a <use> that corrupts a pointer the scene builder later dereferences
 - `<svg><text><rect x="1"/>A</text></svg>`
character data is appended to node->node.text of whatever element is open, and on a <rect> that pointer aliases the geometry floats
 - `<svg ""><g "=""class="l"e=""class="""><style>`
the second class attribute frees the class pointer that the postponed pass still holds