### PR TITLE
gl_engine: make GL_CHECK macro statement-safe

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGl.h
+++ b/src/renderer/gpu_engine/gl/tvgGl.h
@@ -26,7 +26,7 @@
 #ifdef __EMSCRIPTEN__
     #include <GLES3/gl3.h>
     #include <emscripten/html5_webgl.h>
-    #define GL_CHECK(stmt) stmt
+    #define GL_CHECK(stmt) do { stmt; } while(0)
 #else //__EMSCRIPTEN__
     #if defined (THORVG_GL_TARGET_GLES)
         #define TVG_REQUIRE_GL_MAJOR_VER 3
@@ -39,9 +39,10 @@
     #include "tvgCommon.h"
 
     #ifdef _DEBUG
-        #define GL_CHECK(stmt) stmt; assert(glGetError() == GL_NO_ERROR);
+        #include <cassert>
+        #define GL_CHECK(stmt) do { stmt; assert(glGetError() == GL_NO_ERROR); } while(0)
     #else
-        #define GL_CHECK(stmt) stmt
+        #define GL_CHECK(stmt) do { stmt; } while(0)
     #endif
 
     #ifdef _WIN64

--- a/src/renderer/gpu_engine/gl/tvgGlProgram.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlProgram.cpp
@@ -116,7 +116,8 @@ int32_t GlProgram::getUniformBlockIndex(GlShaderUniformBlock block)
     auto& index = mUniformBlockIndices[type];
     if (index != UNKNOWN_LOCATION) return index;
 
-    GL_CHECK(uint32_t blockIndex = glGetUniformBlockIndex(mProgramObj, UNIFORM_BLOCK_NAMES[type]));
+    uint32_t blockIndex;
+    GL_CHECK(blockIndex = glGetUniformBlockIndex(mProgramObj, UNIFORM_BLOCK_NAMES[type]));
     index = blockIndex == GL_INVALID_INDEX ? -1 : static_cast<int32_t>(blockIndex);
     return index;
 }

--- a/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderTask.cpp
@@ -43,7 +43,6 @@ void GlRenderTask::run(GlStateCache& state)
 
     int32_t dLoc = program->getUniformLocation(GlShaderUniform::Depth);
     if (dLoc >= 0) {
-        // fixme: prevent compiler warning: macro expands to multiple statements [-Wmultistatement-macros]
         GL_CHECK(glUniform1f(dLoc, drawDepth));
     }
 


### PR DESCRIPTION
* Wrap `GL_CHECK` in `do { ... } while(0)` so it behaves as a single statement in if/else and other control-flow contexts. It's purely a preprocessor/grammar trick to make a multi-statement macro expand into a single statement (safe inside if/else), with zero runtime cost.
* Include `<cassert>` for the debug assertion
* Move `blockIndex` declaration out of `GL_CHECK` to avoid scoping issues after the macro is wrapped
* Remove a outdated comment in `tvgGlRenderTask.cpp`

Related #4527 #4700

Note that this change will only narrow the scope.
Therefore, if it compiles, there is generally no problem with it.

The reason I also change `GL_CHECK` in non-debug is that a statement itself can also be a multi-statement.