### PR TITLE
svg: support the font-weight attribute

### DIFF
--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -947,9 +947,9 @@ static Scene* _useBuildHelper(SvgParserContext& ctx, const SvgNode* node, const 
     return scene;
 }
 
-static void _applyTextFill(SvgStyleProperty* style, Text* text, const Box& vBox, const Box& viewport)
+static void _applyTextFill(SvgStyleProperty* style, Text* text, const SvgTextNode& textNode, const Box& vBox, const Box& viewport)
 {
-    //If fill property is nullptr then do nothing
+    // If fill property is nullptr then do nothing
     if (style->fill.paint.none) {
         //Do nothing
     } else if (style->fill.paint.gradient) {
@@ -962,13 +962,10 @@ static void _applyTextFill(SvgStyleProperty* style, Text* text, const Box& vBox,
     } else if (style->fill.paint.url) {
         //TODO: Apply the color pointed by url
         TVGLOG("SVG", "The fill's url not supported.");
-    } else if (style->fill.paint.curColor) {
-        //Apply the current style color
-        text->fill(style->color.r, style->color.g, style->color.b);
-        text->opacity(style->fill.opacity);
     } else {
-        //Apply the fill color
-        text->fill(style->fill.paint.color.r, style->fill.paint.color.g, style->fill.paint.color.b);
+        const auto& color = style->fill.paint.curColor ? style->color : style->fill.paint.color;
+        text->fill(color.r, color.g, color.b);
+        if (style->fontWeight >= SvgFontWeight::Weight600) text->outline(textNode.fontSize * 0.03f, color.r, color.g, color.b);
         text->opacity(style->fill.opacity);
     }
 }
@@ -1135,7 +1132,7 @@ static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* 
             if (text) {
                 text->align(child->style->textAnchor, 0.0f);
                 _updatePos(text, textNode, child->style->textAnchor, textPos);
-                _applyTextFill(child->style, text, vBox, ctx.parser->global);
+                _applyTextFill(child->style, text, textNode, vBox, ctx.parser->global);
                 auto paint = _applyFilter(ctx, text, child, vBox, svgPath);
                 paint = _applyComposition(ctx, paint, child, vBox, svgPath);
                 paint = _applyBlend(paint, child);
@@ -1160,7 +1157,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
         auto text = _buildText(textNode, xmlSpace, node->transform, _effectiveBaseline(node->style));
         if (!text) return nullptr;
         text->align(node->style->textAnchor, 0.0f);
-        _applyTextFill(node->style, text, vBox, ctx.parser->global);
+        _applyTextFill(node->style, text, *textNode, vBox, ctx.parser->global);
         auto p = _applyFilter(ctx, text, node, vBox, svgPath);
         p = _applyComposition(ctx, p, node, vBox, svgPath);
         return _applyBlend(p, node);
@@ -1174,7 +1171,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
     if (auto text = _buildText(textNode, xmlSpace, nullptr, _effectiveBaseline(node->style))) {
         text->align(node->style->textAnchor, 0.0f);
         _updatePos(text, *textNode, node->style->textAnchor, textPos);
-        _applyTextFill(node->style, text, vBox, ctx.parser->global);
+        _applyTextFill(node->style, text, *textNode, vBox, ctx.parser->global);
         scene->add(text);
     }
 

--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -947,9 +947,9 @@ static Scene* _useBuildHelper(SvgParserContext& ctx, const SvgNode* node, const 
     return scene;
 }
 
-static void _applyTextFill(SvgStyleProperty* style, Text* text, const Box& vBox, const Box& viewport)
+static void _applyTextFill(SvgStyleProperty* style, Text* text, const SvgTextNode& textNode, const Box& vBox, const Box& viewport)
 {
-    //If fill property is nullptr then do nothing
+    // If fill property is nullptr then do nothing
     if (style->fill.paint.none) {
         //Do nothing
     } else if (style->fill.paint.gradient) {
@@ -962,13 +962,10 @@ static void _applyTextFill(SvgStyleProperty* style, Text* text, const Box& vBox,
     } else if (style->fill.paint.url) {
         //TODO: Apply the color pointed by url
         TVGLOG("SVG", "The fill's url not supported.");
-    } else if (style->fill.paint.curColor) {
-        //Apply the current style color
-        text->fill(style->color.r, style->color.g, style->color.b);
-        text->opacity(style->fill.opacity);
     } else {
-        //Apply the fill color
-        text->fill(style->fill.paint.color.r, style->fill.paint.color.g, style->fill.paint.color.b);
+        const auto& color = style->fill.paint.curColor ? style->color : style->fill.paint.color;
+        text->fill(color.r, color.g, color.b);
+        if (style->fontWeight >= SvgFontWeight::Weight600) text->outline(textNode.fontSize * 0.03f, color.r, color.g, color.b);
         text->opacity(style->fill.opacity);
     }
 }
@@ -1129,7 +1126,7 @@ static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* 
             if (text) {
                 text->align(child->style->textAnchor, 0.0f);
                 _updatePos(text, textNode, child->style->textAnchor, textPos);
-                _applyTextFill(child->style, text, vBox, ctx.parser->global);
+                _applyTextFill(child->style, text, textNode, vBox, ctx.parser->global);
                 auto paint = _applyFilter(ctx, text, child, vBox, svgPath);
                 paint = _applyComposition(ctx, paint, child, vBox, svgPath);
                 paint = _applyBlend(paint, child);
@@ -1154,7 +1151,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
         auto text = _buildText(textNode, xmlSpace, node->transform, node->style->alignmentBaseline);
         if (!text) return nullptr;
         text->align(node->style->textAnchor, 0.0f);
-        _applyTextFill(node->style, text, vBox, ctx.parser->global);
+        _applyTextFill(node->style, text, *textNode, vBox, ctx.parser->global);
         auto p = _applyFilter(ctx, text, node, vBox, svgPath);
         p = _applyComposition(ctx, p, node, vBox, svgPath);
         return _applyBlend(p, node);
@@ -1168,7 +1165,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
     if (auto text = _buildText(textNode, xmlSpace, nullptr, node->style->alignmentBaseline)) {
         text->align(node->style->textAnchor, 0.0f);
         _updatePos(text, *textNode, node->style->textAnchor, textPos);
-        _applyTextFill(node->style, text, vBox, ctx.parser->global);
+        _applyTextFill(node->style, text, *textNode, vBox, ctx.parser->global);
         scene->add(text);
     }
 

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -174,7 +174,8 @@ enum struct SvgStyleFlags
     BlendMode = 0x100000,
     TextAnchor = 0x200000,
     AlignmentBaseline = 0x400000,
-    DominantBaseline = 0x800000
+    DominantBaseline = 0x800000,
+    FontWeight = 0x1000000
 };
 
 constexpr bool operator&(SvgStyleFlags a, SvgStyleFlags b)
@@ -544,6 +545,23 @@ enum class SvgBaseline : uint8_t
     Mathematical
 };
 
+enum class SvgFontWeight : int16_t
+{
+    Invalid = 0,
+    Inherit = -1,
+    Bolder = -2,
+    Lighter = -3,
+    Weight100 = 100,
+    Weight200 = 200,
+    Weight300 = 300,
+    Normal = 400,
+    Weight500 = 500,
+    Weight600 = 600,
+    Bold = 700,
+    Weight800 = 800,
+    Weight900 = 900
+};
+
 struct SvgStyleProperty
 {
     SvgStyleFill fill;
@@ -557,6 +575,7 @@ struct SvgStyleProperty
     float textAnchor;  // 0=start, 0.5=middle, 1=end
     SvgBaseline alignmentBaseline;
     SvgBaseline dominantBaseline;
+    SvgFontWeight fontWeight;
     SvgStyleFlags flags;
     SvgStyleFlags flagsImportance; //indicates the importance of the flag - if set, higher priority is applied (https://drafts.csswg.org/css-cascade-4/#importance)
     bool curColorSet;

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -173,7 +173,8 @@ enum struct SvgStyleFlags
     Filter = 0x80000,
     BlendMode = 0x100000,
     TextAnchor = 0x200000,
-    AlignmentBaseline = 0x400000
+    AlignmentBaseline = 0x400000,
+    FontWeight = 0x800000
 };
 
 constexpr bool operator&(SvgStyleFlags a, SvgStyleFlags b)
@@ -543,6 +544,23 @@ enum class SvgBaseline : uint8_t
     Mathematical
 };
 
+enum class SvgFontWeight : int16_t
+{
+    Invalid = 0,
+    Inherit = -1,
+    Bolder = -2,
+    Lighter = -3,
+    Weight100 = 100,
+    Weight200 = 200,
+    Weight300 = 300,
+    Normal = 400,
+    Weight500 = 500,
+    Weight600 = 600,
+    Bold = 700,
+    Weight800 = 800,
+    Weight900 = 900
+};
+
 struct SvgStyleProperty
 {
     SvgStyleFill fill;
@@ -555,6 +573,7 @@ struct SvgStyleProperty
     char* cssClass;
     float textAnchor;  // 0=start, 0.5=middle, 1=end
     SvgBaseline alignmentBaseline;
+    SvgFontWeight fontWeight;
     SvgStyleFlags flags;
     SvgStyleFlags flagsImportance; //indicates the importance of the flag - if set, higher priority is applied (https://drafts.csswg.org/css-cascade-4/#importance)
     bool curColorSet;

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -160,6 +160,11 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from, bool 
         to->flags |= SvgStyleFlags::DominantBaseline;
         if (from->flagsImportance & SvgStyleFlags::DominantBaseline) to->flagsImportance |= SvgStyleFlags::DominantBaseline;
     }
+    if (((from->flags & SvgStyleFlags::FontWeight) && (overwrite || !(to->flags & SvgStyleFlags::FontWeight))) || _isImportanceApplicable(to->flagsImportance, from->flagsImportance, SvgStyleFlags::FontWeight)) {
+        to->fontWeight = from->fontWeight;
+        to->flags |= SvgStyleFlags::FontWeight;
+        if (from->flagsImportance & SvgStyleFlags::FontWeight) to->flagsImportance |= SvgStyleFlags::FontWeight;
+    }
 }
 
 

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -155,6 +155,11 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from, bool 
         to->flags |= SvgStyleFlags::AlignmentBaseline;
         if (from->flagsImportance & SvgStyleFlags::AlignmentBaseline) to->flagsImportance |= SvgStyleFlags::AlignmentBaseline;
     }
