### PR TITLE
lottie: clamp playback to last frame

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -1047,8 +1047,8 @@ struct LottieRootLayer : LottieGroup
 
     float timeStretch = 1.0f;
     float w = 0.0f, h = 0.0f;
-    float inFrame = 0.0f;
-    float outFrame = 0.0f;
+    float inFrame = 0.0f;   // frame when the layer becomes visible
+    float outFrame = 0.0f;  // frame when the layer becomes invisible
     float startFrame = 0.0f;
 
     bool effect = false;  // true if any effect is activated in its tree
@@ -1216,7 +1216,7 @@ struct LottieComposition
     {
         frameNo += root->inFrame;
         if (frameNo < root->inFrame) frameNo = root->inFrame;
-        if (frameNo >= root->outFrame) frameNo = root->outFrame - 1;
+        if (frameNo > root->outFrame - 1.0f) frameNo = root->outFrame - 1.0f;
     }
 
     LottieRootLayer* root = nullptr;


### PR DESCRIPTION
Clamp fractional frame values at the final valid frame instead of only clamping values at the exclusive out point.

This prevents playback from advancing past the last frame and then jumping backward when progress reaches the animation endpoint.