### PR TITLE
loaders: centralize render surface setup

### DIFF
--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -100,17 +100,17 @@ bool JpgLoader::read()
     if (w == 0 || h == 0) return false;
 
     //determine the image format
+    ColorSpace cs;
     TJPF format;
     if (ImageLoader::cs == ColorSpace::ARGB8888 || ImageLoader::cs == ColorSpace::ARGB8888S) {
         format = TJPF_BGRX;
-        surface.cs = ColorSpace::ARGB8888;
+        cs = ColorSpace::ARGB8888;
     } else {
         format = TJPF_RGBX;
-        surface.cs = ColorSpace::ABGR8888;
+        cs = ColorSpace::ABGR8888;
     }
 
     auto image = (unsigned char *)tjAlloc(static_cast<int>(w) * static_cast<int>(h) * tjPixelSize[format]);
-    if (!image) return false;
 
     //decompress jpg image
     if (tjDecompress2(jpegDecompressor, data, size, image, static_cast<int>(w), 0, static_cast<int>(h), format, 0) < 0) {
@@ -120,15 +120,7 @@ bool JpgLoader::read()
         return false;
     }
 
-    //setup the surface
-    surface.buf8 = image;
-    surface.stride = w;
-    surface.w = w;
-    surface.h = h;
-    surface.channelSize = sizeof(uint32_t);
-    surface.premultiplied = true;
-    surface.alphaIgnored = true;
-
+    surface.setup((pixel_t*)image, w, w, h, sizeof(uint32_t), cs, true);
     clear();
     return true;
 }

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -85,12 +85,15 @@ bool PngLoader::read()
 
     if (w == 0 || h == 0) return false;
 
+    ColorSpace cs;
+
+    // TODO: we can acquire a pre-multiplied image. See "png_structrp"
     if (ImageLoader::cs == ColorSpace::ARGB8888 || ImageLoader::cs == ColorSpace::ARGB8888S) {
         image->format = PNG_FORMAT_BGRA;
-        surface.cs = ColorSpace::ARGB8888S;
+        cs = ColorSpace::ARGB8888S;
     } else {
         image->format = PNG_FORMAT_RGBA;
-        surface.cs = ColorSpace::ABGR8888S;
+        cs = ColorSpace::ABGR8888S;
     }
 
     auto buffer = tvg::malloc<png_byte>(PNG_IMAGE_SIZE((*image)));
@@ -99,14 +102,7 @@ bool PngLoader::read()
         return false;
     }
 
-    //setup the surface
-    surface.buf32 = reinterpret_cast<uint32_t*>(buffer);
-    surface.stride = (uint32_t)w;
-    surface.w = (uint32_t)w;
-    surface.h = (uint32_t)h;
-    surface.channelSize = sizeof(uint32_t);
-    //TODO: we can acquire a pre-multiplied image. See "png_structrp"
-    surface.premultiplied = false;
+    surface.setup(reinterpret_cast<pixel_t*>(buffer), (uint32_t)w, (uint32_t)w, (uint32_t)h, sizeof(uint32_t), cs);
 
     clear();
 

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -35,24 +35,19 @@ void WebpLoader::run(unsigned tid)
     WebPDecoderConfig config;
     if (!WebPInitDecoderConfig(&config)) return;
 
+    ColorSpace cs;
+
     // request premultiplied image data
     if (ImageLoader::cs == ColorSpace::ARGB8888 || ImageLoader::cs == ColorSpace::ARGB8888S) {
         config.output.colorspace = MODE_bgrA;
         if (WebPDecode(data, size, &config) != VP8_STATUS_OK) return;
-        surface.buf8 = config.output.u.RGBA.rgba;
-        surface.cs = ColorSpace::ARGB8888;
+        cs = ColorSpace::ARGB8888;
     } else {
         config.output.colorspace = MODE_rgbA;
         if (WebPDecode(data, size, &config) != VP8_STATUS_OK) return;
-        surface.buf8 = config.output.u.RGBA.rgba;
-        surface.cs = ColorSpace::ABGR8888;
+        cs = ColorSpace::ABGR8888;
     }
-
-    surface.stride = (uint32_t)w;
-    surface.w = (uint32_t)w;
-    surface.h = (uint32_t)h;
-    surface.channelSize = sizeof(uint32_t);
-    surface.premultiplied = true;
+    surface.setup((pixel_t*)config.output.u.RGBA.rgba, (uint32_t)w, (uint32_t)w, (uint32_t)h, sizeof(uint32_t), cs);
 }
 
 

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -38,15 +38,7 @@ void JpgLoader::clear()
 
 void JpgLoader::run(unsigned tid)
 {
-    surface.cs = ColorSpace::ABGR8888;
-    surface.buf8 = jpgdDecompress(decoder);
-    surface.stride = static_cast<uint32_t>(w);
-    surface.w = static_cast<uint32_t>(w);
-    surface.h = static_cast<uint32_t>(h);
-    surface.channelSize = sizeof(uint32_t);
-    surface.premultiplied = true;
-    surface.alphaIgnored = true;
-
+    surface.setup((pixel_t*)jpgdDecompress(decoder), static_cast<uint32_t>(w), static_cast<uint32_t>(w), static_cast<uint32_t>(h), sizeof(uint32_t), ColorSpace::ABGR8888, true);
     clear();
 }
 

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -39,12 +39,7 @@ void PngLoader::run(unsigned tid)
     if (lodepng_decode(&surface.buf8, &width, &height, &state, data, size)) TVGERR("PNG", "Failed to decode image");
     else if (state.info_png.iccp_defined && lodepng_toSrgb(surface.buf8, surface.buf8, width, height, &state)) TVGERR("PNG", "Unsupported ICC color profile");
 
