### PR TITLE
loader: transfer the source data ownership instead of copying

### DIFF
--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -29,10 +29,7 @@
 
 void JpgLoader::clear()
 {
-    if (freeData) tvg::free(data);
-    data = nullptr;
-    size = 0;
-    freeData = false;
+    src.clear();
 }
 
 /************************************************************************/
@@ -55,13 +52,15 @@ JpgLoader::~JpgLoader()
 bool JpgLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (!(data = (unsigned char*)Loader::open(path, size))) return false;
+    uint32_t size;
+    auto data = Loader::open(path, size);
+    if (!data) return false;
+    src.own(data, size);
 
     int width, height, subSample, colorSpace;
-    if (tjDecompressHeader3(jpegDecompressor, data, size, &width, &height, &subSample, &colorSpace) < 0) return false;
+    if (tjDecompressHeader3(jpegDecompressor, src.data, src.size, &width, &height, &subSample, &colorSpace) < 0) return false;
     w = static_cast<float>(width);
     h = static_cast<float>(height);
-    freeData = true;
     return true;
 #else
     return false;
@@ -73,19 +72,10 @@ bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps
     int width, height, subSample, colorSpace;
     if (tjDecompressHeader3(jpegDecompressor, (unsigned char *) data, size, &width, &height, &subSample, &colorSpace) < 0) return false;
 
-    if (copy) {
-        this->data = tvg::malloc<unsigned char>(size);
-        if (!this->data) return false;
-        memcpy((unsigned char *)this->data, data, size);
-        freeData = true;
-    } else {
-        this->data = (unsigned char *) data;
-        freeData = false;
-    }
+    if (!src.assign(data, size, copy)) return false;
 
     w = static_cast<float>(width);
     h = static_cast<float>(height);
-    this->size = size;
 
     return true;
 }
@@ -111,7 +101,7 @@ bool JpgLoader::read()
     auto image = (unsigned char *)tjAlloc(static_cast<int>(w) * static_cast<int>(h) * tjPixelSize[format]);
 
     //decompress jpg image
-    if (tjDecompress2(jpegDecompressor, data, size, image, static_cast<int>(w), 0, static_cast<int>(h), format, 0) < 0) {
+    if (tjDecompress2(jpegDecompressor, src.data, src.size, image, static_cast<int>(w), 0, static_cast<int>(h), format, 0) < 0) {
         TVGERR("JPG LOADER", "%s", tjGetErrorStr());
         tjFree(image);
         image = nullptr;

--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -41,9 +41,6 @@ private:
     void clear();
 
     tjhandle jpegDecompressor;
-    unsigned char* data = nullptr;
-    uint32_t size = 0;
-    bool freeData = false;
 };
 
 #endif //_TVG_JPG_LOADER_H_

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -31,6 +31,7 @@ void PngLoader::clear()
     png_image_free(image);
     tvg::free(image);
     image = nullptr;
+    src.clear();
 }
 
 /************************************************************************/
@@ -67,7 +68,10 @@ bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps
 #ifdef THORVG_FILE_IO_SUPPORT
     image->opaque = nullptr;
 
-    if (!png_image_begin_read_from_memory(image, data, size)) return false;
+    // libpng reads the memory back on png_image_finish_read(), thus keep it alive
+    if (!src.assign(data, size, copy)) return false;
+
+    if (!png_image_begin_read_from_memory(image, src.data, src.size)) return false;
 
     w = (float)image->width;
     h = (float)image->height;

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -40,11 +40,11 @@ void WebpLoader::run(unsigned tid)
     // request premultiplied image data
     if (BitmapLoader::cs == ColorSpace::ARGB8888 || BitmapLoader::cs == ColorSpace::ARGB8888S) {
         config.output.colorspace = MODE_bgrA;
-        if (WebPDecode(data, size, &config) != VP8_STATUS_OK) return;
+        if (WebPDecode(src.data, src.size, &config) != VP8_STATUS_OK) return;
         cs = ColorSpace::ARGB8888;
     } else {
         config.output.colorspace = MODE_rgbA;
-        if (WebPDecode(data, size, &config) != VP8_STATUS_OK) return;
+        if (WebPDecode(src.data, src.size, &config) != VP8_STATUS_OK) return;
         cs = ColorSpace::ABGR8888;
     }
     surface.setup((pixel_t*)config.output.u.RGBA.rgba, (uint32_t)w, (uint32_t)w, (uint32_t)h, sizeof(uint32_t), cs);