+    if (((from->flags & SvgStyleFlags::FontWeight) && (overwrite || !(to->flags & SvgStyleFlags::FontWeight))) || _isImportanceApplicable(to->flagsImportance, from->flagsImportance, SvgStyleFlags::FontWeight)) {
+        to->fontWeight = from->fontWeight;
+        to->flags |= SvgStyleFlags::FontWeight;
+        if (from->flagsImportance & SvgStyleFlags::FontWeight) to->flagsImportance |= SvgStyleFlags::FontWeight;
+    }
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -233,6 +233,32 @@ static int _toOpacity(const char* str)
     return 255;
 }
 
+static SvgFontWeight _toFontWeight(const char* str)
+{
+    if (STR_AS(str, "normal")) return SvgFontWeight::Normal;
+    if (STR_AS(str, "bold")) return SvgFontWeight::Bold;
+    if (STR_AS(str, "inherit")) return SvgFontWeight::Inherit;
+    if (STR_AS(str, "bolder")) return SvgFontWeight::Bolder;
+    if (STR_AS(str, "lighter")) return SvgFontWeight::Lighter;
+
+    char* end = nullptr;
+    auto weight = strtol(str, &end, 10);
+    end = (char*)svgUtilSkipWhiteSpace(end, nullptr);
+    if (*end) return SvgFontWeight::Invalid;
+
+    switch (weight) {
+        case 100: return SvgFontWeight::Weight100;
+        case 200: return SvgFontWeight::Weight200;
+        case 300: return SvgFontWeight::Weight300;
+        case 400: return SvgFontWeight::Normal;
+        case 500: return SvgFontWeight::Weight500;
+        case 600: return SvgFontWeight::Weight600;
+        case 700: return SvgFontWeight::Bold;
+        case 800: return SvgFontWeight::Weight800;
+        case 900: return SvgFontWeight::Weight900;
+        default: return SvgFontWeight::Invalid;
+    }
+}
 
 static SvgMaskType _toMaskType(const char* str)
 {
@@ -1105,6 +1131,12 @@ static void _handleTextAnchorAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* nod
     else node->style->textAnchor = 0.0f;
 }
 
