### PR TITLE
svg: support the dominant-baseline attribute

### DIFF
--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -1012,6 +1012,12 @@ static char* _processText(const char* text, SvgXmlSpace space)
     return processed;
 }
 
+static SvgBaseline _effectiveBaseline(const SvgStyleProperty* style)
+{
+    if (style->alignmentBaseline != SvgBaseline::Auto) return style->alignmentBaseline;
+    return style->dominantBaseline;
+}
+
 static void _applyTextBaseline(Text* text, SvgBaseline baseline, Matrix& transform)
 {
     if (baseline == SvgBaseline::Auto || baseline == SvgBaseline::Alphabetic) return;
@@ -1125,7 +1131,7 @@ static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* 
             if (textNode.x == FLT_MAX) textNode.x = textPos.x;
             if (textNode.y == FLT_MAX) textNode.y = textPos.y;
 
-            auto text = _buildText(&textNode, xmlSpace, nullptr, child->style->alignmentBaseline);
+            auto text = _buildText(&textNode, xmlSpace, nullptr, _effectiveBaseline(child->style));
             if (text) {
                 text->align(child->style->textAnchor, 0.0f);
                 _updatePos(text, textNode, child->style->textAnchor, textPos);
@@ -1151,7 +1157,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
     if (xmlSpace == SvgXmlSpace::None) xmlSpace = SvgXmlSpace::Default;
 
     if (!_hasPositionedTspan(node, 0)) {
-        auto text = _buildText(textNode, xmlSpace, node->transform, node->style->alignmentBaseline);
+        auto text = _buildText(textNode, xmlSpace, node->transform, _effectiveBaseline(node->style));
         if (!text) return nullptr;
         text->align(node->style->textAnchor, 0.0f);
         _applyTextFill(node->style, text, vBox, ctx.parser->global);
@@ -1165,7 +1171,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
 
     Point textPos = {textNode->x, textNode->y};
 
-    if (auto text = _buildText(textNode, xmlSpace, nullptr, node->style->alignmentBaseline)) {
+    if (auto text = _buildText(textNode, xmlSpace, nullptr, _effectiveBaseline(node->style))) {
         text->align(node->style->textAnchor, 0.0f);
         _updatePos(text, *textNode, node->style->textAnchor, textPos);
         _applyTextFill(node->style, text, vBox, ctx.parser->global);

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -173,7 +173,8 @@ enum struct SvgStyleFlags
     Filter = 0x80000,
     BlendMode = 0x100000,
     TextAnchor = 0x200000,
-    AlignmentBaseline = 0x400000
+    AlignmentBaseline = 0x400000,
+    DominantBaseline = 0x800000
 };
 
 constexpr bool operator&(SvgStyleFlags a, SvgStyleFlags b)
@@ -555,6 +556,7 @@ struct SvgStyleProperty
     char* cssClass;
     float textAnchor;  // 0=start, 0.5=middle, 1=end
     SvgBaseline alignmentBaseline;
+    SvgBaseline dominantBaseline;
     SvgStyleFlags flags;
     SvgStyleFlags flagsImportance; //indicates the importance of the flag - if set, higher priority is applied (https://drafts.csswg.org/css-cascade-4/#importance)
     bool curColorSet;

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -155,6 +155,11 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from, bool 
         to->flags |= SvgStyleFlags::AlignmentBaseline;
         if (from->flagsImportance & SvgStyleFlags::AlignmentBaseline) to->flagsImportance |= SvgStyleFlags::AlignmentBaseline;
     }
+    if (((from->flags & SvgStyleFlags::DominantBaseline) && (overwrite || !(to->flags & SvgStyleFlags::DominantBaseline))) || _isImportanceApplicable(to->flagsImportance, from->flagsImportance, SvgStyleFlags::DominantBaseline)) {
+        to->dominantBaseline = from->dominantBaseline;
+        to->flags |= SvgStyleFlags::DominantBaseline;
+        if (from->flagsImportance & SvgStyleFlags::DominantBaseline) to->flagsImportance |= SvgStyleFlags::DominantBaseline;
+    }
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1108,8 +1108,8 @@ static void _handleTextAnchorAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* nod
 static SvgBaseline _toBaseline(const char* str)
 {
     if (STR_AS(str, "alphabetic")) return SvgBaseline::Alphabetic;
-    if (STR_AS(str, "before-edge") || STR_AS(str, "text-before-edge")) return SvgBaseline::BeforeEdge;
-    if (STR_AS(str, "after-edge") || STR_AS(str, "text-after-edge") || STR_AS(str, "ideographic")) return SvgBaseline::AfterEdge;
+    if (STR_AS(str, "before-edge") || STR_AS(str, "text-before-edge") || STR_AS(str, "text-top")) return SvgBaseline::BeforeEdge;
+    if (STR_AS(str, "after-edge") || STR_AS(str, "text-after-edge") || STR_AS(str, "ideographic") || STR_AS(str, "text-bottom")) return SvgBaseline::AfterEdge;
     if (STR_AS(str, "central")) return SvgBaseline::Central;
     if (STR_AS(str, "middle")) return SvgBaseline::Middle;
     if (STR_AS(str, "hanging")) return SvgBaseline::Hanging;
@@ -1121,6 +1121,18 @@ static void _handleAlignmentBaselineAttr(TVG_UNUSED SvgParserContext* ctx, SvgNo
 {
     node->style->flags |= SvgStyleFlags::AlignmentBaseline;
     node->style->alignmentBaseline = _toBaseline(value);
+}
+
+static void _handleDominantBaselineAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* node, const char* value)
+{
+    auto baseline = _toBaseline(value);
+    // unrecognized keywords keep the inherited value, as in the css cascade
+    if (baseline == SvgBaseline::Auto && !STR_AS(value, "auto")) return;
+    // svg 1.1 keyword set only (https://www.w3.org/TR/SVG11/text.html#DominantBaselineProperty):
+    // browsers drop the css-level text-top/text-bottom (https://www.w3.org/TR/css-inline-3/#dominant-baseline-property), keeping the inherited value
+    if (STR_AS(value, "text-top") || STR_AS(value, "text-bottom")) return;
+    node->style->flags |= SvgStyleFlags::DominantBaseline;
+    node->style->dominantBaseline = baseline;
 }
 
 static void _handleCssClassAttr(SvgParserContext* ctx, SvgNode* node, const char* value)
@@ -1170,7 +1182,8 @@ static constexpr struct
     STYLE_DEF(filter, Filter, SvgStyleFlags::Filter),
     STYLE_DEF(mix-blend-mode, MixBlendMode, SvgStyleFlags::BlendMode),
     STYLE_DEF(text-anchor, TextAnchor, SvgStyleFlags::TextAnchor),
-    STYLE_DEF(alignment-baseline, AlignmentBaseline, SvgStyleFlags::AlignmentBaseline)};
+    STYLE_DEF(alignment-baseline, AlignmentBaseline, SvgStyleFlags::AlignmentBaseline),
+    STYLE_DEF(dominant-baseline, DominantBaseline, SvgStyleFlags::DominantBaseline)};
 // clang-format on
 
 static SvgXmlSpace _toXmlSpace(const char* str)
@@ -2995,6 +3008,7 @@ static void _styleInherit(SvgStyleProperty* child, const SvgStyleProperty* paren
     if (!(child->stroke.flags & SvgStrokeFlags::Join)) child->stroke.join = parent->stroke.join;
     if (!(child->stroke.flags & SvgStrokeFlags::Miterlimit)) child->stroke.miterlimit = parent->stroke.miterlimit;
     if (!(child->flags & SvgStyleFlags::TextAnchor)) child->textAnchor = parent->textAnchor;
+    if (!(child->flags & SvgStyleFlags::DominantBaseline)) child->dominantBaseline = parent->dominantBaseline;
 }
 
 
@@ -3013,6 +3027,7 @@ static void _styleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
     if (from->flags & SvgStyleFlags::BlendMode) to->blendMode = from->blendMode;
     if (from->flags & SvgStyleFlags::TextAnchor) to->textAnchor = from->textAnchor;
     if (from->flags & SvgStyleFlags::AlignmentBaseline) to->alignmentBaseline = from->alignmentBaseline;
+    if (from->flags & SvgStyleFlags::DominantBaseline) to->dominantBaseline = from->dominantBaseline;
 
     //Fill
     to->fill.flags = (to->fill.flags | from->fill.flags);


### PR DESCRIPTION
Support to `dominant-baseline` attribute.
Apply inherited dominant-baseline values to text runs, unless alignment-baseline is set.
Ignore SVG 1.1 use-script/no-change/reset-size and CSS text-top/text-bottom values.

issue: https://github.com/thorvg/thorvg/issues/4538