@@ -64,24 +64,22 @@ WebpLoader::~WebpLoader()
 {
     done();
 
-    if (freeData) tvg::free(data);
-    data = nullptr;
-    size = 0;
-    freeData = false;
     WebPFree(surface.buf8);
 }
 
 bool WebpLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (!(data = (unsigned char*)Loader::open(path, size))) return false;
+    uint32_t size;
+    auto data = Loader::open(path, size);
+    if (!data) return false;
+    src.own(data, size);
 
     WebPBitstreamFeatures features;
-    if (WebPGetFeatures(data, size, &features)) return false;
+    if (WebPGetFeatures(src.data, src.size, &features)) return false;
     w = static_cast<float>(features.width);
     h = static_cast<float>(features.height);
     surface.alphaIgnored = !features.has_alpha;
-    freeData = true;
     return true;
 #else
     return false;
@@ -90,22 +88,13 @@ bool WebpLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 
 bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
-    if (copy) {
-        this->data = tvg::malloc<unsigned char>(size);
-        if (!this->data) return false;
-        memcpy((unsigned char *)this->data, data, size);
-        freeData = true;
-    } else {
-        this->data = (unsigned char *) data;
-        freeData = false;
-    }
+    if (!src.assign(data, size, copy)) return false;
 
     WebPBitstreamFeatures features;
-    if (WebPGetFeatures(this->data, size, &features)) return false;
+    if (WebPGetFeatures(src.data, src.size, &features)) return false;
     w = static_cast<float>(features.width);
     h = static_cast<float>(features.height);
     surface.alphaIgnored = !features.has_alpha;
-    this->size = size;
     return true;
 }
 
@@ -114,7 +103,7 @@ bool WebpLoader::read()
 {
     if (!Loader::read()) return true;
 
-    if (!data || w == 0 || h == 0) return false;
+    if (!src.data || w == 0 || h == 0) return false;
 
     TaskScheduler::request(this);
 

--- a/src/loaders/external_webp/tvgWebpLoader.h
+++ b/src/loaders/external_webp/tvgWebpLoader.h
@@ -39,10 +39,6 @@ struct WebpLoader : BitmapLoader, Task
 
 private:
     void run(unsigned tid) override;
-
-    unsigned char* data = nullptr;
-    uint32_t size = 0;
-    bool freeData = false;
 };
 
 #endif //_TVG_WEBP_LOADER_H_

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -29,10 +29,8 @@
 void JpgLoader::clear()
 {
     jpgdDelete(decoder);
-    if (freeData) tvg::free(data);
     decoder = nullptr;
-    data = nullptr;
-    freeData = false;
+    src.clear();
 }
 
 
@@ -77,18 +75,10 @@ bool JpgLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 
 bool JpgLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
-    if (copy) {
-        this->data = tvg::malloc<char>(size);
-        if (!this->data) return false;
-        memcpy((char *)this->data, data, size);
-        freeData = true;
-    } else {
-        this->data = (char *) data;
-        freeData = false;
-    }
+    if (!src.assign(data, size, copy)) return false;
 
     int width, height;
-    decoder = jpgdHeader(this->data, size, &width, &height);
+    decoder = jpgdHeader(src.text(), src.size, &width, &height);
     if (!decoder) return false;
 
     w = static_cast<float>(width);

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -41,8 +41,6 @@ struct JpgLoader : BitmapLoader, Task
 
 private:
     jpeg_decoder* decoder = nullptr;