+static void _handleFontWeightAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* node, const char* value)
+{
+    node->style->fontWeight = _toFontWeight(value);
+    node->style->flags |= SvgStyleFlags::FontWeight;
+}
+
 static SvgBaseline _toBaseline(const char* str)
 {
     if (STR_AS(str, "alphabetic")) return SvgBaseline::Alphabetic;
@@ -1170,7 +1202,8 @@ static constexpr struct
     STYLE_DEF(filter, Filter, SvgStyleFlags::Filter),
     STYLE_DEF(mix-blend-mode, MixBlendMode, SvgStyleFlags::BlendMode),
     STYLE_DEF(text-anchor, TextAnchor, SvgStyleFlags::TextAnchor),
-    STYLE_DEF(alignment-baseline, AlignmentBaseline, SvgStyleFlags::AlignmentBaseline)};
+    STYLE_DEF(alignment-baseline, AlignmentBaseline, SvgStyleFlags::AlignmentBaseline),
+    STYLE_DEF(font-weight, FontWeight, SvgStyleFlags::FontWeight)};
 // clang-format on
 
 static SvgXmlSpace _toXmlSpace(const char* str)
@@ -1208,6 +1241,10 @@ static bool _parseStyleAttr(void* data, const char* key, const char* value, bool
                 }
                 value = duplicate(value, size);
                 importance = true;
