### PR TITLE
media: centralize video playback state management

### DIFF
--- a/src/loaders/media/apple/tvgAvfMediaLoader.h
+++ b/src/loaders/media/apple/tvgAvfMediaLoader.h
@@ -44,7 +44,6 @@ struct AvfMediaLoader : MediaLoader
     AVPlayerLooper* looper = nil;
     id endObserver = nil;
     dispatch_source_t timer = nullptr;
-    bool started = false;  // true after play(), including pause; false after stop() or EOS
 
     // Decoded frame ring buffer and synchronized publication state
     uint32_t* frames[BUFFER_COUNT] = {};

--- a/src/loaders/media/apple/tvgAvfMediaLoader.mm
+++ b/src/loaders/media/apple/tvgAvfMediaLoader.mm
@@ -418,8 +418,7 @@ bool AvfMediaLoader::sync()
 
     curTime = latestTime;
     if (eosPending) {
-        started = false;
-        paused = true;
+        state = State::Stopped;
         eosPending = false;
     }
     if (!frameUpdated) return false;
@@ -439,8 +438,6 @@ Result AvfMediaLoader::play()
 {
     auto restart = curTime >= totalTime;
     _clearEos(*this);
-    started = true;
-    paused = false;
     dispatch_async(queue, ^{
         if (restart) [player seekToTime:kCMTimeZero toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
         [player play];
@@ -451,9 +448,6 @@ Result AvfMediaLoader::play()
 
 Result AvfMediaLoader::pause()
 {
-    if (!started) return Result::InsufficientCondition;
-
-    paused = true;
     dispatch_async(queue, ^{
         [player pause];
         _cancelTimer(*this);
@@ -464,9 +458,6 @@ Result AvfMediaLoader::pause()
 Result AvfMediaLoader::stop()
 {
     _clearEos(*this);
-    curTime = 0.0f;
-    started = false;
-    paused = true;
     dispatch_async(queue, ^{
         [player pause];
         _cancelTimer(*this);
@@ -481,7 +472,6 @@ Result AvfMediaLoader::stop()
 Result AvfMediaLoader::seek(float seconds)
 {
     _clearEos(*this);
-    curTime = seconds;
     dispatch_async(queue, ^{
         auto end = seconds >= totalTime;
         _resetFrame(*this, seconds);
@@ -503,7 +493,6 @@ Result AvfMediaLoader::seek(float seconds)
 
 Result AvfMediaLoader::loop(bool on)
 {
-    looping = on;
     dispatch_async(queue, ^{
         if (on) _removeEndObserver(*this);
         else _startEndObserver(*this);
@@ -513,14 +502,12 @@ Result AvfMediaLoader::loop(bool on)
 
 Result AvfMediaLoader::volume(float volume)
 {
-    audioVolume = volume;
     player.volume = volume;
     return Result::Success;
 }
 
 Result AvfMediaLoader::mute(bool on)
 {
-    muted = on;
     player.muted = on;
     return Result::Success;
 }

--- a/src/loaders/media/tvgMediaLoader.h
+++ b/src/loaders/media/tvgMediaLoader.h
@@ -27,10 +27,17 @@
 
 struct MediaLoader : BitmapLoader
 {
+    enum class State : uint8_t
+    {
+        Stopped,
+        Playing,
+        Paused
+    };
+
     float curTime = 0.0f;      // current playback position in seconds
     float totalTime = 0.0f;    // media duration in seconds
     float audioVolume = 1.0f;  // [0 - 1]
-    bool paused = false;
+    State state = State::Stopped;
     bool muted = false;
     bool looping = false;
 

--- a/src/loaders/media/tvgVideo.cpp
+++ b/src/loaders/media/tvgVideo.cpp
@@ -64,32 +64,46 @@ Video::~Video()
 Result Video::play() noexcept
 {
     FETCH_LOADER(Result::InsufficientCondition);
-    return loader->play();
+    auto ret = loader->play();
+    if (ret == Result::Success) loader->state = MediaLoader::State::Playing;
+    return ret;
 }
 
 Result Video::pause() noexcept
 {
     FETCH_LOADER(Result::InsufficientCondition);
-    return loader->pause();
+    if (loader->state == MediaLoader::State::Stopped) return Result::InsufficientCondition;
+    auto ret = loader->pause();
+    if (ret == Result::Success) loader->state = MediaLoader::State::Paused;
+    return ret;
 }
 
 Result Video::stop() noexcept
 {
     FETCH_LOADER(Result::InsufficientCondition);
-    return loader->stop();
+    auto ret = loader->stop();
+    if (ret == Result::Success) {
+        loader->curTime = 0.0f;
+        loader->state = MediaLoader::State::Stopped;
+    }
+    return ret;
 }
 
 Result Video::seek(float seconds) noexcept
 {
     FETCH_LOADER(Result::InsufficientCondition);
     if (seconds < 0.0f || seconds > loader->totalTime) return Result::InvalidArguments;
-    return loader->seek(seconds);
+    auto ret = loader->seek(seconds);
+    if (ret == Result::Success) loader->curTime = seconds;
+    return ret;
 }
 
 Result Video::loop(bool on) noexcept
 {
     FETCH_LOADER(Result::InsufficientCondition);
-    return loader->loop(on);
+    auto ret = loader->loop(on);
+    if (ret == Result::Success) loader->looping = on;
+    return ret;
 }
 
 bool Video::loop() noexcept
@@ -119,7 +133,9 @@ Result Video::volume(float volume) noexcept
 {
     if (volume < 0.0f || volume > 1.0f) return Result::InvalidArguments;
     FETCH_LOADER(Result::InsufficientCondition);
-    return loader->volume(volume);
+    auto ret = loader->volume(volume);
+    if (ret == Result::Success) loader->audioVolume = volume;
+    return ret;
 }
 
 float Video::volume() const noexcept
@@ -131,7 +147,9 @@ float Video::volume() const noexcept
 Result Video::mute(bool on) noexcept
 {
     FETCH_LOADER(Result::InsufficientCondition);
-    return loader->mute(on);
+    auto ret = loader->mute(on);
+    if (ret == Result::Success) loader->muted = on;
+    return ret;
 }
 
 bool Video::muted() const noexcept


### PR DESCRIPTION
Move playback state transitions to the Video API layer so media backends expose consistent state after successful control requests.

Replace separate playback flags with a compact state enum and leave backend-specific loaders responsible only for platform operations and asynchronous transitions such as end-of-stream.