### PR TITLE
common: extend interpolation support

### DIFF
--- a/src/common/tvgMath.h
+++ b/src/common/tvgMath.h
@@ -82,6 +82,12 @@ static inline constexpr const T& clamp(const T& v, const T& min, const T& max)
     return v;
 }
 
+template<typename T = uint8_t>
+static inline T remap255(float val)
+{
+    return static_cast<T>(nearbyintf(val * 255.0f));
+}
+
 /************************************************************************/
 /* Matrix functions                                                     */
 /************************************************************************/
@@ -400,6 +406,28 @@ static inline bool closed(const Point& lhs, const Point& rhs, float tolerance)
 }
 
 /************************************************************************/
+/* Point3 functions                                                     */
+/************************************************************************/
+
+struct Point3
+{
+    float x, y, z;
+};
+
+static inline Point3 operator+(const Point3& a, const Point3& b)
+{
+    return {a.x + b.x, a.y + b.y, a.z + b.z};
+}
+static inline Point3 operator-(const Point3& a, const Point3& b)
+{
+    return {a.x - b.x, a.y - b.y, a.z - b.z};
+}
+static inline Point3 operator*(const Point3& a, float t)
+{
+    return {a.x * t, a.y * t, a.z * t};
+}
+
+/************************************************************************/
 /* Line functions                                                       */
 /************************************************************************/
 
@@ -544,6 +572,16 @@ static inline T lerp(const T &start, const T &end, float t)
 static inline uint8_t lerp(const uint8_t& start, const uint8_t& end, float t)
 {
     return static_cast<uint8_t>(clamp(static_cast<int>(start + (end - start) * t), 0, 255));
+}
+
+static inline Fill::ColorStop lerp(const Fill::ColorStop& from, const Fill::ColorStop& to, float t)
+{
+    return {
+        tvg::lerp(from.offset, to.offset, t),
+        tvg::lerp(from.r, to.r, t),
+        tvg::lerp(from.g, to.g, t),
+        tvg::lerp(from.b, to.b, t),
+        tvg::lerp(from.a, to.a, t)};
 }
 }
 

--- a/src/loaders/lottie/tvgLottieCommon.h
+++ b/src/loaders/lottie/tvgLottieCommon.h
@@ -116,11 +116,6 @@ struct AssetSrc
     }
 };
 
-static inline int32_t REMAP255(float val)
-{
-    return (int32_t)nearbyintf(val * 255.0f);
-}
-
 static inline RGB32 operator-(const RGB32& lhs, const RGB32& rhs)
 {
     return {lhs.r - rhs.r, lhs.g - rhs.g, lhs.b - rhs.b};
@@ -143,24 +138,6 @@ static inline RGB32 lerp(const RGB32& s, const RGB32& e, float t)
         tvg::clamp((int32_t)(s.g + (e.g - s.g) * t), (int32_t)0, (int32_t)255),
         tvg::clamp((int32_t)(s.b + (e.b - s.b) * t), (int32_t)0, (int32_t)255)
     };
