### PR TITLE
savers/gif: separate color quantization from the palette search structure

### DIFF
--- a/src/savers/gif/tvgGifEncoder.cpp
+++ b/src/savers/gif/tvgGifEncoder.cpp
@@ -53,6 +53,7 @@
 #define TRANSPARENT_THRESHOLD 127
 #define BIT_DEPTH 8
 #define LEAF_NODE 0xff
+#define MAX_PAL_COLORS ((1 << BIT_DEPTH) - 1)
 
 // Simple structure to write out the LZW-compressed portion of the image
 // one bit at a time
@@ -73,6 +74,16 @@ typedef struct
     uint16_t m_next[256];
 } GifLzwNode;
 
+// The boxes the quantization cuts the pixels into.
+// Box i covers the pixels [start[i], start[i] + len[i]) of the working image.
+typedef struct
+{
+    int64_t sse[MAX_PAL_COLORS];      // SSE (Sum of Squared Errors) over the box
+    int start[MAX_PAL_COLORS];        // first pixel of this box within tmpImage
+    int len[MAX_PAL_COLORS];          // how many pixels it holds
+    uint8_t axis[MAX_PAL_COLORS];     // the channel carrying most of the error
+    uint8_t avg[MAX_PAL_COLORS * 3];  // the color that represents the box. alpha channel is not included.
+} GifBoxes;
 
 /************************************************************************/
 /* Internal Class Implementation                                        */
@@ -124,28 +135,13 @@ static void _getClosestPaletteColor( GifPalette* pPal, int r, int g, int b, int*
     }
 }
 
-
-static void _swapPixels(uint8_t* image, int pixA, int pixB)
+static void _swapPixels(uint8_t* image, int pixA, int pixB, int stride)
 {
-    uint8_t rA = image[pixA*4];
-    uint8_t gA = image[pixA*4+1];
-    uint8_t bA = image[pixA*4+2];
-    uint8_t aA = image[pixA*4+3];
-
-    uint8_t rB = image[pixB*4];
-    uint8_t gB = image[pixB*4+1];
-    uint8_t bB = image[pixB*4+2];
-    uint8_t aB = image[pixA*4+3];
-
-    image[pixA*4] = rB;
-    image[pixA*4+1] = gB;
-    image[pixA*4+2] = bB;
-    image[pixA*4+3] = aB;
-
-    image[pixB*4] = rA;
-    image[pixB*4+1] = gA;
-    image[pixB*4+2] = bA;
-    image[pixB*4+3] = aA;
+    for (int cc = 0; cc < stride; ++cc) {
+        uint8_t temp = image[pixA * stride + cc];
+        image[pixA * stride + cc] = image[pixB * stride + cc];
+        image[pixB * stride + cc] = temp;
+    }
 }
 
 // Moves every pixel whose 'elt' component is below splitVal to the front and
@@ -156,113 +152,97 @@ static int _partitionByValue(uint8_t* image, int numPixels, int elt, int splitVa
     int storeIndex = 0;
     for (int ii = 0; ii < numPixels; ++ii) {
         if (image[ii * 4 + elt] < splitVal) {
-            _swapPixels(image, ii, storeIndex);
+            _swapPixels(image, ii, storeIndex, 4);
             ++storeIndex;
         }
     }
     return storeIndex;
 }
 