-    char* data = nullptr;
-    bool freeData = false;
 
     void clear();
     void run(unsigned tid) override;

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -41,7 +41,7 @@ LottieCustomSlot::~LottieCustomSlot()
 
 bool LottieLoader::prepare()
 {
-    LottieParser parser(content, dirName, builder->expressions());
+    LottieParser parser(src.text(), dirName, builder->expressions());
     if (!parser.parse()) return false;
     {
         ScopedLock lock(key);
@@ -70,10 +70,7 @@ void LottieLoader::run(unsigned tid)
 
 void LottieLoader::release()
 {
-    if (copy) {
-        tvg::free((char*)content);
-        content = nullptr;
-    }
+    src.clear();
 }
 
 
@@ -121,7 +118,7 @@ bool LottieLoader::header()
     auto endFrame = 0.0f;
     uint32_t depth = 0;
 
-    auto p = content;
+    auto p = src.text();
 
     while (*p != '\0') {
         if (*p == '{') {
@@ -212,14 +209,8 @@ bool LottieLoader::open(const char* data, uint32_t size, const LoaderOps* _ops, 
     auto ops = static_cast<const PictureOps*>(_ops);
     if (ops->caller != tvg::Type::Picture) return false;
 
-    if (copy) {
-        content = tvg::malloc<char>(size + 1);
-        memcpy((char*)content, data, size);
-        const_cast<char*>(content)[size] = '\0';
-    } else content = data;
+    if (!src.assign(data, size, copy, true)) return false;
 
-    this->size = size;
-    this->copy = copy;
     dirName = ops->rpath ? duplicate(ops->rpath) : duplicate(".");
     builder->resolver = ops->resolver;
 
@@ -231,9 +222,10 @@ bool LottieLoader::open(const char* path, const LoaderOps* ops)
 #ifdef THORVG_FILE_IO_SUPPORT
     if (ops->caller != tvg::Type::Picture) return false;
 
-    if ((content = Loader::open(path, size, true))) {
+    uint32_t size;
+    if (auto content = Loader::open(path, size, true)) {
+        src.own(content, size);
         dirName = tvg::dirname(path);
-        copy = true;
         builder->resolver = static_cast<const PictureOps*>(ops)->resolver;
         return header();
     }
@@ -264,7 +256,7 @@ bool LottieLoader::read()
     // the loading has been already completed
     if (!Loader::read()) return true;
 
-    if (!content || size == 0) return false;
+    if (!src.data || src.size == 0) return false;
 
     TaskScheduler::request(this);
 

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -53,8 +53,6 @@ struct LottieCustomSlot
 
 struct LottieLoader : AnimLoader, Task
 {
-    const char* content = nullptr;      //lottie file data
-    uint32_t size = 0;                  //lottie data size
     float frameNo = 0.0f;               //current frame number
     float frameCnt = 0.0f;
     float frameRate = 0.0f;
@@ -67,7 +65,6 @@ struct LottieLoader : AnimLoader, Task
     Key key;
     char* dirName = nullptr;            //base resource directory
 
-    bool copy = false;                  //"content" is owned by this loader
     bool build = true;                  //require building the lottie scene
 
     LottieLoader();

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -22,6 +22,7 @@
 
 #include "tvgMath.h"
 #include "tvgTaskScheduler.h"
+#include "tvgPicture.h"
 #include "tvgLottieModel.h"
 #include "tvgCompressor.h"
 
@@ -302,8 +303,12 @@ void LottieImage::prepare(bool external)
     //Prepare the Picture image
     auto result = Result::Unknown;
     auto picture = Picture::gen();
-    if (bitmap.size > 0) result = picture->load(bitmap.data, bitmap.size, bitmap.mimeType, nullptr, true);
-    else if (external) result = picture->load(bitmap.path);
+    if (bitmap.size > 0) {
+        //hand it over, as the slot override parsing releases it right after this
+        result = to<PictureImpl>(picture)->load(bitmap.data, bitmap.size, bitmap.mimeType, nullptr, DataOwnership::Transfer);
+        bitmap.data = nullptr;
+        bitmap.size = 0;
+    } else if (external) result = picture->load(bitmap.path);
     if (result == Result::Success) {
         resolved = true;
         bitmap.AssetSrc::release();

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -302,9 +302,12 @@ void LottieImage::prepare(bool external)
     //Prepare the Picture image
     auto result = Result::Unknown;
     auto picture = Picture::gen();
-    if (bitmap.size > 0) result = picture->load(bitmap.data, bitmap.size, bitmap.mimeType);
+    if (bitmap.size > 0) result = picture->load(bitmap.data, bitmap.size, bitmap.mimeType, nullptr, true);
     else if (external) result = picture->load(bitmap.path);
-    if (result == Result::Success) resolved = true;
+    if (result == Result::Success) {
+        resolved = true;
+        bitmap.AssetSrc::release();
+    }
     picture->size(bitmap.width, bitmap.height);
     bitmap.picture = picture;
     picture->ref();

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -36,7 +36,7 @@ void PngLoader::run(unsigned tid)
 
     state.info_raw.colortype = LCT_RGBA;   //request this image format
 
-    if (lodepng_decode(&surface.buf8, &width, &height, &state, data, size)) TVGERR("PNG", "Failed to decode image");
+    if (lodepng_decode(&surface.buf8, &width, &height, &state, src.data, src.size)) TVGERR("PNG", "Failed to decode image");
     else if (state.info_png.iccp_defined && lodepng_toSrgb(surface.buf8, surface.buf8, width, height, &state)) TVGERR("PNG", "Unsupported ICC color profile");
 
     surface.setup(surface.buf32, width, width, height, sizeof(uint32_t), ColorSpace::ABGR8888S);
@@ -56,7 +56,6 @@ PngLoader::PngLoader() : BitmapLoader(FileType::Png)
 PngLoader::~PngLoader()
 {
     done();
-    if (freeData) tvg::free(data);
     tvg::free(surface.buf8);
     lodepng_state_cleanup(&state);
 }
@@ -64,15 +63,17 @@ PngLoader::~PngLoader()
 bool PngLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (!(data = (unsigned char*)Loader::open(path, size))) return false;
+    uint32_t size;
+    auto data = Loader::open(path, size);
+    if (!data) return false;
+    src.own(data, size);
 
     lodepng_state_init(&state);
 
     unsigned int width, height;
-    if (lodepng_inspect(&width, &height, &state, data, size) > 0) return false;
+    if (lodepng_inspect(&width, &height, &state, src.data, src.size) > 0) return false;
     w = static_cast<float>(width);
     h = static_cast<float>(height);
-    freeData = true;
     return true;
 #else
     return false;
@@ -84,19 +85,10 @@ bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps
     unsigned int width, height;
     if (lodepng_inspect(&width, &height, &state, (unsigned char*)(data), size) > 0) return false;
 
-    if (copy) {
-        this->data = tvg::malloc<unsigned char>(size);
-        if (!this->data) return false;
-        memcpy((unsigned char *)this->data, data, size);
-        freeData = true;
-    } else {
-        this->data = (unsigned char *) data;
-        freeData = false;
-    }
+    if (!src.assign(data, size, copy)) return false;
 
     w = static_cast<float>(width);
     h = static_cast<float>(height);
-    this->size = size;
 
     return true;
 }
@@ -104,7 +96,7 @@ bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps
 
 bool PngLoader::read()
 {
-    if (!data || w == 0 || h == 0) return false;
+    if (!src.data || w == 0 || h == 0) return false;
 
     if (!Loader::read()) return true;
 

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -39,9 +39,6 @@ struct PngLoader : BitmapLoader, Task
 
 private:
     LodePNGState state;
-    unsigned char* data = nullptr;
-    uint32_t size = 0;
-    bool freeData = false;
 
     void run(unsigned tid) override;
 };

--- a/src/loaders/sfnt/tvgSfntLoader.cpp
+++ b/src/loaders/sfnt/tvgSfntLoader.cpp
@@ -242,10 +242,9 @@ uint32_t SfntLoader::feedLine(FontMetrics& fm, float box, float x, uint32_t begi
 void SfntLoader::clear()
 {
     if (nomap) {
-        if (freeData) tvg::free(reader->data);
         reader->data = nullptr;
         reader->size = 0;
-        freeData = false;
+        src.clear();
         nomap = false;
     } else {
 #ifdef THORVG_FILE_IO_SUPPORT
@@ -541,15 +540,11 @@ bool SfntLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 
 bool SfntLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
-    reader = gen((uint8_t*)data, size);
+    if (!src.assign(data, size, copy)) return false;
+
+    reader = gen(src.data, src.size);
     if (!reader) return false;
     nomap = true;
-
-    if (copy) {
-        reader->data = tvg::malloc<uint8_t>(size);
-        memcpy((char*)reader->data, data, reader->size);
-        freeData = true;
-    }
 
     return reader->header();
 }

--- a/src/loaders/sfnt/tvgSfntLoader.h
+++ b/src/loaders/sfnt/tvgSfntLoader.h
@@ -43,7 +43,6 @@ struct SfntLoader : public FontLoader
     SfntReader* reader = nullptr;
     char* text = nullptr;
     bool nomap = false;
-    bool freeData = false;
 
     SfntLoader();
     ~SfntLoader();

--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -22,6 +22,7 @@
 
 #include "tvgMath.h" /* to include math.h before cstring */
 #include "tvgShape.h"
+#include "tvgPicture.h"
 #include "tvgCompressor.h"
 #include "tvgFill.h"
 #include "tvgStr.h"
@@ -765,20 +766,12 @@ static Paint* _imageBuildHelper(SvgParserContext& ctx, SvgNode* node, const Box&
         imageMimeTypeEncoding encoding;
         if (!_isValidImageMimeTypeAndEncoding(&href, &mimetype, &encoding)) return nullptr; //not allowed mime type or encoding
         char *decoded = nullptr;
-        if (encoding == imageMimeTypeEncoding::base64) {
-            auto size = b64Decode(href, strlen(href), &decoded);
-            if (picture->load(decoded, size, mimetype) != Result::Success) {
-                tvg::free(decoded);
-                return nullptr;
-            }
-        } else {
-            auto size = svgUtilURLDecode(href, &decoded);
-            if (picture->load(decoded, size, mimetype) != Result::Success) {
-                tvg::free(decoded);
-                return nullptr;
-            }
+        auto size = (encoding == imageMimeTypeEncoding::base64) ? b64Decode(href, strlen(href), &decoded) : svgUtilURLDecode(href, &decoded);
+        //hand it over, so that it outlives this build along with the loader
+        if (to<PictureImpl>(picture)->load(decoded, size, mimetype, nullptr, DataOwnership::Transfer) != Result::Success) {
+            Paint::rel(picture);
+            return nullptr;
         }
-        ctx.images.push(decoded);
     } else {
         if (!strncmp(href, "file://", sizeof("file://") - 1)) href += sizeof("file://") - 1;
         //TODO: protect against recursive svg image loading
@@ -1450,8 +1443,6 @@ Scene* svgSceneBuild(SvgParserContext& ctx, Box vBox, float w, float h, AspectRa
         _updateInvalidViewSize(docNode, vBox, w, h, viewFlag);
         if ((!tvg::equal(vBox.w, prevW) || !tvg::equal(vBox.h, prevH)) && _hasUserSpaceGradients(ctx)) {
             Paint::rel(docNode);
-            ARRAY_FOREACH(p, ctx.images) tvg::free(*p);
-            ctx.images.clear();
             docNode = _sceneBuildHelper(ctx, ctx.doc, vBox, svgPath, false, 0);
         }
     }

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -646,7 +646,6 @@ struct SvgParserContext
     Array<SvgStyleGradient*> gradients;
     Array<SvgStyleGradient*> gradientStack; //For stops
     Array<SvgNodeIdPair> nodesToStyle;
-    Array<char*> images;        //embedded images
     Array<FontFace> fonts;
 
     // TODO: We can remove map and directly use the name instead of id in ThorVG v2

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -3851,16 +3851,12 @@ void SvgLoader::clear(bool all)
 
     if (!all) return;
 
-    if (copy) tvg::free((char*)content);
+    src.clear();
 
     if (root) {
         root->unref();
         root = nullptr;
     }
-
-    size = 0;
-    content = nullptr;
-    copy = false;
 }
 
 
@@ -3873,7 +3869,7 @@ void SvgLoader::run(unsigned tid)
         TVGLOG("SVG", "The <viewBox> width and/or height set to 0 - rendering disabled.");
         root = Scene::gen();
     } else {
-        if (xmlParse(content, size, true, _svgLoaderParser, &(ctx))) {
+        if (xmlParse(src.text(), src.size, true, _svgLoaderParser, &(ctx))) {
             if (ctx.doc) {
                 auto defs = ctx.doc->node.doc.defs;
 
@@ -3941,9 +3937,6 @@ void SvgParserContext::clear(bool all)
 
     if (!all) return;
 
-    ARRAY_FOREACH(p, images) {
-        tvg::free(*p);
-    }
     ARRAY_FOREACH(p, fonts) {
         Text::unload(p->name);
         tvg::free(p->decoded);
@@ -3975,7 +3968,7 @@ bool SvgLoader::header()
     ctx.parser->flags = SvgStopStyleFlags::StopDefault;
     viewFlag = SvgViewFlag::None;
 
-    xmlParse(content, size, true, _svgLoaderParserForValidCheck, &(ctx));
+    xmlParse(src.text(), src.size, true, _svgLoaderParserForValidCheck, &(ctx));
 
     if (!ctx.doc || ctx.doc->type != SvgNodeType::Doc) {
         TVGLOG("SVG", "No SVG File. There is no <svg/>");
@@ -4039,14 +4032,7 @@ bool SvgLoader::open(const char* data, uint32_t size, const LoaderOps* ops, bool
 {
     if (ops->caller != tvg::Type::Picture) return false;
 
-    if (copy) {
-        content = tvg::malloc<char>(size + 1);
-        memcpy((char*)content, data, size);
-        content[size] = '\0';
-    } else content = (char*)data;
-
-    this->size = size;
-    this->copy = copy;
+    if (!src.assign(data, size, copy, true)) return false;
 
     ctx.accessible = static_cast<const PictureOps*>(ops)->accessible;
 
@@ -4058,9 +4044,10 @@ bool SvgLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 #ifdef THORVG_FILE_IO_SUPPORT
     if (ops->caller != tvg::Type::Picture) return false;
 
-    if ((content = Loader::open(path, size, true))) {
+    uint32_t size;
+    if (auto content = Loader::open(path, size, true)) {
+        src.own(content, size);
         ctx.accessible = static_cast<const PictureOps*>(ops)->accessible;
-        copy = true;
         return header();
     }
 #endif
@@ -4083,7 +4070,7 @@ bool SvgLoader::resize(Paint* paint, float w, float h)
 
 bool SvgLoader::read()
 {
-    if (!content || size == 0) return false;
+    if (!src.data || src.size == 0) return false;
 
     if (!Loader::read() || root) return true;
 

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -30,10 +30,7 @@ struct SvgLoader : ImageLoader, Task
 {
     SvgParserContext ctx;
     string svgPath = "";
-    char* content = nullptr;
-    uint32_t size = 0;
     Scene* root = nullptr;
-    bool copy = false;
 
     SvgLoader();
     ~SvgLoader();

--- a/src/loaders/webp/tvgWebpLoader.cpp
+++ b/src/loaders/webp/tvgWebpLoader.cpp
@@ -27,9 +27,7 @@
 
 void WebpLoader::clear()
 {
-    if (freeData) tvg::free(data);
-    data = nullptr;
-    freeData = false;
+    src.clear();
 }
 
 
@@ -40,10 +38,10 @@ void WebpLoader::run(unsigned tid)
 
     // static loader WebPDecodeRGBA/WebPDecodeBGRA returns a premultiplied version.
     if (surface.cs == ColorSpace::ARGB8888 || surface.cs == ColorSpace::ARGB8888S) {
-        buf8 = WebPDecodeBGRA(data, size, nullptr, nullptr);
+        buf8 = WebPDecodeBGRA(src.data, src.size, nullptr, nullptr);
         cs = ColorSpace::ARGB8888;
     } else  {
-        buf8 = WebPDecodeRGBA(data, size, nullptr, nullptr);
+        buf8 = WebPDecodeRGBA(src.data, src.size, nullptr, nullptr);
         cs = ColorSpace::ABGR8888;
     }
     surface.setup((pixel_t*)buf8, static_cast<uint32_t>(w), static_cast<uint32_t>(w), static_cast<uint32_t>(h), sizeof(uint32_t), cs);
@@ -70,14 +68,16 @@ WebpLoader::~WebpLoader()
 bool WebpLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (!(data = (uint8_t*)Loader::open(path, size))) return false;
+    uint32_t size;
+    auto data = Loader::open(path, size);
+    if (!data) return false;
+    src.own(data, size);
 
     WebPBitstreamFeatures features;
-    if (WebPGetFeatures(data, size, &features)) return false;
+    if (WebPGetFeatures(src.data, src.size, &features)) return false;
     w = static_cast<float>(features.width);
     h = static_cast<float>(features.height);
     surface.alphaIgnored = !features.has_alpha;
-    freeData = true;
     return true;
 #else
     return false;
@@ -86,22 +86,13 @@ bool WebpLoader::open(const char* path, TVG_UNUSED const LoaderOps* ops)
 
 bool WebpLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps* ops, bool copy)
 {
-    if (copy) {
-        this->data = tvg::malloc<uint8_t>(size);
-        if (!this->data) return false;
-        memcpy((uint8_t*)this->data, data, size);
-        freeData = true;
-    } else {
-        this->data = (uint8_t*) data;
-        freeData = false;
-    }
+    if (!src.assign(data, size, copy)) return false;
 
     WebPBitstreamFeatures features;
-    if (WebPGetFeatures(this->data, size, &features)) return false;
+    if (WebPGetFeatures(src.data, src.size, &features)) return false;
     w = static_cast<float>(features.width);
     h = static_cast<float>(features.height);
     surface.alphaIgnored = !features.has_alpha;
-    this->size = size;
 
     return true;
 }
@@ -111,7 +102,7 @@ bool WebpLoader::read()
 {
     if (!Loader::read()) return true;
 
-    if (!data || w == 0 || h == 0) return false;
+    if (!src.data || w == 0 || h == 0) return false;
 
     surface.cs = BitmapLoader::cs;
 

--- a/src/loaders/webp/tvgWebpLoader.h
+++ b/src/loaders/webp/tvgWebpLoader.h
@@ -36,10 +36,6 @@ struct WebpLoader : BitmapLoader, Task
     RenderSurface* bitmap() override;
 
 private:
-    uint8_t* data = nullptr;
-    uint32_t size = 0;
-    bool freeData = false;
-
     void clear();
     void run(unsigned tid) override;
 };

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -39,6 +39,63 @@ struct AssetResolver
     void* data;
 };
 
+enum class DataOwnership : uint8_t
+{
+    Borrow = 0,  // the caller keeps it alive, thus shareable by its address
+    Copy,        // the loader duplicates and releases it
+    Transfer     // the loader takes it over, the caller must not touch it anymore
+};
+
+struct SourceData
+{
+    uint8_t* data = nullptr;
+    uint32_t size = 0;
+    bool owned = false;  // release the data on clear()
+
+    ~SourceData()
+    {
+        clear();
+    }
+
+    bool assign(const char* data, uint32_t size, bool copy, bool terminate = false)
+    {
+        clear();
+
+        if (copy) {
+            this->data = tvg::malloc<uint8_t>(terminate ? size + 1 : size);
+            if (!this->data) return false;
+            memcpy(this->data, data, size);
+            if (terminate) this->data[size] = '\0';
+            owned = true;
+        } else this->data = (uint8_t*)data;
+
+        this->size = size;
+
+        return true;
+    }
+
+    void own(char* data, uint32_t size)
+    {
+        clear();
+        this->data = (uint8_t*)data;
+        this->size = size;
+        owned = true;
+    }
+
+    void clear()
+    {
+        if (owned) tvg::free(data);
+        data = nullptr;
+        size = 0;
+        owned = false;
+    }
+
+    const char* text() const
+    {
+        return (const char*)data;
+    }
+};
+
 struct LoaderOps
 {
     Type caller;  // which requests this?
@@ -62,6 +119,7 @@ struct Loader
     uintptr_t hashkey = 0;
     char* hashpath = nullptr;
 
+    SourceData src;              // encoded source data
     FileType type;               // current loader file type
     atomic<uint16_t> sharing{};  // reference count
     bool readied = false;        // read done already
@@ -97,6 +155,13 @@ struct Loader
 
         hashpath = tvg::duplicate(path);
         cached = true;
+        return true;
+    }
+
+    bool adopt(const char* data)  // takes over the borrowed source data
+    {
+        if (src.data != (uint8_t*)data) return false;
+        src.owned = true;
         return true;
     }
 

--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -259,24 +259,35 @@ bool LoaderMgr::retrieve(const char* filename)
     return retrieve(_findFromCache(filename));
 }
 
-tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy)
+tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, DataOwnership ownership)
 {
+    auto shareable = (ownership == DataOwnership::Borrow);
+    auto copy = (ownership == DataOwnership::Copy);
+
     // Note that users could use the same data pointer with the different content.
     // Thus caching is only valid for shareable.
-    if (!copy) {
+    if (shareable) {
         if (auto loader = _findFromCache(data, size, mimeType)) return loader;
     }
+
+    // The candidates borrow the data, so that a rejected trial leaves it intact
+    // for the next one. A loader which consumed the data during open() has
+    // nothing to take over, thus release it here.
+    auto accept = [&](tvg::Loader* loader) {
+        if (ownership == DataOwnership::Transfer) {
+            if (!loader->adopt(data)) tvg::free(const_cast<char*>(data));
+        } else if (shareable && loader->cache(HASH_KEY(data))) {
+            ScopedLock lock(_key);
+            _activeLoaders.back(loader);
+        }
+        return loader;
+    };
 
     // Try with the given MimeType
     if (mimeType) {
         if (auto loader = _findByType(mimeType)) {
-            if (loader->open(data, size, ops, copy)) {
-                if (!copy && loader->cache(HASH_KEY(data))) {
-                    ScopedLock lock(_key);
-                    _activeLoaders.back(loader);
-                }
-                return loader;
-            } else {
+            if (loader->open(data, size, ops, copy)) return accept(loader);
+            else {
                 TVGLOG("LOADER", "Given mimetype \"%s\" seems incorrect or not supported.", mimeType);
                 delete (loader);
             }
@@ -286,15 +297,13 @@ tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mime
     for (int i = 0; i < static_cast<int>(FileType::Unknown); i++) {
         auto loader = _find(static_cast<FileType>(i));
         if (!loader) continue;
-        if (loader->open(data, size, ops, copy)) {
-            if (!copy && loader->cache(HASH_KEY(data))) {
-                ScopedLock lock(_key);
-                _activeLoaders.back(loader);
-            }
-            return loader;
-        }
+        if (loader->open(data, size, ops, copy)) return accept(loader);
         delete (loader);
     }
+
+    // Nobody took the transferred data over, thus release it here.
+    if (ownership == DataOwnership::Transfer) tvg::free(const_cast<char*>(data));
+
     return nullptr;
 }
 

--- a/src/renderer/tvgLoaderMgr.h
+++ b/src/renderer/tvgLoaderMgr.h
@@ -33,7 +33,7 @@ struct LoaderMgr
     static bool init();
     static bool term();
     static Loader* loader(const char* filename, const LoaderOps* ops, bool& invalid);
-    static Loader* loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy);
+    static Loader* loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, DataOwnership ownership);
     static Loader* loader(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy);
     static Loader* loader(const char* name, const char* data, uint32_t size, const char* mimeType, const LoaderOps* ops, bool copy);
     static Loader* font(const char* name);

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -147,11 +147,16 @@ struct PictureImpl : Picture
 
     Result load(const char* data, uint32_t size, const char* mimeType, const char* rpath, bool copy)
     {
-        if (!data || size <= 0) return Result::InvalidArguments;
-        if (vector || bitmap) return Result::InsufficientCondition;
+        return load(data, size, mimeType, rpath, copy ? DataOwnership::Copy : DataOwnership::Borrow);
+    }
+
+    Result load(const char* data, uint32_t size, const char* mimeType, const char* rpath, DataOwnership ownership)
+    {
+        if (!data || size <= 0) return reject(data, ownership, Result::InvalidArguments);
+        if (vector || bitmap) return reject(data, ownership, Result::InsufficientCondition);
 
         PictureOps ops = {resolver, rpath, accessible};
-        return load(LoaderMgr::loader(data, size, mimeType, &ops, copy));
+        return load(LoaderMgr::loader(data, size, mimeType, &ops, ownership));
     }
 
     Result load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, bool copy)
@@ -294,6 +299,13 @@ struct PictureImpl : Picture
         if (vector) return vector->pImpl->bounds();
         else if (impl.renderer) return impl.renderer->region(impl.rd);
         return {};
+    }
+
+    // the transferred data is consumed even if the request is rejected upfront.
+    static Result reject(const char* data, DataOwnership ownership, Result result)
+    {
+        if (ownership == DataOwnership::Transfer) tvg::free(const_cast<char*>(data));
+        return result;
     }
 
     Result load(Loader* loader)


### PR DESCRIPTION
#4632 fixes a use-after-free on lottie image slots. It loads with `copy = true`.
@hermet  noted that we must find a way to skip the memory copy.

The copy gives no benefit here. `LottieImage::prepare()` receives a buffer that
`b64Decode()` allocated a moment before. The caller releases that buffer
immediately after the load. The loader duplicates the buffer with a `malloc` and
a `memcpy` (`src/loaders/png/tvgPngLoader.cpp:87`, and the same code in `jpg` and
`webp`). Then the caller releases the original.

## Solution

The loader takes over the data. It does not duplicate the data.

`DataOwnership` has three values:

| value | cacheable | memcpy | releases the data |
|---|---|---|---|
| `Borrow` (the previous `copy = false`) | yes | no | the caller |
| `Copy` (the previous `copy = true`) | no | yes | the loader |
| `Transfer` (new) | no | **no** | the loader |

`Loader::open()` keeps its `bool copy` parameter. `LoaderMgr` resolves the
transfer alone:

- It offers the data to each candidate as borrowed.
- The candidate that accepts the data takes it over with `Loader::adopt()`.
- A rejected trial leaves the data intact for the next candidate.
- If no candidate accepts the data, `LoaderMgr` releases it.

This keeps all the failure paths in one function. The other design, which sends
the ownership down into each `open()`, is not safe. `JpgLoader::open()` stores
the data before its header check. A rejected trial would release a buffer that
the next candidate still needs.

The public API does not change. `Picture::load(..., bool copy)` maps to `Copy`
or to `Borrow`.

## Unification

`Loader::src` replaces two parallel idioms:

- `data` / `size` / `freeData` in the 6 bitmap loaders
- `content` / `size` / `copy` in the svg loader and the lottie loader

`freeData` no longer exists in the tree.

## Two related defects that this closes

**The external png loader kept no reference to its source.** It borrows the
memory through libpng, and libpng reads that memory back on
`png_image_finish_read()`. Thus the loader could not release a transferred
buffer. It now records the source.

**The svg builder had the same defect as the lottie image slots.**
`SvgParserContext::clear()` releases the decoded image buffers before
`root->unref()` destroys the pictures. The loaders of those pictures borrow the
buffers, and they stay in the cache under the released address. The transfer
removes the `ctx.images` list and both of its release sites.

## Result

Peak footprint of a lottie with 4 embedded 4 MiB images, built-in loaders:

| build | peak | delta |
|---|---|---|
| main | 102.98 MiB | - |
| #4632 (`copy = true`) | 107.00 MiB | +4.03 (one image) |
| this PR | 102.97 MiB | 0.00 |

> This PR is on top of #4632. Please merge #4632 first.