### PR TITLE
renderer: optimize animation updates

### DIFF
--- a/src/loaders/lottie/tvgLottieAnimation.cpp
+++ b/src/loaders/lottie/tvgLottieAnimation.cpp
@@ -46,7 +46,7 @@ Result LottieAnimation::apply(uint32_t id) noexcept
     FETCH_LOADER(Result::InsufficientCondition);
 
     if (loader->apply(id)) {
-        PAINT(pImpl->picture)->mark(RenderUpdateFlag::All);
+        PAINT(pImpl->picture)->mark(RenderUpdateFlag::Children);
         return Result::Success;
     }
 
@@ -59,7 +59,7 @@ Result LottieAnimation::del(uint32_t id) noexcept
     FETCH_LOADER(Result::InsufficientCondition);
 
     if (loader->del(id)) {
-        PAINT(pImpl->picture)->mark(RenderUpdateFlag::All);
+        PAINT(pImpl->picture)->mark(RenderUpdateFlag::Children);
         return Result::Success;
     }
 
@@ -86,7 +86,7 @@ Result LottieAnimation::tween(float from, float to, float progress) noexcept
 {
     FETCH_LOADER(Result::InsufficientCondition);
     if (!loader->tween(from, to, progress)) return Result::InsufficientCondition;
-    PAINT(pImpl->picture)->mark(RenderUpdateFlag::All);
+    PAINT(pImpl->picture)->mark(RenderUpdateFlag::Children);
     return Result::Success;
 }
 
@@ -94,7 +94,7 @@ Result LottieAnimation::tween(float progress) noexcept
 {
     FETCH_LOADER(Result::InsufficientCondition);
     if (!loader->tween(progress)) return Result::InsufficientCondition;
-    PAINT(pImpl->picture)->mark(RenderUpdateFlag::All);
+    PAINT(pImpl->picture)->mark(RenderUpdateFlag::Children);
     return Result::Success;
 }
 

--- a/src/renderer/tvgAnimation.cpp
+++ b/src/renderer/tvgAnimation.cpp
@@ -43,7 +43,7 @@ Result Animation::frame(float no) noexcept
     if (!loader->playable) return Result::NonSupport;
 
     if (static_cast<AnimLoader*>(loader)->frame(no)) {
-        PAINT(pImpl->picture)->mark(RenderUpdateFlag::All);
+        PAINT(pImpl->picture)->mark(RenderUpdateFlag::Children);
         return Result::Success;
     }
     return Result::InsufficientCondition;

--- a/src/renderer/tvgPicture.h
+++ b/src/renderer/tvgPicture.h
@@ -251,6 +251,7 @@ struct PictureImpl : Picture
                 }
             } else {
                 bitmap = loader->bitmap();
+                if (bitmap) return RenderUpdateFlag::Image;
             }
         }
         // animations updates the properties essentially. here update is not necessary.

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -41,7 +41,22 @@ using pixel_t = uint32_t;
 #define DASH_PATTERN_THRESHOLD 0.001f
 
 //TODO: Separate Color & Opacity for more detailed conditional check
-enum RenderUpdateFlag : uint16_t {None = 0, Path = 1, Color = 2, Gradient = 4, Stroke = 8, Transform = 16, Image = 32, GradientStroke = 64, Blend = 128, Clip = 256, All = 0xffff};
+enum RenderUpdateFlag : uint16_t
+{
+    None = 0,
+    Path = 1 << 0,
+    Color = 1 << 1,
+    Gradient = 1 << 2,
+    Stroke = 1 << 3,
+    Transform = 1 << 4,
+    Image = 1 << 5,
+    GradientStroke = 1 << 6,
+    Blend = 1 << 7,
+    Clip = 1 << 8,
+    Children = 1 << 9,  // Force update propagation to child paints
+    All = 0xffff
+};
+
 enum CompositionFlag : uint8_t {Invalid = 0, Opacity = 1, Blending = 2, Masking = 4, PostProcessing = 8};  //Composition Purpose
 
 static inline void operator|=(RenderUpdateFlag& a, const RenderUpdateFlag b)


### PR DESCRIPTION
- Propagate animation changes to child paints without invalidating all renderer data.
- Mark newly loaded bitmap images for an initial renderer update.

issue: #4580