### PR TITLE
lottie: refactor image asset ownership

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -971,14 +971,14 @@ void LottieBuilder::updateImage(LottieGroup* layer)
         return;
     }
 
-    auto picture = image->bitmap.picture;
+    auto picture = image->get();
     if (!picture) return;
 
     //resolve an image asset if need
-    if (resolver && !image->resolved) {
-        resolver->func(picture, image->bitmap.path, resolver->data);
-        picture->size(image->bitmap.width, image->bitmap.height);
-        image->resolved = true;
+    if (resolver && !image->valid) {
+        resolver->func(picture, image->asset.path, resolver->data);
+        picture->size(image->asset.width, image->asset.height);
+        image->valid = true;
     }
 
     //LottieImage can be shared among other layers

--- a/src/loaders/lottie/tvgLottieCommon.h
+++ b/src/loaders/lottie/tvgLottieCommon.h
@@ -101,6 +101,7 @@ struct AssetSrc
     };
     char* mimeType = nullptr;
     uint32_t size = 0;
+    bool external = false;
 
     ~AssetSrc()
     {
@@ -111,8 +112,8 @@ struct AssetSrc
     {
         tvg::free(data);
         tvg::free(mimeType);
-        data = nullptr;
-        mimeType = nullptr;
+        data = mimeType = nullptr;
+        size = 0;
     }
 };
 

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -294,17 +294,20 @@ float LottieTextRange::factor(float frameNo, float totalLen, float idx)
 /* LottieImage                                                          */
 /************************************************************************/
 
-void LottieImage::prepare(bool external)
+Picture* LottieImage::get()
 {
-    //Prepare the Picture image
-    auto result = Result::Unknown;
-    auto picture = Picture::gen();
-    if (bitmap.size > 0) result = picture->load(bitmap.data, bitmap.size, bitmap.mimeType);
-    else if (external) result = picture->load(bitmap.path);
-    if (result == Result::Success) resolved = true;
-    picture->size(bitmap.width, bitmap.height);
-    bitmap.picture = picture;
-    picture->ref();
+    if (!picture) {
+        auto result = Result::Unknown;
+        picture = Picture::gen();
+        picture->ref();
+
+        if (asset.size > 0) result = picture->load(asset.data, asset.size, asset.mimeType);
+        else if (asset.external) result = picture->load(asset.path);
+        picture->size(asset.width, asset.height);
+
+        valid = (result == Result::Success);
+    }
+    return picture;
 }
 
 /************************************************************************/

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -829,19 +829,33 @@ struct LottieGradientStroke : LottieGradient, LottieStroke
 
 struct LottieImage : LottieObject
 {
+    LottieAsset asset;
+    Picture* picture = nullptr;
+    bool valid = false;
+
     LottieImage() : LottieObject(LottieObject::Image) {}
 
-    LottieBitmap bitmap;
-    bool resolved = false;
+    ~LottieImage()
+    {
+        if (picture) picture->unref();
+    }
 
     LottieProperty* override(LottieProperty* prop, bool release) override
     {
+        if (picture) {
+            picture->unref();
+            picture = nullptr;
+        }
+
         LottieProperty* backup = nullptr;
-        OVERRIDE(bitmap);
+        OVERRIDE(asset);
+
+        valid = false;
+
         return backup;
     }
 
-    void prepare(bool external);
+    Picture* get();
 };
 
 struct LottieAudio : LottieObject

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1031,11 +1031,9 @@ void LottieParser::parseAudio(LottieAudio* audio, const char* data, const char* 
 
 void LottieParser::parseImage(LottieImage* image, const char* data, const char* subPath, bool embedded, float width, float height)
 {
-    auto external = false;
-    if (!parseAssetSource(image->bitmap, data, subPath, embedded, "data:image/", external)) return;
-    image->bitmap.width = width;
-    image->bitmap.height = height;
-    image->prepare(external);
+    if (!parseAssetSource(image->asset, data, subPath, embedded, "data:image/", image->asset.external)) return;
+    image->asset.width = width;
+    image->asset.height = height;
 }
 
 LottieObject* LottieParser::parseAsset()
@@ -1073,10 +1071,10 @@ LottieObject* LottieParser::parseAsset()
     }
     if (data) {
         if (!strncmp(data, "data:image/", 11) || width != 0.0f || height != 0.0f) {
-            auto asset = new LottieImage;
-            parseImage(asset, data, subPath, embedded, width, height);
-            if (sid) registerSlot(asset, sid, asset->bitmap);
-            obj = asset;
+            auto image = new LottieImage;
+            parseImage(image, data, subPath, embedded, width, height);
+            if (sid) registerSlot(image, sid, image->asset);
+            obj = image;
         } else if (!strncmp(data, "data:audio/", 11) || !embedded) {
             auto asset = new LottieAudio;
             parseAudio(asset, data, subPath, embedded);
@@ -1732,7 +1730,7 @@ LottieProperty* LottieParser::parse(LottieSlot* slot)
                 else skip();
             }
             if (!obj) return nullptr;
-            prop = new LottieBitmap(static_cast<LottieImage*>(obj)->bitmap);
+            prop = new LottieAsset(static_cast<LottieImage*>(obj)->asset);
             delete(obj);
             break;
         }