+            }
+            if (styleTags[i].flag == SvgStyleFlags::FontWeight && _toFontWeight(value) == SvgFontWeight::Invalid) {
+                if (importance) tvg::free(const_cast<char*>(value));
+                return true;
             }
             if (style) {
                 if (importance || !(node->style->flagsImportance & styleTags[i].flag)) {
@@ -1440,6 +1477,7 @@ static SvgNode* _createNode(SvgNode* parent, SvgNodeType type)
     node->style->stroke.scale = 1.0;
     node->style->paintOrder = _toPaintOrder("fill stroke");
     node->style->display = true;
+    node->style->fontWeight = SvgFontWeight::Normal;
     node->parent = parent;
     node->type = type;
     node->xmlSpace = SvgXmlSpace::None;
@@ -2953,6 +2991,13 @@ static SvgStyleGradient* _cloneGradient(SvgStyleGradient* from)
 
 static void _styleInherit(SvgStyleProperty* child, const SvgStyleProperty* parent)
 {
+    auto parentWeight = parent ? parent->fontWeight : SvgFontWeight::Normal;
+    if (!(child->flags & SvgStyleFlags::FontWeight) || child->fontWeight == SvgFontWeight::Inherit) child->fontWeight = parentWeight;
+    else if (child->fontWeight == SvgFontWeight::Bolder) child->fontWeight = parentWeight <= SvgFontWeight::Weight300 ? SvgFontWeight::Normal : parentWeight <= SvgFontWeight::Weight500 ? SvgFontWeight::Bold
+                                                                                                                                                                                         : SvgFontWeight::Weight900;
+    else if (child->fontWeight == SvgFontWeight::Lighter) child->fontWeight = parentWeight <= SvgFontWeight::Weight500 ? SvgFontWeight::Weight100 : parentWeight <= SvgFontWeight::Bold ? SvgFontWeight::Normal
+                                                                                                                                                                                        : SvgFontWeight::Bold;
+
     if (!parent) return;
 
     //Inherit the property of parent if not present in child.
@@ -3013,6 +3058,7 @@ static void _styleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
     if (from->flags & SvgStyleFlags::BlendMode) to->blendMode = from->blendMode;
     if (from->flags & SvgStyleFlags::TextAnchor) to->textAnchor = from->textAnchor;
     if (from->flags & SvgStyleFlags::AlignmentBaseline) to->alignmentBaseline = from->alignmentBaseline;
+    if (from->flags & SvgStyleFlags::FontWeight) to->fontWeight = from->fontWeight;
 
     //Fill
     to->fill.flags = (to->fill.flags | from->fill.flags);

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -233,6 +233,32 @@ static int _toOpacity(const char* str)
     return 255;
 }
 
+static SvgFontWeight _toFontWeight(const char* str)
+{
+    if (STR_AS(str, "normal")) return SvgFontWeight::Normal;
+    if (STR_AS(str, "bold")) return SvgFontWeight::Bold;
+    if (STR_AS(str, "inherit")) return SvgFontWeight::Inherit;
+    if (STR_AS(str, "bolder")) return SvgFontWeight::Bolder;
+    if (STR_AS(str, "lighter")) return SvgFontWeight::Lighter;
+
+    char* end = nullptr;
+    auto weight = strtol(str, &end, 10);
+    end = (char*)svgUtilSkipWhiteSpace(end, nullptr);
+    if (*end) return SvgFontWeight::Invalid;
+
+    switch (weight) {
+        case 100: return SvgFontWeight::Weight100;
+        case 200: return SvgFontWeight::Weight200;
+        case 300: return SvgFontWeight::Weight300;
+        case 400: return SvgFontWeight::Normal;
+        case 500: return SvgFontWeight::Weight500;
+        case 600: return SvgFontWeight::Weight600;
+        case 700: return SvgFontWeight::Bold;
+        case 800: return SvgFontWeight::Weight800;
+        case 900: return SvgFontWeight::Weight900;
+        default: return SvgFontWeight::Invalid;
+    }
+}
 
 static SvgMaskType _toMaskType(const char* str)
 {
@@ -1105,6 +1131,12 @@ static void _handleTextAnchorAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* nod
     else node->style->textAnchor = 0.0f;
 }
 
+static void _handleFontWeightAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* node, const char* value)
+{
+    node->style->fontWeight = _toFontWeight(value);
+    node->style->flags |= SvgStyleFlags::FontWeight;
+}
+
 static SvgBaseline _toBaseline(const char* str)
 {
     if (STR_AS(str, "alphabetic")) return SvgBaseline::Alphabetic;
@@ -1158,8 +1190,8 @@ static constexpr struct
     styleMethod tagHandler;
     SvgStyleFlags flag;
 } styleTags[] = {
-    // hyphenated names below are macro identifiers, not subtraction; keep them intact
-    // clang-format off
+// hyphenated names below are macro identifiers, not subtraction; keep them intact
+// clang-format off
     STYLE_DEF(color, Color, SvgStyleFlags::Color),
     STYLE_DEF(fill, Fill, SvgStyleFlags::Fill),
     STYLE_DEF(fill-rule, FillRule, SvgStyleFlags::FillRule),
@@ -1183,7 +1215,9 @@ static constexpr struct
     STYLE_DEF(mix-blend-mode, MixBlendMode, SvgStyleFlags::BlendMode),
     STYLE_DEF(text-anchor, TextAnchor, SvgStyleFlags::TextAnchor),
     STYLE_DEF(alignment-baseline, AlignmentBaseline, SvgStyleFlags::AlignmentBaseline),
-    STYLE_DEF(dominant-baseline, DominantBaseline, SvgStyleFlags::DominantBaseline)};
+    STYLE_DEF(dominant-baseline, DominantBaseline, SvgStyleFlags::DominantBaseline),
+    STYLE_DEF(font-weight, FontWeight, SvgStyleFlags::FontWeight)
+};
 // clang-format on
 
 static SvgXmlSpace _toXmlSpace(const char* str)
