### PR TITLE
renderer/picture: remove unused bitmap accessor

### DIFF
--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -227,22 +227,6 @@ struct PictureImpl : Picture
         return new PictureIterator(vector);
     }
 
-    uint32_t* data(uint32_t* w, uint32_t* h)
-    {
-        //Try it, If not loaded yet.
-        impl.mark(load());
-
-        if (loader) {
-            if (w) *w = static_cast<uint32_t>(loader->w);
-            if (h) *h = static_cast<uint32_t>(loader->h);
-        } else {
-            if (w) *w = 0;
-            if (h) *h = 0;
-        }
-        if (bitmap) return bitmap->buf32;
-        else return nullptr;
-    }
-
     RenderUpdateFlag load()
     {
         if (!loader) return RenderUpdateFlag::None;


### PR DESCRIPTION
The public Picture::data() API was removed in c0cb8c0c, 
while its implementation was retained internally for the TVG saver.

The saver was removed in 0e45fabb, leaving PictureImpl::data() unused. 
Remove the obsolete accessor with no public API or ABI impact.