-}
-
-struct Point3
-{
-    float x = 0.0f, y = 0.0f, z = 0.0f;
-};
-
-static inline Point3 operator+(const Point3& a, const Point3& b)
-{
-    return {a.x + b.x, a.y + b.y, a.z + b.z};
-}
-static inline Point3 operator-(const Point3& a, const Point3& b)
-{
-    return {a.x - b.x, a.y - b.y, a.z - b.z};
-}
-static inline Point3 operator*(const Point3& a, float t)
-{
-    return {a.x * t, a.y * t, a.z * t};
 }
 
 }

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -353,36 +353,36 @@ uint32_t LottieGradient::populate(ColorStop& color, size_t count)
         if (cidx == clast || aidx == color.input->count) break;
         if ((*color.input)[cidx] == (*color.input)[aidx]) {
             cs.offset = (*color.input)[cidx];
-            cs.r = (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f);
-            cs.g = (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f);
-            cs.b = (uint8_t)nearbyint((*color.input)[cidx + 3] * 255.0f);
-            cs.a = (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f);
+            cs.r = remap255((*color.input)[cidx + 1]);
+            cs.g = remap255((*color.input)[cidx + 2]);
+            cs.b = remap255((*color.input)[cidx + 3]);
+            cs.a = remap255((*color.input)[aidx + 1]);
             cidx += 4;
             aidx += 2;
         } else if ((*color.input)[cidx] < (*color.input)[aidx]) {
             cs.offset = (*color.input)[cidx];
-            cs.r = (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f);
-            cs.g = (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f);
-            cs.b = (uint8_t)nearbyint((*color.input)[cidx + 3] * 255.0f);
+            cs.r = remap255((*color.input)[cidx + 1]);
+            cs.g = remap255((*color.input)[cidx + 2]);
+            cs.b = remap255((*color.input)[cidx + 3]);
             //generate alpha value
             if (output.count > 0) {
                 auto p = ((*color.input)[cidx] - output.last().offset) / ((*color.input)[aidx] - output.last().offset);
-                cs.a = tvg::lerp<uint8_t>(output.last().a, (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f), p);
-            } else cs.a = (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f);
+                cs.a = tvg::lerp<uint8_t>(output.last().a, remap255((*color.input)[aidx + 1]), p);
+            } else cs.a = remap255((*color.input)[aidx + 1]);
             cidx += 4;
         } else {
             cs.offset = (*color.input)[aidx];
-            cs.a = (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f);
+            cs.a = remap255((*color.input)[aidx + 1]);
             //generate color value
             if (output.count > 0) {
                 auto p = ((*color.input)[aidx] - output.last().offset) / ((*color.input)[cidx] - output.last().offset);
-                cs.r = tvg::lerp<uint8_t>(output.last().r, (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f), p);
-                cs.g = tvg::lerp<uint8_t>(output.last().g, (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f), p);
-                cs.b = tvg::lerp<uint8_t>(output.last().b, (uint8_t)nearbyint((*color.input)[cidx + 3] * 255.0f), p);
+                cs.r = tvg::lerp<uint8_t>(output.last().r, remap255((*color.input)[cidx + 1]), p);
+                cs.g = tvg::lerp<uint8_t>(output.last().g, remap255((*color.input)[cidx + 2]), p);
+                cs.b = tvg::lerp<uint8_t>(output.last().b, remap255((*color.input)[cidx + 3]), p);
             } else {
-                cs.r = (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f);
-                cs.g = (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f);
-                cs.b = (uint8_t)nearbyint((*color.input)[cidx + 3] * 255.0f);
+                cs.r = remap255((*color.input)[cidx + 1]);
+                cs.g = remap255((*color.input)[cidx + 2]);
+                cs.b = remap255((*color.input)[cidx + 3]);
             }
             aidx += 2;
         }
