### PR TITLE
renderer: corrected the loader open return values

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -99,6 +99,7 @@ enum struct Result
     FailedAllocation,      ///< The value returned in case of unsuccessful memory allocation.
     MemoryCorruption,      ///< The value returned in the event of bad memory handling - e.g. failing in pointer releasing or casting
     NonSupport,            ///< The value returned in case of choosing unsupported engine features(options).
+    SystemError,           ///< The value returned when an underlying system operation fails. @note Experimental API
     Unknown = 255          ///< The value returned in all other cases.
 };
 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -112,6 +112,7 @@ typedef enum
     TVG_RESULT_FAILED_ALLOCATION,      ///< The value returned in case of unsuccessful memory allocation.
     TVG_RESULT_MEMORY_CORRUPTION,      ///< The value returned in the event of bad memory handling - e.g. failing in pointer releasing or casting
     TVG_RESULT_NOT_SUPPORTED,          ///< The value returned in case of choosing unsupported engine features(options).
+    TVG_RESULT_SYSTEM_ERROR,           ///< The value returned when an underlying system operation fails. @note Experimental API
     TVG_RESULT_UNKNOWN = 255           ///< The value returned in all other cases.
 } Tvg_Result;
 

--- a/src/loaders/external_jpg/tvgJpgLoader.cpp
+++ b/src/loaders/external_jpg/tvgJpgLoader.cpp
@@ -53,30 +53,29 @@ JpgLoader::~JpgLoader()
     tjFree(surface.buf8);
 }
 
-bool JpgLoader::open(const char* path, const LoaderOps& ops)
+Result JpgLoader::open(const char* path, const LoaderOps& ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (!(data = (unsigned char*)Loader::open(path, size))) return false;
+    if (!(data = (unsigned char*)Loader::open(path, size))) return Result::InvalidArguments;
     owner = Ownership::Transfer;
 
     int width, height, subSample, colorSpace;
-    if (tjDecompressHeader3(jpegDecompressor, data, size, &width, &height, &subSample, &colorSpace) < 0) return false;
+    if (tjDecompressHeader3(jpegDecompressor, data, size, &width, &height, &subSample, &colorSpace) < 0) return Result::InvalidArguments;
     w = static_cast<float>(width);
     h = static_cast<float>(height);
-    return true;
+    return Result::Success;
 #else
-    return false;
+    return Result::NonSupport;
 #endif
 }
 
-bool JpgLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
+Result JpgLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
 {
     int width, height, subSample, colorSpace;
-    if (tjDecompressHeader3(jpegDecompressor, (unsigned char *) data, size, &width, &height, &subSample, &colorSpace) < 0) return false;
+    if (tjDecompressHeader3(jpegDecompressor, (unsigned char*)data, size, &width, &height, &subSample, &colorSpace) < 0) return Result::InvalidArguments;
 
     if (ops.owner == Ownership::Copy) {
         this->data = tvg::malloc<unsigned char>(size);
-        if (!this->data) return false;
         memcpy((unsigned char *)this->data, data, size);
     } else {
         this->data = (unsigned char *) data;
@@ -86,7 +85,7 @@ bool JpgLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
     h = static_cast<float>(height);
     this->size = size;
 
-    return true;
+    return Result::Success;
 }
 
 

--- a/src/loaders/external_jpg/tvgJpgLoader.h
+++ b/src/loaders/external_jpg/tvgJpgLoader.h
@@ -33,8 +33,8 @@ struct JpgLoader : BitmapLoader
     JpgLoader();
     ~JpgLoader();
 
-    bool open(const char* path, const LoaderOps& ops) override;
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     bool read() override;
 
 private:

--- a/src/loaders/external_png/tvgPngLoader.cpp
+++ b/src/loaders/external_png/tvgPngLoader.cpp
@@ -50,32 +50,32 @@ PngLoader::~PngLoader()
     tvg::free(surface.buf32);
 }
 
-bool PngLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
-{
-    image->opaque = nullptr;
-
-    if (!png_image_begin_read_from_file(image, path)) return false;
-
-    w = (float)image->width;
-    h = (float)image->height;
-
-    return true;
-}
-
-bool PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps& ops)
+Result PngLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     image->opaque = nullptr;
 
-    if (!png_image_begin_read_from_memory(image, data, size)) return false;
+    if (!png_image_begin_read_from_file(image, path)) return Result::InvalidArguments;
 
     w = (float)image->width;
     h = (float)image->height;
 
-    return true;
+    return Result::Success;
 #else
-    return false;
+    return Result::NonSupport;
 #endif
+}
+
+Result PngLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps& ops)
+{
+    image->opaque = nullptr;
+
+    if (!png_image_begin_read_from_memory(image, data, size)) return Result::InvalidArguments;
+
+    w = (float)image->width;
+    h = (float)image->height;
+
+    return Result::Success;
 }
 
 

--- a/src/loaders/external_png/tvgPngLoader.h
+++ b/src/loaders/external_png/tvgPngLoader.h
@@ -31,8 +31,8 @@ struct PngLoader : BitmapLoader
     PngLoader();
     ~PngLoader();
 
-    bool open(const char* path, const LoaderOps& ops) override;
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     bool read() override;
 
 private:

