### PR TITLE
wg_engine: preserve premultiplied target contents

### DIFF
--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -496,7 +496,7 @@ void WgCompositor::composeScene(WgContext& context, WgRenderTarget* src, WgRende
     drawMeshImage(context, &meshDataBlit);
 }
 
-void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView, bool premultiplied)
+void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView, bool premultiplied, bool clear)
 {
     assert(!renderPassEncoder);
     const WGPURenderPassDepthStencilAttachment depthStencilAttachment{
@@ -509,8 +509,9 @@ void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRender
     const WGPURenderPassColorAttachment colorAttachment { 
         .view = dstView,
         .depthSlice = WGPU_DEPTH_SLICE_UNDEFINED,
-        .loadOp = WGPULoadOp_Load,
+        .loadOp = clear ? WGPULoadOp_Clear : WGPULoadOp_Load,
         .storeOp = WGPUStoreOp_Store,
+        .clearValue = {0.0, 0.0, 0.0, 0.0}
     };
     const WGPURenderPassDescriptor renderPassDesc{ .colorAttachmentCount = 1, .colorAttachments = &colorAttachment, .depthStencilAttachment = &depthStencilAttachment };
     renderPassEncoder = wgpuCommandEncoderBeginRenderPass(encoder, &renderPassDesc);

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.h
@@ -136,7 +136,7 @@ public:
     void composeScene(WgContext& context, WgRenderTarget* src, WgRenderTarget* mask, WgCompose* compose);
 
     // blit render target to texture view (f.e. screen buffer)
-    void blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView, bool premultiplied);
+    void blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView, bool premultiplied, bool clear);
 
     // effects
     bool gaussianBlur(WgContext& context, WgRenderTarget* dst, const RenderEffectGaussianBlur* params, const WgCompose* compose);

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
@@ -491,10 +491,10 @@ void WgPipelines::initialize(WgContext& context)
         context.device, "The render pipeline blit",
         shader_blit, "vs_main", "fs_main",
         layout_blit, vertexBufferLayoutsImage, 2,
-        WGPUColorWriteMask_All, context.format, blendStateSrc,  // must be preferred screen pixel format
+        WGPUColorWriteMask_All, context.format, blendStateNrm,  // must be preferred screen pixel format
         depthStencilStateScene, multisampleStateX1);
 
-    // TODO: either premultiplied blit or unpremultplied bit used.
+    // TODO: support drawing over existing straight-alpha pixels without overwriting them.
     blit_unpremultiplied = createRenderPipeline(
         context.device, "The render pipeline blit unpremultiplied",
         shader_blit, "vs_main", "fs_main_unpremultiplied",

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -93,7 +93,8 @@ void WgRenderer::clearTargets()
     mTargetSurface.stride = 0;
     mTargetSurface.w = 0;
     mTargetSurface.h = 0;
-
+    mClearBuffer = false;
+    mRenderPending = false;
 }
 
 void WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height, ColorSpace cs)
@@ -299,6 +300,7 @@ bool WgRenderer::postRender()
     mRenderTaskList.clear();
     ARRAY_FOREACH(p, mCompositorList) { delete (*p); };
     mCompositorList.clear();
+    mRenderPending = true;
     return true;
 }
 
@@ -375,7 +377,7 @@ bool WgRenderer::clear()
 {
     if (mContext.invalid()) return false;
 
-    //TODO: clear the current target buffer only if clear() is called
+    mClearBuffer = true;
     return true;
 }
 
@@ -385,6 +387,7 @@ bool WgRenderer::sync()
     if (mContext.invalid()) return false;
 
     disposeObjects();
+    if (!mRenderPending) return true;
 
     // if texture buffer used
     WGPUTexture dstTexture = targetTexture;
@@ -402,12 +405,14 @@ bool WgRenderer::sync()
         WGPUTextureView dstTextureView = mContext.createTextureView(dstTexture);
         WGPUCommandEncoder commandEncoder = mContext.createCommandEncoder();
         // show root offscreen buffer
-        mCompositor.blit(mContext, commandEncoder, &mRenderTargetRoot, dstTextureView, mTargetSurface.premultiplied);
+        mCompositor.blit(mContext, commandEncoder, &mRenderTargetRoot, dstTextureView, mTargetSurface.premultiplied, mClearBuffer);
         mContext.submitCommandEncoder(commandEncoder);
         mContext.releaseCommandEncoder(commandEncoder);
         mContext.releaseTextureView(dstTextureView);
     }
 
+    mClearBuffer = false;
+    mRenderPending = false;
     return true;
 }
 
@@ -444,6 +449,8 @@ Result WgRenderer::target(const WgCanvas::Context& ctx, void* target, uint32_t w
     mTargetSurface.h = h;
     mTargetSurface.cs = cs;
     mTargetSurface.premultiplied = true;  // TODO: by default for v1 backward compat. properly addressed later v2 by aligning with actual alpha mode.
+    mClearBuffer = false;
+    mRenderPending = false;
 
     // configure surface (must be called after context creation)
     if (type == 0) surfaceConfigure((WGPUSurface)target, mContext, w, h, cs);

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -103,6 +103,8 @@ private:
     // rendering states
     RenderSurface mTargetSurface;
     BlendMethod mBlendMethod{};
+    bool mClearBuffer = false;
+    bool mRenderPending = false;
 
     // disposable data list
     Array<RenderData> mDisposeRenderDatas{};


### PR DESCRIPTION
## Motivation

Callers need `draw(false)` to preserve existing target pixels when
compositing ThorVG output over their own content. WGPU instead
replaced the output, discarding that content regardless of the
clear flag.

Honor the API contract for premultiplied targets so callers can
choose whether to preserve or clear their current output.

## Changes

- Compose over existing premultiplied pixels using source-over.
- Clear the target to transparent black when requested.
- Prevent `sync()` without a new draw from compositing an old frame.
- Add regression coverage based on source-over pixel expectations.

## Scope

This change operates on the current target without adding history
textures, pipelines, or rendering passes.

Straight-alpha surfaces still overwrite existing content with
`draw(false)` and require a separate fix.

Related to #4557, #4724