### PR TITLE
media/api: clarify video API behavior

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -529,7 +529,7 @@ TVG_API Tvg_Canvas tvg_swcanvas_create(Tvg_Engine_Option op);
  * @param[in] h The height of the raster image.
  * @param[in] cs The colorspace value defining the way the 32-bits colors should be read/written.
  *
- * @retval TVG_RESULT_INVALID_ARGUMENTS An invalid canvas or buffer pointer passed or one of the @p stride, @p w or @p h being zero.
+ * @retval TVG_RESULT_INVALID_ARGUMENT An invalid canvas or buffer pointer passed or one of the @p stride, @p w or @p h being zero.
  * @retval TVG_RESULT_INSUFFICIENT_CONDITION if the canvas is performing rendering. Please ensure the canvas is synced.
  * @retval TVG_RESULT_NOT_SUPPORTED The software engine is not supported.
  *
@@ -3378,6 +3378,8 @@ TVG_API Tvg_Paint tvg_video_get_picture(Tvg_Video video);
  *
  * @param[in] video The video object.
  *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the video is not loaded.
+ *
  * @note Experimental API
  */
 TVG_API Tvg_Result tvg_video_play(Tvg_Video video);
@@ -3387,6 +3389,8 @@ TVG_API Tvg_Result tvg_video_play(Tvg_Video video);
  *
  * @param[in] video The video object.
  *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the video is not started playing.
+ *
  * @note Experimental API
  */
 TVG_API Tvg_Result tvg_video_pause(Tvg_Video video);
@@ -3395,6 +3399,8 @@ TVG_API Tvg_Result tvg_video_pause(Tvg_Video video);
  * @brief Stops playback and rewinds to the start.
  *
  * @param[in] video The video object.
+ *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the video is not loaded.
  *
  * @note Experimental API
  */
@@ -3406,6 +3412,9 @@ TVG_API Tvg_Result tvg_video_stop(Tvg_Video video);
  * @param[in] video The video object.
  * @param[in] seconds The target playback position in seconds.
  *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the video is not loaded.
+ * @retval TVG_RESULT_INVALID_ARGUMENT If @p seconds is out of range.
+ *
  * @note Experimental API
  */
 TVG_API Tvg_Result tvg_video_seek(Tvg_Video video, float seconds);
@@ -3415,6 +3424,9 @@ TVG_API Tvg_Result tvg_video_seek(Tvg_Video video, float seconds);
  *
  * @param[in] video The video object.
  * @param[in] on @c true to repeat playback, @c false to play once.
+ *               The initial value is @c false.
+ *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the video is not loaded.
  *
  * @see tvg_video_get_loop()
  *
@@ -3438,6 +3450,10 @@ TVG_API bool tvg_video_get_loop(Tvg_Video video);
  *
  * @param[in] video The video object.
  * @param[in] volume The audio volume level in the range [0.0, 1.0].
+ *                   The initial value is @c 1.0.
+ *
+ * @retval TVG_RESULT_INVALID_ARGUMENT If @p volume is out of range.
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the video is not loaded.
  *
  * @see tvg_video_get_volume()
  *
@@ -3463,6 +3479,9 @@ TVG_API float tvg_video_get_volume(Tvg_Video video);
  *
  * @param[in] video The video object.
  * @param[in] on @c true to mute the audio, @c false to unmute.
+ *               The initial value is @c false.
+ *
+ * @retval TVG_RESULT_INSUFFICIENT_CONDITION If the video is not loaded.
  *
  * @see tvg_video_get_muted()
  *

--- a/src/loaders/media/thorvg_media.h
+++ b/src/loaders/media/thorvg_media.h
@@ -62,6 +62,7 @@ struct TVG_API Video final
      * @brief Enables or disables repeated playback.
      *
      * @param[in] on @c true to repeat playback, @c false otherwise.
+     *               The initial value is @c false.
      *
      * @retval Result::InsufficientCondition If the video is not loaded.
      *
@@ -112,6 +113,7 @@ struct TVG_API Video final
      *
      * @param[in] volume The volume level in the range [0.0, 1.0],
      *                   where 0.0 is silent and 1.0 is the original volume.
+     *                   The Initial value is @c 1.0.
      *
      * @retval Result::InsufficientCondition If the video is not loaded.
      * @retval Result::InvalidArguments If @p volume is out of range.
@@ -126,8 +128,6 @@ struct TVG_API Video final
      *
      * @return The current volume level in the range [0.0, 1.0].
      *
-     * @note It returns @c 0, if the video is not loaded.
-     *
      * @see Video::volume(float)
      */
     float volume() const noexcept;
@@ -139,7 +139,8 @@ struct TVG_API Video final
      * volume level. Unmuting restores audio playback using the previously
      * configured volume.
      *
-     * @param[in] on @c true to mute the audio, @c false to unmute it.
+     * @param[in] on @c true to mute the audio or @c false to unmute it.
+     *            The initial value is @c false.
      *
      * @retval Result::InsufficientCondition If the video is not loaded.
      *
@@ -152,8 +153,6 @@ struct TVG_API Video final
      * @brief Retrieves whether the video audio is currently muted.
      *
      * @return @c true if the audio is muted, @c false otherwise.
-     *
-     * @note It returns @c false, if the video is not loaded.
      *
      * @see Video::mute()
      */


### PR DESCRIPTION
- document C API error conditions and the initial loop, volume, and mute values.

- remove load-state restrictions from the C++ declarations for controls whose state can be accessed before the media resource is ready.