--- a/src/loaders/external_webp/tvgWebpLoader.cpp
+++ b/src/loaders/external_webp/tvgWebpLoader.cpp
@@ -66,24 +66,24 @@ WebpLoader::~WebpLoader()
     WebPFree(surface.buf8);
 }
 
-bool WebpLoader::open(const char* path, const LoaderOps& ops)
+Result WebpLoader::open(const char* path, const LoaderOps& ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (!(data = (unsigned char*)Loader::open(path, size))) return false;
+    if (!(data = (unsigned char*)Loader::open(path, size))) return Result::InvalidArguments;
     owner = Ownership::Transfer;
 
     WebPBitstreamFeatures features;
-    if (WebPGetFeatures(data, size, &features)) return false;
+    if (WebPGetFeatures(data, size, &features)) return Result::InvalidArguments;
     w = static_cast<float>(features.width);
     h = static_cast<float>(features.height);
     surface.alphaIgnored = !features.has_alpha;
-    return true;
+    return Result::Success;
 #else
-    return false;
+    return Result::NonSupport;
 #endif
 }
 
-bool WebpLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
+Result WebpLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
 {
     if (ops.owner == Ownership::Copy) {
         this->data = tvg::malloc<unsigned char>(size);
@@ -94,12 +94,12 @@ bool WebpLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
     owner = ops.owner;
 
     WebPBitstreamFeatures features;
-    if (WebPGetFeatures(this->data, size, &features)) return false;
+    if (WebPGetFeatures(this->data, size, &features)) return Result::InvalidArguments;
     w = static_cast<float>(features.width);
     h = static_cast<float>(features.height);
     surface.alphaIgnored = !features.has_alpha;
     this->size = size;
-    return true;
+    return Result::Success;
 }
 
 

--- a/src/loaders/external_webp/tvgWebpLoader.h
+++ b/src/loaders/external_webp/tvgWebpLoader.h
@@ -31,8 +31,8 @@ struct WebpLoader : BitmapLoader, Task
     WebpLoader() : BitmapLoader(FileType::Webp) {}
     ~WebpLoader();
 
-    bool open(const char* path, const LoaderOps& ops) override;
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     bool read() override;
 
     RenderSurface* bitmap() override;

--- a/src/loaders/jpg/tvgJpgLoader.cpp
+++ b/src/loaders/jpg/tvgJpgLoader.cpp
@@ -54,27 +54,26 @@ JpgLoader::~JpgLoader()
     tvg::free(surface.buf8);
 }
 
-bool JpgLoader::open(const char* path, const LoaderOps& ops)
+Result JpgLoader::open(const char* path, const LoaderOps& ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     int width, height;
-    if (!(decoder = jpgdHeader(path, &width, &height))) return false;
+    if (!(decoder = jpgdHeader(path, &width, &height))) return Result::InvalidArguments;
 
     w = static_cast<float>(width);
     h = static_cast<float>(height);
     owner = Ownership::Transfer;
 
-    return true;
+    return Result::Success;
 #else
-    return false;
+    return Result::NonSupport;
 #endif
 }
 
-bool JpgLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
+Result JpgLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
 {
     if (ops.owner == Ownership::Copy) {
         this->data = tvg::malloc<char>(size);
-        if (!this->data) return false;
         memcpy((char *)this->data, data, size);
     } else {
         this->data = (char *) data;
@@ -83,12 +82,12 @@ bool JpgLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
 
     int width, height;
     decoder = jpgdHeader(this->data, size, &width, &height);
-    if (!decoder) return false;
+    if (!decoder) return Result::InvalidArguments;
 
     w = static_cast<float>(width);
     h = static_cast<float>(height);
 
-    return true;
+    return Result::Success;
 }
 
 bool JpgLoader::read()

--- a/src/loaders/jpg/tvgJpgLoader.h
+++ b/src/loaders/jpg/tvgJpgLoader.h
@@ -32,8 +32,8 @@ struct JpgLoader : BitmapLoader, Task
     JpgLoader() : BitmapLoader(FileType::Jpg) {}
     ~JpgLoader();
 
-    bool open(const char* path, const LoaderOps& ops) override;
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     bool read() override;
     bool close() override;
 

--- a/src/loaders/lottie/tvgLottieLoader.cpp
+++ b/src/loaders/lottie/tvgLottieLoader.cpp
@@ -101,7 +101,7 @@ LottieLoader::~LottieLoader()
     tvg::free(dirName);
 }
 
-bool LottieLoader::header()
+Result LottieLoader::header()
 {
     //A single thread doesn't need to perform intensive tasks.
     if (TaskScheduler::threads() == 0) {
@@ -111,9 +111,9 @@ bool LottieLoader::header()
             h = static_cast<float>(comp->h);
             segmentEnd = frameCnt = comp->frameCnt();
             frameRate = comp->frameRate;
-            return true;
+            return Result::Success;
         }
-        return false;
+        return Result::InvalidArguments;
     }
 
     //Quickly validate the given Lottie file without parsing in order to get the animation info.
@@ -197,20 +197,20 @@ bool LottieLoader::header()
 
     if (frameRate < FLOAT_EPSILON) {
         TVGLOG("LOTTIE", "Not a Lottie file? Frame rate is 0!");
-        return false;
+        return Result::InvalidArguments;
     }
 
     segmentEnd = frameCnt = (endFrame - startFrame);
 
     TVGLOG("LOTTIE", "info: frame rate = %f, duration = %f size = %f x %f", frameRate, frameCnt / frameRate, w, h);
 
