### PR TITLE
sw_engine: move global shared state to stack local for RasterTexmap

### DIFF
--- a/src/renderer/cpu_engine/tvgSwRasterTexmap.h
+++ b/src/renderer/cpu_engine/tvgSwRasterTexmap.h
@@ -34,10 +34,13 @@ struct Polygon
    Vertex vertex[3];
 };
 
-//Careful! Shared resource, No support threading
-static float dudx, dvdx;
-static float dxdya, dxdyb, dudya, dvdya;
-static float xa, xb, ua, va;
+struct TexmapState
+{
+    // Each textured polygon owns its scan-converter state.
+    float dudx, dvdx;
+    float dxdya, dxdyb, dudya, dvdya;
+    float xa, xb, ua, va;
+};
 
 
 static inline int32_t _modf(float v)
@@ -64,23 +67,23 @@ static uint8_t _feathering(int iru, int irv, int ar, int ab, int sw, int sh)
 }
 
 
-static bool _rasterMaskedPolygonImageSegment(SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, bool needAA)
+static bool _rasterMaskedPolygonImageSegment(TexmapState& state, SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, bool needAA)
 {
     TVGERR("SW_ENGINE", "TODO: _rasterMaskedPolygonImageSegment()");
     return false;
 }
 
 
-static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, bool needAA)
+static void _rasterBlendingPolygonImageSegment(TexmapState& state, SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, bool needAA)
 {
     if (surface->channelSize == sizeof(uint8_t)) {
         TVGERR("SW_ENGINE", "Not supported grayscale Textmap polygon!");
         return;
     }
 
-    auto _dudx = dudx, _dvdx = dvdx;
-    auto _dxdya = dxdya, _dxdyb = dxdyb, _dudya = dudya, _dvdya = dvdya;
-    auto _xa = xa, _xb = xb, _ua = ua, _va = va;
+    auto _dudx = state.dudx, _dvdx = state.dvdx;
+    auto _dxdya = state.dxdya, _dxdyb = state.dxdyb, _dudya = state.dudya, _dvdya = state.dvdya;
+    auto _xa = state.xa, _xb = state.xb, _ua = state.ua, _va = state.va;
     auto sbuf = image.buf32;
     auto dbuf = surface->buf32;
     auto sw = static_cast<int32_t>(image.w);
@@ -164,18 +167,18 @@ static void _rasterBlendingPolygonImageSegment(SwSurface* surface, const SwImage
 
         ++y;
     }
-    xa = _xa;
-    xb = _xb;
-    ua = _ua;
-    va = _va;
+    state.xa = _xa;
+    state.xb = _xb;
+    state.ua = _ua;
+    state.va = _va;
 }
 
 
-static void _rasterPolygonImageSegment32(SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, bool matting, bool needAA)
+static void _rasterPolygonImageSegment32(TexmapState& state, SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, bool matting, bool needAA)
 {
-    auto _dudx = dudx, _dvdx = dvdx;
-    auto _dxdya = dxdya, _dxdyb = dxdyb, _dudya = dudya, _dvdya = dvdya;
-    auto _xa = xa, _xb = xb, _ua = ua, _va = va;
+    auto _dudx = state.dudx, _dvdx = state.dvdx;
+    auto _dxdya = state.dxdya, _dxdyb = state.dxdyb, _dudya = state.dudya, _dvdya = state.dvdya;
+    auto _xa = state.xa, _xb = state.xb, _ua = state.ua, _va = state.va;
     auto sbuf = image.buf32;
     auto dbuf = surface->buf32;
     auto sw = static_cast<int32_t>(image.w);
@@ -276,18 +279,18 @@ static void _rasterPolygonImageSegment32(SwSurface* surface, const SwImage& imag
 
         ++y;
     }
-    xa = _xa;
-    xb = _xb;
-    ua = _ua;
-    va = _va;
+    state.xa = _xa;
+    state.xb = _xb;
+    state.ua = _ua;
+    state.va = _va;
 }
 
 // no anti-aliasing, no interpolation for the fastest cheap masking
