### PR TITLE
wg_engine: fix compiler warning for WgStageBufferSolidColor

### DIFF
--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.h
@@ -186,7 +186,7 @@ public:
     void release(WgContext& context);
 };
 
-class WgStageBufferSolidColor;
+struct WgStageBufferSolidColor;
 
 class WgStageBufferGeometry {
 private:


### PR DESCRIPTION
The forward declaration of `WgStageBufferSolidColor` uses `class`, while its definition uses `struct`.

### Environment

- GCC 16.1.0 (MSYS2 UCRT64)
- Meson 1.11.2
- Windows x86_64

### Reproduction

```powershell
meson setup build-wg-log '-Dengines=wg' '-Dcpp_args=-Wmismatched-tags'
ninja -C build-wg-log install
```

### Compiler warning

```text
tvgWgRenderData.h:189:7: warning: 'WgStageBufferSolidColor' declared with a mismatched class-key 'class' [-Wmismatched-tags]
tvgWgRenderData.h:189:7: note: replace the class-key with 'struct'
tvgWgRenderData.h:209:8: note: 'WgStageBufferSolidColor' defined as 'struct' here
```

Use `struct` consistently for the forward declaration and definition.