### PR TITLE
loaders/jpg: prevent buffer overflow

### DIFF
--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include <climits>
 #include <turbojpeg.h>
 #include "tvgJpgLoader.h"
 
@@ -105,6 +106,8 @@ bool JpgLoader::read()
         format = TJPF_RGBX;
         cs = ColorSpace::ABGR8888;
     }
+
+    if (static_cast<int>(w) > INT_MAX / static_cast<int>(h) / tjPixelSize[format]) return false;
 
     auto image = (unsigned char *)tjAlloc(static_cast<int>(w) * static_cast<int>(h) * tjPixelSize[format]);
 


### PR DESCRIPTION
issue: https://github.com/thorvg/thorvg/security/advisories/GHSA-v45v-rfh3-xmp4


### main

<img width="1357" height="232" alt="image" src="https://github.com/user-attachments/assets/74f40756-12f7-4f5e-81c8-b8861c9bacec" />

### fetch 

-  Returns failure without triggering the overflow.