### PR TITLE
lottie: unify layer timing points

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -981,7 +981,7 @@ void LottieBuilder::updateImage(LottieLayer* layer, float frameNo)
     }
 
     layer->scene->add(picture->refCnt() == 1 ? picture : picture->duplicate());
-    image->play((frameNo - layer->inFrame) / (layer->outFrame - layer->inFrame));
+    image->play((frameNo - layer->inPoint) / (layer->outPoint - layer->inPoint));
 }
 
 
@@ -1547,7 +1547,7 @@ void LottieBuilder::updateLayer(LottieComposition* comp, Scene* scene, LottieLay
     layer->scene = nullptr;
 
     //visibility
-    if (frameNo < layer->inFrame || frameNo >= layer->outFrame) {
+    if (frameNo < layer->inPoint || frameNo >= layer->outPoint) {
         layer->invalidate();
         return;
     }
@@ -1722,13 +1722,13 @@ void LottieBuilder::updateAudio(LottieComposition* comp, LottieLayer* layer, flo
     if (layer->children.empty()) return;
 
     auto ctrl = layer->audio();
-    auto active = frameNo >= layer->inFrame && frameNo < layer->outFrame;
+    auto active = frameNo >= layer->inPoint && frameNo < layer->outPoint;
     auto volume = active ? ctrl->volume(frameNo, tween, exps) : 100.0f;
 
     // audio condition is changed
     if ((active != ctrl->prevActive) || (active && !tvg::equal(volume, ctrl->prevVolume))) {
         auto& src = static_cast<LottieAudio*>(layer->children.first())->src;
-        auto offset = active ? (layer->remap(comp, frameNo, exps) - layer->remap(comp, layer->inFrame, exps)) / comp->frameRate : 0.0f;
+        auto offset = active ? (layer->remap(comp, frameNo, exps) - layer->remap(comp, layer->inPoint, exps)) / comp->frameRate : 0.0f;
         LottieAudioResolver info = {src.data, src.mimeType, src.size, offset, volume, active, (src.size > 0)};
         audioResolver.func(info, audioResolver.data);
     }

--- a/src/loaders/lottie/tvgLottieExpressions.cpp
+++ b/src/loaders/lottie/tvgLottieExpressions.cpp
@@ -489,16 +489,16 @@ static void _buildLayer(jerry_value_t context, float frameNo, LottieLayer* layer
     jerry_object_set_sz(context, "hasParent", hasParent);
     jerry_value_free(hasParent);
 
-    auto inPoint = jerry_number(layer->inFrame / exp->comp->frameRate);
+    auto inPoint = jerry_number(layer->inPoint / exp->comp->frameRate);
     jerry_object_set_sz(context, "inPoint", inPoint);
     jerry_value_free(inPoint);
 
-    auto outPoint = jerry_number(layer->outFrame / exp->comp->frameRate);
+    auto outPoint = jerry_number(layer->outPoint / exp->comp->frameRate);
     jerry_object_set_sz(context, "outPoint", outPoint);
     jerry_value_free(outPoint);
 
     //TODO: Confirm exp->layer->comp->timeAtFrame() ?
-    auto startTime = jerry_number(exp->comp->timeAtFrame(layer->startFrame));
+    auto startTime = jerry_number(exp->comp->timeAtFrame(layer->inPoint));
     jerry_object_set_sz(context, "startTime", startTime);
     jerry_value_free(startTime);
 
@@ -1127,7 +1127,7 @@ static jerry_value_t _loopOut(const jerry_call_info_t* info, const jerry_value_t
     auto data = static_cast<ExpContent*>(jerry_object_get_native_ptr(info->function, &freeCb));
     auto mode = static_cast<LottieProperty::Loop>((int) _loopCommon(args, argsCnt) + LOOP_OUT_OFFSET);
     auto key = (argsCnt > 1) ? jerry_value_as_int32(args[1]) : 0;
-    return _buildValue(data->exp->property->loop(data->frameNo, key, mode, data->exp->layer->outFrame), data->exp->property);
+    return _buildValue(data->exp->property->loop(data->frameNo, key, mode, data->exp->layer->outPoint), data->exp->property);
 }
 
 
@@ -1145,7 +1145,7 @@ static jerry_value_t _loopIn(const jerry_call_info_t* info, const jerry_value_t 
     auto data = static_cast<ExpContent*>(jerry_object_get_native_ptr(info->function, &freeCb));
     auto mode = _loopCommon(args, argsCnt);
     auto key = (argsCnt > 1) ? jerry_value_as_int32(args[1]) : 0;
-    return _buildValue(data->exp->property->loop(data->frameNo, key, mode, data->exp->layer->outFrame), data->exp->property);
+    return _buildValue(data->exp->property->loop(data->frameNo, key, mode, data->exp->layer->outPoint), data->exp->property);
 }
 
 
@@ -1418,11 +1418,11 @@ void LottieExpressions::buildGlobal(Context& context, float frameNo, LottieExpre
     jerry_object_set_sz(context.global, EXP_INDEX, index);
     jerry_value_free(index);
 
-    auto inPoint = jerry_number(exp->layer->inFrame / exp->comp->frameRate);
+    auto inPoint = jerry_number(exp->layer->inPoint / exp->comp->frameRate);
     jerry_object_set_sz(context.global, "inPoint", inPoint);
     jerry_value_free(inPoint);
 
-    auto outPoint = jerry_number(exp->layer->outFrame / exp->comp->frameRate);
+    auto outPoint = jerry_number(exp->layer->outPoint / exp->comp->frameRate);
     jerry_object_set_sz(context.global, "outPoint", outPoint);
     jerry_value_free(outPoint);
 }

--- a/src/loaders/lottie/tvgLottieModel.cpp
+++ b/src/loaders/lottie/tvgLottieModel.cpp
@@ -596,7 +596,7 @@ void LottieGroup::prepare()
 float LottieRootLayer::remap(LottieComposition* comp, float frameNo, LottieExpressions* exp)
 {
     if (timeRemap.frames || timeRemap.value >= 0.0f) return comp->frameAtTime(timeRemap(frameNo, exp));
-    return (frameNo - startFrame) / timeStretch;
+    return (frameNo - inPoint) / timeStretch;
 }
 
 LottieLayer* LottieRootLayer::layerById(unsigned long id)

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -1047,9 +1047,8 @@ struct LottieRootLayer : LottieGroup
 
     float timeStretch = 1.0f;
     float w = 0.0f, h = 0.0f;
-    float inFrame = 0.0f;   // frame when the layer becomes visible
-    float outFrame = 0.0f;  // frame when the layer becomes invisible
-    float startFrame = 0.0f;
+    float inPoint = 0.0f;   // frame when the layer becomes visible
+    float outPoint = 0.0f;  // frame when the layer becomes invisible
 
     bool effect = false;  // true if any effect is activated in its tree
 
@@ -1195,12 +1194,12 @@ struct LottieComposition
 
     float timeAtFrame(float frameNo)
     {
-        return (frameNo - root->inFrame) / frameRate;
+        return (frameNo - root->inPoint) / frameRate;
     }
 
     float frameCnt() const
     {
-        return root->outFrame - root->inFrame;
+        return root->outPoint - root->inPoint;
     }
 
     LottieLayer* asset(unsigned long id)
@@ -1214,9 +1213,9 @@ struct LottieComposition
 
     void clamp(float& frameNo)
     {
-        frameNo += root->inFrame;
-        if (frameNo < root->inFrame) frameNo = root->inFrame;
-        if (frameNo > root->outFrame - 1.0f) frameNo = root->outFrame - 1.0f;
+        frameNo += root->inPoint;
+        if (frameNo < root->inPoint) frameNo = root->inPoint;
+        if (frameNo > root->outPoint - 1.0f) frameNo = root->outPoint - 1.0f;
     }
 
     LottieRootLayer* root = nullptr;

--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -1047,8 +1047,8 @@ struct LottieRootLayer : LottieGroup
 
     float timeStretch = 1.0f;
     float w = 0.0f, h = 0.0f;
-    float inFrame = 0.0f;
-    float outFrame = 0.0f;
+    float inFrame = 0.0f;   // frame when the layer becomes visible
+    float outFrame = 0.0f;  // frame when the layer becomes invisible
     float startFrame = 0.0f;
 
     bool effect = false;  // true if any effect is activated in its tree
@@ -1216,7 +1216,7 @@ struct LottieComposition
     {
         frameNo += root->inFrame;
         if (frameNo < root->inFrame) frameNo = root->inFrame;
-        if (frameNo >= root->outFrame) frameNo = root->outFrame - 1;
+        if (frameNo > root->outFrame - 1.0f) frameNo = root->outFrame - 1.0f;
     }
 
     LottieRootLayer* root = nullptr;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -1595,9 +1595,8 @@ LottieLayer* LottieParser::parseLayer(LottieRootLayer* precomp)
         }
         else if (KEY_AS("ao")) layer->autoOrient = getInt();
         else if (KEY_AS("shapes")) parseShapes(layer->children);
-        else if (KEY_AS("ip")) layer->inFrame = getFloat();
-        else if (KEY_AS("op")) layer->outFrame = getFloat();
-        else if (KEY_AS("st")) layer->startFrame = getFloat();
+        else if (KEY_AS("ip")) layer->inPoint = getFloat();
+        else if (KEY_AS("op")) layer->outPoint = getFloat();
         else if (KEY_AS("bm")) layer->blendMethod = (BlendMethod) getInt();
         else if (KEY_AS("parent")) layer->pix = getInt();
         else if (KEY_AS("tm")) parseTimeRemap(layer);
@@ -1792,14 +1791,14 @@ bool LottieParser::parse()
 
     Array<LottieGlyph*> glyphs;
 
-    auto startFrame = 0.0f;
-    auto endFrame = 0.0f;
+    auto inPoint = 0.0f;
+    auto outPoint = 0.0f;
 
     while (auto key = nextObjectKey()) {
         if (KEY_AS("v")) comp->version = getStringCopy();
         else if (KEY_AS("fr")) comp->frameRate = getFloat();
-        else if (KEY_AS("ip")) startFrame = getFloat();
-        else if (KEY_AS("op")) endFrame = getFloat();
+        else if (KEY_AS("ip")) inPoint = getFloat();
+        else if (KEY_AS("op")) outPoint = getFloat();
         else if (KEY_AS("w")) comp->w = getFloat();
         else if (KEY_AS("h")) comp->h = getFloat();
         else if (KEY_AS("nm")) comp->name = getStringCopy();
@@ -1817,8 +1816,8 @@ bool LottieParser::parse()
         return false;
     }
 
-    comp->root->inFrame = startFrame;
-    comp->root->outFrame = endFrame;
+    comp->root->inPoint = inPoint;
+    comp->root->outPoint = outPoint;
 
     postProcess(glyphs);
 


### PR DESCRIPTION
- Rename the layer timing fields to `inPoint` and `outPoint` to match the official Lottie `ip` and `op` properties. 
- Remove support for the legacy (non-official) `st` property because it conflicts with `ip`, and use the in point consistently as the layer timing origin.

This aligns visibility, media playback, frame remapping, and expression values with the same frame range.