### PR TITLE
svg: optimize named color lookup with binary search

### DIFF
--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -461,6 +461,7 @@ static unsigned char _parseColor(const char* value, char** end)
 }
 
 
+// sorted by name
 static constexpr struct
 {
     const char* name;
@@ -694,7 +695,7 @@ static bool _toColor(const char* str, uint8_t& r, uint8_t&g, uint8_t& b, char** 
             }
         }
     } else {
-        //Handle named color (binary search)
+        // Handle named color (binary search) - colors[] must remain sorted
         int low = 0, high = static_cast<int>(sizeof(colors) / sizeof(colors[0])) - 1;
         while (low <= high) {
             auto mid = (low + high) / 2;

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -491,8 +491,8 @@ static constexpr struct
     { "darkcyan", 0xff008b8b },
     { "darkgoldenrod", 0xffb8860b },
     { "darkgray", 0xffa9a9a9 },
-    { "darkgrey", 0xffa9a9a9 },
     { "darkgreen", 0xff006400 },
+    { "darkgrey", 0xffa9a9a9 },
     { "darkkhaki", 0xffbdb76b },
     { "darkmagenta", 0xff8b008b },
     { "darkolivegreen", 0xff556b2f },
@@ -520,9 +520,9 @@ static constexpr struct
     { "gold", 0xffffd700 },
     { "goldenrod", 0xffdaa520 },
     { "gray", 0xff808080 },
-    { "grey", 0xff808080 },
     { "green", 0xff008000 },
     { "greenyellow", 0xffadff2f },
+    { "grey", 0xff808080 },
     { "honeydew", 0xfff0fff0 },
     { "hotpink", 0xffff69b4 },
     { "indianred", 0xffcd5c5c },
@@ -538,8 +538,8 @@ static constexpr struct
     { "lightcyan", 0xffe0ffff },
     { "lightgoldenrodyellow", 0xfffafad2 },
     { "lightgray", 0xffd3d3d3 },
-    { "lightgrey", 0xffd3d3d3 },
     { "lightgreen", 0xff90ee90 },
+    { "lightgrey", 0xffd3d3d3 },
     { "lightpink", 0xffffb6c1 },
     { "lightsalmon", 0xffffa07a },
     { "lightseagreen", 0xff20b2aa },
@@ -694,14 +694,19 @@ static bool _toColor(const char* str, uint8_t& r, uint8_t&g, uint8_t& b, char** 
             }
         }
     } else {
-        //Handle named color
-        for (unsigned int i = 0; i < (sizeof(colors) / sizeof(colors[0])); i++) {
-            if (!strcasecmp(colors[i].name, str)) {
-                r = ((uint8_t*)(&(colors[i].value)))[2];
-                g = ((uint8_t*)(&(colors[i].value)))[1];
-                b = ((uint8_t*)(&(colors[i].value)))[0];
+        //Handle named color (binary search)
+        int low = 0, high = static_cast<int>(sizeof(colors) / sizeof(colors[0])) - 1;
+        while (low <= high) {
+            auto mid = (low + high) / 2;
+            auto cmp = strcasecmp(str, colors[mid].name);
+            if (cmp == 0) {
+                r = ((uint8_t*)(&(colors[mid].value)))[2];
+                g = ((uint8_t*)(&(colors[mid].value)))[1];
+                b = ((uint8_t*)(&(colors[mid].value)))[0];
                 return true;
             }
+            if (cmp < 0) high = mid - 1;
+            else low = mid + 1;
         }
     }
     return false;


### PR DESCRIPTION
- Replace linear search O(N) with binary search O(log N) in _toColor()
- Update the sorting of the colors[] array to alphabetical order to support binary search

issue: #4621 

Benchmark results (1M iterations):
- Best case (first entries): linear ~17ms, binary ~45ms
- Average case (mid entries): linear ~310ms, binary ~45ms (~7x faster)
- Worst case (last entries): linear ~536ms, binary ~44ms (~12x faster)

---


| Scenario | Color Name (Index) | Linear Search Time | Binary Search Time | Performance Comparison |
|---|---|---:|---:|---|
| **Best Case** (Front of array) | `aliceblue` (1st) | 16.03 ms | 51.99 ms | Linear is ~**3.2x** faster |
| | `antiquewhite` (2nd) | 20.71 ms | 38.13 ms | Linear is ~**1.8x** faster |
| | `aqua` (3rd) | 17.92 ms | 38.48 ms | Linear is ~**2.1x** faster |
| **Average Case** (Middle of array) | `lightgray` (Around middle) | 297.83 ms | 55.01 ms | Binary is ~**5.4x** faster |
| | `lightgreen` (Around middle) | 310.45 ms | 68.69 ms | Binary is ~**4.5x** faster |
| | `lightgrey` (Middle) | 319.62 ms | 12.02 ms | Binary is ~**26.6x** faster |
| **Worst Case** (End of array) | `yellow` (Near end) | 529.80 ms | 41.43 ms | Binary is ~**12.8x** faster |
| | `yellowgreen` (Near end) | 547.99 ms | 54.50 ms | Binary is ~**10.0x** faster |
| | `whitesmoke` (Last) | 531.03 ms | 36.91 ms | Binary is ~**14.4x** faster |