-    return true;
+    return Result::Success;
 }
 
-bool LottieLoader::open(const char* data, uint32_t size, const LoaderOps& _ops)
+Result LottieLoader::open(const char* data, uint32_t size, const LoaderOps& _ops)
 {
     auto ops = static_cast<const PictureOps*>(&_ops);
-    if (ops->caller != tvg::Type::Picture) return false;
+    if (ops->caller != tvg::Type::Picture) return Result::InvalidArguments;
 
     if (ops->owner == Ownership::Copy) {
         content = tvg::malloc<char>(size + 1);
@@ -226,10 +226,10 @@ bool LottieLoader::open(const char* data, uint32_t size, const LoaderOps& _ops)
     return header();
 }
 
-bool LottieLoader::open(const char* path, const LoaderOps& ops)
+Result LottieLoader::open(const char* path, const LoaderOps& ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (ops.caller != tvg::Type::Picture) return false;
+    if (ops.caller != tvg::Type::Picture) return Result::InvalidArguments;
 
     if ((content = Loader::open(path, size, true))) {
         dirName = tvg::dirname(path);
@@ -237,8 +237,10 @@ bool LottieLoader::open(const char* path, const LoaderOps& ops)
         builder->resolver = static_cast<const PictureOps*>(&ops)->resolver;
         return header();
     }
+    return Result::InvalidArguments;
+#else
+    return Result::NonSupport;
 #endif
-    return false;
 }
 
 

--- a/src/loaders/lottie/tvgLottieLoader.h
+++ b/src/loaders/lottie/tvgLottieLoader.h
@@ -71,8 +71,8 @@ struct LottieLoader : AnimLoader, Task
     LottieLoader();
     ~LottieLoader();
 
-    bool open(const char* path, const LoaderOps& ops) override;
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     bool resize(Paint* paint, float w, float h) override;
     bool read() override;
     Paint* paint() override;
@@ -104,7 +104,7 @@ struct LottieLoader : AnimLoader, Task
 
 private:
     bool ready();
-    bool header();
+    Result header();
     void clear();
     float startFrame();
     void run(unsigned tid) override;

--- a/src/loaders/media/apple/tvgAvfMediaLoader.h
+++ b/src/loaders/media/apple/tvgAvfMediaLoader.h
@@ -62,8 +62,8 @@ struct AvfMediaLoader : MediaLoader
     ~AvfMediaLoader();
 
     // Loader interface
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
-    bool open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
     bool read() override;
     bool sync() override;
 

--- a/src/loaders/media/apple/tvgAvfMediaLoader.mm
+++ b/src/loaders/media/apple/tvgAvfMediaLoader.mm
@@ -272,10 +272,10 @@ static void _finishPlayback(AvfMediaLoader& loader)
     _readStillFrame(loader, loader.totalTime);
 }
 
-static bool _buildQueue(AvfMediaLoader& loader)
+static Result _buildQueue(AvfMediaLoader& loader)
 {
     auto item = [[AVPlayerItem alloc] initWithAsset:loader.asset];
-    if (!item) return false;
+    if (!item) return Result::FailedAllocation;
     if (loader.composition) item.videoComposition = loader.composition;
 
     // Keep playback looper-backed; the end observer stops playback when looping is off.
@@ -285,7 +285,7 @@ static bool _buildQueue(AvfMediaLoader& loader)
     }
 
     [item release];
-    return loader.looper != nil;
+    return loader.looper ? Result::Success : Result::SystemError;
 }
 
 static void _removeEndObserver(AvfMediaLoader& loader)
@@ -342,7 +342,7 @@ AvfMediaLoader::~AvfMediaLoader()
     _unrefQueue();
 }
 
-bool AvfMediaLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
+Result AvfMediaLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
 {
     // AVURLAsset cannot open a memory buffer directly, so expose it through a temporary file URL.
     auto pathTemplate = [NSTemporaryDirectory() stringByAppendingPathComponent:@"thorvg-media-XXXXXX.mp4"];
@@ -350,7 +350,7 @@ bool AvfMediaLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
     auto fd = ::mkstemps(path, 4);
     if (fd < 0) {
         ::free(path);
-        return false;
+        return Result::SystemError;
     }
 
     uint32_t offset = 0;
@@ -360,7 +360,7 @@ bool AvfMediaLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
             ::close(fd);
             ::unlink(path);
             ::free(path);
-            return false;
+            return Result::SystemError;
         }
         offset += static_cast<uint32_t>(written);
     }
@@ -368,26 +368,27 @@ bool AvfMediaLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
     ::close(fd);
 
     tempPath = [[NSString alloc] initWithUTF8String:path];
-    if (open(tempPath.fileSystemRepresentation, ops)) {
+    auto ret = open(tempPath.fileSystemRepresentation, ops);
+    if (ret == Result::Success) {
         ::free(path);
-        return true;
+        return Result::Success;
     }
 
     ::unlink(path);
     ::free(path);
 
-    return false;
+    return ret;
 }
 
