### PR TITLE
cpu_engine: allow subpixel-aligned axis-aligned rects

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -1047,8 +1047,8 @@ struct LottieRootLayer : LottieGroup
 
     float timeStretch = 1.0f;
     float w = 0.0f, h = 0.0f;
-    float inFrame = 0.0f;
-    float outFrame = 0.0f;
+    float inFrame = 0.0f;   // frame when the layer becomes visible
+    float outFrame = 0.0f;  // frame when the layer becomes invisible
     float startFrame = 0.0f;
 
     bool effect = false;  // true if any effect is activated in its tree
@@ -1216,7 +1216,7 @@ struct LottieComposition
     {
         frameNo += root->inFrame;
         if (frameNo < root->inFrame) frameNo = root->inFrame;
-        if (frameNo >= root->outFrame) frameNo = root->outFrame - 1;
+        if (frameNo > root->outFrame - 1.0f) frameNo = root->outFrame - 1.0f;
     }
 
     LottieRootLayer* root = nullptr;

--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -32,6 +32,7 @@
 #define SW_CURVE_TYPE_POINT 0
 #define SW_CURVE_TYPE_CUBIC 1
 #define SW_COLOR_TABLE 1024
+#define SW_FRAC_BITS 6
 
 struct SwCompositor;
 struct SwSurface;

--- a/src/renderer/cpu_engine/tvgSwShape.cpp
+++ b/src/renderer/cpu_engine/tvgSwShape.cpp
@@ -328,7 +328,6 @@ static SwOutline* _genDashOutline(const RenderShape* rshape, SwMpool* mpool, uns
 
 static bool _axisAlignedRect(const SwOutline* outline)
 {
-    // TODO: We can return false if the coordinates have a fractional part, for smoother rectangle movement
     if (outline->out.count != 5) return false;
     if (outline->types[2] == SW_CURVE_TYPE_CUBIC) return false;
 
@@ -343,6 +342,15 @@ static bool _axisAlignedRect(const SwOutline* outline)
     if ((*pt2 == a && *pt4 == b) || (*pt2 == b && *pt4 == a)) return true;
 
     return false;
+}
+
+// Check whether all outline points are aligned to pixel boundaries
+static bool _pixelAligned(const SwOutline* outline)
+{
+    uint32_t bits = 0;
+    ARRAY_FOREACH(pt, outline->out)
+        bits |= pt->x | pt->y;
+    return !(bits & ((1u << SW_FRAC_BITS) - 1));
 }
 
 static SwOutline* _genOutline(const RenderShape* rshape, SwMpool* mpool, unsigned tid, bool trimmed = false)
@@ -428,7 +436,7 @@ bool shapeGenRle(SwShape& shape, const RenderShape* rshape, const Matrix& transf
     utilExport(outline, transform, bbox);
 
     shape.outline = outline;
-    shape.fastTrack = !composite && _axisAlignedRect(outline);
+    shape.fastTrack = !composite && _axisAlignedRect(outline) && _pixelAligned(outline);
 
     if (!utilBBox(bbox, clipBox, renderBox, shape.fastTrack)) return false;
     shape.bbox = renderBox;


### PR DESCRIPTION
## Problem & Solution

The fast-track condition did not check for fractional coordinates. A rectangle off the pixel grid therefore took the fast-track and was rendered from the bounding box that `utilBBox()` had rounded to whole pixels, so its edges were not antialiased and the shape was drawn up to half a pixel away from where the path put it.

Add `_pixelAligned()` to verify that every point of the outline sits on a pixel boundary, and require it for the fast-track.

## Performance

Axis-aligned rectangles at fractional coordinates no longer take the fast-track, so they now go through the slower RLE path. This costs performance.

Ryzen 7 9700X, `hyperfine -N -w 1 -r 10`, 200 squares of one size moved every frame over 300 frames. Mean time, in ms.

| square | main | this PR | change |
|---|---:|---:|---:|
| 20x20 | 18.2 | 42.2 | **+131.8%** |
| 60x60 | 28.8 | 91.9 | **+218.9%** |
| 150x150 | 69.8 | 217.2 | **+211.2%** |
| 400x400 | 328.3 | 826.9 | **+151.9%** |

> Rectangles at integer coordinates still take the fast-track. Their times do not change.

An axis-aligned rectangle is simple enough that its spans can be computed directly instead of swept. A follow-up can do that.

issue: #4663

This also resolves the '_The edges of axis-aligned rectangles_' case of #3840