-static void _rasterPolygonImageSegment8(SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, TVG_UNUSED bool needAA)
+static void _rasterPolygonImageSegment8(TexmapState& state, SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, TVG_UNUSED bool needAA)
 {
-    auto _dudx = dudx, _dvdx = dvdx;
-    auto _dxdya = dxdya, _dxdyb = dxdyb, _dudya = dudya, _dvdya = dvdya;
-    auto _xa = xa, _xb = xb, _ua = ua, _va = va;
+    auto _dudx = state.dudx, _dvdx = state.dvdx;
+    auto _dxdya = state.dxdya, _dxdyb = state.dxdyb, _dudya = state.dudya, _dvdya = state.dvdya;
+    auto _xa = state.xa, _xb = state.xb, _ua = state.ua, _va = state.va;
     auto sbuf = image.buf32;
     auto dbuf = surface->buf8;
     int32_t x1, x2, x, y;
@@ -333,22 +336,22 @@ static void _rasterPolygonImageSegment8(SwSurface* surface, const SwImage& image
         _va += _dvdya;
         ++y;
     }
-    xa = _xa;
-    xb = _xb;
-    ua = _ua;
-    va = _va;
+    state.xa = _xa;
+    state.xb = _xb;
+    state.ua = _ua;
+    state.va = _va;
 }
 
 
-static void _rasterPolygonImageSegment(SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, bool matting, bool needAA)
+static void _rasterPolygonImageSegment(TexmapState& state, SwSurface* surface, const SwImage& image, const RenderRegion& bbox, int yStart, int yEnd, uint8_t opacity, bool matting, bool needAA)
 {
-    if (surface->channelSize == sizeof(uint32_t)) _rasterPolygonImageSegment32(surface, image, bbox, yStart, yEnd, opacity, matting, needAA);
-    else if (surface->channelSize == sizeof(uint8_t)) _rasterPolygonImageSegment8(surface, image, bbox, yStart, yEnd, opacity, needAA);
+    if (surface->channelSize == sizeof(uint32_t)) _rasterPolygonImageSegment32(state, surface, image, bbox, yStart, yEnd, opacity, matting, needAA);
+    else if (surface->channelSize == sizeof(uint8_t)) _rasterPolygonImageSegment8(state, surface, image, bbox, yStart, yEnd, opacity, needAA);
 }
 
 
 /* This mapping algorithm is based on Mikael Kalms's. */