-bool AvfMediaLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
+Result AvfMediaLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
 {
+#ifdef THORVG_FILE_IO_SUPPORT
     // Open the media asset and keep the first video track.
     auto url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:path]];
     auto asset = [[AVURLAsset alloc] initWithURL:url options:nil];
     if (!asset || !asset.playable) {
-        TVGERR("AVF", "Failed to open media: %s", path);
         [asset release];
-        return false;
+        return Result::InvalidArguments;
     }
 
     // Use the async track loader to avoid the deprecated sync API.
@@ -403,17 +404,15 @@ bool AvfMediaLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
     dispatch_release(semaphore);
 
     if (!track) {
-        TVGERR("AVF", "No video track found: %s", path);
         [asset release];
-        return false;
+        return Result::InvalidArguments;
     }
 
     auto duration = _seconds(asset.duration);
     if (duration <= TIME_EPSILON) {
-        TVGERR("AVF", "Invalid media duration: %s", path);
         [track release];
         [asset release];
-        return false;
+        return Result::InvalidArguments;
     }
 
     this->asset = asset;
@@ -424,12 +423,12 @@ bool AvfMediaLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
     composition = _composition(asset, track, displaySize);
     w = static_cast<float>(fabs(displaySize.width));
     h = static_cast<float>(fabs(displaySize.height));
-    if (w == 0 || h == 0) return false;
+    if (w == 0 || h == 0) return Result::InvalidArguments;
 
     totalTime = duration;
 
     player = [[AVQueuePlayer alloc] init];
-    if (!player) return false;
+    if (!player) return Result::FailedAllocation;
 
     // Prepare playback; the timer starts only when play() is called.
     player.automaticallyWaitsToMinimizeStalling = NO;
@@ -438,6 +437,9 @@ bool AvfMediaLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
     _startEndObserver(*this);
 
     return _buildQueue(*this);
+#else
+    return Result::NonSupport;
+#endif
 }
 
 bool AvfMediaLoader::read()

--- a/src/loaders/media/web/tvgWebMediaLoader.cpp
+++ b/src/loaders/media/web/tvgWebMediaLoader.cpp
@@ -46,14 +46,14 @@ WebMediaLoader::~WebMediaLoader()
     tvg::free(surface.buf32);
 }
 
-bool WebMediaLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps& ops)
+Result WebMediaLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps& ops)
 {
     auto generator = val::module_property("createMediaPlayer");
-    if (generator.isUndefined()) return false;
+    if (generator.isUndefined()) return Result::NonSupport;
 
     auto bytes = val::global("Uint8Array").new_(val(typed_memory_view(size, reinterpret_cast<const uint8_t*>(data))));
     js = WebMediaPlayer(generator(reinterpret_cast<uintptr_t>(this), bytes));
-    return !js.isNull();
+    return !js.isNull() ? Result::Success : Result::SystemError;
 }
 
 bool WebMediaLoader::sync()

--- a/src/loaders/media/web/tvgWebMediaLoader.h
+++ b/src/loaders/media/web/tvgWebMediaLoader.h
@@ -36,7 +36,7 @@ struct WebMediaLoader : MediaLoader
     ~WebMediaLoader();
 
     // Loader interface
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     RenderSurface* bitmap() override;
     bool sync() override;
 

--- a/src/loaders/png/tvgPngLoader.cpp
+++ b/src/loaders/png/tvgPngLoader.cpp
@@ -61,28 +61,28 @@ PngLoader::~PngLoader()
     lodepng_state_cleanup(&state);
 }
 
-bool PngLoader::open(const char* path, const LoaderOps& ops)
+Result PngLoader::open(const char* path, const LoaderOps& ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (!(data = (unsigned char*)Loader::open(path, size))) return false;
+    if (!(data = (unsigned char*)Loader::open(path, size))) return Result::InvalidArguments;
     owner = Ownership::Transfer;
 
     lodepng_state_init(&state);
 
     unsigned int width, height;
-    if (lodepng_inspect(&width, &height, &state, data, size) > 0) return false;
+    if (lodepng_inspect(&width, &height, &state, data, size) > 0) return Result::InvalidArguments;
     w = static_cast<float>(width);
     h = static_cast<float>(height);
-    return true;
+    return Result::Success;
 #else
-    return false;
+    return Result::NonSupport;
 #endif
 }
 
