### PR TITLE
svg: support text spacing

### DIFF
--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -1073,17 +1073,43 @@ static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const
     return text;
 }
 
-static void _updatePos(Text* text, const SvgTextNode& textNode, float anchor, Point& textPos)
+static float _applyLetterSpacing(Text* text, float letterSpacing)
+{
+    if (letterSpacing == 0.0f) return 1.0f;
+
+    auto utf8 = text->text();
+    auto advance = 0.0f;
+    uint32_t gaps = 0;
+    GlyphMetrics gm;
+    while (utf8 && *utf8) {
+        if (text->metrics(utf8, gm, &utf8) != Result::Success) return 1.0f;
+        if (utf8 && *utf8) {
+            advance += gm.advance;
+            ++gaps;
+        }
+    }
+    if (advance <= 0.0f) return 1.0f;
+
+    // Text::spacing() scales advances, so match the total offset using the measured glyph gaps.
+    auto scale = 1.0f + letterSpacing * gaps / advance;
+    if (scale < 0.0f) scale = 0.0f;
+    text->spacing(scale, 1.0f);
+    return scale;
+}
+
+static void _updatePos(Text* text, const SvgTextNode& textNode, float anchor, float spacingScale, Point& textPos)
 {
     auto advance = 0.0f;
     if (auto utf8 = text->text()) {
         GlyphMetrics gm;
-        while (utf8) {
-            if (text->metrics(utf8, gm, &utf8) == Result::Success) advance += gm.advance;
-            else break;
+        while (utf8 && *utf8) {
+            if (text->metrics(utf8, gm, &utf8) != Result::Success) break;
+            advance += gm.advance;
         }
     }
-    textPos.x = textNode.x + textNode.dx + (1.0f - anchor) * advance;
+    // Text::spacing() scales every glyph advance, so scale the measured
+    // advance the same way to stay in sync with the rendered output.
+    textPos.x = textNode.x + textNode.dx + (1.0f - anchor) * advance * spacingScale;
     textPos.y = textNode.y + textNode.dy;
 }
 
@@ -1131,7 +1157,9 @@ static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* 
             auto text = _buildText(&textNode, xmlSpace, nullptr, _effectiveBaseline(child->style));
             if (text) {
                 text->align(child->style->textAnchor, 0.0f);
-                _updatePos(text, textNode, child->style->textAnchor, textPos);
+                _applyTextFill(child->style, text, textNode, vBox, ctx.parser->global);
+                auto spacingScale = _applyLetterSpacing(text, child->style->letterSpacing);
+                _updatePos(text, textNode, child->style->textAnchor, spacingScale, textPos);
                 _applyTextFill(child->style, text, textNode, vBox, ctx.parser->global);
                 auto paint = _applyFilter(ctx, text, child, vBox, svgPath);
                 paint = _applyComposition(ctx, paint, child, vBox, svgPath);
@@ -1157,6 +1185,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
         auto text = _buildText(textNode, xmlSpace, node->transform, _effectiveBaseline(node->style));
         if (!text) return nullptr;
         text->align(node->style->textAnchor, 0.0f);
+        _applyLetterSpacing(text, node->style->letterSpacing);
         _applyTextFill(node->style, text, *textNode, vBox, ctx.parser->global);
         auto p = _applyFilter(ctx, text, node, vBox, svgPath);
         p = _applyComposition(ctx, p, node, vBox, svgPath);
@@ -1170,7 +1199,8 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
 
     if (auto text = _buildText(textNode, xmlSpace, nullptr, _effectiveBaseline(node->style))) {
         text->align(node->style->textAnchor, 0.0f);
-        _updatePos(text, *textNode, node->style->textAnchor, textPos);
+        auto spacingScale = _applyLetterSpacing(text, node->style->letterSpacing);
+        _updatePos(text, *textNode, node->style->textAnchor, spacingScale, textPos);
         _applyTextFill(node->style, text, *textNode, vBox, ctx.parser->global);
         scene->add(text);
     }

--- a/src/loaders/svg/tvgSvgBuilder.cpp
+++ b/src/loaders/svg/tvgSvgBuilder.cpp
@@ -1073,25 +1073,28 @@ static Text* _buildText(const SvgTextNode* textNode, SvgXmlSpace xmlSpace, const
     return text;
 }
 
-static float _applyLetterSpacing(Text* text, float letterSpacing)
+static float _applySpacing(Text* text, float letterSpacing, float wordSpacing)
 {
-    if (letterSpacing == 0.0f) return 1.0f;
+    if (letterSpacing == 0.0f && wordSpacing == 0.0f) return 1.0f;
 
     auto utf8 = text->text();
     auto advance = 0.0f;
     uint32_t gaps = 0;
+    uint32_t spaces = 0;
     GlyphMetrics gm;
     while (utf8 && *utf8) {
+        auto space = *utf8 == ' ';
         if (text->metrics(utf8, gm, &utf8) != Result::Success) return 1.0f;
         if (utf8 && *utf8) {
             advance += gm.advance;
             ++gaps;
+            if (space) ++spaces;
         }
     }
     if (advance <= 0.0f) return 1.0f;
 
-    // Text::spacing() scales advances, so match the total offset using the measured glyph gaps.
-    auto scale = 1.0f + letterSpacing * gaps / advance;
+    // Text::spacing() scales advances, so match the total offset using measured gaps.
+    auto scale = 1.0f + (letterSpacing * gaps + wordSpacing * spaces) / advance;
     if (scale < 0.0f) scale = 0.0f;
     text->spacing(scale, 1.0f);
     return scale;
@@ -1157,8 +1160,7 @@ static void _buildTspanScene(SvgParserContext& ctx, const SvgNode* node, Scene* 
             auto text = _buildText(&textNode, xmlSpace, nullptr, _effectiveBaseline(child->style));
             if (text) {
                 text->align(child->style->textAnchor, 0.0f);
-                _applyTextFill(child->style, text, textNode, vBox, ctx.parser->global);
-                auto spacingScale = _applyLetterSpacing(text, child->style->letterSpacing);
+                auto spacingScale = _applySpacing(text, child->style->letterSpacing, child->style->wordSpacing);
                 _updatePos(text, textNode, child->style->textAnchor, spacingScale, textPos);
                 _applyTextFill(child->style, text, textNode, vBox, ctx.parser->global);
                 auto paint = _applyFilter(ctx, text, child, vBox, svgPath);
@@ -1185,7 +1187,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
         auto text = _buildText(textNode, xmlSpace, node->transform, _effectiveBaseline(node->style));
         if (!text) return nullptr;
         text->align(node->style->textAnchor, 0.0f);
-        _applyLetterSpacing(text, node->style->letterSpacing);
+        _applySpacing(text, node->style->letterSpacing, node->style->wordSpacing);
         _applyTextFill(node->style, text, *textNode, vBox, ctx.parser->global);
         auto p = _applyFilter(ctx, text, node, vBox, svgPath);
         p = _applyComposition(ctx, p, node, vBox, svgPath);
@@ -1199,7 +1201,7 @@ static Paint* _textBuildHelper(SvgParserContext& ctx, const SvgNode* node, const
 
     if (auto text = _buildText(textNode, xmlSpace, nullptr, _effectiveBaseline(node->style))) {
         text->align(node->style->textAnchor, 0.0f);
-        auto spacingScale = _applyLetterSpacing(text, node->style->letterSpacing);
+        auto spacingScale = _applySpacing(text, node->style->letterSpacing, node->style->wordSpacing);
         _updatePos(text, *textNode, node->style->textAnchor, spacingScale, textPos);
         _applyTextFill(node->style, text, *textNode, vBox, ctx.parser->global);
         scene->add(text);

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -175,7 +175,8 @@ enum struct SvgStyleFlags
     TextAnchor = 0x200000,
     AlignmentBaseline = 0x400000,
     DominantBaseline = 0x800000,
-    FontWeight = 0x1000000
+    FontWeight = 0x1000000,
+    LetterSpacing = 0x2000000
 };
 
 constexpr bool operator&(SvgStyleFlags a, SvgStyleFlags b)
@@ -576,11 +577,13 @@ struct SvgStyleProperty
     SvgBaseline alignmentBaseline;
     SvgBaseline dominantBaseline;
     SvgFontWeight fontWeight;
+    float letterSpacing;
     SvgStyleFlags flags;
     SvgStyleFlags flagsImportance; //indicates the importance of the flag - if set, higher priority is applied (https://drafts.csswg.org/css-cascade-4/#importance)
     bool curColorSet;
     bool paintOrder; //true if default (fill, stroke), false otherwise
     bool display;
+    bool letterSpacingRelative;
     BlendMethod blendMode;
 };
 

--- a/src/loaders/svg/tvgSvgCommon.h
+++ b/src/loaders/svg/tvgSvgCommon.h
@@ -176,7 +176,8 @@ enum struct SvgStyleFlags
     AlignmentBaseline = 0x400000,
     DominantBaseline = 0x800000,
     FontWeight = 0x1000000,
-    LetterSpacing = 0x2000000
+    LetterSpacing = 0x2000000,
+    WordSpacing = 0x4000000
 };
 
 constexpr bool operator&(SvgStyleFlags a, SvgStyleFlags b)
@@ -578,12 +579,14 @@ struct SvgStyleProperty
     SvgBaseline dominantBaseline;
     SvgFontWeight fontWeight;
     float letterSpacing;
+    float wordSpacing;
     SvgStyleFlags flags;
     SvgStyleFlags flagsImportance; //indicates the importance of the flag - if set, higher priority is applied (https://drafts.csswg.org/css-cascade-4/#importance)
     bool curColorSet;
     bool paintOrder; //true if default (fill, stroke), false otherwise
     bool display;
     bool letterSpacingRelative;
+    bool wordSpacingRelative;
     BlendMethod blendMode;
 };
 

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -171,6 +171,12 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from, bool 
         to->flags |= SvgStyleFlags::LetterSpacing;
         if (from->flagsImportance & SvgStyleFlags::LetterSpacing) to->flagsImportance |= SvgStyleFlags::LetterSpacing;
     }
+    if (((from->flags & SvgStyleFlags::WordSpacing) && (overwrite || !(to->flags & SvgStyleFlags::WordSpacing))) || _isImportanceApplicable(to->flagsImportance, from->flagsImportance, SvgStyleFlags::WordSpacing)) {
+        to->wordSpacing = from->wordSpacing;
+        to->wordSpacingRelative = from->wordSpacingRelative;
+        to->flags |= SvgStyleFlags::WordSpacing;
+        if (from->flagsImportance & SvgStyleFlags::WordSpacing) to->flagsImportance |= SvgStyleFlags::WordSpacing;
+    }
 }
 
 

--- a/src/loaders/svg/tvgSvgCssStyle.cpp
+++ b/src/loaders/svg/tvgSvgCssStyle.cpp
@@ -165,6 +165,12 @@ static void _copyStyle(SvgStyleProperty* to, const SvgStyleProperty* from, bool 
         to->flags |= SvgStyleFlags::FontWeight;
         if (from->flagsImportance & SvgStyleFlags::FontWeight) to->flagsImportance |= SvgStyleFlags::FontWeight;
     }
+    if (((from->flags & SvgStyleFlags::LetterSpacing) && (overwrite || !(to->flags & SvgStyleFlags::LetterSpacing))) || _isImportanceApplicable(to->flagsImportance, from->flagsImportance, SvgStyleFlags::LetterSpacing)) {
+        to->letterSpacing = from->letterSpacing;
+        to->letterSpacingRelative = from->letterSpacingRelative;
+        to->flags |= SvgStyleFlags::LetterSpacing;
+        if (from->flagsImportance & SvgStyleFlags::LetterSpacing) to->flagsImportance |= SvgStyleFlags::LetterSpacing;
+    }
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1167,6 +1167,32 @@ static void _handleDominantBaselineAttr(TVG_UNUSED SvgParserContext* ctx, SvgNod
     node->style->dominantBaseline = baseline;
 }
 
+//toFloat() consumes the "em" suffix, so detect font-relative units from the value's tail instead of its end pointer
+static bool _isFontRelativeUnit(const char* value)
+{
+    auto p = value + strlen(value);
+    while (p > value && isspace((unsigned char)p[-1])) --p;
+    auto end = p;
+    while (p > value && isalpha((unsigned char)p[-1])) --p;
+    if (end - p != 2) return false;  //so that "rem" is not mistaken for "em"
+    return !strncmp(p, "em", 2) || !strncmp(p, "ex", 2);
+}
+
+static void _handleLetterSpacingAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* node, const char* value)
+{
+    node->style->flags |= SvgStyleFlags::LetterSpacing;
+    node->style->letterSpacingRelative = false;
+    if (STR_AS(value, "normal")) {
+        node->style->letterSpacing = 0.0f;
+        return;
+    }
+    char* end = nullptr;
+    auto parsed = toFloat(value, &end);
+    auto percentage = _isPercentage(end);
+    node->style->letterSpacingRelative = percentage || _isFontRelativeUnit(value);
+    node->style->letterSpacing = parsed * (percentage ? 0.01f : _unitScale(value, 1.0f));
+}
+
 static void _handleCssClassAttr(SvgParserContext* ctx, SvgNode* node, const char* value)
 {
     auto cssClass = &node->style->cssClass;
@@ -1216,7 +1242,8 @@ static constexpr struct
     STYLE_DEF(text-anchor, TextAnchor, SvgStyleFlags::TextAnchor),
     STYLE_DEF(alignment-baseline, AlignmentBaseline, SvgStyleFlags::AlignmentBaseline),
     STYLE_DEF(dominant-baseline, DominantBaseline, SvgStyleFlags::DominantBaseline),
-    STYLE_DEF(font-weight, FontWeight, SvgStyleFlags::FontWeight)
+    STYLE_DEF(font-weight, FontWeight, SvgStyleFlags::FontWeight),
+    STYLE_DEF(letter-spacing, LetterSpacing, SvgStyleFlags::LetterSpacing)
 };
 // clang-format on
 
