### PR TITLE
loader: refactoring for separating bitmap loader state

### DIFF
--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -39,11 +39,9 @@ void JpgLoader::clear()
 /* External Class Implementation                                        */
 /************************************************************************/
 
-JpgLoader::JpgLoader() : ImageLoader(FileType::Jpg)
+JpgLoader::JpgLoader() : BitmapLoader(FileType::Jpg), jpegDecompressor(tjInitDecompress())
 {
-    jpegDecompressor = tjInitDecompress();
 }
-
 
 JpgLoader::~JpgLoader()
 {
@@ -102,7 +100,7 @@ bool JpgLoader::read()
     //determine the image format
     ColorSpace cs;
     TJPF format;
-    if (ImageLoader::cs == ColorSpace::ARGB8888 || ImageLoader::cs == ColorSpace::ARGB8888S) {
+    if (BitmapLoader::cs == ColorSpace::ARGB8888 || BitmapLoader::cs == ColorSpace::ARGB8888S) {
         format = TJPF_BGRX;
         cs = ColorSpace::ARGB8888;
     } else {

--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -28,7 +28,7 @@
 using tjhandle = void*;
 
 //TODO: Use Task?
-struct JpgLoader : ImageLoader
+struct JpgLoader : BitmapLoader
 {
     JpgLoader();
     ~JpgLoader();

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -37,7 +37,7 @@ void PngLoader::clear()
 /* External Class Implementation                                        */
 /************************************************************************/
 
-PngLoader::PngLoader() : ImageLoader(FileType::Png)
+PngLoader::PngLoader() : BitmapLoader(FileType::Png)
 {
     image = tvg::calloc<png_image>(1, sizeof(png_image));
     image->version = PNG_IMAGE_VERSION;
@@ -88,7 +88,7 @@ bool PngLoader::read()
     ColorSpace cs;
 
     // TODO: we can acquire a pre-multiplied image. See "png_structrp"
-    if (ImageLoader::cs == ColorSpace::ARGB8888 || ImageLoader::cs == ColorSpace::ARGB8888S) {
+    if (BitmapLoader::cs == ColorSpace::ARGB8888 || BitmapLoader::cs == ColorSpace::ARGB8888S) {
         image->format = PNG_FORMAT_BGRA;
         cs = ColorSpace::ARGB8888S;
     } else {

--- a/src/loaders/external_png/tvgPngLoader.h
+++ b/src/loaders/external_png/tvgPngLoader.h
@@ -26,7 +26,7 @@
 #include <png.h>
 #include "tvgLoader.h"
 
-struct PngLoader : ImageLoader
+struct PngLoader : BitmapLoader
 {
     PngLoader();
     ~PngLoader();

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -38,7 +38,7 @@ void WebpLoader::run(unsigned tid)
     ColorSpace cs;
 
     // request premultiplied image data
-    if (ImageLoader::cs == ColorSpace::ARGB8888 || ImageLoader::cs == ColorSpace::ARGB8888S) {
+    if (BitmapLoader::cs == ColorSpace::ARGB8888 || BitmapLoader::cs == ColorSpace::ARGB8888S) {
         config.output.colorspace = MODE_bgrA;
         if (WebPDecode(data, size, &config) != VP8_STATUS_OK) return;
         cs = ColorSpace::ARGB8888;
@@ -55,7 +55,7 @@ void WebpLoader::run(unsigned tid)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-WebpLoader::WebpLoader() : ImageLoader(FileType::Webp)
+WebpLoader::WebpLoader() : BitmapLoader(FileType::Webp)
 {
 }
 
@@ -126,5 +126,5 @@ RenderSurface* WebpLoader::bitmap()
 {
     this->done();
 
-    return ImageLoader::bitmap();
+    return BitmapLoader::bitmap();
 }

--- a/src/loaders/external_webp/tvgWebpLoader.h
+++ b/src/loaders/external_webp/tvgWebpLoader.h
@@ -26,7 +26,7 @@
 #include "tvgLoader.h"
 #include "tvgTaskScheduler.h"
 
-struct WebpLoader : ImageLoader, Task
+struct WebpLoader : BitmapLoader, Task
 {
     WebpLoader();
     ~WebpLoader();

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -47,7 +47,7 @@ void JpgLoader::run(unsigned tid)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-JpgLoader::JpgLoader() : ImageLoader(FileType::Jpg)
+JpgLoader::JpgLoader() : BitmapLoader(FileType::Jpg)
 {
 
 }
@@ -97,8 +97,6 @@ bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps
     return true;
 }
 
-
-
 bool JpgLoader::read()
 {
     if (!Loader::read()) return true;
@@ -122,5 +120,5 @@ bool JpgLoader::close()
 RenderSurface* JpgLoader::bitmap()
 {
     this->done();
-    return ImageLoader::bitmap();
+    return BitmapLoader::bitmap();
 }

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -27,7 +27,7 @@
 #include "tvgTaskScheduler.h"
 #include "tvgJpgd.h"
 
-struct JpgLoader : ImageLoader, Task
+struct JpgLoader : BitmapLoader, Task
 {
     JpgLoader();
     ~JpgLoader();

--- a/src/loaders/media/tvgMediaLoader.h
+++ b/src/loaders/media/tvgMediaLoader.h
@@ -25,7 +25,7 @@
 
 #include "tvgLoader.h"
 
-struct MediaLoader : ImageLoader
+struct MediaLoader : BitmapLoader
 {
     float curTime = 0.0f;      // current playback position in seconds
     float totalTime = 0.0f;    // media duration in seconds
@@ -34,7 +34,7 @@ struct MediaLoader : ImageLoader
     bool muted = false;
     bool looping = false;
 
-    MediaLoader() : ImageLoader(FileType::Media, true) {}
+    MediaLoader() : BitmapLoader(FileType::Media, true) {}
     virtual ~MediaLoader(){};
 
     virtual Result play() = 0;                // start or resume playback

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -47,7 +47,7 @@ void PngLoader::run(unsigned tid)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-PngLoader::PngLoader() : ImageLoader(FileType::Png)
+PngLoader::PngLoader() : BitmapLoader(FileType::Png)
 {
     lodepng_state_init(&state);
 }
@@ -117,5 +117,5 @@ bool PngLoader::read()
 RenderSurface* PngLoader::bitmap()
 {
     this->done();
-    return ImageLoader::bitmap();
+    return BitmapLoader::bitmap();
 }

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -26,7 +26,7 @@
 #include "tvgLodePng.h"
 #include "tvgTaskScheduler.h"
 
-struct PngLoader : ImageLoader, Task
+struct PngLoader : BitmapLoader, Task
 {
     PngLoader();
     ~PngLoader();

--- a/src/loaders/raw/tvgRawLoader.cpp
+++ b/src/loaders/raw/tvgRawLoader.cpp
@@ -23,11 +23,9 @@
 #include "tvgLoader.h"
 #include "tvgRawLoader.h"
 
-
-RawLoader::RawLoader() : ImageLoader(FileType::Raw)
+RawLoader::RawLoader() : BitmapLoader(FileType::Raw)
 {
 }
-
 
 RawLoader::~RawLoader()
 {

--- a/src/loaders/raw/tvgRawLoader.h
+++ b/src/loaders/raw/tvgRawLoader.h
@@ -23,7 +23,7 @@
 #ifndef _TVG_RAW_LOADER_H_
 #define _TVG_RAW_LOADER_H_
 
-struct RawLoader : ImageLoader
+struct RawLoader : BitmapLoader
 {
     bool copy = false;
 

--- a/src/loaders/webp/tvgWebpLoader.cpp
+++ b/src/loaders/webp/tvgWebpLoader.cpp
@@ -55,7 +55,7 @@ void WebpLoader::run(unsigned tid)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-WebpLoader::WebpLoader() : ImageLoader(FileType::Webp)
+WebpLoader::WebpLoader() : BitmapLoader(FileType::Webp)
 {
 }
 
@@ -113,7 +113,7 @@ bool WebpLoader::read()
 
     if (!data || w == 0 || h == 0) return false;
 
-    surface.cs = ImageLoader::cs;
+    surface.cs = BitmapLoader::cs;
 
     TaskScheduler::request(this);
 
@@ -132,6 +132,5 @@ bool WebpLoader::close()
 RenderSurface* WebpLoader::bitmap()
 {
     this->done();
-
-    return ImageLoader::bitmap();
+    return BitmapLoader::bitmap();
 }

--- a/src/loaders/webp/tvgWebpLoader.h
+++ b/src/loaders/webp/tvgWebpLoader.h
@@ -23,7 +23,7 @@
 #include "tvgLoader.h"
 #include "tvgTaskScheduler.h"
 
-struct WebpLoader : ImageLoader, Task
+struct WebpLoader : BitmapLoader, Task
 {
     WebpLoader();
     ~WebpLoader();

--- a/src/renderer/tvgCanvas.cpp
+++ b/src/renderer/tvgCanvas.cpp
@@ -130,7 +130,7 @@ Result SwCanvas::target(uint32_t* buffer, uint32_t stride, uint32_t w, uint32_t 
     pImpl->status = Status::Damaged;  // Paints must be updated again with this new target.
 
     //FIXME: The value must be associated with an individual canvas instance.
-    ImageLoader::cs = static_cast<ColorSpace>(cs);
+    BitmapLoader::cs = static_cast<ColorSpace>(cs);
 
     return Result::Success;
 #endif
@@ -181,7 +181,7 @@ Result GlCanvas::target(void* display, void* surface, void* context, int32_t id,
     pImpl->status = Status::Damaged;  // Paints must be updated again with this new target.
 
     //FIXME: The value must be associated with an individual canvas instance.
-    ImageLoader::cs = static_cast<ColorSpace>(cs);
+    BitmapLoader::cs = static_cast<ColorSpace>(cs);
 
     return Result::Success;
 #endif
@@ -241,7 +241,7 @@ Result WgCanvas::target(const Context& context, void* target, uint32_t w, uint32
     pImpl->status = Status::Damaged;  // Paints must be updated again with this new target.
 
     //FIXME: The value must be associated with an individual canvas instance.
-    ImageLoader::cs = static_cast<ColorSpace>(cs);
+    BitmapLoader::cs = static_cast<ColorSpace>(cs);
 
     return Result::Success;
 #endif

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -64,7 +64,7 @@ struct Loader
 
     FileType type;               // current loader file type
     atomic<uint16_t> sharing{};  // reference count
-    bool readied = false;        // read done already.
+    bool readied = false;        // read done already
     bool cached = false;         // cached for sharing
 
     Loader(FileType type) : type(type) {}
@@ -148,22 +148,28 @@ struct Loader
 
 struct ImageLoader : Loader
 {
-    static atomic<ColorSpace> cs;  // desired value
-
     float w = 0, h = 0;  // default image size
-    RenderSurface surface;
-    bool playable = false;  // true if this loader supports playback
+    bool playable;       // true if this loader supports playback
 
     ImageLoader(FileType type, bool playable = false) : Loader(type), playable(playable) {}
 
-    virtual Paint* paint() { return nullptr; }
     virtual const AccessorEntity* access(uint32_t id) { return nullptr; }
     virtual void access(AccessorCallback& cb) {}
+    virtual Paint* paint() { return nullptr; }
+    virtual RenderSurface* bitmap() { return nullptr; }
+};
 
-    virtual RenderSurface* bitmap()
+struct BitmapLoader : ImageLoader
+{
+    static atomic<ColorSpace> cs;  // desired value
+
+    RenderSurface surface;
+
+    BitmapLoader(FileType type, bool playable = false) : ImageLoader(type, playable) {}
+
+    RenderSurface* bitmap() override
     {
-        if (surface.data) return &surface;
-        return nullptr;
+        return surface.data ? &surface : nullptr;
     }
 };
 

--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -65,7 +65,7 @@ uintptr_t HASH_KEY(const char* data)
 /************************************************************************/
 
 // TODO: remove it.
-atomic<ColorSpace> ImageLoader::cs{ColorSpace::ARGB8888};
+atomic<ColorSpace> BitmapLoader::cs{ColorSpace::ARGB8888};
 
 static Key _key;
 static Inlist<tvg::Loader> _activeLoaders;


### PR DESCRIPTION
Move bitmap-specific surface and color-space state into a dedicated BitmapLoader subclass. Keep ImageLoader generic for vector loaders and store the playback capability in the common Loader base.