-bool PngLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
+Result PngLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
 {
     unsigned int width, height;
-    if (lodepng_inspect(&width, &height, &state, (unsigned char*)(data), size) > 0) return false;
+    if (lodepng_inspect(&width, &height, &state, (unsigned char*)(data), size) > 0) return Result::InvalidArguments;
 
     if (ops.owner == Ownership::Copy) {
         this->data = tvg::malloc<unsigned char>(size);
@@ -95,7 +95,7 @@ bool PngLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
     h = static_cast<float>(height);
     this->size = size;
 
-    return true;
+    return Result::Success;
 }
 
 

--- a/src/loaders/png/tvgPngLoader.h
+++ b/src/loaders/png/tvgPngLoader.h
@@ -31,8 +31,8 @@ struct PngLoader : BitmapLoader, Task
     PngLoader();
     ~PngLoader();
 
-    bool open(const char* path, const LoaderOps& ops) override;
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     bool read() override;
 
     RenderSurface* bitmap() override;

--- a/src/loaders/sfnt/tvgSfntLoader.cpp
+++ b/src/loaders/sfnt/tvgSfntLoader.cpp
@@ -481,24 +481,27 @@ void SfntLoader::wrapEllipsis(FontMetrics& fm, const Point& box, const char* utf
     _align(fm.align, box, {cursor.x, fm.size.y}, line, out.pts.count, out);  //last line
 }
 
-SfntReader* SfntLoader::gen(uint8_t* data, uint32_t size)
+Result SfntLoader::gen(uint8_t* data, uint32_t size, SfntReader*& out)
 {
     if (size > 4) {
         auto type = uint32_t(data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3]);
         if (type == 0x00010000 || type == 0x74727565) {  // ttf (scalable font)
 #ifdef THORVG_TTF_LOADER_SUPPORT
-            return new TtfReader(data, size);
+            out = new TtfReader(data, size);
+            return Result::Success;
+#else
+            return Result::NonSupport;
 #endif
-            TVGLOG("SFNT", "TrueType (TTF) is not supported");
         } else if (type == 0x4F54544F) {  // otf (OTTO)
 #ifdef THORVG_OTF_LOADER_SUPPORT
-            return new OtfReader(data, size);
+            out = new OtfReader(data, size);
+            return Result::Success;
+#else
+            return Result::NonSupport;
 #endif
-            TVGLOG("SFNT", "OpenType (OTF) is not supported");
         }
     }
-    TVGERR("SFNT", "Invalid SFNT format!");
-    return nullptr;
+    return Result::InvalidArguments;
 }
 
 /************************************************************************/
@@ -524,25 +527,24 @@ SfntLoader::~SfntLoader()
     clear();
 }
 
-bool SfntLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
+Result SfntLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
     uint32_t size;
     auto data = _map(this, path, size);
-    if (!data) return false;
-    reader = gen(data, size);
-    if (reader) {
-        name = tvg::filename(path);
-        return reader->header();
-    }
+    if (!data) return Result::InvalidArguments;
+    auto ret = gen(data, size, reader);
+    if (ret != Result::Success) return ret;
+    name = tvg::filename(path);
+    return reader->header() ? Result::Success : Result::InvalidArguments;
 #endif
-    return false;
+    return Result::NonSupport;
 }
 
-bool SfntLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps& ops)
+Result SfntLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOps& ops)
 {
-    reader = gen((uint8_t*)data, size);
-    if (!reader) return false;
+    auto ret = gen((uint8_t*)data, size, reader);
+    if (ret != Result::Success) return ret;
     nomap = true;
 
     if (ops.owner == Ownership::Copy) {
@@ -551,7 +553,7 @@ bool SfntLoader::open(const char* data, uint32_t size, TVG_UNUSED const LoaderOp
     }
     owner = ops.owner;
 
-    return reader->header();
+    return reader->header() ? Result::Success : Result::InvalidArguments;
 }
 
 bool SfntLoader::get(FontMetrics& fm, char* text, uint32_t len, RenderPath& out)

--- a/src/loaders/sfnt/tvgSfntLoader.h
+++ b/src/loaders/sfnt/tvgSfntLoader.h
@@ -50,8 +50,8 @@ struct SfntLoader : public FontLoader
     using FontLoader::open;
     using FontLoader::read;
 
-    bool open(const char* path, const LoaderOps& ops) override;
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     void transform(Paint* paint, FontMetrics& fm, float italicShear) override;
     bool get(FontMetrics& fm, char* text, uint32_t len, RenderPath& out) override;
     void copy(const FontMetrics& in, FontMetrics& out) override;
@@ -59,7 +59,7 @@ struct SfntLoader : public FontLoader
     void metrics(const FontMetrics& fm, TextMetrics& out) override;
     bool metrics(const FontMetrics& fm, const char* ch, GlyphMetrics& out, const char** next) override;
 
-    static SfntReader* gen(uint8_t* data, uint32_t size);
+    static Result gen(uint8_t* data, uint32_t size, SfntReader*& out);
 
 private:
     float height(uint32_t loc, float spacing)

--- a/src/loaders/svg/tvgSvgLoader.cpp
+++ b/src/loaders/svg/tvgSvgLoader.cpp
@@ -4091,7 +4091,7 @@ SvgLoader::~SvgLoader()
 }
 
 
-bool SvgLoader::header()
+Result SvgLoader::header()
 {
     //For valid check, only <svg> tag is parsed first.
     //If the <svg> tag is found, the loaded file is valid and stores viewbox information.
@@ -4104,7 +4104,7 @@ bool SvgLoader::header()
 
     if (!ctx.doc || ctx.doc->type != SvgNodeType::Doc) {
         TVGLOG("SVG", "No SVG File. There is no <svg/>");
-        return false;
+        return Result::InvalidArguments;
     }
 
     viewFlag = ctx.doc->node.doc.viewFlag;
@@ -4157,12 +4157,12 @@ bool SvgLoader::header()
 
         run(0);
     }
-    return true;
+    return Result::Success;
 }
 