@@ -3055,6 +3082,7 @@ static void _styleInherit(SvgStyleProperty* child, const SvgStyleProperty* paren
     if (!(child->stroke.flags & SvgStrokeFlags::Miterlimit)) child->stroke.miterlimit = parent->stroke.miterlimit;
     if (!(child->flags & SvgStyleFlags::TextAnchor)) child->textAnchor = parent->textAnchor;
     if (!(child->flags & SvgStyleFlags::DominantBaseline)) child->dominantBaseline = parent->dominantBaseline;
+    if (!(child->flags & SvgStyleFlags::LetterSpacing)) child->letterSpacing = parent->letterSpacing;
 }
 
 
@@ -3075,6 +3103,10 @@ static void _styleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
     if (from->flags & SvgStyleFlags::AlignmentBaseline) to->alignmentBaseline = from->alignmentBaseline;
     if (from->flags & SvgStyleFlags::DominantBaseline) to->dominantBaseline = from->dominantBaseline;
     if (from->flags & SvgStyleFlags::FontWeight) to->fontWeight = from->fontWeight;
+    if (from->flags & SvgStyleFlags::LetterSpacing) {
+        to->letterSpacing = from->letterSpacing;
+        to->letterSpacingRelative = from->letterSpacingRelative;
+    }
 
     //Fill
     to->fill.flags = (to->fill.flags | from->fill.flags);
