### PR TITLE
renderer/trimpath: normalize offsets beyond one period

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -1409,6 +1409,7 @@ struct TVG_API Shape : Paint
      * @brief Sets the trim of the shape along the defined path segment, allowing control over which part of the shape is visible.
      *
      * If the values of the arguments @p begin and @p end exceed the 0-1 range, they are wrapped around in a manner similar to angle wrapping, effectively treating the range as circular.
+     * If the span between @p begin and @p end is a full period or longer, the entire path is displayed.
      *
      * @param[in] begin Specifies the start of the segment to display along the path.
      * @param[in] end Specifies the end of the segment to display along the path.

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -639,6 +639,13 @@ static void _get(float& begin, float& end)
     begin -= shift;
     end -= shift;
 
+    //a span of a full period or longer covers the entire path
+    if (fabsf(end - begin) >= 1.0f) {
+        begin = 0.0f;
+        end = 1.0f;
+        return;
+    }
+
     auto loop = true;
 
     if (begin > 1.0f && end > 1.0f) loop = false;

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -634,6 +634,11 @@ static void _trim(const PathCommand* inCmds, uint32_t inCmdsCnt, const Point* in
 
 static void _get(float& begin, float& end)
 {
+    //fold both values by one common integer offset to keep the span's length and orientation
+    auto shift = floorf(begin);
+    begin -= shift;
+    end -= shift;
+
     auto loop = true;
 
     if (begin > 1.0f && end > 1.0f) loop = false;

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -407,4 +407,57 @@ TEST_CASE("Intersection", "[tvgSwEngine]")
     REQUIRE(Initializer::term() == Result::Success);
 }
 
+TEST_CASE("Trimpath Normalization", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        //binary-exact offsets so folded and reference pairs rasterize identically
+        auto render = [](float begin, float end) {
+            vector<uint32_t> buffer(100 * 100, 0);
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas);
+            REQUIRE(canvas->target(buffer.data(), 100, 100, 100, ColorSpace::ARGB8888) == Result::Success);
+
+            auto shape = Shape::gen();
+            REQUIRE(shape);
+            REQUIRE(shape->appendCircle(50, 50, 40, 40) == Result::Success);
+            REQUIRE(shape->strokeFill(255, 255, 255, 255) == Result::Success);
+            REQUIRE(shape->strokeWidth(4) == Result::Success);
+            REQUIRE(shape->trimpath(begin, end) == Result::Success);
+            REQUIRE(canvas->add(shape) == Result::Success);
+            REQUIRE(canvas->draw(true) == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+            return buffer;
+        };
+
+        auto pixels = [](const vector<uint32_t>& buffer) {
+            auto cnt = 0u;
+            for (auto px : buffer) {
+                if (px > 0) ++cnt;
+            }
+            return cnt;
+        };
+
+        //regression: inputs within [-1, 2] behave as before
+        REQUIRE(render(1.25f, 1.5f) == render(0.25f, 0.5f));
+        REQUIRE(render(-0.75f, -0.5f) == render(0.25f, 0.5f));
+
+        //offsets beyond one period wrap instead of rendering nothing
+        auto wrapped = render(4.25f, 4.5f);
+        REQUIRE(pixels(wrapped) > 0);
+        REQUIRE(wrapped == render(0.25f, 0.5f));
+        REQUIRE(render(-5.75f, -5.5f) == render(0.25f, 0.5f));
+        //crossing the seam
+        REQUIRE(render(10.875f, 11.125f) == render(0.875f, 1.125f));
+
+        //a span of a full period or longer covers the entire path
+        //(compared against (1, 2) rather than (0, 1), since the latter disables
+        //trimming and draws a closed shape whose seam rasterizes differently)
+        auto full = render(16.0f, 18.5f);
+        REQUIRE(pixels(full) > pixels(wrapped));
+        REQUIRE(full == render(1.0f, 2.0f));
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
 #endif


### PR DESCRIPTION
`trimpath()` documents that `begin`/`end` outside the 0-1 range "are wrapped around in a manner similar to angle wrapping, effectively treating the range as circular", but `_get()` in `tvgRender.cpp` applied a `±1.0f` correction at most once. Only inputs within `[-1, 2]` were normalized; anything beyond rendered nothing at all.

This breaks the most natural way to drive a rotating trim animation, since the offset grows without bound:

```cpp
// once elapsed exceeds ~5.9s, begin > 2.0 and the shape silently disappears
shape->trimpath(0.34f * elapsed, 0.34f * elapsed + 0.2f);
```

The failure is silent. `_trim()` converts the pair into absolute arc lengths, so `begin = 2.06` on a path of length 1382 puts `trimStart` at ~2847, past the end of the path. The walk in `_trimPath()` then satisfies no branch and emits nothing, while `RenderTrimPath::trim()` still returns `true` (it only fails on `pts.count < 2` or `begin == end`). Callers proceed with an empty path, and there is no exception, log, or `Result` error.

The first commit folds both values by one common integer offset before the existing seam logic. Subtracting the same offset from both preserves the span's length and orientation, so every input in the previously working `[-1, 2]` domain reduces to exactly the same pair as before:

| input | before | after |
|---|---|---|
| `(0.3, 0.7)` | `(0.3, 0.7)` | same |
| `(1.3, 1.7)` | `(0.3, 0.7)` | same |
| `(-0.7, -0.3)` | `(0.3, 0.7)` | same |
| `(0.9, 1.1)` | `(0.9, 0.1)` wrapped | same |
| `(3.06, 3.26)` | nothing rendered | `(0.06, 0.26)` |
| `(-5.3, -5.1)` | nothing rendered | `(0.7, 0.9)` |

The second commit is separated for review because it defines behavior rather than preserving it. A span of a full period or longer (e.g. `(0.0, 2.0)`) previously reduced to an arbitrary sub-segment or an empty result depending on the values. Such a span geometrically covers the entire path, so it is now clamped to `(0, 1)`, and the header documents this.

The third commit adds coverage in `test/testSwEngine.cpp`, rendering trimmed strokes into offscreen buffers and requiring that out-of-range offsets produce pixel-identical output to their in-range counterparts. All offsets are binary-exact fractions so the folded and reference values rasterize identically without a tolerance. The full-period case is compared against `(1, 2)` rather than `(0, 1)`, since `RenderTrimPath::valid()` treats `(0, 1)` as "no trim" and draws a closed shape whose seam rasterizes differently from an open trimmed one.

Verified with `ninja -C build test` (all unit tests pass). 

Issues: #4630