-bool SvgLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
+Result SvgLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
 {
-    if (ops.caller != tvg::Type::Picture) return false;
+    if (ops.caller != tvg::Type::Picture) return Result::InvalidArguments;
 
     if (ops.owner == Ownership::Copy) {
         content = tvg::malloc<char>(size + 1);
@@ -4177,18 +4177,20 @@ bool SvgLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
     return header();
 }
 
-bool SvgLoader::open(const char* path, const LoaderOps& ops)
+Result SvgLoader::open(const char* path, const LoaderOps& ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (ops.caller != tvg::Type::Picture) return false;
+    if (ops.caller != tvg::Type::Picture) return Result::InvalidArguments;
 
     if ((content = Loader::open(path, size, true))) {
         ctx.accessible = static_cast<const PictureOps*>(&ops)->accessible;
         owner = Ownership::Transfer;
         return header();
     }
+    return Result::InvalidArguments;
+#else
+    return Result::NonSupport;
 #endif
-    return false;
 }
 
 

--- a/src/loaders/svg/tvgSvgLoader.h
+++ b/src/loaders/svg/tvgSvgLoader.h
@@ -37,8 +37,8 @@ struct SvgLoader : ImageLoader, Task
     SvgLoader() : ImageLoader(FileType::Svg) {}
     ~SvgLoader();
 
-    bool open(const char* path, const LoaderOps& ops) override;
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     bool resize(Paint* paint, float w, float h) override;
     bool read() override;
     bool close() override;
@@ -54,7 +54,7 @@ private:
     AspectRatioMeetOrSlice meetOrSlice = AspectRatioMeetOrSlice::Meet;
     Box vbox{};
 
-    bool header();
+    Result header();
     void clear(bool all = true);
     void run(unsigned tid) override;
 };

--- a/src/loaders/webp/tvgWebpLoader.cpp
+++ b/src/loaders/webp/tvgWebpLoader.cpp
@@ -62,24 +62,24 @@ WebpLoader::~WebpLoader()
     tvg::free(surface.buf8);
 }
 
-bool WebpLoader::open(const char* path, const LoaderOps& ops)
+Result WebpLoader::open(const char* path, const LoaderOps& ops)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
-    if (!(data = (uint8_t*)Loader::open(path, size))) return false;
+    if (!(data = (uint8_t*)Loader::open(path, size))) return Result::InvalidArguments;
     owner = Ownership::Transfer;
 
     WebPBitstreamFeatures features;
-    if (WebPGetFeatures(data, size, &features)) return false;
+    if (WebPGetFeatures(data, size, &features)) return Result::InvalidArguments;
     w = static_cast<float>(features.width);
     h = static_cast<float>(features.height);
     surface.alphaIgnored = !features.has_alpha;
-    return true;
+    return Result::Success;
 #else
-    return false;
+    return Result::NonSupport;
 #endif
 }
 
-bool WebpLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
+Result WebpLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
 {
     if (ops.owner == Ownership::Copy) {
         this->data = tvg::malloc<uint8_t>(size);
@@ -90,13 +90,13 @@ bool WebpLoader::open(const char* data, uint32_t size, const LoaderOps& ops)
     owner = ops.owner;
 
     WebPBitstreamFeatures features;
-    if (WebPGetFeatures(this->data, size, &features)) return false;
+    if (WebPGetFeatures(this->data, size, &features)) return Result::InvalidArguments;
     w = static_cast<float>(features.width);
     h = static_cast<float>(features.height);
     surface.alphaIgnored = !features.has_alpha;
     this->size = size;
 
-    return true;
+    return Result::Success;
 }
 
 

--- a/src/loaders/webp/tvgWebpLoader.h
+++ b/src/loaders/webp/tvgWebpLoader.h
@@ -28,8 +28,8 @@ struct WebpLoader : BitmapLoader, Task
     WebpLoader() : BitmapLoader(FileType::Webp) {}
     ~WebpLoader();
 
-    bool open(const char* path, const LoaderOps& ops) override;
-    bool open(const char* data, uint32_t size, const LoaderOps& ops) override;
+    Result open(const char* path, const LoaderOps& ops) override;
+    Result open(const char* data, uint32_t size, const LoaderOps& ops) override;
     bool read() override;
     bool close() override;
 

--- a/src/renderer/tvgLoader.h
+++ b/src/renderer/tvgLoader.h
@@ -110,8 +110,8 @@ struct Loader
         return true;
     }
 
-    virtual bool open(const char* path, const LoaderOps& ops) { return false; }
-    virtual bool open(const char* data, uint32_t size, const LoaderOps& ops) { return false; }
+    virtual Result open(const char* path, const LoaderOps& ops) { return Result::NonSupport; }
+    virtual Result open(const char* data, uint32_t size, const LoaderOps& ops) { return Result::NonSupport; }
     virtual bool resize(Paint* paint, float w, float h) { return false; }
     virtual bool sync() { return false; };  // finish immediately if any async update jobs, return true if something has been updated.
 

--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -119,19 +119,23 @@ static tvg::Loader* _find(FileType type)
 }
 
 #ifdef THORVG_FILE_IO_SUPPORT