@@ -3762,6 +3794,10 @@ static bool _svgLoaderParser(void* data, XMLType type, const char* content, unsi
 static void _updateStyle(SvgNode* node, SvgStyleProperty* parentStyle)
 {
     _styleInherit(node->style, parentStyle);
+    if (node->style->letterSpacingRelative) {
+        node->style->letterSpacing *= _findEmBaseFontSize(node);
+        node->style->letterSpacingRelative = false;
+    }
     ARRAY_FOREACH(p, node->child) {
         _updateStyle(*p, node->style);
     }

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -1193,6 +1193,21 @@ static void _handleLetterSpacingAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* 
     node->style->letterSpacing = parsed * (percentage ? 0.01f : _unitScale(value, 1.0f));
 }
 
+static void _handleWordSpacingAttr(TVG_UNUSED SvgParserContext* ctx, SvgNode* node, const char* value)
+{
+    node->style->flags |= SvgStyleFlags::WordSpacing;
+    node->style->wordSpacingRelative = false;
+    if (STR_AS(value, "normal")) {
+        node->style->wordSpacing = 0.0f;
+        return;
+    }
+    char* end = nullptr;
+    auto parsed = toFloat(value, &end);
+    auto percentage = _isPercentage(end);
+    node->style->wordSpacingRelative = percentage || _isFontRelativeUnit(value);
+    node->style->wordSpacing = parsed * (percentage ? 0.01f : _unitScale(value, 1.0f));
+}
+
 static void _handleCssClassAttr(SvgParserContext* ctx, SvgNode* node, const char* value)
 {
     auto cssClass = &node->style->cssClass;
@@ -1243,7 +1258,8 @@ static constexpr struct
     STYLE_DEF(alignment-baseline, AlignmentBaseline, SvgStyleFlags::AlignmentBaseline),
     STYLE_DEF(dominant-baseline, DominantBaseline, SvgStyleFlags::DominantBaseline),
     STYLE_DEF(font-weight, FontWeight, SvgStyleFlags::FontWeight),
-    STYLE_DEF(letter-spacing, LetterSpacing, SvgStyleFlags::LetterSpacing)
+    STYLE_DEF(letter-spacing, LetterSpacing, SvgStyleFlags::LetterSpacing),
+    STYLE_DEF(word-spacing, WordSpacing, SvgStyleFlags::WordSpacing)
 };
 // clang-format on
 
@@ -3083,6 +3099,7 @@ static void _styleInherit(SvgStyleProperty* child, const SvgStyleProperty* paren
     if (!(child->flags & SvgStyleFlags::TextAnchor)) child->textAnchor = parent->textAnchor;
     if (!(child->flags & SvgStyleFlags::DominantBaseline)) child->dominantBaseline = parent->dominantBaseline;
     if (!(child->flags & SvgStyleFlags::LetterSpacing)) child->letterSpacing = parent->letterSpacing;
+    if (!(child->flags & SvgStyleFlags::WordSpacing)) child->wordSpacing = parent->wordSpacing;
 }
 
 
@@ -3106,6 +3123,10 @@ static void _styleCopy(SvgStyleProperty* to, const SvgStyleProperty* from)
     if (from->flags & SvgStyleFlags::LetterSpacing) {
         to->letterSpacing = from->letterSpacing;
         to->letterSpacingRelative = from->letterSpacingRelative;
+    }
+    if (from->flags & SvgStyleFlags::WordSpacing) {
+        to->wordSpacing = from->wordSpacing;
+        to->wordSpacingRelative = from->wordSpacingRelative;
     }
 
     //Fill
@@ -3797,6 +3818,10 @@ static void _updateStyle(SvgNode* node, SvgStyleProperty* parentStyle)
     if (node->style->letterSpacingRelative) {
         node->style->letterSpacing *= _findEmBaseFontSize(node);
         node->style->letterSpacingRelative = false;
+    }
+    if (node->style->wordSpacingRelative) {
+        node->style->wordSpacing *= _findEmBaseFontSize(node);
+        node->style->wordSpacingRelative = false;
     }
     ARRAY_FOREACH(p, node->child) {
         _updateStyle(*p, node->style);


### PR DESCRIPTION
This adds SVG `letter-spacing` and `word-spacing` support for presentation attributes and CSS.
It supports inheritance, `normal`, absolute lengths, and font-relative units. Spacing values are converted to a relative scale using measured glyph advances, and tspan positioning accounts for both properties.
Since `Text::spacing()` only scales glyph advances, the requested total offset is preserved but distributed across glyph advances. 

*Exact per-gap spacing requires text layout support for absolute offsets after font positioning.

Issue: #4107
