### PR TITLE
cpu_engine: fix an partial rendering flickering issue

### DIFF
--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -81,6 +81,7 @@ struct SwTask : Task
     bool complete()
     {
         prvBox = valid ? curBox : RenderRegion{};
+        nodirty = false;
         return true;
     }
 


### PR DESCRIPTION
when rendering is requested without an update, the buffer is not cleared. A stale no-dirty flag could cause the existing buffer to be overwritten, resulting in visual corruption.

This fix resets the task no-dirty flag after each render. This prevents a task prepared with dirty-region tracking disabled from bypassing partial rendering on subsequent frames. Now unnecesary rendering wouldn't be triggered Unless the full rendering or buffer clear were presented.

issue: #4566