-static tvg::Loader* _findByPath(const char* filename, bool& invalid)
+static tvg::Loader* _findByPath(const char* filename, Result& ret)
 {
     auto ext = fileext(filename);
     if (ext) {
-        if (!strcmp(ext, "svg")) return _find(FileType::Svg);
-        if (!strcmp(ext, "lot") || !strcmp(ext, "json")) return _find(FileType::Lot);
-        if (!strcmp(ext, "ttf") || !strcmp(ext, "ttc") || !strcmp(ext, "otf") || !strcmp(ext, "otc")) return _find(FileType::Sfnt);
-        if (!strcmp(ext, "png")) return _find(FileType::Png);
-        if (!strcmp(ext, "jpg")) return _find(FileType::Jpg);
-        if (!strcmp(ext, "webp")) return _find(FileType::Webp);
-        if (!strcmp(ext, "mp4")) return _find(FileType::Media);  // TODO: add common media formats        
+        auto type = FileType::Unknown;
+        if (!strcmp(ext, "svg")) type = FileType::Svg;
+        else if (!strcmp(ext, "lot") || !strcmp(ext, "json")) type = FileType::Lot;
+        else if (!strcmp(ext, "ttf") || !strcmp(ext, "ttc") || !strcmp(ext, "otf") || !strcmp(ext, "otc")) type = FileType::Sfnt;
+        else if (!strcmp(ext, "png")) type = FileType::Png;
+        else if (!strcmp(ext, "jpg")) type = FileType::Jpg;
+        else if (!strcmp(ext, "webp")) type = FileType::Webp;
+        else if (!strcmp(ext, "mp4")) type = FileType::Media;  // TODO: add common media formats
+        if (type != FileType::Unknown) {
+            ret = Result::NonSupport;
+            return _find(type);
+        }
     }
-    invalid = true;  // invalid file path outside ThorVG's scope.
     return nullptr;
 }
 #endif
@@ -153,11 +157,6 @@ static FileType _convert(const char* mimeType)
     else TVGLOG("RENDERER", "Given mimetype is unknown = \"%s\".", mimeType);
 
     return type;
-}
-
-static tvg::Loader* _findByType(const char* mimeType)
-{
-    return _find(_convert(mimeType));
 }
 
 static tvg::Loader* _findFromCache(const char* filename)
@@ -221,26 +220,32 @@ bool LoaderMgr::retrieve(Loader* loader)
     return true;
 }
 
