### PR TITLE
sfnt/otf: support CID-keyed CFF fonts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -74,3 +74,4 @@ For definitions and responsibilities of each project role, see [Roles & Responsi
 - Sunyong Jeong @jeongsunyong
 - Park Sung Jun @J-unStiN
 - Yoonseok Kang @DaengDo
+- Ralf Preininger @rpreininger

--- a/src/loaders/sfnt/tvgOtfReader.cpp
+++ b/src/loaders/sfnt/tvgOtfReader.cpp
@@ -128,11 +128,77 @@ uint32_t OtfReader::localSubrs(Array<int32_t>& args, uint32_t offset, uint32_t s
     while (ptr < end) {
         auto b = u8(ptr);
         if (DICT(args, b, ptr)) continue;
-        // sub routine offset is relative to the start of Private DICT
+        // subroutine offset is relative to the start of Private DICT
         if (b == 19 && args.count > 0) return base + args.last();
         ++ptr;
         args.clear();
     }
+    return 0;
+}
+
+uint32_t OtfReader::fdSubrs(uint32_t glyph)
+{
+    int32_t fd = -1;
+    auto format = u8(fdSelect);
+
+    // FDSelect format 0 stores one font dictionary index per glyph.
+    if (format == 0) {
+        fd = u8(fdSelect + 1 + glyph);
+    // FDSelect format 3 groups consecutive glyphs into ranges. Each range
+    // ends at the first glyph of the following range (or the sentinel).
+    } else if (format == 3) {
+        auto nRanges = u16(fdSelect + 1);
+        auto ranges = fdSelect + 3;
+
+        for (uint16_t i = 0; i < nRanges; ++i) {
+            auto range = ranges + i * 3;
+            auto first = u16(range);
+            auto next = u16(range + 3);
+            auto rangeFd = u8(range + 2);
+
+            if (glyph >= first && glyph < next) {
+                fd = rangeFd;
+                break;
+            }
+        }
+    } else return 0;
+
+    auto count = u16(fdArray);
+    if (fd < 0 || static_cast<uint32_t>(fd) >= count) return 0;
+
+    // Locate the selected Font DICT in the FDArray INDEX. CFF INDEX offsets
+    // are one-based and relative to the beginning of the object data.
+    auto offSize = u8(fdArray + 2);
+    auto offsets = fdArray + 3;
+    auto data = offsets + (count + 1) * offSize;
+    auto begin = data + (offset(offsets + fd * offSize, offSize) - 1);
+    auto end = data + (offset(offsets + (fd + 1) * offSize, offSize) - 1);
+
+    Array<int32_t> args(32);
+    auto ptr = begin;
+
+    while (ptr < end) {
+        auto b = u8(ptr);
+
+        if (b == 12) {
+            ptr += 2;
+            args.clear();
+            continue;
+        }
+        if (DICT(args, b, ptr)) continue;
+
+        // The Private operator supplies [size, offset] for the Private DICT;
+        // its Subrs operator, if present, identifies the local Subr INDEX.
+        if (b == 18 && args.count >= 2) {  // Private
+            auto privateSize = args[args.count - 2];
+            auto privateOffset = args[args.count - 1];
+            return localSubrs(args, privateOffset, privateSize);
+        }
+
+        ++ptr;
+        args.clear();
+    }
+
     return 0;
 }
 
@@ -181,7 +247,19 @@ bool OtfReader::CFF()
 
     while (ptr < end) {
         auto b = u8(ptr);
+
+        // CID-keyed font offsets use escaped Top DICT operators.
+        if (b == 12) {
+            auto op = u8(ptr + 1);
+            if (op == 36) fdArray = cff + args.last();
+            else if (op == 37) fdSelect = cff + args.last();
+            ptr += 2;
+            args.clear();
+            continue;
+        }
+
         if (DICT(args, b, ptr)) continue;
+
         // CharStrings
         if (b == 17) {
             toCharStrings = args.last();
@@ -310,7 +388,7 @@ void OtfReader::rLineCurve(Array<float>& v, Point& pos, RenderPath& path)
     path.cubicTo(cp1, cp2, pos);
 }
 
-void OtfReader::operand(Array<float>& v, uint8_t b, uint32_t& p)
+bool OtfReader::operand(Array<float>& v, uint8_t b, uint32_t& p)
 {
     if (b >= 32) {
         if (b <= 246) {
@@ -329,10 +407,11 @@ void OtfReader::operand(Array<float>& v, uint8_t b, uint32_t& p)
     } else if (b == 28) {
         v.push(float(i16(p + 1)));
         p += 3;
-    } else if (b == 29) {
-        v.push(float(i32(p + 1)));
-        p += 5;
+    } else {
+        TVGERR("OTF", "Unsupported CharString opcode: %u", b);
+        return false;
     }
+    return true;
 }
 
 bool OtfReader::charStrings(RenderPath& path, uint32_t glyph)
@@ -340,6 +419,8 @@ bool OtfReader::charStrings(RenderPath& path, uint32_t glyph)
     // get the glyph data offset
     auto count = u16(toCharStrings);
     if (glyph >= count) return false;
+
+    if (fdSelect && fdArray) subrs = fdSubrs(glyph);
 
     auto size = u8(toCharStrings + 2);
     auto base = toCharStrings + 3;
@@ -357,10 +438,16 @@ bool OtfReader::charStrings(RenderPath& path, uint32_t glyph)
     SubRoutine subRoutines[SUBROUTINE_MAX];   // subroutine stack
     auto srp = 0;  // subroutine stack pointer
     Array<float> values(40);  // values stack for path coordinates
+    auto nStems = 0;          // running hint count, needed to size the hintmask/cntrmask operands
 
     while (p < end) {
         auto b = u8(p);
         switch (b) {
+            case 1:    // TODO: hstem
+            case 3: {  // TODO: vstem
+                nStems += values.count / 2;
+                break;
+            }
             case 4: {  // vmoveto
                 pos.y -= values.pick();
                 path.moveTo(pos);
@@ -394,7 +481,7 @@ bool OtfReader::charStrings(RenderPath& path, uint32_t glyph)
                 rrCurveTo(values, pos, path);
                 break;
             }
-            case 10: {
+            case 10: {  // callsubr
                 if (this->subRoutine(values.pick(), subrs, p, end, subRoutines, srp)) continue;
                 return false;
             }
@@ -407,12 +494,24 @@ bool OtfReader::charStrings(RenderPath& path, uint32_t glyph)
                 continue;
             }
             case 12: {  // 2-byte escape operator
+                values.clear();
                 p += 2;
-                break;
+                continue;
             }
             case 14: {  // close
                 path.close();
                 break;
+            }
+            case 18: {  // TODO: hstemhm
+                nStems += values.count / 2;
+                break;
+            }
+            case 19:                         // hintmask
+            case 20: {                       // cntrmask
+                nStems += values.count / 2;  // pending operands are an implicit vstemhm
+                p += 1 + (nStems + 7) / 8;   // operator byte + one mask bit per stem
+                values.clear();
+                continue;
             }
             case 21: {  // rmoveto
                 pos.y -= values.pick();
@@ -423,6 +522,10 @@ bool OtfReader::charStrings(RenderPath& path, uint32_t glyph)
             case 22: {  // hmoveto
                 pos.x += values.pick();
                 path.moveTo(pos);
+                break;
+            }
+            case 23: {  // TODO: vstemhm
+                nStems += values.count / 2;
                 break;
             }
             case 24: {  // rcurveline
@@ -441,7 +544,7 @@ bool OtfReader::charStrings(RenderPath& path, uint32_t glyph)
                 alignedCurve(values, pos, path, true);
                 break;
             }
-            case 29: {
+            case 29: {  // callgsubr
                 if (this->subRoutine(values.pick(), gsubrs, p, end, subRoutines, srp)) continue;
                 return false;
             }
@@ -454,8 +557,8 @@ bool OtfReader::charStrings(RenderPath& path, uint32_t glyph)
                 break;
             }
             default: {
-                operand(values, b, p);
-                continue;
+                if (operand(values, b, p)) continue;
+                return false;
             }
         }
         values.clear();

--- a/src/loaders/sfnt/tvgOtfReader.cpp
+++ b/src/loaders/sfnt/tvgOtfReader.cpp
@@ -218,15 +218,16 @@ uint32_t OtfReader::fdSubrs(uint32_t glyph)
 //     ├── offSize (u8)
 //     ├── offset array [(count + 1) * offSize]
 //     └── data (CharString bytecode per glyph)
-bool OtfReader::CFF()
+Result OtfReader::CFF()
 {
-    cff = table("CFF ");  // PostScript outlines
-    auto cff2 = false;
-    if (!cff) {
-        cff = table("CFF2");  // variable font
-        cff2 = true;
+    cff = table("CFF ");
+    if (!cff || !validate(cff, 4)) {
+        if (table("CFF2")) {
+            TVGLOG("OTF", "CFF2 is not supported");
+            return Result::NonSupport;
+        }
+        return Result::InvalidArguments;
     }
-    if (!cff || !validate(cff, 4)) return false;
 
     auto p = cff + u8(cff + 2);  // skip the header size
 
@@ -235,7 +236,7 @@ bool OtfReader::CFF()
 
     // parse Top DICT INDEX
     auto count = u16(p);
-    if (count == 0) return false;
+    if (count == 0) return Result::InvalidArguments;
 
     Array<int32_t> args(32);  // arguments stack for CFF decoding
 
@@ -270,15 +271,15 @@ bool OtfReader::CFF()
         ++ptr;
         args.clear();
     }
-    if (toCharStrings == 0) return false;
+    if (toCharStrings == 0) return Result::InvalidArguments;
     toCharStrings += cff;
 
     p = skip(p);             // jump to the end of INDEX
-    if (!cff2) p = skip(p);  // only cff1 has the String INDEX
+    p = skip(p);             // jump to the end of String INDEX
 
     gsubrs = p;
 
-    return true;
+    return Result::Success;
 }
 
 bool OtfReader::subRoutine(float operand, uint32_t subrs, uint32_t& p, uint32_t& end, SubRoutine* subRoutines, int& srp)
@@ -571,10 +572,10 @@ bool OtfReader::charStrings(RenderPath& path, uint32_t glyph)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-bool OtfReader::header()
+Result OtfReader::header()
 {
-    if (!SfntReader::header()) return false;
-    return CFF();
+    if (SfntReader::header() == Result::Success) return CFF();
+    return Result::InvalidArguments;
 }
 
 bool OtfReader::positioning(uint32_t lglyph, uint32_t rglyph, Point& out)

--- a/src/loaders/sfnt/tvgOtfReader.h
+++ b/src/loaders/sfnt/tvgOtfReader.h
@@ -47,6 +47,8 @@ private:
     uint32_t toCharStrings = 0;  // CharStrings offset in Top DICT INDEX in the cff table
     uint32_t gsubrs = 0;         // global Subr INDEX
     uint32_t subrs = 0;          // local Subr INDEX
+    uint32_t fdArray = 0;        // font DICT INDEX for CID-keyed fonts
+    uint32_t fdSelect = 0;       // glyph-to-font DICT mapping
 
     uint32_t skip(uint32_t idx);
     int32_t offset(uint32_t base, uint8_t size);
@@ -55,11 +57,12 @@ private:
     bool name(uint32_t idx);
     bool DICT(Array<int32_t>& args, uint8_t b, uint32_t& ptr);
     uint32_t localSubrs(Array<int32_t>& args, uint32_t offset, uint32_t size);
+    uint32_t fdSubrs(uint32_t glyph);
     bool charStrings(RenderPath& path, uint32_t glyph);
 
     // CharStrings decoding sub-routines
     bool subRoutine(float operand, uint32_t subrs, uint32_t& p, uint32_t& end, SubRoutine* stack, int& ssp);
-    void operand(Array<float>& v, uint8_t b, uint32_t& p);
+    bool operand(Array<float>& v, uint8_t b, uint32_t& p);
     void alternatingCurve(Array<float>& v, Point& pos, RenderPath& path, bool horizontal);
     void alignedCurve(Array<float>& v, Point& pos, RenderPath& path, bool horizontal);
     void rrCurveTo(Array<float>& v, Point& pos, RenderPath& path);

--- a/src/loaders/sfnt/tvgOtfReader.h
+++ b/src/loaders/sfnt/tvgOtfReader.h
@@ -33,7 +33,7 @@ struct OtfReader : SfntReader
         SfntReader(data, size)
     {}
 
-    bool header() override;
+    Result header() override;
     bool positioning(uint32_t lglyph, uint32_t rglyph, Point& out) override;
     bool convert(SfntGlyph& glyph, uint32_t codepoint, RenderPath& path) override;
 
@@ -53,7 +53,7 @@ private:
     uint32_t skip(uint32_t idx);
     int32_t offset(uint32_t base, uint8_t size);
 
-    bool CFF();
+    Result CFF();
     bool name(uint32_t idx);
     bool DICT(Array<int32_t>& args, uint8_t b, uint32_t& ptr);
     uint32_t localSubrs(Array<int32_t>& args, uint32_t offset, uint32_t size);

--- a/src/loaders/sfnt/tvgSfntLoader.cpp
+++ b/src/loaders/sfnt/tvgSfntLoader.cpp
@@ -536,7 +536,7 @@ Result SfntLoader::open(const char* path, TVG_UNUSED const LoaderOps& ops)
     auto ret = gen(data, size, reader);
     if (ret != Result::Success) return ret;
     name = tvg::filename(path);
-    return reader->header() ? Result::Success : Result::InvalidArguments;
+    return reader->header();
 #endif
     return Result::NonSupport;
 }
@@ -553,7 +553,7 @@ Result SfntLoader::open(const char* data, uint32_t size, TVG_UNUSED const Loader
     }
     owner = ops.owner;
 
-    return reader->header() ? Result::Success : Result::InvalidArguments;
+    return reader->header();
 }
 
 bool SfntLoader::get(FontMetrics& fm, char* text, uint32_t len, RenderPath& out)

--- a/src/loaders/sfnt/tvgSfntReader.cpp
+++ b/src/loaders/sfnt/tvgSfntReader.cpp
@@ -208,20 +208,20 @@ uint32_t SfntReader::glyph(uint32_t codepoint)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-bool SfntReader::header()
+Result SfntReader::header()
 {
-    if (!validate(0, 12)) return false;
+    if (!validate(0, 12)) return Result::InvalidArguments;
 
     // header
     auto head = table("head");
-    if (!head || !validate(head, 54)) return false;
+    if (!head || !validate(head, 54)) return Result::InvalidArguments;
 
     metrics.unitsPerEm = u16(head + 18);
     metrics.locaFormat = u16(head + 50);
 
     // horizontal header
     auto hhea = table("hhea");
-    if (!hhea || !validate(hhea, 36)) return false;
+    if (!hhea || !validate(hhea, 36)) return Result::InvalidArguments;
 
     metrics.hhea.ascent = i16(hhea + 4);
     metrics.hhea.descent = i16(hhea + 6);
@@ -230,22 +230,22 @@ bool SfntReader::header()
     metrics.numHmtx = u16(hhea + 34);
 
     maxp = table("maxp");
-    if (!maxp || !validate(maxp, 6)) return false;
+    if (!maxp || !validate(maxp, 6)) return Result::InvalidArguments;
 
     // glyph outlines count
     auto glyphs = u16(maxp + 4);
-    if (glyphs == 0) return false;
+    if (glyphs == 0) return Result::InvalidArguments;
 
     // horizontal metrics count
     auto hmtxs = u16(hhea + 34);
-    if (hmtxs == 0 || hmtxs > glyphs) return false;
+    if (hmtxs == 0 || hmtxs > glyphs) return Result::InvalidArguments;
 
     cmap = table("cmap");
-    if (!cmap || !validate(cmap, 4)) return false;
+    if (!cmap || !validate(cmap, 4)) return Result::InvalidArguments;
 
     // horizontal metrics
     hmtx = table("hmtx");
-    if (!validate(hmtx, metrics.numHmtx * 4)) return false;
+    if (!validate(hmtx, metrics.numHmtx * 4)) return Result::InvalidArguments;
 
-    return true;
+    return Result::Success;
 }

--- a/src/loaders/sfnt/tvgSfntReader.h
+++ b/src/loaders/sfnt/tvgSfntReader.h
@@ -62,7 +62,7 @@ struct SfntReader
         data(data), size(size) {}
     virtual ~SfntReader() {}
 
-    virtual bool header();
+    virtual Result header();
     virtual bool positioning(uint32_t lglyph, uint32_t rglyph, Point& out) = 0;
     virtual bool convert(SfntGlyph& glyph, uint32_t codepoint, RenderPath& path) = 0;
 

--- a/src/loaders/sfnt/tvgTtfReader.cpp
+++ b/src/loaders/sfnt/tvgTtfReader.cpp
@@ -276,22 +276,23 @@ bool TtfReader::convert(RenderPath& path, SfntGlyph& glyph, uint32_t glyphOffset
 /* External Class Implementation                                        */
 /************************************************************************/
 
-bool TtfReader::header()
+Result TtfReader::header()
 {
-    if (!SfntReader::header()) return false;
+    if (SfntReader::header() == Result::Success) {
+        kern = table("kern");
+        if (kern) {
+            if (!validate(kern, 4)) return Result::InvalidArguments;
+            if (u16(kern) != 0) return Result::InvalidArguments;
+        }
 
-    kern = table("kern");
-    if (kern) {
-        if (!validate(kern, 4)) return false;
-        if (u16(kern) != 0) return false;
+        loca = table("loca");
+        glyf = table("glyf");
+
+        if (!loca || !glyf) return Result::InvalidArguments;
+
+        return Result::Success;
     }
-
-    loca = table("loca");
-    glyf = table("glyf");
-
-    if (!loca || !glyf) return false;
-
-    return true;
+    return Result::InvalidArguments;
 }
 
 bool TtfReader::positioning(uint32_t lglyph, uint32_t rglyph, Point& out)

--- a/src/loaders/sfnt/tvgTtfReader.h
+++ b/src/loaders/sfnt/tvgTtfReader.h
@@ -30,7 +30,7 @@ struct TtfReader : SfntReader
     TtfReader(uint8_t* data, uint32_t size) :
         SfntReader(data, size) {}
 
-    bool header() override;
+    Result header() override;
     bool positioning(uint32_t lglyph, uint32_t rglyph, Point& out) override;
     bool convert(SfntGlyph& glyph, uint32_t codepoint, RenderPath& path) override;
 

--- a/src/renderer/tvgLoaderMgr.cpp
+++ b/src/renderer/tvgLoaderMgr.cpp
@@ -242,6 +242,8 @@ tvg::Loader* LoaderMgr::loader(const char* filename, LoaderOps& ops, Result& ret
         delete (loader);
     }
 
+    if (ret == Result::NonSupport) return nullptr;
+
     // Unknown MimeType. Try with the candidates in the order
     for (int i = 0; i < static_cast<int>(FileType::Unknown); i++) {
         if (auto loader = _find(static_cast<FileType>(i))) {
@@ -294,6 +296,8 @@ tvg::Loader* LoaderMgr::loader(const char* data, uint32_t size, const char* mime
             }
         }
     }
+
+    if (ret == Result::NonSupport) return nullptr;
 
     // Unknown MimeType. Try with the candidates in the order
     for (int i = 0; i < static_cast<int>(FileType::Unknown); i++) {


### PR DESCRIPTION
- Resolve glyph-specific local subroutines through FDSelect and FDArray.
- Track stem hints and skip hint masks while decoding CharStrings.
- Reject unsupported CharString operators instead of silently continuing.

issue: #4614, #4670

Co-Authored-By: Ralf Preininger (@rpreininger)

<img width="842" height="162" alt="image" src="https://github.com/user-attachments/assets/103f7d7e-d49e-4f2a-9b27-a80ac9694f79" />

Note: Current ThorVG CFF2 / Hinting is not supported.