@@ -393,9 +393,9 @@ uint32_t LottieGradient::populate(ColorStop& color, size_t count)
     //color remains
     while (cidx + 3 < clast) {
         cs.offset = (*color.input)[cidx];
-        cs.r = (uint8_t)nearbyint((*color.input)[cidx + 1] * 255.0f);
-        cs.g = (uint8_t)nearbyint((*color.input)[cidx + 2] * 255.0f);
-        cs.b = (uint8_t)nearbyint((*color.input)[cidx + 3] * 255.0f);
+        cs.r = remap255((*color.input)[cidx + 1]);
+        cs.g = remap255((*color.input)[cidx + 2]);
+        cs.b = remap255((*color.input)[cidx + 3]);
         cs.a = (output.count > 0) ? output.last().a : 255;
         if (cs.a < 255) opaque = false;
         output.push(cs);
@@ -405,7 +405,7 @@ uint32_t LottieGradient::populate(ColorStop& color, size_t count)
     //alpha remains
     while (aidx < color.input->count) {
         cs.offset = (*color.input)[aidx];
-        cs.a = (uint8_t)nearbyint((*color.input)[aidx + 1] * 255.0f);
+        cs.a = remap255((*color.input)[aidx + 1]);
         if (cs.a < 255) opaque = false;
         if (output.count > 0) {
             cs.r = output.last().r;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -790,7 +790,7 @@ struct LottieTransform : LottieObject
     struct Dimension3
     {
         LottieFloat rx = 0.0f, ry = 0.0f;  // use the rotation for z rotation
-        LottieScalar3 orient = Point3{0.0f, 0.0f, 0.0f};
+        LottieScalar3 orient = {};
     }* ddd = nullptr;
 };
 

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -336,9 +336,9 @@ bool LottieParser::getValue(RGB32& color)
         if (!nextArrayValue()) return false;
     }
 
-    color.r = REMAP255(getFloat());
-    color.g = REMAP255(getFloat());
-    color.b = REMAP255(getFloat());
+    color.r = remap255<int32_t>(getFloat());
+    color.g = remap255<int32_t>(getFloat());
+    color.b = remap255<int32_t>(getFloat());
 
     while (nextArrayValue()) getFloat(); //drop
 

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -749,12 +749,7 @@ struct LottieColorStop : LottieProperty
         Array<Fill::ColorStop> result;
 
         for (auto i = 0; i < count; ++i, ++s, ++e) {
-            auto offset = tvg::lerp(s->offset, e->offset, t);
-            auto r = tvg::lerp(s->r, e->r, t);
-            auto g = tvg::lerp(s->g, e->g, t);
-            auto b = tvg::lerp(s->b, e->b, t);
-            auto a = tvg::lerp(s->a, e->a, t);
-            result.push({offset, r, g, b, a});
+            result.push(tvg::lerp(*s, *e, t));
         }
         return fill->colorStops(result.data, count);
     }

--- a/src/loaders/lottie/tvgLottieTween.h
+++ b/src/loaders/lottie/tvgLottieTween.h
@@ -270,11 +270,7 @@ public:
         if (fromCnt != toCnt) TVGLOG("LOTTIE", "Tweening has different numbers of color data in consecutive frames.");
 
         for (uint32_t i = 0; i < std::min(fromCnt, toCnt); ++i, ++to, ++from) {
-            const_cast<Fill::ColorStop*>(to)->offset = tvg::lerp(from->offset, to->offset, progress);
-            const_cast<Fill::ColorStop*>(to)->r = tvg::lerp(from->r, to->r, progress);
-            const_cast<Fill::ColorStop*>(to)->g = tvg::lerp(from->g, to->g, progress);
-            const_cast<Fill::ColorStop*>(to)->b = tvg::lerp(from->b, to->b, progress);
-            const_cast<Fill::ColorStop*>(to)->a = tvg::lerp(from->a, to->a, progress);
+            *const_cast<Fill::ColorStop*>(to) = lerp(*from, *to, progress);
         }
 
         // capture the current

--- a/src/renderer/gpu_engine/wg/tvgWgShaderTypes.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgShaderTypes.cpp
@@ -22,6 +22,7 @@
 
 #include "tvgWgShaderTypes.h"
 #include <cassert>
+#include <cstring>
 #include "tvgMath.h"
 #include "tvgFill.h"
 
@@ -144,46 +145,47 @@ void WgShaderTypeGradientData::update(const Fill* fill)
     const Fill::ColorStop* stops = nullptr;
     auto stopCnt = fill->colorStops(&stops);
     if (stopCnt == 0) return;
+
+    auto assign = [](uint8_t* dst, const Fill::ColorStop& color) {
+        std::memcpy(dst, &color.r, 4);
+    };
+
     static Array<Fill::ColorStop> sstops(stopCnt);
     sstops.clear();
     sstops.push(stops[0]);
+
     // filter by increasing offset
