### PR TITLE
lottie: prevent crash on unsupported slot targets

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -184,6 +184,7 @@ void LottieSlot::reset()
     if (!overridden) return;
 
     ARRAY_FOREACH(pair, pairs) {
+        if (!pair->prop) continue;  //the target didn't support this slot property
         pair->obj->override(pair->prop, true);
         delete(pair->prop);
         pair->prop = nullptr;
@@ -198,6 +199,7 @@ void LottieSlot::apply(LottieProperty* prop, bool byDefault)
 
     //apply slot object to all targets
     ARRAY_FOREACH(pair, pairs) {
+        if (!pair->obj) continue;  //the sid was registered without a target
         auto backup = pair->obj->override(prop, release);
         if (!release) pair->prop = backup;
     }

--- a/test/testLottie.cpp
+++ b/test/testLottie.cpp
@@ -243,6 +243,16 @@ TEST_CASE("Lottie Slot", "[tvgLottie]")
         REQUIRE(animation->apply(id17) == Result::Success);
         REQUIRE(animation->apply(0) == Result::Success);
         REQUIRE(animation->del(id17) == Result::Success);
+
+        //Slot Test 11: Unsupported Slot Target
+        //rect_anchor_point is registered as a slot but no override() handles it
+        const char* unsupportedSlot = R"({"rect_anchor_point":{"p":{"a":0,"k":[10,10]}}})";
+        auto id18 = animation->gen(unsupportedSlot);
+        REQUIRE(id18 > 0);
+        REQUIRE(animation->apply(id18) == Result::Success);
+        REQUIRE(animation->apply(0) == Result::Success);
+        REQUIRE(animation->apply(id18) == Result::Success);
+        REQUIRE(animation->del(id18) == Result::Success);
     }
     REQUIRE(Initializer::term() == Result::Success);
 }


### PR DESCRIPTION
Split out of #4692 as requested in https://github.com/thorvg/thorvg/pull/4692#discussion_r3850426758.

`registerSlot()` creates a slot pair for any property carrying a `sid`, with no check that the pair is actually usable. Two ways it isn't:

1. **Null backup** — the target's `override()` doesn't handle the property, so `LottieOverride::apply()` never matches and `pair->prop` stays null. `reset()` then dereferenced it.
2. **Null target** — `parseProperty()`'s `obj` defaults to `nullptr` and several call sites omit it, so the pair is registered with no object at all. `apply()` then dereferenced it. `transform->anchor` (tvgLottieParser.cpp:609) is one; polystar, `ddd->rx/ry/rz/orient` and the separate-coord `x`/`y` are others.

The two are one fix: guarding only `apply()` moves the crash to `reset()`, since a skipped pair leaves `prop` null.

Both cases are live on main. For the first, gradient `s`/`e`/`h`/`a` are registered as slot targets (tvgLottieParser.cpp:770-773) but `LottieGradient::override()` handles only `colorStops` and `opacity` — a sid on any of them segfaults in `reset()` today. #4692 fixes that particular instance; this guards the class, so the next slot target added without extending `override()` degrades instead of crashing.

### Test

`rect_anchor_point` is already registered in `test/resources/slot.lot`, so no fixture change is needed — the sample is just a slot that targets it. Verified under ASAN:

| `apply()` guard | `reset()` guard | result |
|---|---|---|
| ✗ | ✗ | SEGV in `LottieSlot::apply()`, tvgLottieModel.cpp:201 |
| ✓ | ✗ | SEGV in `LottieSlot::reset()`, tvgLottieModel.cpp:187 |
| ✓ | ✓ | pass — full suite 13911 assertions / 88 cases |

### Alternative worth considering

Guarding at the use sites is the minimal fix. Rejecting the registration instead — having `registerSlot()` bail on a null `obj`, or passing `obj` at the call sites that currently omit it — would stop these pairs existing in the first place. Happy to go that way if you prefer it.