### PR TITLE
gl: support blur quality levels

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
@@ -37,9 +37,16 @@ struct GlGaussianBlur
     float sigma{};
     float scale{};
     float extend{};
-    float dummy0{};
+    float quality{};
 };
 
+static float _blurQuality(uint8_t quality, float extend)
+{
+    float step = 1.0f;
+    if (quality <= 33) step = 3.0f;
+    else if (quality <= 66) step = 2.0f;
+    return std::min(step, float(std::max(int(extend), 1)));
+}
 
 bool GlEffect::region(RenderEffectGaussianBlur* effect)
 {
@@ -63,6 +70,7 @@ void GlEffect::update(RenderEffectGaussianBlur* effect, const Matrix& transform)
     blur->sigma = effect->sigma;
     blur->scale = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
     blur->extend = 2 * blur->sigma * blur->scale;
+    blur->quality = _blurQuality(effect->quality, blur->extend);
     effect->rd = blur;
     effect->valid = (blur->extend > 0);
 }
@@ -143,6 +151,7 @@ void GlEffect::update(RenderEffectDropShadow* effect, const Matrix& transform)
     dropShadow->offset[0] = offset.x;
     dropShadow->offset[1] = offset.y;
     dropShadow->extend = 2 * std::max(effect->sigma * scale + std::abs(offset.x), effect->sigma * scale + std::abs(offset.y));
+    dropShadow->quality = _blurQuality(effect->quality, dropShadow->extend);
     effect->rd = dropShadow;
     effect->valid = (dropShadow->extend >= 0);
 }

--- a/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlShaderSrc.cpp
@@ -1091,7 +1091,7 @@ layout(std140) uniform Gaussian {
     float sigma;
     float scale;
     float extend;
-    float dummy0;
+    float quality;
 } uGaussian;
 
 layout(std140) uniform Viewport {
@@ -1113,17 +1113,22 @@ void main()
     float sigma = uGaussian.sigma * uGaussian.scale;
     float weightSum = 0.0;
     int radius = int(uGaussian.extend);
+    int quality = int(uGaussian.quality);
     vec2 texelStep = vec2(0.0, texelSize.y);
 
     // Clamp the kernel range once so edge pixels skip taps outside the valid viewport.
     int first = max(-radius, int(ceil(uViewport.vp.y - gl_FragCoord.y)));
     int last = min(radius, int(ceil(uViewport.vp.w - gl_FragCoord.y)) - 1);
+    int remainder = first % quality;
+    if (remainder < 0) remainder += quality;
+    if (remainder > 0) first += quality - remainder;
     vec2 coord = vUV + texelStep * float(first);
-    for (int y = first; y <= last; ++y) {
+    vec2 sampleStep = texelStep * float(quality);
+    for (int y = first; y <= last; y += quality) {
         float weight = gaussian(float(y), sigma);
         colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
-        coord += texelStep;
+        coord += sampleStep;
     }
     FragColor = weightSum > 0.0 ? colorSum / weightSum : texture(uSrcTexture, vUV);
 } 
@@ -1135,7 +1140,7 @@ layout(std140) uniform Gaussian {
     float sigma;
     float scale;
     float extend;
-    float dummy0;
+    float quality;
 } uGaussian;
 
 layout(std140) uniform Viewport {
@@ -1157,17 +1162,22 @@ void main()
     float sigma = uGaussian.sigma * uGaussian.scale;
     float weightSum = 0.0;
     int radius = int(uGaussian.extend);
+    int quality = int(uGaussian.quality);
     vec2 texelStep = vec2(texelSize.x, 0.0);
 
     // Clamp the kernel range once so edge pixels skip taps outside the valid viewport.
     int first = max(-radius, int(ceil(uViewport.vp.x - gl_FragCoord.x)));
     int last = min(radius, int(ceil(uViewport.vp.z - gl_FragCoord.x)) - 1);
+    int remainder = first % quality;
+    if (remainder < 0) remainder += quality;
+    if (remainder > 0) first += quality - remainder;
     vec2 coord = vUV + texelStep * float(first);
-    for (int x = first; x <= last; ++x) {
+    vec2 sampleStep = texelStep * float(quality);
+    for (int x = first; x <= last; x += quality) {
         float weight = gaussian(float(x), sigma);
         colorSum += texture(uSrcTexture, coord) * weight;
         weightSum += weight;
-        coord += texelStep;
+        coord += sampleStep;
     }
     FragColor = weightSum > 0.0 ? colorSum / weightSum : texture(uSrcTexture, vUV);
 } 


### PR DESCRIPTION
Adjust Gaussian blur sampling intervals based on the requested effect quality. Apply the same quality mapping to drop shadows to reduce texture samples at lower quality levels.

tested [flying.json](https://github.com/thorvg/thorvg.test-suite/blob/main/lottie/performance/flying.json) performance: (1900x1900)

- high: 250 fps
<img width="987" height="975" alt="image" src="https://github.com/user-attachments/assets/6ee5860e-ed62-460f-b307-6ab1e67777fc" />

- medium: 390 fps (1.56x)
<img width="993" height="986" alt="image" src="https://github.com/user-attachments/assets/699c1956-a9a1-400e-9a68-6be4dddfdbd3" />

- low: 445 fps (1.78x)
<img width="991" height="987" alt="image" src="https://github.com/user-attachments/assets/e3762b3a-fdd3-4199-b2fc-299e3d706c80" />