-    for (uint32_t i = 1; i < stopCnt; i++)
-        if (sstops.last().offset < stops[i].offset)
-            sstops.push(stops[i]);
-        else if (sstops.last().offset == stops[i].offset)
-            sstops.last() = stops[i];
+    for (uint32_t i = 1; i < stopCnt; i++) {
+        if (sstops.last().offset < stops[i].offset) sstops.push(stops[i]);
+        else if (sstops.last().offset == stops[i].offset) sstops.last() = stops[i];
+    }
+
     // head
     uint32_t range_s = 0;
     uint32_t range_e = uint32_t(sstops[0].offset * (WG_TEXTURE_GRADIENT_SIZE-1));
-    for (uint32_t ti = range_s; (ti < range_e) && (ti < WG_TEXTURE_GRADIENT_SIZE); ti++) {
-        data[ti * 4 + 0] = sstops[0].r;
-        data[ti * 4 + 1] = sstops[0].g;
-        data[ti * 4 + 2] = sstops[0].b;
-        data[ti * 4 + 3] = sstops[0].a;
+    auto dst = data + range_s * 4;
+    for (uint32_t ti = range_s; (ti < range_e) && (ti < WG_TEXTURE_GRADIENT_SIZE); ti++, dst += 4) {
+        assign(dst, sstops[0]);
     }
+
     // body
     for (uint32_t di = 1; di < sstops.count; di++) {
-        range_s = uint32_t(sstops[di-1].offset * (WG_TEXTURE_GRADIENT_SIZE-1));
-        range_e = uint32_t(sstops[di-0].offset * (WG_TEXTURE_GRADIENT_SIZE-1));
+        range_s = uint32_t(sstops[di - 1].offset * (WG_TEXTURE_GRADIENT_SIZE - 1));
+        range_e = uint32_t(sstops[di - 0].offset * (WG_TEXTURE_GRADIENT_SIZE - 1));
         float delta = 1.0f/(range_e - range_s);
-        for (uint32_t ti = range_s; (ti < range_e) && (ti < WG_TEXTURE_GRADIENT_SIZE); ti++) {
-            float t = (ti - range_s) * delta;
-            data[ti * 4 + 0] = tvg::lerp(sstops[di-1].r, sstops[di].r, t);
-            data[ti * 4 + 1] = tvg::lerp(sstops[di-1].g, sstops[di].g, t);
-            data[ti * 4 + 2] = tvg::lerp(sstops[di-1].b, sstops[di].b, t);
-            data[ti * 4 + 3] = tvg::lerp(sstops[di-1].a, sstops[di].a, t);
+        dst = data + range_s * 4;
+        for (uint32_t ti = range_s; (ti < range_e) && (ti < WG_TEXTURE_GRADIENT_SIZE); ti++, dst += 4) {
+            assign(dst, tvg::lerp(sstops[di - 1], sstops[di], (ti - range_s) * delta));
         }
     }
+
     // tail
     const tvg::Fill::ColorStop& colorStopLast = sstops.last();
     range_s = uint32_t(colorStopLast.offset * (WG_TEXTURE_GRADIENT_SIZE-1));
     range_e = WG_TEXTURE_GRADIENT_SIZE;
-    for (uint32_t ti = range_s; ti < range_e; ti++) {
-        data[ti * 4 + 0] = colorStopLast.r;
-        data[ti * 4 + 1] = colorStopLast.g;
-        data[ti * 4 + 2] = colorStopLast.b;
-        data[ti * 4 + 3] = colorStopLast.a;
+    dst = data + range_s * 4;
+    for (uint32_t ti = range_s; ti < range_e; ti++, dst += 4) {
+        assign(dst, colorStopLast);
     }
 }
 


### PR DESCRIPTION
- Move Point3 and its arithmetic operators into tvgMath so the generic interpolation helper can handle three-dimensional values consistently.
- Add a ColorStop lerp overload and reuse it for Lottie property interpolation and tweening.
- Optimize WebGPU gradient generation by interpolating complete color stops and writing them through incremented data pointers.