### PR TITLE
gl: optimize Gaussian blur weight calculation

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
@@ -38,6 +38,10 @@ struct GlGaussianBlur
     float scale{};
     float extend{};
     float quality{};
+    float invTwoSigmaSquared{};
+    float dummy0{};
+    float dummy1{};
+    float dummy2{};
 };
 
 static float _blurQuality(uint8_t quality, float extend)
@@ -69,8 +73,10 @@ void GlEffect::update(RenderEffectGaussianBlur* effect, const Matrix& transform)
     if (!blur) blur = tvg::malloc<GlGaussianBlur>(sizeof(GlGaussianBlur));
     blur->sigma = effect->sigma;
     blur->scale = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
-    blur->extend = 2 * blur->sigma * blur->scale;
+    const auto sigma = blur->sigma * blur->scale;
+    blur->extend = 2 * sigma;
     blur->quality = _blurQuality(effect->quality, blur->extend);
+    blur->invTwoSigmaSquared = tvg::zero(sigma) ? 0.0f : -0.5f / (sigma * sigma);
     effect->rd = blur;
     effect->valid = (blur->extend > 0);
 }
@@ -143,6 +149,8 @@ void GlEffect::update(RenderEffectDropShadow* effect, const Matrix& transform)
 
     dropShadow->sigma = effect->sigma;
     dropShadow->scale = scale;
+    const auto sigma = dropShadow->sigma * dropShadow->scale;
+    dropShadow->invTwoSigmaSquared = tvg::zero(sigma) ? 0.0f : -0.5f / (sigma * sigma);
     dropShadow->color[3] = effect->color[3] / 255.0f;
     //Drop shadow effect applies blending in the shader (GL_BLEND disabled), so the color should be premultiplied:
     dropShadow->color[0] = effect->color[0] / 255.0f * dropShadow->color[3];
@@ -150,7 +158,7 @@ void GlEffect::update(RenderEffectDropShadow* effect, const Matrix& transform)
     dropShadow->color[2] = effect->color[2] / 255.0f * dropShadow->color[3];
     dropShadow->offset[0] = offset.x;
     dropShadow->offset[1] = offset.y;
-    dropShadow->extend = 2 * std::max(effect->sigma * scale + std::abs(offset.x), effect->sigma * scale + std::abs(offset.y));
+    dropShadow->extend = 2 * std::max(sigma + std::abs(offset.x), sigma + std::abs(offset.y));
     dropShadow->quality = _blurQuality(effect->quality, dropShadow->extend);
     effect->rd = dropShadow;
     effect->valid = (dropShadow->extend >= 0);

--- a/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
@@ -1084,6 +1084,7 @@ in vec2 vUV;
 out vec4 FragColor;
 
 float gaussian(float x) {
+    if (uGaussian.invTwoSigmaSquared == 0.0) return x == 0.0 ? 1.0 : 0.0;
     return exp(x * x * uGaussian.invTwoSigmaSquared);
 }
 
@@ -1135,6 +1136,7 @@ in vec2 vUV;
 out vec4 FragColor;
 
 float gaussian(float x) {
+    if (uGaussian.invTwoSigmaSquared == 0.0) return x == 0.0 ? 1.0 : 0.0;
     return exp(x * x * uGaussian.invTwoSigmaSquared);
 }
 

--- a/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
@@ -1070,6 +1070,10 @@ layout(std140) uniform Gaussian {
     float scale;
     float extend;
     float quality;
+    float invTwoSigmaSquared;
+    float dummy0;
+    float dummy1;
+    float dummy2;
 } uGaussian;
 
 layout(std140) uniform Viewport {
@@ -1079,16 +1083,14 @@ layout(std140) uniform Viewport {
 in vec2 vUV;
 out vec4 FragColor;
 
-float gaussian(float x, float sigma) {
-    float exponent = -x * x / (2.0 * sigma * sigma);
-    return exp(exponent) / (sqrt(2.0 * 3.141592) * sigma);
+float gaussian(float x) {
+    return exp(x * x * uGaussian.invTwoSigmaSquared);
 }
 
 void main()
 {
     vec2 texelSize = 1.0 / vec2(textureSize(uSrcTexture, 0));
     vec4 colorSum = vec4(0.0);
-    float sigma = uGaussian.sigma * uGaussian.scale;
     float weightSum = 0.0;
     int radius = int(uGaussian.extend);
     int quality = int(uGaussian.quality);
@@ -1103,7 +1105,7 @@ void main()
     vec2 coord = vUV + texelStep * float(first);
     vec2 sampleStep = texelStep * float(quality);
     for (int y = first; y <= last; y += quality) {
-        float weight = gaussian(float(y), sigma);
+        float weight = gaussian(float(y));
         colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
         coord += sampleStep;
@@ -1119,6 +1121,10 @@ layout(std140) uniform Gaussian {
     float scale;
     float extend;
     float quality;
+    float invTwoSigmaSquared;
+    float dummy0;
+    float dummy1;
+    float dummy2;
 } uGaussian;
 
 layout(std140) uniform Viewport {
@@ -1128,16 +1134,14 @@ layout(std140) uniform Viewport {
 in vec2 vUV;
 out vec4 FragColor;
 
-float gaussian(float x, float sigma) {
-    float exponent = -x * x / (2.0 * sigma * sigma);
-    return exp(exponent) / (sqrt(2.0 * 3.141592) * sigma);
+float gaussian(float x) {
+    return exp(x * x * uGaussian.invTwoSigmaSquared);
 }
 
 void main()
 {
     vec2 texelSize = 1.0 / vec2(textureSize(uSrcTexture, 0));
     vec4 colorSum = vec4(0.0);
-    float sigma = uGaussian.sigma * uGaussian.scale;
     float weightSum = 0.0;
     int radius = int(uGaussian.extend);
     int quality = int(uGaussian.quality);
@@ -1152,7 +1156,7 @@ void main()
     vec2 coord = vUV + texelStep * float(first);
     vec2 sampleStep = texelStep * float(quality);
     for (int x = first; x <= last; x += quality) {
-        float weight = gaussian(float(x), sigma);
+        float weight = gaussian(float(x));
         colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
         coord += sampleStep;
@@ -1168,9 +1172,14 @@ layout(std140) uniform DropShadow {
     float sigma;
     float scale;
     float extend;
+    float quality;
+    float invTwoSigmaSquared;
     float dummy0;
+    float dummy1;
+    float dummy2;
     vec4 color;
     vec2 offset;
+    vec2 dummy3;
 } uDropShadow;
 
 in vec2 vUV;


### PR DESCRIPTION
Precompute the Gaussian exponent coefficient on the CPU and pass it to the GL blur shaders.

  This avoids repeated square-root and division operations for every blur sample. The normalization factor is omitted
  because it is canceled out by the weight normalization.

  Tested with GL unit tests and a 1024×1024 before/after comparison.
  Only 2 / 1,048,576 pixels differ, by one channel value.

  issue: #4426
  
  left: before / right: after
<img width="2048" height="1024" alt="side-by-side" src="https://github.com/user-attachments/assets/78556546-562e-4999-bf00-2855647dd712" />

