### PR TITLE
lottie: fix use-after-free on image slot overrides

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -302,9 +302,12 @@ void LottieImage::prepare(bool external)
     //Prepare the Picture image
     auto result = Result::Unknown;
     auto picture = Picture::gen();
-    if (bitmap.size > 0) result = picture->load(bitmap.data, bitmap.size, bitmap.mimeType);
+    if (bitmap.size > 0) result = picture->load(bitmap.data, bitmap.size, bitmap.mimeType, nullptr, true);
     else if (external) result = picture->load(bitmap.path);
-    if (result == Result::Success) resolved = true;
+    if (result == Result::Success) {
+        resolved = true;
+        bitmap.AssetSrc::release();
+    }
     picture->size(bitmap.width, bitmap.height);
     bitmap.picture = picture;
     picture->ref();


### PR DESCRIPTION
## Problem

Applying image slot overrides (`LottieAnimation::override`) intermittently renders the wrong image in a slot, or nothing at all. With multiple image slots in one override batch, updating one slot can corrupt others. The corruption is nondeterministic and much easier to reproduce with `threads > 0`.

## Root cause

`LottieImage::prepare()` loads the encoded image with the default `copy = false`, so the picture loader borrows `bitmap.data` (e.g. `PngLoader::open` stores the pointer with `freeData = false`) and, with threading enabled, queues the actual decode on a worker via `TaskScheduler::request`.

Two callers free that buffer while the loader still holds it:

1. **Slot override parsing** (`tvgLottieParser.cpp`, `LottieProperty::Type::Image` case): after `parseAsset()` → `prepare()`, it copies the bitmap into a `LottieBitmap` prop - whose copy-ctor keeps only `picture`/`width`/`height` - and immediately `delete(obj)`s the parsed `LottieImage`. `~LottieBitmap` → `release()` → `tvg::free(data)`.
2. **`LottieImage::override()`**: releases the previously-owned buffer while the Picture (and its cached loader) live on.

Consequences:

- The queued decode reads freed memory → the slot renders garbage or fails to decode and draws nothing (permanently, since the dead Picture survives).
- The loader stays registered in `LoaderMgr`'s cache under `HASH_KEY(data)` - the raw freed address. When the allocator recycles that address for the next image's base64 buffer (common for consecutive slots in one batch), `_findFromCache` matches type + address and silently binds the new image to the previous image's decoded surface.

The cache code's own comment states the invariant being violated: *"caching is only valid for shareable."* A buffer that gets freed out from under the loader is not shareable.

## Fix

Pass `copy = true` in `LottieImage::prepare()`. The loader then owns its copy of the encoded data (freeing the caller's buffer is safe at any point), and `copy = true` also skips pointer-keyed cache registration, eliminating the aliasing path. Cost is one memcpy of the encoded data per image load.

An alternative would be transferring ownership of `data`/`size`/`mimeType` into `LottieBitmap`'s copy in the parser, which avoids the memcpy but does not address `override()` or the cache key. Happy to rework in that direction if preferred.

## Testing

- Full unit test suite passes (`-Dloaders="lottie, png, jpg, svg" -Dthreads=true`), including the `Lottie Slot` cases.
- Reproduced and verified the fix downstream in a production iOS app using thorvg through dotlottie-rs (software renderer, `threads = 2`, animations with 4 image slots re-overridden interactively): before the patch, slot updates intermittently blanked or cross-bound other slots; after it, behavior is correct across repeated override batches, pauses, and restarts.