-tvg::Loader* LoaderMgr::loader(const char* filename, const LoaderOps& ops, bool& invalid)
+tvg::Loader* LoaderMgr::loader(const char* filename, LoaderOps& ops, Result& ret)
 {
 #ifdef THORVG_FILE_IO_SUPPORT
+    if (!filename) return nullptr;
+
     if (auto loader = _findFromCache(filename)) return loader;
 
-    if (auto loader = _findByPath(filename, invalid)) {
-        if (loader->open(filename, ops)) {
+    ret = Result::InvalidArguments;
+
+    if (auto loader = _findByPath(filename, ret)) {
+        // respect the return value here, but ignore trials with unknown MIME types.
+        ret = loader->open(filename, ops);
+        if (ret == Result::Success) {
             if (loader->cache(filename)) {
                 ScopedLock lock(_key);
                 _activeLoaders.back(loader);
             }
             return loader;
         }
-        invalid = true;
         delete (loader);
     }
+
     // Unknown MimeType. Try with the candidates in the order
     for (int i = 0; i < static_cast<int>(FileType::Unknown); i++) {
         if (auto loader = _find(static_cast<FileType>(i))) {
-            if (loader->open(filename, ops)) {
+            if (loader->open(filename, ops) == Result::Success) {
                 if (loader->cache(filename)) {
                     ScopedLock lock(_key);
                     _activeLoaders.back(loader);
@@ -250,6 +255,9 @@ tvg::Loader* LoaderMgr::loader(const char* filename, const LoaderOps& ops, bool&
             delete (loader);
         }
     }
+#else
+    TVGLOG("RENDERER", "FILE IO is disabled!");
+    ret = Result::NonSupport;
 #endif
     return nullptr;
 }
@@ -259,7 +267,7 @@ bool LoaderMgr::retrieve(const char* filename)
     return retrieve(_findFromCache(filename));
 }
 
-tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps& ops)
+tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mimeType, LoaderOps& ops, Result& ret)
 {
     // Note that users could use the same data pointer with the different content.
     // Thus caching is only valid for shareable.
@@ -269,8 +277,12 @@ tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mime
 
     // Try with the given MimeType
     if (mimeType) {
-        if (auto loader = _findByType(mimeType)) {
-            if (loader->open(data, size, ops)) {
+        auto type = _convert(mimeType);
+        if (type != FileType::Unknown) ret = Result::NonSupport;
+        if (auto loader = _find(type)) {
+            // respect the return value here, but ignore trials with unknown MIME types.
+            ret = loader->open(data, size, ops);
+            if (ret == Result::Success) {
                 if (ops.owner == Ownership::Borrow && loader->cache(HASH_KEY(data))) {
                     ScopedLock lock(_key);
                     _activeLoaders.back(loader);
@@ -282,11 +294,12 @@ tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mime
             }
         }
     }
+
     // Unknown MimeType. Try with the candidates in the order
     for (int i = 0; i < static_cast<int>(FileType::Unknown); i++) {
         auto loader = _find(static_cast<FileType>(i));
         if (!loader) continue;
-        if (loader->open(data, size, ops)) {
+        if (loader->open(data, size, ops) == Result::Success) {
             if (ops.owner == Ownership::Borrow && loader->cache(HASH_KEY(data))) {
                 ScopedLock lock(_key);
                 _activeLoaders.back(loader);
@@ -334,7 +347,7 @@ tvg::Loader* LoaderMgr::loader(const char* name, const char* data, uint32_t size
 
     // function is dedicated for SFNT-based font loading
     auto loader = new SfntLoader;
-    if (loader->open(data, size, ops)) {
+    if (loader->open(data, size, ops) == Result::Success) {
         loader->name = duplicate(name);
         loader->cached = true;  // force it.
         ScopedLock lock(_key);

--- a/src/renderer/tvgLoaderMgr.h
+++ b/src/renderer/tvgLoaderMgr.h
@@ -32,8 +32,8 @@ struct LoaderMgr
 {
     static bool init();
     static bool term();
-    static Loader* loader(const char* filename, const LoaderOps& ops, bool& invalid);
-    static Loader* loader(const char* data, uint32_t size, const char* mimeType, const LoaderOps& ops);
+    static Loader* loader(const char* filename, LoaderOps& ops, Result& ret);
+    static Loader* loader(const char* data, uint32_t size, const char* mimeType, LoaderOps& ops, Result& ret);
     static Loader* loader(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, Ownership owner);
     static Loader* loader(const char* name, const char* data, uint32_t size, const char* mimeType, const LoaderOps& ops);
     static Loader* font(const char* name);

--- a/src/renderer/tvgPicture.cpp
+++ b/src/renderer/tvgPicture.cpp
@@ -40,13 +40,8 @@ Type Picture::type() const noexcept
 
 Result Picture::load(const char* filename) noexcept
 {
-#ifdef THORVG_FILE_IO_SUPPORT
     if (!filename) return Result::InvalidArguments;
     return to<PictureImpl>(this)->load(filename);
-#else
-    TVGLOG("RENDERER", "FILE IO is disabled!");
-    return Result::NonSupport;
-#endif
 }
 
 

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -138,11 +138,9 @@ struct PictureImpl : Picture
         if (vector || bitmap) return Result::InsufficientCondition;
 
         PictureOps ops = {Ownership::Transfer, resolver, nullptr, accessible};
-        auto invalid = false;  // invalid path
-        auto loader = LoaderMgr::loader(filename, ops, invalid);
-        if (loader) return load(loader);
-        if (invalid) return Result::InvalidArguments;
-        return Result::NonSupport;
+        auto ret = Result::InvalidArguments;
+        auto loader = LoaderMgr::loader(filename, ops, ret);
+        return loader ? load(loader) : ret;
     }
 
     Result load(const char* data, uint32_t size, const char* mimeType, const char* rpath, const Ownership owner)
@@ -151,14 +149,17 @@ struct PictureImpl : Picture
         if (vector || bitmap) return Result::InsufficientCondition;
 
         PictureOps ops = {owner, resolver, rpath, accessible};
-        return load(LoaderMgr::loader(data, size, mimeType, ops));
+        auto ret = Result::InvalidArguments;
+        auto loader = LoaderMgr::loader(data, size, mimeType, ops, ret);
+        return loader ? load(loader) : ret;
     }
 
     Result load(const uint32_t* data, uint32_t w, uint32_t h, ColorSpace cs, Ownership owner)
     {
         if (!data || w <= 0 || h <= 0 || cs == ColorSpace::Unknown)  return Result::InvalidArguments;
         if (vector) return Result::InsufficientCondition;
-        return load(LoaderMgr::loader(data, w, h, cs, owner));
+        auto loader = LoaderMgr::loader(data, w, h, cs, owner);
+        return loader ? load(loader) : Result::NonSupport;
     }
 
     Result set(std::function<bool(Paint* paint, const char* src, void* data)> resolver, void* data)
@@ -298,8 +299,6 @@ struct PictureImpl : Picture
 
     Result load(Loader* loader)
     {
-        if (!loader) return Result::NonSupport;
-
         //Same resource has been loaded.
         if (this->loader == loader) {
             this->loader->sharing--;  //make it sure the reference counting.

--- a/src/renderer/tvgText.cpp
+++ b/src/renderer/tvgText.cpp
@@ -46,17 +46,9 @@ Result Text::size(float size) noexcept
 
 Result Text::load(const char* filename) noexcept
 {
-#ifdef THORVG_FILE_IO_SUPPORT
     LoaderOps ops = {Type::Text, Ownership::Transfer};
-    auto invalid = false;   // invalid path
-    auto loader = LoaderMgr::loader(filename, ops, invalid);
-    if (loader) return Result::Success;
-    if (invalid) return Result::InvalidArguments;
-    else return Result::NonSupport;
-#else
-    TVGLOG("RENDERER", "FILE IO is disabled!");
-    return Result::NonSupport;
-#endif
+    auto ret = Result::InvalidArguments;
+    return LoaderMgr::loader(filename, ops, ret) ? Result::Success: ret;
 }
 
 
@@ -69,13 +61,8 @@ Result Text::load(const char* name, const char* data, uint32_t size, const char*
 Result Text::unload(const char* filename) noexcept
 {
     if (!filename) return Result::InvalidArguments;
-#ifdef THORVG_FILE_IO_SUPPORT
     if (LoaderMgr::retrieve(filename)) return Result::Success;
     return Result::InsufficientCondition;
-#else
-    TVGLOG("RENDERER", "FILE IO is disabled!");
-    return Result::NonSupport;
-#endif
 }
 
 


### PR DESCRIPTION
- Return detailed Result values from loader open methods.
- Preserve loader errors through format detection and fallback.
- Report NonSupport when loaders or file I/O are disabled.
- Check Apple media loader success explicitly.
- Added a new error return value - SystemError.

issue: #4670