### PR TITLE
lottie/audio: fix the audio offset of trimmed layers

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -1726,7 +1726,7 @@ void LottieBuilder::updateAudio(LottieComposition* comp, LottieLayer* layer, flo
     // audio condition is changed
     if ((active != ctrl->prevActive) || (active && !tvg::equal(volume, ctrl->prevVolume))) {
         auto& src = static_cast<LottieAudio*>(layer->children.first())->src;
-        auto offset = active ? (layer->remap(comp, frameNo, exps) - layer->remap(comp, layer->inPoint, exps)) / comp->frameRate : 0.0f;
+        auto offset = active ? layer->remap(comp, frameNo, exps) / comp->frameRate : 0.0f;
         LottieAudioResolver info = {src.data, src.mimeType, src.size, offset, volume, active, (src.size > 0)};
         audioResolver.func(info, audioResolver.data);
     }


### PR DESCRIPTION
The offset subtracted the layer in-point, which cancels out the start time. A trimmed audio
at its head then always played from the beginning of the source, so the trimmed part was heard and the tail was cut off instead.

Use the remapped layer time directly, keeping the source position that `st` defines and remaining correct under time stretch and remapping.

sample: [lottie-audio-trim.json](https://github.com/user-attachments/files/31418395/lottie-audio-trim.json)
(_The asset should sound from "B"_)

### Before (_Start from 0s_)
```
[audio] play (embedded) offset=0.006s volume=100
[audio] |=======>--------------------------------|   0.01s  vol 100
[audio] |=======>--------------------------------|   0.02s  vol 100
[audio] |=======>--------------------------------|   0.02s  vol 100
[audio] |=======>--------------------------------|   0.03s  vol 100
[audio] |========>-------------------------------|   0.04s  vol 100
[audio] |========>-------------------------------|   0.05s  vol 100
```

### After (_Start from 0.97s as trimmed_)
```
[audio] play (embedded) offset=0.972s volume=100
[audio] |=======>--------------------------------|   0.97s  vol 100
[audio] |=======>--------------------------------|   0.98s  vol 100
[audio] |=======>--------------------------------|   0.99s  vol 100
[audio] |=======>--------------------------------|   1.00s  vol 100
[audio] |========>-------------------------------|   1.00s  vol 100
```