-static void _rasterPolygonImage(SwSurface* surface, const SwImage& image, const RenderRegion& bbox, Polygon& polygon, uint8_t opacity, bool needAA)
+static void _rasterPolygonImage(TexmapState& state, SwSurface* surface, const SwImage& image, const RenderRegion& bbox, Polygon& polygon, uint8_t opacity, bool needAA)
 {
     float x[3] = {polygon.vertex[0].pt.x, polygon.vertex[1].pt.x, polygon.vertex[2].pt.x};
     float y[3] = {polygon.vertex[0].pt.y, polygon.vertex[1].pt.y, polygon.vertex[2].pt.y};
@@ -393,8 +396,8 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage& image, const 
     if (tvg::zero(denom)) return;
 
     denom = 1 / denom;   //Reciprocal for speeding up
-    dudx = ((u[2] - u[0]) * (y[1] - y[0]) - (u[1] - u[0]) * (y[2] - y[0])) * denom;
-    dvdx = ((v[2] - v[0]) * (y[1] - y[0]) - (v[1] - v[0]) * (y[2] - y[0])) * denom;
+    state.dudx = ((u[2] - u[0]) * (y[1] - y[0]) - (u[1] - u[0]) * (y[2] - y[0])) * denom;
+    state.dvdx = ((v[2] - v[0]) * (y[1] - y[0]) - (v[1] - v[0]) * (y[2] - y[0])) * denom;
     auto dudy = ((u[1] - u[0]) * (x[2] - x[0]) - (u[2] - u[0]) * (x[1] - x[0])) * denom;
     auto dvdy = ((v[1] - v[0]) * (x[2] - x[0]) - (v[2] - v[0]) * (x[1] - x[0])) * denom;
 
@@ -415,34 +418,34 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage& image, const 
     //Longer edge is on the left side
     if (!side) {
         //Calculate slopes along left edge
-        dxdya = dxdy[1];
-        dudya = dxdya * dudx + dudy;
-        dvdya = dxdya * dvdx + dvdy;
+        state.dxdya = dxdy[1];
+        state.dudya = state.dxdya * state.dudx + dudy;
+        state.dvdya = state.dxdya * state.dvdx + dvdy;
 
         //Perform subpixel pre-stepping along left edge
         auto dy = 1.0f - (y[0] - yi[0]);
-        xa = x[0] + dy * dxdya;
-        ua = u[0] + dy * dudya;
-        va = v[0] + dy * dvdya;
+        state.xa = x[0] + dy * state.dxdya;
+        state.ua = u[0] + dy * state.dudya;
+        state.va = v[0] + dy * state.dvdya;
 
         //Draw upper segment if possibly visible
         if (yi[0] < yi[1]) {
             off_y = y[0] < bbox.min.y ? (bbox.min.y - y[0]) : 0;
-            xa += (off_y * dxdya);
-            ua += (off_y * dudya);
-            va += (off_y * dvdya);
+            state.xa += (off_y * state.dxdya);
+            state.ua += (off_y * state.dudya);
+            state.va += (off_y * state.dvdya);
 
             // Set right edge X-slope and perform subpixel pre-stepping
-            dxdyb = dxdy[0];
-            xb = x[0] + dy * dxdyb + (off_y * dxdyb);
+            state.dxdyb = dxdy[0];
+            state.xb = x[0] + dy * state.dxdyb + (off_y * state.dxdyb);
 
             if (compositing) {
-                if (_matting(surface)) _rasterPolygonImageSegment(surface, image, bbox, yi[0], yi[1], opacity, true, needAA);
-                else _rasterMaskedPolygonImageSegment(surface, image, bbox, yi[0], yi[1], opacity, needAA);
+                if (_matting(surface)) _rasterPolygonImageSegment(state, surface, image, bbox, yi[0], yi[1], opacity, true, needAA);
+                else _rasterMaskedPolygonImageSegment(state, surface, image, bbox, yi[0], yi[1], opacity, needAA);
             } else if (blending) {
-                _rasterBlendingPolygonImageSegment(surface, image, bbox, yi[0], yi[1], opacity, needAA);
+                _rasterBlendingPolygonImageSegment(state, surface, image, bbox, yi[0], yi[1], opacity, needAA);
             } else {
-                _rasterPolygonImageSegment(surface, image, bbox, yi[0], yi[1], opacity, false, needAA);
+                _rasterPolygonImageSegment(state, surface, image, bbox, yi[0], yi[1], opacity, false, needAA);
             }
             upper = true;
         }
@@ -450,74 +453,74 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage& image, const 
         if (yi[1] < yi[2]) {
             off_y = y[1] < bbox.min.y ? (bbox.min.y - y[1]) : 0;
             if (!upper) {
-                xa += (off_y * dxdya);
-                ua += (off_y * dudya);
-                va += (off_y * dvdya);
+                state.xa += (off_y * state.dxdya);
+                state.ua += (off_y * state.dudya);
+                state.va += (off_y * state.dvdya);
             }
             // Set right edge X-slope and perform subpixel pre-stepping
-            dxdyb = dxdy[2];
-            xb = x[1] + (1 - (y[1] - yi[1])) * dxdyb + (off_y * dxdyb);
+            state.dxdyb = dxdy[2];
+            state.xb = x[1] + (1 - (y[1] - yi[1])) * state.dxdyb + (off_y * state.dxdyb);
             if (compositing) {
-                if (_matting(surface)) _rasterPolygonImageSegment(surface, image, bbox, yi[1], yi[2], opacity, true, needAA);
-                else _rasterMaskedPolygonImageSegment(surface, image, bbox, yi[1], yi[2], opacity, needAA);
+                if (_matting(surface)) _rasterPolygonImageSegment(state, surface, image, bbox, yi[1], yi[2], opacity, true, needAA);
+                else _rasterMaskedPolygonImageSegment(state, surface, image, bbox, yi[1], yi[2], opacity, needAA);
             } else if (blending) {
-                _rasterBlendingPolygonImageSegment(surface, image, bbox, yi[1], yi[2], opacity, needAA);
+                _rasterBlendingPolygonImageSegment(state, surface, image, bbox, yi[1], yi[2], opacity, needAA);
             } else {
-                _rasterPolygonImageSegment(surface, image, bbox, yi[1], yi[2], opacity, false, needAA);
+                _rasterPolygonImageSegment(state, surface, image, bbox, yi[1], yi[2], opacity, false, needAA);
             }
         }
     //Longer edge is on the right side
     } else {
         //Set right edge X-slope and perform subpixel pre-stepping
-        dxdyb = dxdy[1];
+        state.dxdyb = dxdy[1];
         auto dy = 1.0f - (y[0] - yi[0]);
-        xb = x[0] + dy * dxdyb;
+        state.xb = x[0] + dy * state.dxdyb;
 
         //Draw upper segment if possibly visible
         if (yi[0] < yi[1]) {
             off_y = y[0] < bbox.min.y ? (bbox.min.y - y[0]) : 0;
-            xb += (off_y *dxdyb);
+            state.xb += (off_y * state.dxdyb);
 
             // Set slopes along left edge and perform subpixel pre-stepping
-            dxdya = dxdy[0];
-            dudya = dxdya * dudx + dudy;
-            dvdya = dxdya * dvdx + dvdy;
+            state.dxdya = dxdy[0];
+            state.dudya = state.dxdya * state.dudx + dudy;
+            state.dvdya = state.dxdya * state.dvdx + dvdy;
 
-            xa = x[0] + dy * dxdya + (off_y * dxdya);
-            ua = u[0] + dy * dudya + (off_y * dudya);
-            va = v[0] + dy * dvdya + (off_y * dvdya);
+            state.xa = x[0] + dy * state.dxdya + (off_y * state.dxdya);
+            state.ua = u[0] + dy * state.dudya + (off_y * state.dudya);
+            state.va = v[0] + dy * state.dvdya + (off_y * state.dvdya);
 
             if (compositing) {
-                if (_matting(surface)) _rasterPolygonImageSegment(surface, image, bbox, yi[0], yi[1], opacity, true, needAA);
-                else _rasterMaskedPolygonImageSegment(surface, image, bbox, yi[0], yi[1], opacity, needAA);
+                if (_matting(surface)) _rasterPolygonImageSegment(state, surface, image, bbox, yi[0], yi[1], opacity, true, needAA);
+                else _rasterMaskedPolygonImageSegment(state, surface, image, bbox, yi[0], yi[1], opacity, needAA);
             } else if (blending) {
-                _rasterBlendingPolygonImageSegment(surface, image, bbox, yi[0], yi[1], opacity, needAA);
+                _rasterBlendingPolygonImageSegment(state, surface, image, bbox, yi[0], yi[1], opacity, needAA);
             } else {
-                _rasterPolygonImageSegment(surface, image, bbox, yi[0], yi[1], opacity, false, needAA);
+                _rasterPolygonImageSegment(state, surface, image, bbox, yi[0], yi[1], opacity, false, needAA);
             }
             upper = true;
         }
         //Draw lower segment if possibly visible
         if (yi[1] < yi[2]) {
             off_y = y[1] < bbox.min.y ? (bbox.min.y - y[1]) : 0;
-            if (!upper) xb += (off_y *dxdyb);
+            if (!upper) state.xb += (off_y * state.dxdyb);
 
             // Set slopes along left edge and perform subpixel pre-stepping
-            dxdya = dxdy[2];
-            dudya = dxdya * dudx + dudy;
-            dvdya = dxdya * dvdx + dvdy;
+            state.dxdya = dxdy[2];
+            state.dudya = state.dxdya * state.dudx + dudy;
+            state.dvdya = state.dxdya * state.dvdx + dvdy;
             dy = 1 - (y[1] - yi[1]);
-            xa = x[1] + dy * dxdya + (off_y * dxdya);
-            ua = u[1] + dy * dudya + (off_y * dudya);
-            va = v[1] + dy * dvdya + (off_y * dvdya);
+            state.xa = x[1] + dy * state.dxdya + (off_y * state.dxdya);
+            state.ua = u[1] + dy * state.dudya + (off_y * state.dudya);
+            state.va = v[1] + dy * state.dvdya + (off_y * state.dvdya);
 
             if (compositing) {
-                if (_matting(surface)) _rasterPolygonImageSegment(surface, image, bbox, yi[1], yi[2], opacity, true, needAA);
-                else _rasterMaskedPolygonImageSegment(surface, image, bbox, yi[1], yi[2], opacity, needAA);
+                if (_matting(surface)) _rasterPolygonImageSegment(state, surface, image, bbox, yi[1], yi[2], opacity, true, needAA);
+                else _rasterMaskedPolygonImageSegment(state, surface, image, bbox, yi[1], yi[2], opacity, needAA);
             } else if (blending) {
-                _rasterBlendingPolygonImageSegment(surface, image, bbox, yi[1], yi[2], opacity, needAA);
+                _rasterBlendingPolygonImageSegment(state, surface, image, bbox, yi[1], yi[2], opacity, needAA);
             } else {
-                _rasterPolygonImageSegment(surface, image, bbox, yi[1], yi[2], opacity, false, needAA);
+                _rasterPolygonImageSegment(state, surface, image, bbox, yi[1], yi[2], opacity, false, needAA);
             }
         }
     }
@@ -539,6 +542,7 @@ static void _rasterPolygonImage(SwSurface* surface, const SwImage& image, const 
 bool rasterTexmapPolygon(SwSurface* surface, const SwImage& image, const Matrix& transform, const RenderRegion& bbox, uint8_t opacity)
 {
     //Prepare vertices. Shift XY coordinates to match the sub-pixeling technique.
+    TexmapState state;
     Vertex vertices[4];
     vertices[0] = {{0.0f, 0.0f}, {0.0f, 0.0f}};
     vertices[1] = {{float(image.w), 0.0f}, {float(image.w), 0.0f}};
@@ -561,14 +565,14 @@ bool rasterTexmapPolygon(SwSurface* surface, const SwImage& image, const Matrix&
     polygon.vertex[1] = vertices[1];
     polygon.vertex[2] = vertices[3];
 
-    _rasterPolygonImage(surface, image, bbox, polygon, opacity, needAA);
+    _rasterPolygonImage(state, surface, image, bbox, polygon, opacity, needAA);
 
     //Draw the second polygon
     polygon.vertex[0] = vertices[1];
     polygon.vertex[1] = vertices[2];
     polygon.vertex[2] = vertices[3];
 
-    _rasterPolygonImage(surface, image, bbox, polygon, opacity, needAA);
+    _rasterPolygonImage(state, surface, image, bbox, polygon, opacity, needAA);
 
 #if 0
     if (_compositing(surface) && _masking(surface) && !_direct(surface->compositor->method)) {


### PR DESCRIPTION
Currently rendering Lottie with image asset cannot be correctly multi-threaded on CPU because [rasterTexmapPolygon](https://github.com/thorvg/thorvg/blob/7903c55477feab74d5319db38e58993a1e413b8b/src/renderer/cpu_engine/tvgSwRasterTexmap.h#L539) uses some static state variables that when multiple `SwCanvas` draw images concurrently they will interfere, causing the rendered image partially drawn or completely broken.