### PR TITLE
renderer: fixed a wgpu regression during main dev.

### DIFF
--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -343,7 +343,7 @@ struct SceneImpl : Scene
         target->ref();
 
         //Relocated the paint to the current scene space
-        timpl->mark(RenderUpdateFlag::Transform);
+        timpl->mark(RenderUpdateFlag::Transform | RenderUpdateFlag::Color);
 
         if (!at) {
             paints.push_back(target);


### PR DESCRIPTION
Mark relocated paints for color updates because changing their parent can change inherited opacity. This prevents renderers from retaining stale effective opacity when paints are reused.

issue: #4735