@@ -1221,6 +1255,10 @@ static bool _parseStyleAttr(void* data, const char* key, const char* value, bool
                 }
                 value = duplicate(value, size);
                 importance = true;
+            }
+            if (styleTags[i].flag == SvgStyleFlags::FontWeight && _toFontWeight(value) == SvgFontWeight::Invalid) {
+                if (importance) tvg::free(const_cast<char*>(value));
+                return true;
             }
             if (style) {
                 if (importance || !(node->style->flagsImportance & styleTags[i].flag)) {
@@ -1453,6 +1491,7 @@ static SvgNode* _createNode(SvgNode* parent, SvgNodeType type)
     node->style->stroke.scale = 1.0;
     node->style->paintOrder = _toPaintOrder("fill stroke");
     node->style->display = true;
+    node->style->fontWeight = SvgFontWeight::Normal;
     node->parent = parent;
     node->type = type;
     node->xmlSpace = SvgXmlSpace::None;
@@ -2966,6 +3005,13 @@ static SvgStyleGradient* _cloneGradient(SvgStyleGradient* from)
 
 static void _styleInherit(SvgStyleProperty* child, const SvgStyleProperty* parent)
 {
+    auto parentWeight = parent ? parent->fontWeight : SvgFontWeight::Normal;
+    if (!(child->flags & SvgStyleFlags::FontWeight) || child->fontWeight == SvgFontWeight::Inherit) child->fontWeight = parentWeight;
+    else if (child->fontWeight == SvgFontWeight::Bolder) child->fontWeight = parentWeight <= SvgFontWeight::Weight300 ? SvgFontWeight::Normal : parentWeight <= SvgFontWeight::Weight500 ? SvgFontWeight::Bold
+                                                                                                                                                                                         : SvgFontWeight::Weight900;
+    else if (child->fontWeight == SvgFontWeight::Lighter) child->fontWeight = parentWeight <= SvgFontWeight::Weight500 ? SvgFontWeight::Weight100 : parentWeight <= SvgFontWeight::Bold ? SvgFontWeight::Normal
+                                                                                                                                                                                        : SvgFontWeight::Bold;
+
     if (!parent) return;
 
     //Inherit the property of parent if not present in child.
@@ -3028,6 +3074,7 @@ static void _styleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
     if (from->flags & SvgStyleFlags::TextAnchor) to->textAnchor = from->textAnchor;
     if (from->flags & SvgStyleFlags::AlignmentBaseline) to->alignmentBaseline = from->alignmentBaseline;
     if (from->flags & SvgStyleFlags::DominantBaseline) to->dominantBaseline = from->dominantBaseline;
+    if (from->flags & SvgStyleFlags::FontWeight) to->fontWeight = from->fontWeight;
 
     //Fill
     to->fill.flags = (to->fill.flags | from->fill.flags);


### PR DESCRIPTION
Parse font-weight from presentation attributes and inline styles on text and tspan, plus CSS rules on text and inherited container styles.

Support normal, bold, inherit, bolder, lighter, and numeric values from 100 through 900 in 100-step increments.

Map weights 100-500 to regular rendering and 600-900 to a same-color synthetic outline for solid fills.

issue: #4107