--- a/src/loaders/lottie/tvgLottieProperty.h
+++ b/src/loaders/lottie/tvgLottieProperty.h
@@ -180,10 +180,10 @@ struct LottieProperty
     LottieProperty(Type type = Type::Invalid) : type(type) {}
     virtual ~LottieProperty() {}
 
-    virtual uint32_t frameCnt() = 0;
-    virtual uint32_t nearest(float frameNo) = 0;
-    virtual float frameNo(int32_t key) = 0;
-    virtual float loop(float frameNo, uint32_t key, Loop mode, float inout) = 0;
+    virtual uint32_t frameCnt() { return 0; }
+    virtual uint32_t nearest(float frameNo) { return 0; }
+    virtual float frameNo(int32_t key) { return 0; }
+    virtual float loop(float frameNo, TVG_UNUSED uint32_t key, TVG_UNUSED Loop mode, TVG_UNUSED float inout) { return frameNo; }
 
     bool copy(LottieProperty* rhs, bool shallow)
     {
@@ -933,50 +933,36 @@ struct LottieTextDoc : LottieProperty
     void prepare() {}
 };
 
-struct LottieBitmap : LottieProperty, AssetSrc
+struct LottieAsset : LottieProperty, AssetSrc
 {
-    Picture *picture = nullptr;
     float width = 0.0f;
     float height = 0.0f;
 
-    LottieBitmap() : LottieProperty(LottieProperty::Type::Image) {}
+    LottieAsset() : LottieProperty(LottieProperty::Type::Image) {}
 
-    LottieBitmap(const LottieBitmap& rhs)
+    LottieAsset(const LottieAsset& rhs)
     {
-        copy(const_cast<LottieBitmap&>(rhs));
+        copy(const_cast<LottieAsset&>(rhs));
     }
 
-    ~LottieBitmap()
-    {
-        release();
-    }
-
-    void release()
-    {
-        AssetSrc::release();
-
-        if (picture) {
-            picture->unref();
-            picture = nullptr;
-        }
-    }
-
-    uint32_t frameCnt() override { return 0; }
-    uint32_t nearest(float frameNo) override { return 0; }
-    float frameNo(int32_t key) override { return 0; }
-    float loop(float frameNo, TVG_UNUSED uint32_t key, TVG_UNUSED Loop mode, TVG_UNUSED float inout) override { return frameNo; }
-
-    void copy(LottieBitmap& rhs, bool shallow = true)
+    void copy(LottieAsset& rhs, bool shallow = true)
     {
         if (LottieProperty::copy(&rhs, shallow)) return;
 
         release();
 
-        if (rhs.picture) {
-            picture = rhs.picture;
-            picture->ref();
+        if (shallow) {
+            data = rhs.data;
+            mimeType = rhs.mimeType;
+            rhs.data = rhs.mimeType = nullptr;
+        } else {
+            // TODO: make it shareable data without copy?
+            if (rhs.size > 0) data = static_cast<char*>(memcpy(tvg::malloc<char>(rhs.size), rhs.data, rhs.size));
+            else path = tvg::duplicate(rhs.path);
+            mimeType = tvg::duplicate(rhs.mimeType);
         }
-
+        size = rhs.size;
+        external = rhs.external;
         width = rhs.width;
         height = rhs.height;
     }


### PR DESCRIPTION
Move runtime picture ownership from slot properties to LottieImage and create pictures lazily when the builder requests them.

Keep image source data in LottieAsset so slot overrides can replace and restore image assets without sharing picture instances.

Also provide default property timeline methods for static assets.