-    //setup the surface
-    surface.stride = width;
-    surface.w = width;
-    surface.h = height;
-    surface.cs = ColorSpace::ABGR8888S;
-    surface.channelSize = sizeof(uint32_t);
+    surface.setup(surface.buf32, width, width, height, sizeof(uint32_t), ColorSpace::ABGR8888S);
 }
 
 

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -46,19 +46,11 @@ bool RawLoader::open(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs
 
     if (copy) {
         surface.buf32 = tvg::malloc<uint32_t>(sizeof(uint32_t) * w * h);
-        if (!surface.buf32) return false;
         memcpy((void*)surface.buf32, data, sizeof(uint32_t) * w * h);
+    } else {
+        surface.buf32 = const_cast<uint32_t*>(data);
     }
-    else surface.buf32 = const_cast<uint32_t*>(data);
-
-    //setup the surface
-    surface.stride = w;
-    surface.w = w;
-    surface.h = h;
-    surface.cs = cs;
-    surface.channelSize = sizeof(uint32_t);
-    surface.premultiplied = (cs == ColorSpace::ABGR8888 || cs == ColorSpace::ARGB8888) ? true : false;
-
+    surface.setup(surface.buf32, w, w, h, sizeof(uint32_t), cs);
     return true;
 }
 

--- a/src/loaders/webp/tvgWebpLoader.cpp
+++ b/src/loaders/webp/tvgWebpLoader.cpp
@@ -35,21 +35,18 @@ void WebpLoader::clear()
 
 void WebpLoader::run(unsigned tid)
 {
+    ColorSpace cs;
+    uint8_t* buf8;
+
     // static loader WebPDecodeRGBA/WebPDecodeBGRA returns a premultiplied version.
     if (surface.cs == ColorSpace::ARGB8888 || surface.cs == ColorSpace::ARGB8888S) {
-        surface.buf8 = WebPDecodeBGRA(data, size, nullptr, nullptr);
-        surface.cs = ColorSpace::ARGB8888;
+        buf8 = WebPDecodeBGRA(data, size, nullptr, nullptr);
+        cs = ColorSpace::ARGB8888;
     } else  {
-        surface.buf8 = WebPDecodeRGBA(data, size, nullptr, nullptr);
-        surface.cs = ColorSpace::ABGR8888;
+        buf8 = WebPDecodeRGBA(data, size, nullptr, nullptr);
+        cs = ColorSpace::ABGR8888;
     }
-
-    surface.stride = static_cast<uint32_t>(w);
-    surface.w = static_cast<uint32_t>(w);
-    surface.h = static_cast<uint32_t>(h);
-    surface.channelSize = sizeof(uint32_t);
-    surface.premultiplied = true;
-
+    surface.setup((pixel_t*)buf8, static_cast<uint32_t>(w), static_cast<uint32_t>(w), static_cast<uint32_t>(h), sizeof(uint32_t), cs);
     clear();
 }
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -74,9 +74,7 @@ struct RenderSurface
     bool premultiplied = false;         //Alpha-premultiplied
     bool alphaIgnored = false;          // If true, the alpha channel can be ignored.
 
-    RenderSurface()
-    {
-    }
+    RenderSurface() = default;
 
     RenderSurface(const RenderSurface* rhs)
     {
@@ -88,6 +86,18 @@ struct RenderSurface
         channelSize = rhs->channelSize;
         premultiplied = rhs->premultiplied;
         alphaIgnored = rhs->alphaIgnored;
+    }
+
+    void setup(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, uint8_t channelSize, ColorSpace cs, bool alphaIgnored = false)
+    {
+        this->data = data;
+        this->stride = stride;
+        this->w = w;
+        this->h = h;
+        this->channelSize = channelSize;
+        this->cs = cs;
+        this->premultiplied = (cs == ColorSpace::ABGR8888 || cs == ColorSpace::ARGB8888);
+        this->alphaIgnored = alphaIgnored;
     }
 };
 


### PR DESCRIPTION
Add RenderSurface::setup() to initialize decoded data, dimensions, color space, and alpha flags consistently.

Use it in raster loaders to remove duplicate surface field assignments.