### PR TITLE
lottie: fix double-applied solid layer opacity

### DIFF
--- a/src/loaders/lottie/tvgLottieBuilder.cpp
+++ b/src/loaders/lottie/tvgLottieBuilder.cpp
@@ -955,9 +955,7 @@ void LottieBuilder::updatePrecomp(LottieComposition* comp, LottieLayer* precomp,
 
 void LottieBuilder::updateSolid(LottieLayer* layer)
 {
-    auto solidFill = layer->statical.pooling(true);
-    solidFill->opacity(layer->cache.opacity);
-    layer->scene->add(solidFill);
+    layer->scene->add(layer->statical.pooling(true));
 }
 
 void LottieBuilder::updateImage(LottieLayer* layer, float frameNo)


### PR DESCRIPTION
updateLayer() already applies the layer opacity to layer->scene

sample : [lottie-solid-opacity.json](https://github.com/user-attachments/files/31453917/lottie-solid-opacity.json)


| Before | After | Expectation |
|---|---|---|
| <img width="1802" height="1510" alt="Before" src="https://github.com/user-attachments/assets/5d6c67cc-633f-46fa-8a91-501faff30a52" /> | <img width="1810" height="1510" alt="After" src="https://github.com/user-attachments/assets/8d51707c-af06-45b6-a4d5-dba0ae582523" /> | <img width="1042" height="936" alt="Expectation" src="https://github.com/user-attachments/assets/8daceef7-b62c-4b62-bc7d-789c0357a3fa" /> |