-// Builds a palette by creating a k-d tree of all pixels in the image
-static void _splitPalette(uint8_t* image, int numPixels, int firstElt, int lastElt, int splitElt, int splitDist, int treeNode, GifPalette* pal)
+// Returns the value carried by the count/2-th element along the given channel.
+// 'below' receives how many elements fall strictly under the returned value.
+static int _findMedianValue(const uint8_t* data, int count, int axis, int stride, int* below)
 {
-    if(lastElt <= firstElt || numPixels == 0) return;
-
-    // base case, bottom of the tree
-    if (lastElt == firstElt + 1) {
-        // otherwise, take the average of all colors in this subcube
-        uint64_t r=0, g=0, b=0;
-        for(int ii=0; ii<numPixels; ++ii) {
-            r += image[ii*4+0];
-            g += image[ii*4+1];
-            b += image[ii*4+2];
-        }
-
-        r += (uint64_t)numPixels / 2;  // round to nearest
-        g += (uint64_t)numPixels / 2;
-        b += (uint64_t)numPixels / 2;
-
-        r /= (uint64_t)numPixels;
-        g /= (uint64_t)numPixels;
-        b /= (uint64_t)numPixels;
-
-        pal->r[firstElt] = (uint8_t)r;
-        pal->g[firstElt] = (uint8_t)g;
-        pal->b[firstElt] = (uint8_t)b;
-        return;
-    }
-
-    // Find the axis with the largest range
-    int minR = 255, maxR = 0;
-    int minG = 255, maxG = 0;
-    int minB = 255, maxB = 0;
-
-    for (int ii=0; ii<numPixels; ++ii) {
-        int r = image[ii*4+0];
-        int g = image[ii*4+1];
-        int b = image[ii*4+2];
-
-        if(r > maxR) maxR = r;
-        if(r < minR) minR = r;
-
-        if(g > maxG) maxG = g;
-        if(g < minG) minG = g;
-
-        if(b > maxB) maxB = b;
-        if(b < minB) minB = b;
-    }
-
-    int rRange = maxR - minR;
-    int gRange = maxG - minG;
-    int bRange = maxB - minB;
-
-    // If every pixel in this range is the same color, there is nothing left to split.
-    // Fill the whole range with that color, then mark the node as a leaf.
-    if (rRange == 0 && gRange == 0 && bRange == 0) {
-        for (int ii = firstElt; ii < lastElt; ++ii) {
-            pal->r[ii] = image[0];
-            pal->g[ii] = image[1];
-            pal->b[ii] = image[2];
-        }
-        pal->treeSplitElt[treeNode] = LEAF_NODE;
-        pal->treeSplit[treeNode] = (uint8_t)firstElt;
-        return;
-    }
-
-    // Pick the axis with widest range, rather than cycling through
-    // the axes as the original k-d tree does.
-    int splitCom = 1;
-    if (bRange > gRange) splitCom = 2;
-    if (rRange > bRange && rRange > gRange) splitCom = 0;
-
-    // Find the median value along that axis from a histogram of the component.
     uint32_t hist[256] = {};
-    for (int ii = 0; ii < numPixels; ++ii)
-        ++hist[image[ii * 4 + splitCom]];
+    for (int ii = 0; ii < count; ++ii)
+        ++hist[data[ii * stride + axis]];
 
     int acc = 0;
-    int splitVal = 0;
     for (int v = 0; v < 256; ++v) {
         acc += hist[v];
-        if (acc > numPixels / 2) {
-            splitVal = v;
-            break;
+        if (acc > count / 2) {
+            if (below) *below = acc - (int)hist[v];
+            return v;
+        }
+    }
+    return 0;
+}
+
+// Computes the SSE, axis and average color of a box.
+// The SSE is how much color error it holds, the axis is the channel holding most of it.
+// A box with one color has an SSE of 0, so it won't be split.
+static void _computeBoxStats(const uint8_t* image, GifBoxes* boxes, int idx)
+{
+    auto pixels = image + boxes->start[idx] * 4;
+    int64_t sum[3] = {};
+    int64_t sqsum[3] = {};
+
+    auto len = boxes->len[idx];
+
+    for (int ii = 0; ii < len; ++ii) {
+        for (int cc = 0; cc < 3; ++cc) {
+            int64_t v = pixels[ii * 4 + cc];
+            sum[cc] += v;
+            sqsum[cc] += v * v;
         }
     }
 
-    // If the median is the smallest value in this range,
+    int64_t worst = -1;
+    boxes->sse[idx] = 0;
+    boxes->axis[idx] = 0;
+
+    // Compute the squared error of each axis
+    // and store average color
+    for (int cc = 0; cc < 3; ++cc) {
+        // sqerr = sqsum - sum*sum/len
+        // sum*sum/len = q*q*len + 2*q*r + r*r/len
+        auto q = sum[cc] / len;
+        auto r = sum[cc] % len;
+        auto sqerr = sqsum[cc] - (q * q * len + 2 * q * r + r * r / len);
+
+        boxes->sse[idx] += sqerr;
+        if (sqerr > worst) {
+            worst = sqerr;
+            boxes->axis[idx] = (uint8_t)cc;
+        }
+        boxes->avg[idx * 3 + cc] = (uint8_t)((sum[cc] + len / 2) / len);
+    }
+}
+
+// Cuts the box in two at the median value of the axis that carries the most error.
+// The left stays in idx, the right goes to rhsIdx.
+static void _splitBox(uint8_t* image, GifBoxes* boxes, int idx, int rhsIdx)
+{
+    auto pixels = image + boxes->start[idx] * 4;
+
+    // Find the median value along that axis from a histogram
+    int below = -1;
+    int splitVal = _findMedianValue(pixels, boxes->len[idx], boxes->axis[idx], 4, &below);
+
+    // If the median is the smallest value in this box,
     // move the boundary up by one to keep its whole run on the left, otherwise
-    // the left subtree comes out empty and its palette entries go unwritten.
-    if (acc - (int)hist[splitVal] == 0) ++splitVal;
+    // the left comes out empty and _computeBoxStats will be broken.
+    if (below == 0) ++splitVal;
 
-    int subPixelsA = _partitionByValue(image, numPixels, splitCom, splitVal);
-    int subPixelsB = numPixels - subPixelsA;
+    auto left = _partitionByValue(pixels, boxes->len[idx], boxes->axis[idx], splitVal);
 
-    pal->treeSplitElt[treeNode] = (uint8_t)splitCom;
-    pal->treeSplit[treeNode] = (uint8_t)splitVal;
+    boxes->start[rhsIdx] = boxes->start[idx] + left;
+    boxes->len[rhsIdx] = boxes->len[idx] - left;
 
-    _splitPalette(image, subPixelsA, firstElt, splitElt, splitElt-splitDist, splitDist/2, treeNode*2, pal);
-    _splitPalette(image+subPixelsA*4, subPixelsB, splitElt, lastElt,  splitElt+splitDist, splitDist/2, treeNode*2+1, pal);
+    boxes->len[idx] = left;
+
+    _computeBoxStats(image, boxes, idx);
+    _computeBoxStats(image, boxes, rhsIdx);
 }
 
 // Finds all pixels that have changed from the previous image and
@@ -292,10 +272,80 @@ static int _pickChangedPixels(const uint8_t* lastFrame, uint8_t* frame, int numP
     return numChanged;
 }
 
+// Builds the k-d tree the lookup walks, over the finished palette colors.
+// Every node splits its colors in half, so the walk never goes deeper than BIT_DEPTH.
+// firstElt/lastElt are the palette slots this subtree owns.
+// The root owns [1, 256), since 0 is reserved for transparency.
+static void _buildSearchTree(GifPalette* pal, uint8_t* colors, int count, int firstElt, int lastElt, int treeRoot)
+{
+    // Nothing left to split
+    if (count == 1) {
+        pal->r[firstElt] = colors[0];
+        pal->g[firstElt] = colors[1];
+        pal->b[firstElt] = colors[2];
 
-// Creates a palette by placing all the image pixels in a k-d tree and then averaging the blocks at the bottom.
-// This is known as the "modified median split" technique
-static void _makePalette(GifWriter* writer, const uint8_t* lastFrame, const uint8_t* nextFrame, uint32_t width, uint32_t height, int bitDepth, bool transparent)
+        // If current depth is not 8
+        if (treeRoot <= (1 << BIT_DEPTH) - 1) {
+            pal->treeSplitElt[treeRoot] = LEAF_NODE;
+            pal->treeSplit[treeRoot] = (uint8_t)firstElt;
+        }
+
+        // Palette entries in range [firstElt + 1, lastElt) remain the same as prior frame,
+        // but never accessed by _getClosestPaletteColor. So it is safe.
+        // Palette dump may show these unused 'ghost entries'.
+        return;
+    }
+
+    // Cut on the channel the colors are most spread out over
+    uint8_t min[3] = {255, 255, 255};
+    uint8_t max[3] = {0, 0, 0};
+    for (int ii = 0; ii < count; ++ii) {
+        for (int cc = 0; cc < 3; ++cc) {
+            if (colors[ii * 3 + cc] < min[cc]) min[cc] = colors[ii * 3 + cc];
+            if (colors[ii * 3 + cc] > max[cc]) max[cc] = colors[ii * 3 + cc];
+        }
+    }
+
+    // Find the axis with the largest range
+    int axis = 0;
+    for (int cc = 1; cc < 3; ++cc) {
+        if (max[cc] - min[cc] > max[axis] - min[axis])
+            axis = cc;
+    }
+
+    // Find the median value along that axis from a histogram
+    int splitVal = _findMedianValue(colors, count, axis, 3, nullptr);
+
+    // Use Dutch National Flag to reorder colors
+    int low = 0;
+    int mid = 0;
+    int high = count;
+    while (mid < high) {
+        int v = colors[mid * 3 + axis];
+        if (v < splitVal) {
+            _swapPixels(colors, mid, low, 3);
+            ++low;
+            ++mid;
+        } else if (v > splitVal) {
+            --high;
+            _swapPixels(colors, mid, high, 3);
+        } else {
+            ++mid;
+        }
+    }
+
+    auto splitElt = (firstElt + lastElt) / 2;
+
+    pal->treeSplitElt[treeRoot] = (uint8_t)axis;
+    pal->treeSplit[treeRoot] = (uint8_t)splitVal;
+
+    _buildSearchTree(pal, colors, count / 2, firstElt, splitElt, treeRoot * 2);
+    _buildSearchTree(pal, colors + (count / 2) * 3, count - count / 2, splitElt, lastElt, treeRoot * 2 + 1);
+}
+
+// Quantizes the pixels into up to MAX_PAL_COLORS colors by cutting them into boxes in RGB space and averaging each box.
+// A k-d tree is then built over those colors, which is what fills in the palette entries.
+static void _makePalette(GifWriter* writer, const uint8_t* lastFrame, const uint8_t* nextFrame, uint32_t width, uint32_t height, bool transparent)
 {
     auto& pal = writer->pal;
 
@@ -305,16 +355,36 @@ static void _makePalette(GifWriter* writer, const uint8_t* lastFrame, const uint
     int numPixels = (int)(width * height);
     numPixels = _pickChangedPixels(lastFrame, writer->tmpImage, numPixels, transparent);
 
-    const int lastElt = 1 << bitDepth;
-    const int splitElt = lastElt/2;
-    const int splitDist = splitElt/2;
+    if (numPixels == 0) return;
 
-    _splitPalette(writer->tmpImage, numPixels, 1, lastElt, splitElt, splitDist, 1, &pal);
+    // Start with a single large box that contains the picked pixels
+    GifBoxes boxes;
+    boxes.start[0] = 0;
+    boxes.len[0] = numPixels;
+    _computeBoxStats(writer->tmpImage, &boxes, 0);
 
-    // add the bottom node for the transparency index
-    pal.treeSplit[1 << (bitDepth-1)] = 0;
-    pal.treeSplitElt[1 << (bitDepth-1)] = 0;
-    pal.r[0] = pal.g[0] = pal.b[0] = 0;
+    int numBoxes = 1;
+
+    // Split boxes until there are MAX_PAL_COLORS of them
+    while (numBoxes < MAX_PAL_COLORS) {
+        // Select the box with the highest error for splitting
+        int target = -1;
+        int64_t worst = 0;
+        for (int ii = 0; ii < numBoxes; ++ii) {
+            if (boxes.sse[ii] > worst) {
+                worst = boxes.sse[ii];
+                target = ii;
+            }
+        }
+
+        // If every box holds a single color
+        if (target < 0) break;
+
+        _splitBox(writer->tmpImage, &boxes, target, numBoxes);
+        ++numBoxes;
+    }
+
+    _buildSearchTree(&pal, boxes.avg, numBoxes, 1, 1 << BIT_DEPTH, 1);
 }
 
 
@@ -612,7 +682,7 @@ bool gifWriteFrame(GifWriter* writer, const uint8_t* image, uint32_t width, uint
     const uint8_t* oldImage = writer->firstFrame? NULL : writer->oldImage;
     writer->firstFrame = false;
 
-    _makePalette(writer, oldImage, image, width, height, 8, transparent);
+    _makePalette(writer, oldImage, image, width, height, transparent);
     _thresholdImage(writer, oldImage, image, width, height, transparent);
     _writeLzwImage(writer, width, height, delay, transparent);
 


### PR DESCRIPTION
## Problem

Palette entries were split in half at every k-d tree node. This did not depend on how many colors each subtree had. A subtree with only a few colors got the same number of entries as a subtree with many colors.

So duplicate colors filled the palette. Colors that were actually different got merged together and lost. The exported GIF could not reproduce these colors.

## Solution

Palette colors are now chosen by splitting the box that holds the highest **SSE** (Sum of Squared Errors), not by half.

But splitting by a ratio other than half can make the tree very deep, and it causes a big bottleneck during search.

To fix this, we now separate two stages in `_makePalette`:

1. Color quantization
2. k-d tree construction

The structure built during color quantization is no longer reused for palette search.

1. Color quantization
- Picks up to 255 colors for the palette.
- Splits the box with the largest SSE. The split axis is the one with the highest squared error.
- The split point could also use SSE, but I use the median value instead, as a simple trade-off.

2. k-d tree construction
- Builds a separate k-d tree, used for palette search.
- Selects the axis with the widest range. Splits the colors in half.
- Before splitting, elements must be sorted into three groups: values less than splitVal, equal to splitVal, and greater than splitVal. This is done using the Dutch National Flag (DNF) algorithm.

## Results

All outputs below use a **transparent background**, where the problem shows most clearly.

| file | rendering (before) | rendering (after) |
| --- | --- | --- |
| traveling.json (frame 521) | <img width="600" height="600" alt="before_0521" src="https://github.com/user-attachments/assets/47a957bf-b255-427e-adbf-8aa4b3c974bf" /> | <img width="600" height="600" alt="after_0521" src="https://github.com/user-attachments/assets/d131589d-8eb9-481f-ba01-f775bed69b7b" /> |
| ghost.json (frame 0) | <img width="600" height="600" alt="before_0000" src="https://github.com/user-attachments/assets/9cf69304-b5e8-4af6-aa17-8ff2a30aca79" /> | <img width="600" height="600" alt="after_0000" src="https://github.com/user-attachments/assets/cc1abb29-282d-41e9-92da-412945ae3257" />|
| guitar.json (frame 6) | <img width="600" height="600" alt="before_0006" src="https://github.com/user-attachments/assets/f8a962a0-0442-44c8-a987-106d1e85de2d" /> | <img width="600" height="600" alt="after_0006" src="https://github.com/user-attachments/assets/e33a3769-f1b5-4e81-a1b4-7676a703cd97" /> |
| train.json (frame 0) | <img width="600" height="600" alt="before_0000" src="https://github.com/user-attachments/assets/1235e42a-7738-4ff6-a6aa-e0d4c02da33e" /> | <img width="600" height="600" alt="after_0000" src="https://github.com/user-attachments/assets/8a9108c8-89c0-414f-a487-27bc185fb626" /> |

The palette dumps show fewer duplicate entries and more distinct colors in the palette.

| file | palette (before) | palette (after) |
|---|---|---|
| expressions_traveling.json | [dump](https://github.com/user-attachments/assets/158109b6-b4ac-4d51-8772-208479c14d45) | [dump](https://github.com/user-attachments/assets/bb21f4fe-836a-4692-948c-c277e59fc7d0) |
| ghost.json | [dump](https://github.com/user-attachments/assets/e7e74540-8ad9-4ffa-8c8d-13f326cc3ac6) | [dump](https://github.com/user-attachments/assets/e42c17cd-6a20-4d05-b83a-6762340e3d60) |
| guitar.json | [dump](https://github.com/user-attachments/assets/2898c942-a9cd-465e-b1f3-c6a122b55e43) | [dump](https://github.com/user-attachments/assets/ac558a4d-37e8-41e3-938b-30f40d9456ec) |
| train.json | [dump](https://github.com/user-attachments/assets/0f7c8351-014e-42f8-96a7-8cb92f82d8d2) | [dump](https://github.com/user-attachments/assets/ddedd719-de9b-433c-a757-3bd5c871f0d5) |

> The palette dumps were produced with [this script](https://gist.github.com/alpakaDurumi/6ead468e1b2fefe55abd70185578826b). Each row is a frame and each column is one of the 256 entries in that frame's local color table. Panel on the right shows only the unique colors of the same frame.

## Performance

151 [thorvg.example](https://github.com/thorvg/thorvg.example) lottie assets × transparent/white background (302 cases), `tvg-lottie2gif` defaults (600x600, 30 fps), release builds, hyperfine 1.19.0 `-N -w 1 -r 10`.

#4655 recently reworked palette generation, but I think it was a transitional step, not the end of it. So I also measured the revision before #4655. The `pre-#4655` column shows the result of both changes together.

Median per-case change in `tvg-lottie2gif` wall time, mean in parentheses:

| | vs `main`(3a2ce05) | vs `pre-#4655`(3a6efe9) |
|---|---:|---:|
| all | **+9.13%** (+17.02%) | **-14.00%** (-16.64%) |
| transparent | +17.18% (+26.12%) | -23.80% (-23.65%) |
| white | +6.53% (+7.92%) | -8.70% (-9.63%) |
| faster cases | 11 / 302 | 299 / 302 |

**callgrind** shows more recursive calls in `_getClosestPaletteColor()`. The likely reason is that this patch keeps more distinct colors in the palette: a walk that used to end early in a subtree of duplicate colors now goes deeper.

<details>
<summary>3 most regressed vs main</summary>

| asset | bg | main | this branch | change |
|---|---|---:|---:|---:|
| extensions/slot0 | transparent | 230.4 ms | 516.0 ms | +123.9% |
| water_filling | transparent | 874.4 ms | 1742.9 ms | +99.3% |
| textrange | transparent | 807.1 ms | 1594.8 ms | +97.6% |

</details>

<details>
<summary>3 regressed vs pre-#4655</summary>

| asset | bg | pre-#4655 | this branch | change |
|---|---|---:|---:|---:|
| new_design | white | 2996.1 ms | 4154.8 ms | +38.7% |
| sample | transparent | 251.2 ms | 301.6 ms | +20.1% |
| expressions/10444 | white | 93.4 ms | 97.0 ms | +3.9% |

</details>

issue: #4669