### PR TITLE
meson: fix simd_type detection for aarch64 cpus

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -120,7 +120,7 @@ if get_option('simd')
   elif host_machine.cpu_family().startswith('arm')
     config_h.set10('THORVG_NEON_VECTOR_SUPPORT', true)
     simd_type = 'neon-arm'
-  elif host_machine.cpu().startswith('aarch')
+  elif host_machine.cpu_family().startswith('aarch64')
     config_h.set10('THORVG_NEON_VECTOR_SUPPORT', true)
     simd_type = 'neon-aarch'
   endif


### PR DESCRIPTION
`host_machine.cpu()` returns specific cpu model (for example `cortex-a72`), which would never match the condition. 
This replaces it with the `cpu_family()`, as is used in the conditions above, to match aarch64. 
Note: `cpu_family` values are defined [here](https://mesonbuild.com/Reference-tables.html#cpu-families)