### PR TITLE
wg: streamline shape render data

### DIFF
--- a/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.cpp
@@ -166,16 +166,22 @@ void WgContext::releaseSampler(WGPUSampler& sampler)
 
 bool WgContext::allocateBufferUniform(WGPUBuffer& buffer, const void* data, uint64_t size)
 {
-    if ((buffer) && (wgpuBufferGetSize(buffer) >= size))
-        wgpuQueueWriteBuffer(queue, buffer, 0, data, size);
-    else {
+    return allocateBufferUniform(buffer, data, size, size);
+}
+
+bool WgContext::allocateBufferUniform(WGPUBuffer& buffer, const void* data, uint64_t capacity, uint64_t size)
+{
+    if (capacity == 0) return false;
+
+    auto changed = false;
+    if (!buffer || wgpuBufferGetSize(buffer) < capacity) {
         releaseBuffer(buffer);
-        const WGPUBufferDescriptor bufferDesc { .usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform, .size = size };
+        const WGPUBufferDescriptor bufferDesc { .usage = WGPUBufferUsage_CopyDst | WGPUBufferUsage_Uniform, .size = capacity };
         buffer = wgpuDeviceCreateBuffer(device, &bufferDesc);
-        wgpuQueueWriteBuffer(queue, buffer, 0, data, size);
-        return true;
+        changed = true;
     }
-    return false;
+    if (size) wgpuQueueWriteBuffer(queue, buffer, 0, data, size);
+    return changed;
 }
 
 bool WgContext::allocateBufferVertex(WGPUBuffer& buffer, const void* data, uint64_t size)

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.h
@@ -60,6 +60,7 @@ struct WgContext
 
     // create buffer objects (return true, if buffer handle was changed)
     bool allocateBufferUniform(WGPUBuffer& buffer, const void* data, uint64_t size);
+    bool allocateBufferUniform(WGPUBuffer& buffer, const void* data, uint64_t capacity, uint64_t size);
     bool allocateBufferVertex(WGPUBuffer& buffer, const void* data, uint64_t size);
     bool allocateBufferIndex(WGPUBuffer& buffer, const uint32_t* data, uint64_t size);
 

--- a/src/renderer/gpu_engine/wg/tvgWgCommon.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCommon.h
@@ -27,7 +27,8 @@
 #include "tvgGpuCommon.h"
 #include "tvgWgBindGroups.h"
 
-struct WgContext {
+struct WgContext
+{
     WGPUInstance instance{};
     WGPUAdapter adapter{};
     WGPUDevice device{};

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -155,9 +155,6 @@ void WgCompositor::copyTexture(const WgRenderTarget* dst, const WgRenderTarget* 
 
 void WgCompositor::copyTexture(const WgRenderTarget* dst, const WgRenderTarget* src, const RenderRegion& region)
 {
-    assert(dst);
-    assert(src);
-    assert(commandEncoder);
     const WGPUTexelCopyTextureInfo texSrc { .texture = src->texture, .origin = { .x = (uint32_t)region.min.x, .y = (uint32_t)region.min.y } };
     const WGPUTexelCopyTextureInfo texDst { .texture = dst->texture, .origin = { .x = (uint32_t)region.min.x, .y = (uint32_t)region.min.y } };
     const WGPUExtent3D copySize { .width = region.w(), .height = region.h(), .depthOrArrayLayers = 1 };
@@ -167,8 +164,6 @@ void WgCompositor::copyTexture(const WgRenderTarget* dst, const WgRenderTarget* 
 
 void WgCompositor::beginRenderPassMS(WGPUCommandEncoder commandEncoder, WgRenderTarget* target, bool clear, WGPUColor clearColor)
 {
-    assert(target);
-    assert(commandEncoder);
     // do not start same render bass
     if (target == currentTarget) return;
     // we must to end render pass first
@@ -251,64 +246,59 @@ void WgCompositor::flush(WgContext& context)
     context.submit();
 }
 
-
-void WgCompositor::requestShape(WgRenderDataShape* renderData)
+void WgCompositor::requestShape(WgRenderShape* rdata)
 {
-    stageBufferGeometry.append(renderData);
+    stageBufferGeometry.append(rdata);
 
-    auto& shapeSettings = renderData->renderSettingsShape;
-    auto& shapeSolid = renderData->solidShape;
-    if (shapeSettings.fillType == WgRenderSettingsType::Solid) shapeSolid.colorInd = stageBufferSolidColor.append(shapeSolid.packedColor());
-    else shapeSettings.bindGroupInd = stageBufferPaint.append(shapeSettings.settings);
+    auto& shapeSettings = rdata->shape.setting;
+    auto& shapeSolid = rdata->shape.solid;
+    if (shapeSettings.fillType == WgRenderSettingsType::Solid) shapeSolid.colorIdx = stageBufferSolidColor.append(shapeSolid.packedColor());
+    else shapeSettings.bindGroupIdx = stageBufferPaint.append(shapeSettings.settings);
 
-    if (renderData->meshStrokes.vbuffer.count > 0) {
+    if (!rdata->stroke.mesh.vbuffer.empty()) {
         Matrix viewMatrix{2.0f / width, 0.0f, -1.0f, 0.0f, -2.0f / height, 1.0f, 0.0f, 0.0f, 1.0f};
-        WgShaderTypeMat4x4fBlock strokeViewMat{{viewMatrix * renderData->transform}, {}};
-        renderData->strokeViewMatInd = stageBufferViewMat.append(strokeViewMat);
+        WgShaderTypeMat4x4fBlock strokeViewMat{{viewMatrix * rdata->transform}, {}};
+        rdata->strokeViewMatIdx = stageBufferViewMat.append(strokeViewMat);
     }
 
-    if (!renderData->renderSettingsStroke.skip && renderData->meshStrokes.vbuffer.count > 0) {
-        auto& strokeSettings = renderData->renderSettingsStroke;
-        auto& strokeSolid = renderData->solidStroke;
-        if (strokeSettings.fillType == WgRenderSettingsType::Solid) strokeSolid.colorInd = stageBufferSolidColor.append(strokeSolid.packedColor());
-        else strokeSettings.bindGroupInd = stageBufferPaint.append(strokeSettings.settings);
+    if (rdata->stroke.setting.valid && !rdata->stroke.mesh.vbuffer.empty()) {
+        auto& strokeSettings = rdata->stroke.setting;
+        auto& strokeSolid = rdata->stroke.solid;
+        if (strokeSettings.fillType == WgRenderSettingsType::Solid) strokeSolid.colorIdx = stageBufferSolidColor.append(strokeSolid.packedColor());
+        else strokeSettings.bindGroupIdx = stageBufferPaint.append(strokeSettings.settings);
     }
-    ARRAY_FOREACH(p, renderData->clips)
-        requestShape((WgRenderDataShape*)(*p));
+    ARRAY_FOREACH(p, rdata->clips)
+        requestShape((WgRenderShape*)(*p));
 }
 
-
-void WgCompositor::requestImage(WgRenderDataPicture* renderData)
+void WgCompositor::requestImage(WgRenderPicture* rdata)
 {
-    stageBufferGeometry.append(renderData);
-    renderData->renderSettings.bindGroupInd = stageBufferPaint.append(renderData->renderSettings.settings);
-    ARRAY_FOREACH(p, renderData->clips)
-        requestShape((WgRenderDataShape*)(*p));
+    stageBufferGeometry.append(rdata);
+    rdata->renderSettings.bindGroupIdx = stageBufferPaint.append(rdata->renderSettings.settings);
+    ARRAY_FOREACH(p, rdata->clips)
+        requestShape((WgRenderShape*)(*p));
 }
 
-void WgCompositor::requestSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgSolidBatchRange& range)
+void WgCompositor::requestSolidBatch(const Array<WgRenderShape*>& renderShapes, WgSolidBatchRange& range)
 {
-    stageBufferGeometry.appendSolidBatch(renderDataShapes, stageBufferSolidColor, range);
-    range.viewport = renderDataShapes[0]->viewport;
+    stageBufferGeometry.appendSolidBatch(renderShapes, stageBufferSolidColor, range);
+    range.viewport = renderShapes[0]->viewport;
 }
 
-void WgCompositor::requestStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range)
+void WgCompositor::requestStencilBatch(const Array<WgRenderShape*>& renderShapes, WgStencilBatchRange& range)
 {
-    assert(renderDataShapes.count > 1);
-    stageBufferGeometry.appendStencilBatch(renderDataShapes, range);
-    range.viewport = renderDataShapes[0]->viewport;
-    range.fillRule = renderDataShapes[0]->fillRule;
+    stageBufferGeometry.appendStencilBatch(renderShapes, range);
+    range.viewport = renderShapes[0]->viewport;
+    range.fillRule = renderShapes[0]->fillRule;
     range.solidOnly = true;
 
     uint32_t pendingColorCount = 0;
     auto colorsStarted = false;
 
-    ARRAY_FOREACH(p, renderDataShapes) {
-        auto renderData = *p;
-        assert(!renderData->convex);
-        assert(renderData->fillRule == range.fillRule);
-        auto& settings = renderData->renderSettingsShape;
-        const auto count = renderData->meshBBox.vbuffer.count;
+    ARRAY_FOREACH(p, renderShapes) {
+        auto rdata = *p;
+        auto& settings = rdata->shape.setting;
+        const auto count = rdata->meshBBox.vbuffer.count;
 
         if (settings.fillType == WgRenderSettingsType::Solid) {
             if (!colorsStarted) {
@@ -316,57 +306,52 @@ void WgCompositor::requestStencilBatch(const Array<WgRenderDataShape*>& renderDa
                 if (pendingColorCount) stageBufferSolidColor.appendRepeated({}, pendingColorCount);
                 colorsStarted = true;
             }
-            stageBufferSolidColor.appendRepeated(renderData->solidShape.packedColor(), count);
+            stageBufferSolidColor.appendRepeated(rdata->shape.solid.packedColor(), count);
         } else {
-            assert(settings.fillType == WgRenderSettingsType::Linear || settings.fillType == WgRenderSettingsType::Radial);
             range.solidOnly = false;
-            settings.bindGroupInd = stageBufferPaint.append(settings.settings);
+            settings.bindGroupIdx = stageBufferPaint.append(settings.settings);
             if (colorsStarted) stageBufferSolidColor.appendRepeated({}, count);
             else pendingColorCount += count;
         }
     }
 }
 
-void WgCompositor::renderShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod)
+void WgCompositor::renderShape(WgContext& context, WgRenderShape* rdata, BlendMethod blendMethod)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
     // apply clip path if necessary
-    if (!renderData->clips.empty()) {
-        renderClipPath(context, renderData);
-        if (renderData->strokeFirst) {
-            clipStrokes(context, renderData);
-            clipShape(context, renderData);
+    if (!rdata->clips.empty()) {
+        renderClipPath(context, rdata);
+        if (rdata->strokeFirst) {
+            clipStrokes(context, rdata);
+            clipShape(context, rdata);
         } else {
-            clipShape(context, renderData);
-            clipStrokes(context, renderData);
+            clipShape(context, rdata);
+            clipStrokes(context, rdata);
         }
-        clearClipPath(context, renderData);
+        clearClipPath(context, rdata);
     // use custom blending
     } else if (blendMethod != BlendMethod::Normal) {
-        if (renderData->strokeFirst) {
-            blendStrokes(context, renderData, blendMethod);
-            blendShape(context, renderData, blendMethod);
+        if (rdata->strokeFirst) {
+            blendStrokes(context, rdata, blendMethod);
+            blendShape(context, rdata, blendMethod);
         } else {
-            blendShape(context, renderData, blendMethod);
-            blendStrokes(context, renderData, blendMethod);
+            blendShape(context, rdata, blendMethod);
+            blendStrokes(context, rdata, blendMethod);
         }
     // use direct hardware blending
     } else {
-        if (renderData->strokeFirst) {
-            drawStrokes(context, renderData);
-            drawShape(context, renderData);
+        if (rdata->strokeFirst) {
+            drawStrokes(context, rdata);
+            drawShape(context, rdata);
         } else {
-            drawShape(context, renderData);
-            drawStrokes(context, renderData);
+            drawShape(context, rdata);
+            drawStrokes(context, rdata);
         }
     }
 }
 
 void WgCompositor::renderSolidBatch(const WgSolidBatchRange& range)
 {
-    assert(renderPassEncoder);
-
     const uint64_t vertexSize = static_cast<uint64_t>(range.vertexCount) * sizeof(Point);
     const uint64_t colorSize = static_cast<uint64_t>(range.vertexCount) * sizeof(RenderColor);
     const uint64_t indexSize = static_cast<uint64_t>(range.indexCount) * sizeof(uint32_t);
@@ -381,13 +366,8 @@ void WgCompositor::renderSolidBatch(const WgSolidBatchRange& range)
     wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.indexCount, 1, 0, 0, 0);
 }
 
-void WgCompositor::renderStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, const WgStencilBatchRange& range)
+void WgCompositor::renderStencilBatch(const Array<WgRenderShape*>& renderShapes, const WgStencilBatchRange& range)
 {
-    assert(renderPassEncoder);
-    assert(renderDataShapes.count > 1);
-    assert(range.stencil.vertexCount > 0 && range.stencil.indexCount > 0);
-    assert(range.cover.vertexCount > 0 && range.cover.indexCount > 0);
-
     const uint64_t stencilVertexSize = static_cast<uint64_t>(range.stencil.vertexCount) * sizeof(Point);
     const uint64_t stencilIndexSize = static_cast<uint64_t>(range.stencil.indexCount) * sizeof(uint32_t);
     const uint64_t coverVertexSize = static_cast<uint64_t>(range.cover.vertexCount) * sizeof(Point);
@@ -417,21 +397,20 @@ void WgCompositor::renderStencilBatch(const Array<WgRenderDataShape*>& renderDat
     uint32_t firstIndex = 0;
     bool colorsBound = false;
 
-    auto p = renderDataShapes.begin();
-    const auto end = renderDataShapes.end();
+    auto p = renderShapes.begin();
+    const auto end = renderShapes.end();
     while (p < end) {
-        auto renderData = *p;
-        auto& settings = renderData->renderSettingsShape;
+        auto rdata = *p;
+        auto& settings = rdata->shape.setting;
         const auto batchFirstIndex = firstIndex;
 
         do {
-            const auto indexCount = renderData->meshBBox.ibuffer.count;
+            const auto indexCount = rdata->meshBBox.ibuffer.count;
             const uint64_t nextIndex = static_cast<uint64_t>(firstIndex) + indexCount;
-            assert(indexCount > 0 && firstIndex <= range.cover.indexCount && nextIndex <= range.cover.indexCount);
             firstIndex = static_cast<uint32_t>(nextIndex);
             if (++p == end || settings.fillType != WgRenderSettingsType::Solid) break;
-            renderData = *p;
-        } while (renderData->renderSettingsShape.fillType == WgRenderSettingsType::Solid);
+            rdata = *p;
+        } while (rdata->shape.setting.fillType == WgRenderSettingsType::Solid);
 
         if (settings.fillType == WgRenderSettingsType::Solid) {
             if (!colorsBound) {
@@ -440,39 +419,31 @@ void WgCompositor::renderStencilBatch(const Array<WgRenderDataShape*>& renderDat
             }
             wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_stencil_batch);
         } else {
-            assert(settings.fillType == WgRenderSettingsType::Linear || settings.fillType == WgRenderSettingsType::Radial);
-            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
             wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
             wgpuRenderPassEncoderSetPipeline(renderPassEncoder, settings.fillType == WgRenderSettingsType::Linear ? pipelines.linear : pipelines.radial);
         }
         wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, firstIndex - batchFirstIndex, 1, batchFirstIndex, 0, 0);
     }
-
-    assert(firstIndex == range.cover.indexCount);
 }
 
-void WgCompositor::renderImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod)
+void WgCompositor::renderImage(WgContext& context, WgRenderPicture* rdata, BlendMethod blendMethod)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
     // apply clip path if necessary
-    if (renderData->clips.count != 0) {
-        renderClipPath(context, renderData);
-        clipImage(context, renderData);
-        clearClipPath(context, renderData);
+    if (rdata->clips.count != 0) {
+        renderClipPath(context, rdata);
+        clipImage(context, rdata);
+        clearClipPath(context, rdata);
     // use custom blending
     } else if (blendMethod != BlendMethod::Normal)
-        blendImage(context, renderData, blendMethod);
+        blendImage(context, rdata, blendMethod);
     // use direct hardware blending
-    else drawImage(context, renderData);
+    else drawImage(context, rdata);
 }
 
 
 void WgCompositor::renderScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose)
 {
-    assert(scene);
-    assert(compose);
-    assert(renderPassEncoder);
     // use custom blending
     if (compose->blend != BlendMethod::Normal)
         blendScene(context, scene, compose);
@@ -483,10 +454,6 @@ void WgCompositor::renderScene(WgContext& context, WgRenderTarget* scene, WgComp
 
 void WgCompositor::composeScene(WgContext& context, WgRenderTarget* src, WgRenderTarget* mask, WgCompose* cmp)
 {
-    assert(cmp);
-    assert(src);
-    assert(mask);
-    assert(renderPassEncoder);
     RenderRegion rect = shrinkRenderRegion(cmp->aabb);
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rect.x(), rect.y(), rect.w(), rect.h());
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
@@ -498,7 +465,6 @@ void WgCompositor::composeScene(WgContext& context, WgRenderTarget* src, WgRende
 
 void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRenderTarget* src, WGPUTextureView dstView, bool premultiplied)
 {
-    assert(!renderPassEncoder);
     const WGPURenderPassDepthStencilAttachment depthStencilAttachment{
         .view = texViewDepthStencil,
         .depthLoadOp = WGPULoadOp_Load,
@@ -525,8 +491,6 @@ void WgCompositor::blit(WgContext& context, WGPUCommandEncoder encoder, WgRender
 
 void WgCompositor::drawMesh(WgContext& context, WgMeshData* meshData)
 {
-    assert(meshData);
-    assert(renderPassEncoder);
     uint64_t icount = meshData->ibuffer.count;
     uint64_t vsize = meshData->vbuffer.count * sizeof(Point);
     uint64_t isize = icount * sizeof(uint32_t);
@@ -552,8 +516,6 @@ void WgCompositor::drawMeshSolid(WgContext& context, WgMeshData* meshData, uint3
 
 void WgCompositor::drawMeshImage(WgContext& context, WgMeshData* meshData)
 {
-    assert(meshData);
-    assert(renderPassEncoder);
     uint64_t icount = meshData->ibuffer.count;
     uint64_t vsize = meshData->vbuffer.count * sizeof(Point);
     uint64_t isize = icount * sizeof(uint32_t);
@@ -563,26 +525,23 @@ void WgCompositor::drawMeshImage(WgContext& context, WgMeshData* meshData)
     wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, icount, 1, 0, 0, 0);
 };
 
-
-void WgCompositor::drawShape(WgContext& context, WgRenderDataShape* renderData)
+void WgCompositor::drawShape(WgContext& context, WgRenderShape* rdata)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
-    if (renderData->renderSettingsShape.skip || renderData->meshShape.vbuffer.count == 0 || renderData->viewport.invalid()) return;
-    WgRenderSettings& settings = renderData->renderSettingsShape;
-    const bool convex = renderData->convex;
-    WgMeshData* mesh = renderData->convex ? &renderData->meshShape : &renderData->meshBBox;
+    if (!rdata->shape.setting.valid || rdata->shape.mesh.vbuffer.empty() || rdata->viewport.invalid()) return;
+    auto& settings = rdata->shape.setting;
+    auto convex = rdata->convex;
+    auto mesh = rdata->convex ? &rdata->shape.mesh : &rdata->meshBBox;
 
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
 
     // setup stencil rules
     if (!convex) {
-        WGPURenderPipeline stencilPipeline = (renderData->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
+        WGPURenderPipeline stencilPipeline = (rdata->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, stencilPipeline);
         // draw to stencil (first pass)
-        drawMesh(context, &renderData->meshShape);
+        drawMesh(context, &rdata->shape.mesh);
     }
 
     // setup fill rules
@@ -591,41 +550,38 @@ void WgCompositor::drawShape(WgContext& context, WgRenderDataShape* renderData)
 
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, convex ? pipelines.solid_conv : pipelines.solid);
-        drawMeshSolid(context, mesh, renderData->solidShape.colorInd);
+        drawMeshSolid(context, mesh, rdata->shape.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, convex ? pipelines.linear_conv : pipelines.linear);
         drawMesh(context, mesh);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, convex ? pipelines.radial_conv : pipelines.radial);
         drawMesh(context, mesh);
     }
 }
 
-
-void WgCompositor::blendShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod)
+void WgCompositor::blendShape(WgContext& context, WgRenderShape* rdata, BlendMethod blendMethod)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
-    if (renderData->renderSettingsShape.skip || renderData->meshShape.vbuffer.count == 0 || renderData->viewport.invalid()) return;
-    WgRenderSettings& settings = renderData->renderSettingsShape;
+    if (!rdata->shape.setting.valid || rdata->shape.mesh.vbuffer.empty() || rdata->viewport.invalid()) return;
+    WgRenderSettings& settings = rdata->shape.setting;
     // copy current render target data to dst target
     WgRenderTarget *target = currentTarget;
     endRenderPass();
     copyTexture(&targetTemp0, target);
     beginRenderPassMS(commandEncoder, target, false);
     // render shape with blend settings
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // setup stencil rules
-    WGPURenderPipeline stencilPipeline = (renderData->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
+    WGPURenderPipeline stencilPipeline = (rdata->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, stencilPipeline);
     // draw to stencil (first pass)
-    drawMesh(context, &renderData->meshShape);
+    drawMesh(context, &rdata->shape.mesh);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
@@ -633,117 +589,108 @@ void WgCompositor::blendShape(WgContext& context, WgRenderDataShape* renderData,
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_blend[blendMethodInd]);
-        drawMeshSolid(context, &renderData->meshBBox, renderData->solidShape.colorInd);
+        drawMeshSolid(context, &rdata->meshBBox, rdata->shape.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear_blend[blendMethodInd]);
-        drawMesh(context, &renderData->meshBBox);
+        drawMesh(context, &rdata->meshBBox);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial_blend[blendMethodInd]);
-        drawMesh(context, &renderData->meshBBox);
+        drawMesh(context, &rdata->meshBBox);
     }
 }
 
-
-void WgCompositor::clipShape(WgContext& context, WgRenderDataShape* renderData)
+void WgCompositor::clipShape(WgContext& context, WgRenderShape* rdata)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
-    if (renderData->renderSettingsShape.skip || renderData->meshShape.vbuffer.count == 0 || renderData->viewport.invalid()) return;
-    WgRenderSettings& settings = renderData->renderSettingsShape;
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    if (!rdata->shape.setting.valid || rdata->shape.mesh.vbuffer.empty() || rdata->viewport.invalid()) return;
+    WgRenderSettings& settings = rdata->shape.setting;
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // setup stencil rules
-    WGPURenderPipeline stencilPipeline = (renderData->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
+    WGPURenderPipeline stencilPipeline = (rdata->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, stencilPipeline);
     // draw to stencil (first pass)
-    drawMesh(context, &renderData->meshShape);
+    drawMesh(context, &rdata->shape.mesh);
     // merge depth and stencil buffer
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.merge_depth_stencil);
-    drawMesh(context, &renderData->meshBBox);
+    drawMesh(context, &rdata->meshBBox);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
-        drawMeshSolid(context, &renderData->meshBBox, renderData->solidShape.colorInd);
+        drawMeshSolid(context, &rdata->meshBBox, rdata->shape.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear);
-        drawMesh(context, &renderData->meshBBox);
+        drawMesh(context, &rdata->meshBBox);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial);
-        drawMesh(context, &renderData->meshBBox);
+        drawMesh(context, &rdata->meshBBox);
     }
 }
 
-
-void WgCompositor::drawStrokes(WgContext& context, WgRenderDataShape* renderData)
+void WgCompositor::drawStrokes(WgContext& context, WgRenderShape* rdata)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
-    if (renderData->renderSettingsStroke.skip || renderData->meshStrokes.vbuffer.count == 0 || renderData->viewport.invalid()) return;
-    WgRenderSettings& settings = renderData->renderSettingsStroke;
-    auto strokeView = stageBufferViewMat[renderData->strokeViewMatInd];
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    if (!rdata->stroke.setting.valid || rdata->stroke.mesh.vbuffer.empty() || rdata->viewport.invalid()) return;
+    WgRenderSettings& settings = rdata->stroke.setting;
+    auto strokeView = stageBufferViewMat[rdata->strokeViewMatIdx];
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // draw strokes to stencil (first pass)
     // setup stencil rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
     // draw to stencil (first pass)
-    drawMesh(context, &renderData->meshStrokes);
+    drawMesh(context, &rdata->stroke.mesh);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
-        drawMeshSolid(context, &renderData->meshStrokesBBox, renderData->solidStroke.colorInd);
+        drawMeshSolid(context, &rdata->stroke.bbox, rdata->stroke.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear);
-        drawMesh(context, &renderData->meshStrokesBBox);
+        drawMesh(context, &rdata->stroke.bbox);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial);
-        drawMesh(context, &renderData->meshStrokesBBox);
+        drawMesh(context, &rdata->stroke.bbox);
     }
 }
 
-
-void WgCompositor::blendStrokes(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod)
+void WgCompositor::blendStrokes(WgContext& context, WgRenderShape* rdata, BlendMethod blendMethod)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
-    if (renderData->renderSettingsStroke.skip || renderData->meshStrokes.vbuffer.count == 0 || renderData->viewport.invalid()) return;
-    WgRenderSettings& settings = renderData->renderSettingsStroke;
-    auto strokeView = stageBufferViewMat[renderData->strokeViewMatInd];
+    if (!rdata->stroke.setting.valid || rdata->stroke.mesh.vbuffer.empty() || rdata->viewport.invalid()) return;
+    WgRenderSettings& settings = rdata->stroke.setting;
+    auto strokeView = stageBufferViewMat[rdata->strokeViewMatIdx];
     // copy current render target data to dst target
     WgRenderTarget *target = currentTarget;
     endRenderPass();
     copyTexture(&targetTemp0, target);
     beginRenderPassMS(commandEncoder, target, false);
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // draw strokes to stencil (first pass)
     // setup stencil rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
     // draw to stencil (first pass)
-    drawMesh(context, &renderData->meshStrokes);
+    drawMesh(context, &rdata->stroke.mesh);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
@@ -751,93 +698,84 @@ void WgCompositor::blendStrokes(WgContext& context, WgRenderDataShape* renderDat
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_blend[blendMethodInd]);
-        drawMeshSolid(context, &renderData->meshStrokesBBox, renderData->solidStroke.colorInd);
+        drawMeshSolid(context, &rdata->stroke.bbox, rdata->stroke.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear_blend[blendMethodInd]);
-        drawMesh(context, &renderData->meshStrokesBBox);
+        drawMesh(context, &rdata->stroke.bbox);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial_blend[blendMethodInd]);
-        drawMesh(context, &renderData->meshStrokesBBox);
+        drawMesh(context, &rdata->stroke.bbox);
     }
 };
 
-
-void WgCompositor::clipStrokes(WgContext& context, WgRenderDataShape* renderData)
+void WgCompositor::clipStrokes(WgContext& context, WgRenderShape* rdata)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
-    if (renderData->renderSettingsStroke.skip || renderData->meshStrokes.vbuffer.count == 0 || renderData->viewport.invalid()) return;
-    WgRenderSettings& settings = renderData->renderSettingsStroke;
-    auto strokeView = stageBufferViewMat[renderData->strokeViewMatInd];
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    if (!rdata->stroke.setting.valid || rdata->stroke.mesh.vbuffer.empty() || rdata->viewport.invalid()) return;
+    WgRenderSettings& settings = rdata->stroke.setting;
+    auto strokeView = stageBufferViewMat[rdata->strokeViewMatIdx];
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // draw strokes to stencil (first pass)
     // setup stencil rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
     // draw to stencil (first pass)
-    drawMesh(context, &renderData->meshStrokes);
+    drawMesh(context, &rdata->stroke.mesh);
     // merge depth and stencil buffer
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.merge_depth_stencil);
-    drawMesh(context, &renderData->meshBBox);
+    drawMesh(context, &rdata->meshBBox);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
-        drawMeshSolid(context, &renderData->meshStrokesBBox, renderData->solidStroke.colorInd);
+        drawMeshSolid(context, &rdata->stroke.bbox, rdata->stroke.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear);
-        drawMesh(context, &renderData->meshStrokesBBox);
+        drawMesh(context, &rdata->stroke.bbox);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial);
-        drawMesh(context, &renderData->meshStrokesBBox);
+        drawMesh(context, &rdata->stroke.bbox);
     }
 }
 
-
-void WgCompositor::drawImage(WgContext& context, WgRenderDataPicture* renderData)
+void WgCompositor::drawImage(WgContext& context, WgRenderPicture* rdata)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
-    if (renderData->viewport.invalid() || !renderData->imageBindGroup) return;
-    WgRenderSettings& settings = renderData->renderSettings;
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    if (rdata->viewport.invalid() || !rdata->imageBindGroup) return;
+    WgRenderSettings& settings = rdata->renderSettings;
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // draw stencil
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
-    drawMeshImage(context, &renderData->meshData);
+    drawMeshImage(context, &rdata->meshData);
     // draw image
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderData->imageBindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->imageBindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image);
-    drawMeshImage(context, &renderData->meshData);
+    drawMeshImage(context, &rdata->meshData);
 }
 
-
-void WgCompositor::blendImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod)
+void WgCompositor::blendImage(WgContext& context, WgRenderPicture* rdata, BlendMethod blendMethod)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
-    if (renderData->viewport.invalid() || !renderData->imageBindGroup) return;
-    WgRenderSettings& settings = renderData->renderSettings;
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    if (rdata->viewport.invalid() || !rdata->imageBindGroup) return;
+    WgRenderSettings& settings = rdata->renderSettings;
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // copy current render target data to dst target
     WgRenderTarget *target = currentTarget;
     endRenderPass();
@@ -847,51 +785,45 @@ void WgCompositor::blendImage(WgContext& context, WgRenderDataPicture* renderDat
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
-    drawMeshImage(context, &renderData->meshData);
+    drawMeshImage(context, &rdata->meshData);
     // blend image
     uint32_t blendMethodInd = (uint32_t)blendMethod;
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderData->imageBindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->imageBindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image_blend[blendMethodInd]);
-    drawMeshImage(context, &renderData->meshData);
+    drawMeshImage(context, &rdata->meshData);
 };
 
-
-void WgCompositor::clipImage(WgContext& context, WgRenderDataPicture* renderData)
+void WgCompositor::clipImage(WgContext& context, WgRenderPicture* rdata)
 {
-    assert(renderData);
-    assert(renderPassEncoder);
-    if (renderData->viewport.invalid() || !renderData->imageBindGroup) return;
-    WgRenderSettings& settings = renderData->renderSettings;
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    if (rdata->viewport.invalid() || !rdata->imageBindGroup) return;
+    WgRenderSettings& settings = rdata->renderSettings;
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // setup stencil rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
-    drawMeshImage(context, &renderData->meshData);
+    drawMeshImage(context, &rdata->meshData);
     // merge depth and stencil buffer
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.merge_depth_stencil);
-    drawMeshImage(context, &renderData->meshData);
+    drawMeshImage(context, &rdata->meshData);
     // draw image
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupInd], 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderData->imageBindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->imageBindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image);
-    drawMeshImage(context, &renderData->meshData);
+    drawMeshImage(context, &rdata->meshData);
 }
 
 
 void WgCompositor::drawScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose)
 {
-    assert(scene);
-    assert(compose);
-    assert(currentTarget);
     // draw scene
     RenderRegion rect = shrinkRenderRegion(compose->aabb);
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rect.x(), rect.y(), rect.w(), rect.h());
@@ -905,9 +837,6 @@ void WgCompositor::drawScene(WgContext& context, WgRenderTarget* scene, WgCompos
 
 void WgCompositor::blendScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose)
 {
-    assert(scene);
-    assert(compose);
-    assert(currentTarget);
     // copy current render target data to dst target
     WgRenderTarget *target = currentTarget;
     endRenderPass();
@@ -925,107 +854,91 @@ void WgCompositor::blendScene(WgContext& context, WgRenderTarget* scene, WgCompo
     drawMeshImage(context, &meshDataBlit);
 }
 
-
-void WgCompositor::markupClipPath(WgContext& context, WgRenderDataShape* renderData)
+void WgCompositor::markupClipPath(WgContext& context, WgRenderShape* rdata)
 {
-    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, renderData->viewport.x(), renderData->viewport.y(), renderData->viewport.w(), renderData->viewport.h());
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // markup stencil
-    if (renderData->meshStrokes.vbuffer.count > 0) {
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, stageBufferViewMat[renderData->strokeViewMatInd], 0, nullptr);
+    if (rdata->stroke.mesh.vbuffer.count > 0) {
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, stageBufferViewMat[rdata->strokeViewMatIdx], 0, nullptr);
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
-        drawMesh(context, &renderData->meshStrokes);
-    } else if (renderData->meshShape.vbuffer.count > 0) {
+        drawMesh(context, &rdata->stroke.mesh);
+    } else if (rdata->shape.mesh.vbuffer.count > 0) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
-        WGPURenderPipeline stencilPipeline = (renderData->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
+        WGPURenderPipeline stencilPipeline = (rdata->fillRule == FillRule::NonZero) ? pipelines.nonzero : pipelines.evenodd;
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, stencilPipeline);
-        drawMesh(context, &renderData->meshShape);
+        drawMesh(context, &rdata->shape.mesh);
     }
 }
 
-
-void WgCompositor::renderClipPath(WgContext& context, WgRenderDataPaint* paint)
+void WgCompositor::renderClipPath(WgContext& context, WgRenderPaint* paint)
 {
-    assert(paint);
-    assert(renderPassEncoder);
-    assert(paint->clips.count > 0);
     // reset scissor recr to full screen
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, 0, 0, width, height);
-    // get render data
-    WgRenderDataShape* renderData0 = (WgRenderDataShape*)paint->clips[0];
+    auto rdata0 = (WgRenderShape*)paint->clips[0];
     // markup stencil
-    markupClipPath(context, renderData0);
+    markupClipPath(context, rdata0);
     // copy stencil to depth
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.copy_stencil_to_depth);
-    drawMesh(context, &renderData0->meshBBox);
+    drawMesh(context, &rdata0->meshBBox);
     // merge clip paths with AND logic
     for (auto p = paint->clips.begin() + 1; p < paint->clips.end(); ++p) {
-        // get render data
-        WgRenderDataShape* renderData = (WgRenderDataShape*)(*p);
+        auto rdata = (WgRenderShape*)(*p);
         // markup stencil
-        markupClipPath(context, renderData);
+        markupClipPath(context, rdata);
         // copy stencil to depth (clear stencil)
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[190], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.copy_stencil_to_depth_interm);
-        drawMesh(context, &renderData->meshBBox);
+        drawMesh(context, &rdata->meshBBox);
         // copy depth to stencil
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 1);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[190], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.copy_depth_to_stencil);
-        drawMesh(context, &renderData->meshBBox);
+        drawMesh(context, &rdata->meshBBox);
         // clear depth current (keep stencil)
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[255], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.clear_depth);
-        drawMesh(context, &renderData->meshBBox);
+        drawMesh(context, &rdata->meshBBox);
         // clear depth original (keep stencil)
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[255], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.clear_depth);
-        drawMesh(context, &renderData0->meshBBox);
+        drawMesh(context, &rdata0->meshBBox);
         // copy stencil to depth (clear stencil)
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.copy_stencil_to_depth);
-        drawMesh(context, &renderData->meshBBox);
+        drawMesh(context, &rdata->meshBBox);
     }
 }
 
-
-void WgCompositor::clearClipPath(WgContext& context, WgRenderDataPaint* paint)
+void WgCompositor::clearClipPath(WgContext& context, WgRenderPaint* paint)
 {
-    assert(paint);
-    assert(renderPassEncoder);
-    assert(paint->clips.count > 0);
     // reset scissor recr to full screen
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, 0, 0, width, height);
     // get render data
     ARRAY_FOREACH(p, paint->clips) {
-        WgRenderDataShape* renderData = (WgRenderDataShape*)(*p);
+        WgRenderShape* rdata = (WgRenderShape*)(*p);
         // set transformations
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[255], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.clear_depth);
-        drawMesh(context, &renderData->meshBBox);
+        drawMesh(context, &rdata->meshBBox);
     }
 }
 
 
 bool WgCompositor::gaussianBlur(WgContext& context, WgRenderTarget* dst, const RenderEffectGaussianBlur* params, const WgCompose* compose)
 {
-    assert(dst);
-    assert(params);
-    assert(params->rd);
-    assert(!renderPassEncoder);
-
-    auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
+    auto effectParams = (WgRenderEffectParams*)params->rd;
     auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst);
@@ -1033,14 +946,14 @@ bool WgCompositor::gaussianBlur(WgContext& context, WgRenderTarget* dst, const R
         beginRenderPass(commandEncoder, &targetTemp0); {
             wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
             wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, dst->bindGroupTexture, 0, nullptr);
-            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, renderDataParams->bindGroupParams, 0, nullptr);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, effectParams->bindGroupParams, 0, nullptr);
             wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.gaussian_horz);
             drawMeshImage(context, &meshDataBlit);
         } endRenderPass();
         beginRenderPass(commandEncoder, dst); {
             wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
             wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, targetTemp0.bindGroupTexture, 0, nullptr);
-            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, renderDataParams->bindGroupParams, 0, nullptr);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, effectParams->bindGroupParams, 0, nullptr);
             wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.gaussian_vert);
             drawMeshImage(context, &meshDataBlit);
         } endRenderPass();
@@ -1048,7 +961,7 @@ bool WgCompositor::gaussianBlur(WgContext& context, WgRenderTarget* dst, const R
         beginRenderPass(commandEncoder, dst); {
             wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
             wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, targetTemp0.bindGroupTexture, 0, nullptr);
-            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, renderDataParams->bindGroupParams, 0, nullptr);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, effectParams->bindGroupParams, 0, nullptr);
             wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.gaussian_horz);
             drawMeshImage(context, &meshDataBlit);
         } endRenderPass();
@@ -1056,7 +969,7 @@ bool WgCompositor::gaussianBlur(WgContext& context, WgRenderTarget* dst, const R
         beginRenderPass(commandEncoder, dst); {
             wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
             wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, targetTemp0.bindGroupTexture, 0, nullptr);
-            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, renderDataParams->bindGroupParams, 0, nullptr);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, effectParams->bindGroupParams, 0, nullptr);
             wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.gaussian_vert);
             drawMeshImage(context, &meshDataBlit);
         } endRenderPass();
@@ -1068,12 +981,7 @@ bool WgCompositor::gaussianBlur(WgContext& context, WgRenderTarget* dst, const R
 
 bool WgCompositor::dropShadow(WgContext& context, WgRenderTarget* dst, const RenderEffectDropShadow* params, const WgCompose* compose)
 {
-    assert(dst);
-    assert(params);
-    assert(params->rd);
-    assert(!renderPassEncoder);
-
-    auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
+    auto effectParams = (WgRenderEffectParams*)params->rd;
     auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst);
@@ -1083,7 +991,7 @@ bool WgCompositor::dropShadow(WgContext& context, WgRenderTarget* dst, const Ren
         beginRenderPass(commandEncoder, &targetTemp0); {
             wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
             wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, dst->bindGroupTexture, 0, nullptr);
-            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, renderDataParams->bindGroupParams, 0, nullptr);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, effectParams->bindGroupParams, 0, nullptr);
             wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.gaussian_horz);
             drawMeshImage(context, &meshDataBlit);
         } endRenderPass();
@@ -1091,7 +999,7 @@ bool WgCompositor::dropShadow(WgContext& context, WgRenderTarget* dst, const Ren
         beginRenderPass(commandEncoder, &targetTemp1); {
             wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
             wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, targetTemp0.bindGroupTexture, 0, nullptr);
-            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, renderDataParams->bindGroupParams, 0, nullptr);
+            wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, effectParams->bindGroupParams, 0, nullptr);
             wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.gaussian_vert);
             drawMeshImage(context, &meshDataBlit);
         } endRenderPass();
@@ -1102,7 +1010,7 @@ bool WgCompositor::dropShadow(WgContext& context, WgRenderTarget* dst, const Ren
         wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp1.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, renderDataParams->bindGroupParams, 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, effectParams->bindGroupParams, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.dropshadow);
         drawMeshImage(context, &meshDataBlit);
     } endRenderPass();
@@ -1112,19 +1020,14 @@ bool WgCompositor::dropShadow(WgContext& context, WgRenderTarget* dst, const Ren
 
 bool WgCompositor::fillEffect(WgContext& context, WgRenderTarget* dst, const RenderEffectFill* params, const WgCompose* compose)
 {
-    assert(dst);
-    assert(params);
-    assert(params->rd);
-    assert(!renderPassEncoder);
-
-    auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
+    auto effectParams = (WgRenderEffectParams*)params->rd;
     auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst, aabb);
     beginRenderPass(commandEncoder, dst); {
         wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, targetTemp0.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, renderDataParams->bindGroupParams, 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, effectParams->bindGroupParams, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.fill_effect);
         drawMeshImage(context, &meshDataBlit);
     } endRenderPass();
@@ -1135,19 +1038,14 @@ bool WgCompositor::fillEffect(WgContext& context, WgRenderTarget* dst, const Ren
 
 bool WgCompositor::tintEffect(WgContext& context, WgRenderTarget* dst, const RenderEffectTint* params, const WgCompose* compose)
 {
-    assert(dst);
-    assert(params);
-    assert(params->rd);
-    assert(!renderPassEncoder);
-
-    auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
+    auto effectParams = (WgRenderEffectParams*)params->rd;
     auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst, aabb);
     beginRenderPass(commandEncoder, dst); {
         wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, targetTemp0.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, renderDataParams->bindGroupParams, 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, effectParams->bindGroupParams, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.tint_effect);
         drawMeshImage(context, &meshDataBlit);
     } endRenderPass();
@@ -1157,19 +1055,14 @@ bool WgCompositor::tintEffect(WgContext& context, WgRenderTarget* dst, const Ren
 
 bool WgCompositor::tritoneEffect(WgContext& context, WgRenderTarget* dst, const RenderEffectTritone* params, const WgCompose* compose)
 {
-    assert(dst);
-    assert(params);
-    assert(params->rd);
-    assert(!renderPassEncoder);
-
-    auto renderDataParams = (WgRenderDataEffectParams*)params->rd;
+    auto effectParams = (WgRenderEffectParams*)params->rd;
     auto aabb = shrinkRenderRegion(compose->aabb);
 
     copyTexture(&targetTemp0, dst, aabb);
     beginRenderPass(commandEncoder, dst); {
         wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, aabb.x(), aabb.y(), aabb.w(), aabb.h());
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, targetTemp0.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, renderDataParams->bindGroupParams, 0, nullptr);
+        wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, effectParams->bindGroupParams, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.tritone_effect);
         drawMeshImage(context, &meshDataBlit);
     } endRenderPass();

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.h
@@ -82,28 +82,28 @@ private:
     void drawMeshImage(WgContext& context, WgMeshData* meshData);
 
     // shapes
-    void drawShape(WgContext& context, WgRenderDataShape* renderData);
-    void blendShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
-    void clipShape(WgContext& context, WgRenderDataShape* renderData);
+    void drawShape(WgContext& context, WgRenderShape* rdata);
+    void blendShape(WgContext& context, WgRenderShape* rdata, BlendMethod blendMethod);
+    void clipShape(WgContext& context, WgRenderShape* rdata);
 
     // strokes
-    void drawStrokes(WgContext& context, WgRenderDataShape* renderData);
-    void blendStrokes(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
-    void clipStrokes(WgContext& context, WgRenderDataShape* renderData);
+    void drawStrokes(WgContext& context, WgRenderShape* rdata);
+    void blendStrokes(WgContext& context, WgRenderShape* rdata, BlendMethod blendMethod);
+    void clipStrokes(WgContext& context, WgRenderShape* rdata);
 
     // images
-    void drawImage(WgContext& context, WgRenderDataPicture* renderData);
-    void blendImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod);
-    void clipImage(WgContext& context, WgRenderDataPicture* renderData);
+    void drawImage(WgContext& context, WgRenderPicture* rdata);
+    void blendImage(WgContext& context, WgRenderPicture* rdata, BlendMethod blendMethod);
+    void clipImage(WgContext& context, WgRenderPicture* rdata);
 
     // scenes
     void drawScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose);
     void blendScene(WgContext& context, WgRenderTarget* src, WgCompose* compose);
 
     // the renderer prioritizes clipping with the stroke over the shape's fill
-    void markupClipPath(WgContext& context, WgRenderDataShape* renderData);
-    void renderClipPath(WgContext& context, WgRenderDataPaint* paint);
-    void clearClipPath(WgContext& context, WgRenderDataPaint* paint);
+    void markupClipPath(WgContext& context, WgRenderShape* rdata);
+    void renderClipPath(WgContext& context, WgRenderPaint* paint);
+    void clearClipPath(WgContext& context, WgRenderPaint* paint);
     void updateViewMat(WgContext& context, uint32_t width, uint32_t height);
 public:
     void initialize(WgContext& context, uint32_t width, uint32_t height);
@@ -122,16 +122,16 @@ public:
     void flush(WgContext& context);
 
     // request shapes for drawing (staging)
-    void requestShape(WgRenderDataShape* renderData);
-    void requestImage(WgRenderDataPicture* renderData);
-    void requestSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgSolidBatchRange& range);
-    void requestStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range);
+    void requestShape(WgRenderShape* rdata);
+    void requestImage(WgRenderPicture* rdata);
+    void requestSolidBatch(const Array<WgRenderShape*>& renderShapes, WgSolidBatchRange& range);
+    void requestStencilBatch(const Array<WgRenderShape*>& renderShapes, WgStencilBatchRange& range);
 
     // render shapes, images and scenes
-    void renderShape(WgContext& context, WgRenderDataShape* renderData, BlendMethod blendMethod);
+    void renderShape(WgContext& context, WgRenderShape* rdata, BlendMethod blendMethod);
     void renderSolidBatch(const WgSolidBatchRange& range);
-    void renderStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, const WgStencilBatchRange& range);
-    void renderImage(WgContext& context, WgRenderDataPicture* renderData, BlendMethod blendMethod);
+    void renderStencilBatch(const Array<WgRenderShape*>& renderShapes, const WgStencilBatchRange& range);
+    void renderImage(WgContext& context, WgRenderPicture* rdata, BlendMethod blendMethod);
     void renderScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose);
     void composeScene(WgContext& context, WgRenderTarget* src, WgRenderTarget* mask, WgCompose* compose);
 

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -439,8 +439,8 @@ void WgRenderEffectParamsPool::release(WgContext& context)
 
 void WgStageBufferUniformBase::flush(WgContext& context, WGPUBuffer& buffer, const void* data, uint64_t reserved, uint32_t count, uint64_t stride)
 {
-    // Upload reserved storage to avoid reallocating the GPU buffer as data grows.
-    if (context.allocateBufferUniform(buffer, data, reserved)) releaseBindGroups(context);
+    // Reserve GPU storage for growth, but upload only initialized elements.
+    if (context.allocateBufferUniform(buffer, data, reserved, uint64_t(count) * stride)) releaseBindGroups(context);
 
     for (uint32_t i = bbuffer.count; i < count; ++i)
         bbuffer.push(context.layouts.createBindGroupBuffer1Un(buffer, i * stride, stride));

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -67,7 +67,7 @@ void WgImageData::release(WgContext& context)
 // WgRenderSettings
 //***********************************************************************
 
-uint8_t WgRenderSettings::updateOpacity(tvg::ColorSpace cs, uint8_t opacity)
+uint8_t WgRenderSettings::update(tvg::ColorSpace cs, uint8_t opacity)
 {
     auto effectiveOpacity = static_cast<uint8_t>(opacity * opacityMultiplier);
     settings.options.update(cs, effectiveOpacity);
@@ -92,47 +92,45 @@ void WgRenderSettings::release(WgContext& context)
 };
 
 //***********************************************************************
-// WgRenderDataPaint
+// WgRenderPaint
 //***********************************************************************
 
-void WgRenderDataPaint::release(WgContext& context)
+void WgRenderPaint::release(WgContext& context)
 {
     clips.clear();
 };
 
-void WgRenderDataPaint::updateClips(const Array<RenderData>& clips)
+void WgRenderPaint::update(const Array<RenderData>& clips)
 {
     this->clips.clear();
-    // RenderData == WgRenderDataPaint*, just copy it.
-    this->clips = *((Array<WgRenderDataPaint*>*)&clips);
+    // RenderData == WgRenderPaint*, just copy it.
+    this->clips = *((Array<WgRenderPaint*>*)&clips);
 }
 
 //***********************************************************************
-// WgRenderDataShape
+// WgRenderShape
 //***********************************************************************
 
-void WgRenderDataShape::updateBBox(BBox bb)
+void WgRenderShape::updateBBox(const BBox& bb)
 {
     bbox.min = tvg::min(bbox.min, bb.min);
     bbox.max = tvg::max(bbox.max, bb.max);
 }
 
-
-void WgRenderDataShape::updateVisibility(const RenderShape& rshape, uint8_t opacity)
+void WgRenderShape::updateVisibility(const RenderShape& rshape, uint8_t opacity)
 {
-    renderSettingsShape.skip = (rshape.color.a * opacity == 0) && (!rshape.fill);
-    renderSettingsStroke.skip = rshape.stroke ? (rshape.stroke->color.a * opacity == 0) && (!rshape.stroke->fill) : true;
+    shape.setting.valid = rshape.fill || (rshape.color.a * opacity > 0);
+    stroke.setting.valid = rshape.stroke && (rshape.stroke->fill || (rshape.stroke->color.a * opacity > 0));
 }
 
-
-void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag flag, const Matrix& matrix)
+void WgRenderShape::updateMeshes(const RenderShape& rshape, RenderUpdateFlag flag, const Matrix& matrix)
 {
     releaseMeshes();  //Optimize: bad idea to reset meshes always. it could re-use the meshes if there haven't been any path changes.
 
     convex = false;
     strokeFirst = rshape.strokeFirst();
-    renderSettingsShape.opacityMultiplier = 1.0f;
-    renderSettingsStroke.opacityMultiplier = 1.0f;
+    shape.setting.opacityMultiplier = 1.0f;
+    stroke.setting.opacityMultiplier = 1.0f;
 
     // optimize path
     auto& optPath = RenderPath::scratch();
@@ -163,25 +161,25 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
     if (updatePath || (flag & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient))) {
         if (optPathSkipFill) {
             // Too-thin fills are suppressed instead of going through thin fallback.
-            meshShape.clear();
+            shape.mesh.clear();
         } else {
             BBox bbox;
             // Drawable thin fills are tessellated as a minimal-width stroke.
             if (optPathThin && tvg::zero(rshape.strokeWidth())) {
-                WgStroker stroker(&meshShape, MIN_WG_STROKE_WIDTH, StrokeCap::Butt, StrokeJoin::Bevel);
+                WgStroker stroker(&shape.mesh, MIN_WG_STROKE_WIDTH, StrokeCap::Butt, StrokeJoin::Bevel);
                 stroker.run(optPath);
                 bbox = stroker.getBBox();
-                renderSettingsShape.opacityMultiplier = MIN_WG_STROKE_ALPHA;
+                shape.setting.opacityMultiplier = MIN_WG_STROKE_ALPHA;
             } else {
-                WgBWTessellator bwTess{&meshShape};
+                WgBWTessellator bwTess{&shape.mesh};
                 bwTess.tessellate(optPath);
                 convex = bwTess.convex;
                 bbox = bwTess.getBBox();
             }
-            if (meshShape.ibuffer.empty()) {
-                meshShape.clear();
+            if (shape.mesh.ibuffer.empty()) {
+                shape.mesh.clear();
             } else {
-                meshShapeBBox.bbox(bbox.min, bbox.max);
+                shape.bbox.bbox(bbox.min, bbox.max);
                 updateBBox(bbox);
             }
         }
@@ -196,34 +194,33 @@ void WgRenderDataShape::updateMeshes(const RenderShape &rshape, RenderUpdateFlag
 
         //run stroking only if it's valid
         if (!tvg::zero(strokeWidthWorld)) {
-            WgStroker stroker(&meshStrokes, strokeWidth, rshape.strokeCap(), rshape.strokeJoin(), rshape.strokeMiterlimit(), qualityScale);
+            WgStroker stroker(&stroke.mesh, strokeWidth, rshape.strokeCap(), rshape.strokeJoin(), rshape.strokeMiterlimit(), qualityScale);
             auto& dashed = RenderPath::scratch();
             if (gpuStrokeDash(rshape, dashed, nullptr)) stroker.run(dashed);
             else stroker.run(optStrokePath);
-            renderSettingsStroke.opacityMultiplier = 1.0f;
-            if (meshStrokes.ibuffer.empty()) {
-                meshStrokes.clear();
+            stroke.setting.opacityMultiplier = 1.0f;
+            if (stroke.mesh.ibuffer.empty()) {
+                stroke.mesh.clear();
             } else {
                 auto bbox = stroker.getBBox();
-                meshStrokesBBox.bbox(bbox.min, bbox.max);
+                stroke.bbox.bbox(bbox.min, bbox.max);
                 auto strokeBounds = gpuTransformBounds(stroker.bounds(), matrix);
                 updateBBox({{(float)strokeBounds.min.x, (float)strokeBounds.min.y}, {(float)strokeBounds.max.x, (float)strokeBounds.max.y}});
             }
         }
     }
     // update shapes bbox (with empty path handling)
-    if (!meshShape.vbuffer.empty() || !meshStrokes.vbuffer.empty()) updateAABB();
+    if (!shape.mesh.vbuffer.empty() || !stroke.mesh.vbuffer.empty()) updateAABB();
     else bbox = aabb = {{0, 0}, {0, 0}};
     meshBBox.bbox(bbox.min, bbox.max);
 }
 
-
-void WgRenderDataShape::releaseMeshes()
+void WgRenderShape::releaseMeshes()
 {
-    meshStrokes.clear();
-    meshStrokesBBox.clear();
-    meshShape.clear();
-    meshShapeBBox.clear();
+    stroke.mesh.clear();
+    stroke.bbox.clear();
+    shape.mesh.clear();
+    shape.bbox.clear();
     meshBBox.clear();
     bbox.min = {FLT_MAX, FLT_MAX};
     bbox.max = {0.0f, 0.0f};
@@ -231,41 +228,38 @@ void WgRenderDataShape::releaseMeshes()
     clips.clear();
 }
 
-
-void WgRenderDataShape::release(WgContext& context)
+void WgRenderShape::release(WgContext& context)
 {
     releaseMeshes();
-    renderSettingsStroke.release(context);
-    renderSettingsShape.release(context);
-    WgRenderDataPaint::release(context);
+    stroke.setting.release(context);
+    shape.setting.release(context);
+    WgRenderPaint::release(context);
 };
 
 //***********************************************************************
-// WgRenderDataShapePool
+// WgRenderShapePool
 //***********************************************************************
 
-WgRenderDataShape* WgRenderDataShapePool::allocate(WgContext& context)
+WgRenderShape* WgRenderShapePool::allocate(WgContext& context)
 {
-    WgRenderDataShape* renderData{};
+    WgRenderShape* rdata{};
     if (mPool.count > 0) {
-        renderData = mPool.pick();
+        rdata = mPool.pick();
     } else {
-        renderData = new WgRenderDataShape();
-        mList.push(renderData);
+        rdata = new WgRenderShape();
+        mList.push(rdata);
     }
-    return renderData;
+    return rdata;
 }
 
-
-void WgRenderDataShapePool::free(WgContext& context, WgRenderDataShape* renderData)
+void WgRenderShapePool::free(WgContext& context, WgRenderShape* rdata)
 {
-    renderData->releaseMeshes();
-    renderData->clips.clear();
-    mPool.push(renderData);
+    rdata->releaseMeshes();
+    rdata->clips.clear();
+    mPool.push(rdata);
 }
 
-
-void WgRenderDataShapePool::release(WgContext& context)
+void WgRenderShapePool::release(WgContext& context)
 {
     ARRAY_FOREACH(p, mList) {
         (*p)->release(context);
@@ -276,15 +270,15 @@ void WgRenderDataShapePool::release(WgContext& context)
 }
 
 //***********************************************************************
-// WgRenderDataPicture
+// WgRenderPicture
 //***********************************************************************
 
-void WgRenderDataPicture::updateSurface(const RenderSurface* surface, const Matrix& transform)
+void WgRenderPicture::update(const RenderSurface* surface, const Matrix& transform)
 {
     meshData.imageBox(surface->w, surface->h, transform);
 }
 
-void WgRenderDataPicture::setImage(WGPUTexture texture, WGPUBindGroup bindGroup, const RenderSurface* surface, FilterMethod filter, uint16_t stamp)
+void WgRenderPicture::setImage(WGPUTexture texture, WGPUBindGroup bindGroup, const RenderSurface* surface, FilterMethod filter, uint16_t stamp)
 {
     imageTexture = texture;
     imageBindGroup = bindGroup;
@@ -293,13 +287,13 @@ void WgRenderDataPicture::setImage(WGPUTexture texture, WGPUBindGroup bindGroup,
     imageStamp = texture ? stamp : 0;
 }
 
-void WgRenderDataPicture::releaseTexture(WgTextureMgr& textures, WgContext& context)
+void WgRenderPicture::releaseTexture(WgTextureMgr& textures, WgContext& context)
 {
     if (imageTexture && imageStamp == textures.stamp) textures.release(context, imageSource, imageFilter, imageTexture);
     clearImage();
 }
 
-void WgRenderDataPicture::clearImage()
+void WgRenderPicture::clearImage()
 {
     imageTexture = nullptr;
     imageBindGroup = nullptr;
@@ -308,38 +302,36 @@ void WgRenderDataPicture::clearImage()
     imageStamp = 0;
 }
 
-void WgRenderDataPicture::release(WgContext& context)
+void WgRenderPicture::release(WgContext& context)
 {
     renderSettings.release(context);
     clearImage();
-    WgRenderDataPaint::release(context);
+    WgRenderPaint::release(context);
 }
 
 //***********************************************************************
-// WgRenderDataPicturePool
+// WgRenderPicturePool
 //***********************************************************************
 
-WgRenderDataPicture* WgRenderDataPicturePool::allocate(WgContext& context)
+WgRenderPicture* WgRenderPicturePool::allocate(WgContext& context)
 {
-    WgRenderDataPicture* renderData{};
+    WgRenderPicture* rdata{};
     if (mPool.count > 0) {
-        renderData = mPool.pick();
+        rdata = mPool.pick();
     } else {
-        renderData = new WgRenderDataPicture();
-        mList.push(renderData);
+        rdata = new WgRenderPicture();
+        mList.push(rdata);
     }
-    return renderData;
+    return rdata;
 }
 
-
-void WgRenderDataPicturePool::free(WgContext& context, WgRenderDataPicture* renderData)
+void WgRenderPicturePool::free(WgContext& context, WgRenderPicture* rdata)
 {
-    renderData->clips.clear();
-    mPool.push(renderData);
+    rdata->clips.clear();
+    mPool.push(rdata);
 }
 
-
-void WgRenderDataPicturePool::release(WgContext& context)
+void WgRenderPicturePool::release(WgContext& context)
 {
     ARRAY_FOREACH(p, mList) {
         (*p)->release(context);
@@ -350,10 +342,10 @@ void WgRenderDataPicturePool::release(WgContext& context)
 }
 
 //***********************************************************************
-// WgRenderDataEffectParams
+// WgRenderEffectParams
 //***********************************************************************
 
-void WgRenderDataEffectParams::update(WgContext& context, WgShaderTypeEffectParams& effectParams)
+void WgRenderEffectParams::update(WgContext& context, WgShaderTypeEffectParams& effectParams)
 {
     if (context.allocateBufferUniform(bufferParams, &effectParams.params, sizeof(effectParams.params))) {
         context.layouts.releaseBindGroup(bindGroupParams);
@@ -361,8 +353,7 @@ void WgRenderDataEffectParams::update(WgContext& context, WgShaderTypeEffectPara
     }
 }
 
-
-void WgRenderDataEffectParams::update(WgContext& context, RenderEffectGaussianBlur* gaussian, const Matrix& transform)
+void WgRenderEffectParams::update(WgContext& context, RenderEffectGaussianBlur* gaussian, const Matrix& transform)
 {
     assert(gaussian);
     WgShaderTypeEffectParams effectParams;
@@ -371,8 +362,7 @@ void WgRenderDataEffectParams::update(WgContext& context, RenderEffectGaussianBl
     extend = effectParams.extend;
 }
 
-
-void WgRenderDataEffectParams::update(WgContext& context, RenderEffectDropShadow* dropShadow, const Matrix& transform)
+void WgRenderEffectParams::update(WgContext& context, RenderEffectDropShadow* dropShadow, const Matrix& transform)
 {
     assert(dropShadow);
     WgShaderTypeEffectParams effectParams;
@@ -382,8 +372,7 @@ void WgRenderDataEffectParams::update(WgContext& context, RenderEffectDropShadow
     offset = effectParams.offset;
 }
 
-
-void WgRenderDataEffectParams::update(WgContext& context, RenderEffectFill* fill)
+void WgRenderEffectParams::update(WgContext& context, RenderEffectFill* fill)
 {
     assert(fill);
     WgShaderTypeEffectParams effectParams;
@@ -391,8 +380,7 @@ void WgRenderDataEffectParams::update(WgContext& context, RenderEffectFill* fill
     update(context, effectParams);
 }
 
-
-void WgRenderDataEffectParams::update(WgContext& context, RenderEffectTint* tint)
+void WgRenderEffectParams::update(WgContext& context, RenderEffectTint* tint)
 {
     assert(tint);
     WgShaderTypeEffectParams effectParams;
@@ -400,8 +388,7 @@ void WgRenderDataEffectParams::update(WgContext& context, RenderEffectTint* tint
     update(context, effectParams);
 }
 
-
-void WgRenderDataEffectParams::update(WgContext& context, RenderEffectTritone* tritone)
+void WgRenderEffectParams::update(WgContext& context, RenderEffectTritone* tritone)
 {
     assert(tritone);
     WgShaderTypeEffectParams effectParams;
@@ -409,8 +396,7 @@ void WgRenderDataEffectParams::update(WgContext& context, RenderEffectTritone* t
     update(context, effectParams);
 }
 
-
-void WgRenderDataEffectParams::release(WgContext& context)
+void WgRenderEffectParams::release(WgContext& context)
 {
     context.releaseBuffer(bufferParams);
     context.layouts.releaseBindGroup(bindGroupParams);
@@ -420,26 +406,24 @@ void WgRenderDataEffectParams::release(WgContext& context)
 // WgRenderDataColorsPool
 //***********************************************************************
 
-WgRenderDataEffectParams* WgRenderDataEffectParamsPool::allocate(WgContext& context)
+WgRenderEffectParams* WgRenderEffectParamsPool::allocate(WgContext& context)
 {
-    WgRenderDataEffectParams* renderData{};
+    WgRenderEffectParams* rdata{};
     if (mPool.count > 0) {
-        renderData = mPool.pick();
+        rdata = mPool.pick();
     } else {
-        renderData = new WgRenderDataEffectParams();
-        mList.push(renderData);
+        rdata = new WgRenderEffectParams();
+        mList.push(rdata);
     }
-    return renderData;
+    return rdata;
 }
 
-
-void WgRenderDataEffectParamsPool::free(WgContext& context, WgRenderDataEffectParams* renderData)
+void WgRenderEffectParamsPool::free(WgContext& context, WgRenderEffectParams* rdata)
 {
-    if (renderData) mPool.push(renderData);
+    if (rdata) mPool.push(rdata);
 }
 
-
-void WgRenderDataEffectParamsPool::release(WgContext& context)
+void WgRenderEffectParamsPool::release(WgContext& context)
 {
     ARRAY_FOREACH(p, mList) {
         (*p)->release(context);
@@ -452,6 +436,22 @@ void WgRenderDataEffectParamsPool::release(WgContext& context)
 //***********************************************************************
 // WgStageBufferGeometry
 //***********************************************************************
+
+void WgStageBufferUniformBase::flush(WgContext& context, WGPUBuffer& buffer, const void* data, uint64_t reserved, uint32_t count, uint64_t stride)
+{
+    // Upload reserved storage to avoid reallocating the GPU buffer as data grows.
+    if (context.allocateBufferUniform(buffer, data, reserved)) releaseBindGroups(context);
+
+    for (uint32_t i = bbuffer.count; i < count; ++i)
+        bbuffer.push(context.layouts.createBindGroupBuffer1Un(buffer, i * stride, stride));
+}
+
+void WgStageBufferUniformBase::releaseBindGroups(WgContext& context)
+{
+    ARRAY_FOREACH(p, bbuffer)
+       context.layouts.releaseBindGroup(*p);
+    bbuffer.clear();
+}
 
 void WgStageBufferGeometry::append(WgMeshData* meshData)
 {
@@ -485,43 +485,41 @@ void WgStageBufferGeometry::append(WgMeshData* meshData)
     }
 }
 
-
-void WgStageBufferGeometry::append(WgRenderDataShape* renderDataShape)
+void WgStageBufferGeometry::append(WgRenderShape* renderShape)
 {
-    append(&renderDataShape->meshShape);
-    append(&renderDataShape->meshShapeBBox);
-    append(&renderDataShape->meshStrokes);
-    append(&renderDataShape->meshStrokesBBox);
-    append(&renderDataShape->meshBBox);
+    append(&renderShape->shape.mesh);
+    append(&renderShape->shape.bbox);
+    append(&renderShape->stroke.mesh);
+    append(&renderShape->stroke.bbox);
+    append(&renderShape->meshBBox);
 }
 
-
-void WgStageBufferGeometry::append(WgRenderDataPicture* renderDataPicture)
+void WgStageBufferGeometry::append(WgRenderPicture* renderPicture)
 {
-    append(&renderDataPicture->meshData);
+    append(&renderPicture->meshData);
 }
 
-void WgStageBufferGeometry::appendSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range)
+void WgStageBufferGeometry::appendSolidBatch(const Array<WgRenderShape*>& renderShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range)
 {
-    appendBatch(renderDataShapes, range, &WgRenderDataShape::meshShape);
+    appendBatch(renderShapes, range, false);
     if (colors.vbuffer.reserved < colors.vbuffer.count + range.vertexCount)
         colors.vbuffer.grow(std::max(range.vertexCount, colors.vbuffer.reserved));
     range.colorOffset = colors.vbuffer.count * sizeof(RenderColor);
 
-    ARRAY_FOREACH(shape, renderDataShapes) {
-        const auto& mesh = (*shape)->meshShape;
-        colors.appendRepeated((*shape)->solidShape.packedColor(), mesh.vbuffer.count);
+    ARRAY_FOREACH(shape, renderShapes) {
+        const auto& mesh = (*shape)->shape.mesh;
+        colors.appendRepeated((*shape)->shape.solid.packedColor(), mesh.vbuffer.count);
     }
 }
 
-void WgStageBufferGeometry::appendBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgGeometryRange& range, WgMeshData WgRenderDataShape::*meshMember)
+void WgStageBufferGeometry::appendBatch(const Array<WgRenderShape*>& renderShapes, WgGeometryRange& range, bool cover)
 {
-    assert(renderDataShapes.count > 1);
+    assert(renderShapes.count > 1);
 
     uint32_t vertexCount = 0;
     uint32_t indexCount = 0;
-    ARRAY_FOREACH(p, renderDataShapes) {
-        const auto& mesh = (*p)->*meshMember;
+    ARRAY_FOREACH(p, renderShapes) {
+        const auto& mesh = cover ? (*p)->meshBBox : (*p)->shape.mesh;
         vertexCount += mesh.vbuffer.count;
         indexCount += mesh.ibuffer.count;
     }
@@ -542,8 +540,8 @@ void WgStageBufferGeometry::appendBatch(const Array<WgRenderDataShape*>& renderD
     uint32_t baseVertex = 0;
     auto vertexDst = vbuffer.data + vbuffer.count;
     auto indexDst = ibuffer.data + ibuffer.count;
-    ARRAY_FOREACH(p, renderDataShapes) {
-        const auto& mesh = (*p)->*meshMember;
+    ARRAY_FOREACH(p, renderShapes) {
+        const auto& mesh = cover ? (*p)->meshBBox : (*p)->shape.mesh;
         const uint32_t meshVertexBytes = mesh.vbuffer.count * sizeof(Point);
         memcpy(vertexDst, mesh.vbuffer.data, meshVertexBytes);
         vertexDst += meshVertexBytes;
@@ -560,10 +558,10 @@ void WgStageBufferGeometry::appendBatch(const Array<WgRenderDataShape*>& renderD
     ibuffer.count += indexBytes;
 }
 
-void WgStageBufferGeometry::appendStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range)
+void WgStageBufferGeometry::appendStencilBatch(const Array<WgRenderShape*>& renderShapes, WgStencilBatchRange& range)
 {
-    appendBatch(renderDataShapes, range.stencil, &WgRenderDataShape::meshShape);
-    appendBatch(renderDataShapes, range.cover, &WgRenderDataShape::meshBBox);
+    appendBatch(renderShapes, range.stencil, false);
+    appendBatch(renderShapes, range.cover, true);
 }
 
 void WgStageBufferGeometry::release(WgContext& context)
@@ -670,21 +668,20 @@ bool WgIntersector::isPointInMesh(const Point& p, const WgMeshData& mesh)
     return (crossings % 2) == 1;
 }
 
-bool WgIntersector::intersectClips(const Point& pt, const Array<WgRenderDataPaint*>& clips)
+bool WgIntersector::intersectClips(const Point& pt, const Array<WgRenderPaint*>& clips)
 {
     for (uint32_t i = 0; i < clips.count; i++) {
-        auto clip = (WgRenderDataShape*)clips[i];
-        if (!isPointInMesh(pt, clip->meshShape)) return false;
+        auto clip = (WgRenderShape*)clips[i];
+        if (!isPointInMesh(pt, clip->shape.mesh)) return false;
     }
     return true;
 }
 
-
-bool WgIntersector::intersectShape(const RenderRegion region, const WgRenderDataShape* shape)
+bool WgIntersector::intersectShape(const RenderRegion region, const WgRenderShape* shape)
 {
-    if (!shape || ((shape->meshShape.ibuffer.count == 0) && (shape->meshStrokes.ibuffer.count == 0))) return false;
+    if (!shape || ((shape->shape.mesh.ibuffer.count == 0) && (shape->stroke.mesh.ibuffer.count == 0))) return false;
     Matrix inverseModel;
-    auto testStroke = !shape->renderSettingsStroke.skip && inverse(&shape->transform, &inverseModel);
+    auto testStroke = shape->stroke.setting.valid && inverse(&shape->transform, &inverseModel);
     auto sizeX = region.sw();
     auto sizeY = region.sh();
     for (int32_t y = 0; y <= sizeY; y++) {
@@ -692,16 +689,15 @@ bool WgIntersector::intersectShape(const RenderRegion region, const WgRenderData
             Point pt{(float)x + region.min.x, (float)y + region.min.y};
             if (y % 2 == 1) pt.y = (float) sizeY - y - sizeY % 2 + region.min.y;
             if (intersectClips(pt, shape->clips)) {
-                if (!shape->renderSettingsShape.skip && isPointInMesh(pt, shape->meshShape)) return true;
-                if (testStroke && isPointInTris(pt * inverseModel, shape->meshStrokes)) return true;
+                if (shape->shape.setting.valid && isPointInMesh(pt, shape->shape.mesh)) return true;
+                if (testStroke && isPointInTris(pt * inverseModel, shape->stroke.mesh)) return true;
             }
         }
     }
     return false;
 }
 
-
-bool WgIntersector::intersectImage(const RenderRegion region, const WgRenderDataPicture* image)
+bool WgIntersector::intersectImage(const RenderRegion region, const WgRenderPicture* image)
 {
     if (!image) return false;
     auto sizeX = region.sw();

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.h
@@ -28,6 +28,7 @@
 #include "tvgWgShaderTypes.h"
 
 struct WgTextureMgr;
+struct WgStageBufferSolidColor;
 
 struct WgImageData
 {
@@ -45,59 +46,70 @@ static_assert(sizeof(RenderColor) == 4, "Solid color vertex data must remain tig
 
 struct WgSolidData
 {
-    uint32_t colorInd{};
+    uint32_t colorIdx{};
     RenderColor color{};
     uint8_t opacity = 255;
 
-    RenderColor packedColor() const { return {color.r, color.g, color.b, MULTIPLY(color.a, opacity)}; }
+    RenderColor packedColor() const
+    {
+        return {color.r, color.g, color.b, MULTIPLY(color.a, opacity)};
+    }
 };
 
 struct WgRenderSettings
 {
-    uint32_t bindGroupInd{};
+    uint32_t bindGroupIdx{};
     WgShaderTypePaintSettings settings;
     WgImageData gradientData;
     WgRenderSettingsType fillType{};
     float opacityMultiplier = 1.0f;
-    bool skip{};
+    bool valid = false;
 
-    uint8_t updateOpacity(tvg::ColorSpace cs, uint8_t opacity);
+    uint8_t update(tvg::ColorSpace cs, uint8_t opacity);
     void update(WgContext& context, const Fill* fill, const Matrix* modelTransform, bool updateColorRamp);
     void release(WgContext& context);
 };
 
-struct WgRenderDataPaint
+struct WgRenderPaint
 {
     BBox aabb{{},{}};
     RenderRegion viewport{};
-    Array<WgRenderDataPaint*> clips;
+    Array<WgRenderPaint*> clips;
     Matrix transform;
 
-    virtual ~WgRenderDataPaint() {};
+    virtual ~WgRenderPaint(){};
     virtual void release(WgContext& context);
     virtual Type type() { return Type::Undefined; };
 
-    void updateClips(const Array<RenderData>& clips);
+    void update(const Array<RenderData>& clips);
 };
 
-struct WgRenderDataShape: public WgRenderDataPaint
+struct WgRenderShape : WgRenderPaint
 {
-    WgRenderSettings renderSettingsShape{};
-    WgSolidData solidShape{};
-    WgRenderSettings renderSettingsStroke{};
-    WgSolidData solidStroke{};
-    WgMeshData meshBBox{};
-    WgMeshData meshShape{};
-    WgMeshData meshShapeBBox{};
-    WgMeshData meshStrokes{};
-    WgMeshData meshStrokesBBox{};
-    bool strokeFirst{};
-    FillRule fillRule{};
-    bool convex{};
-    BBox bbox;
-    uint32_t strokeViewMatInd{};
+    struct
+    {
+        WgRenderSettings setting;
+        WgSolidData solid;
+        WgMeshData mesh;
+        WgMeshData bbox;
+    } shape;
 
-    void updateBBox(BBox bb);
+    struct
+    {
+        WgRenderSettings setting;
+        WgSolidData solid;
+        WgMeshData mesh;
+        WgMeshData bbox;
+    } stroke;
+
+    WgMeshData meshBBox;
+    FillRule fillRule;
+    BBox bbox;
+    uint32_t strokeViewMatIdx;
+    bool convex;
+    bool strokeFirst;
+
+    void updateBBox(const BBox& bb);
     void updateAABB() { aabb = bbox; }
     void updateVisibility(const RenderShape& rshape, uint8_t opacity);
     void updateMeshes(const RenderShape& rshape, RenderUpdateFlag flag, const Matrix& matrix);
@@ -106,18 +118,20 @@ struct WgRenderDataShape: public WgRenderDataPaint
     Type type() override { return Type::Shape; };
 };
 
-class WgRenderDataShapePool {
-private:
-    Array<WgRenderDataShape*> mPool;
-    Array<WgRenderDataShape*> mList;
-public:
-    WgRenderDataShape* allocate(WgContext& context);
-    void free(WgContext& context, WgRenderDataShape* renderData);
+struct WgRenderShapePool
+{
+    Array<WgRenderShape*> mPool;
+    Array<WgRenderShape*> mList;
+
+    WgRenderShape* allocate(WgContext& context);
+    void free(WgContext& context, WgRenderShape* rdata);
     void release(WgContext& context);
 };
 
-struct WgRenderDataPicture: public WgRenderDataPaint
+struct WgRenderPicture : WgRenderPaint
 {
+    using WgRenderPaint::update;
+
     WgRenderSettings renderSettings{};
     WGPUTexture imageTexture{};
     WGPUBindGroup imageBindGroup{};
@@ -126,7 +140,7 @@ struct WgRenderDataPicture: public WgRenderDataPaint
     uint16_t imageStamp = 0;
     WgMeshData meshData{};
 
-    void updateSurface(const RenderSurface* surface, const Matrix& transform);
+    void update(const RenderSurface* surface, const Matrix& transform);
     void setImage(WGPUTexture texture, WGPUBindGroup bindGroup, const RenderSurface* surface, FilterMethod filter, uint16_t stamp);
     void releaseTexture(WgTextureMgr& textures, WgContext& context);
     void clearImage();
@@ -134,13 +148,13 @@ struct WgRenderDataPicture: public WgRenderDataPaint
     Type type() override { return Type::Picture; };
 };
 
-class WgRenderDataPicturePool {
-private:
-    Array<WgRenderDataPicture*> mPool;
-    Array<WgRenderDataPicture*> mList;
-public:
-    WgRenderDataPicture* allocate(WgContext& context);
-    void free(WgContext& context, WgRenderDataPicture* dataPicture);
+struct WgRenderPicturePool
+{
+    Array<WgRenderPicture*> mPool;
+    Array<WgRenderPicture*> mList;
+
+    WgRenderPicture* allocate(WgContext& context);
+    void free(WgContext& context, WgRenderPicture* dataPicture);
     void release(WgContext& context);
 };
 
@@ -164,13 +178,13 @@ struct WgStencilBatchRange
     WgGeometryRange cover{};
     size_t colorOffset{};
     RenderRegion viewport{};
-    FillRule fillRule{};
+    FillRule fillRule = FillRule::NonZero;
     bool solidOnly{};
 };
 
 // gaussian blur, drop shadow, fill, tint, tritone
 #define WG_GAUSSIAN_MAX_LEVEL 3
-struct WgRenderDataEffectParams
+struct WgRenderEffectParams
 {
     WGPUBindGroup bindGroupParams{};
     WGPUBuffer bufferParams{};
@@ -186,37 +200,33 @@ struct WgRenderDataEffectParams
     void release(WgContext& context);
 };
 
-// effect params pool
-class WgRenderDataEffectParamsPool {
-private:
+struct WgRenderEffectParamsPool
+{
     // pool contains all created but unused render data for params
-    Array<WgRenderDataEffectParams*> mPool;
+    Array<WgRenderEffectParams*> mPool;
     // list contains all created render data for params
     // to ensure that all created instances will be released
-    Array<WgRenderDataEffectParams*> mList;
-public:
-    WgRenderDataEffectParams* allocate(WgContext& context);
-    void free(WgContext& context, WgRenderDataEffectParams* renderData);
+    Array<WgRenderEffectParams*> mList;
+
+    WgRenderEffectParams* allocate(WgContext& context);
+    void free(WgContext& context, WgRenderEffectParams* rdata);
     void release(WgContext& context);
 };
 
-struct WgStageBufferSolidColor;
-
-class WgStageBufferGeometry {
-private:
+struct WgStageBufferGeometry
+{
     Array<uint8_t> vbuffer;
     Array<uint8_t> ibuffer;
-    void appendBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgGeometryRange& range, WgMeshData WgRenderDataShape::*meshMember);
+    void appendBatch(const Array<WgRenderShape*>& renderShapes, WgGeometryRange& range, bool cover);
 
-public:
     WGPUBuffer vbuffer_gpu{};
     WGPUBuffer ibuffer_gpu{};
 
     void append(WgMeshData* meshData);
-    void append(WgRenderDataShape* renderDataShape);
-    void append(WgRenderDataPicture* renderDataPicture);
-    void appendSolidBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range);
-    void appendStencilBatch(const Array<WgRenderDataShape*>& renderDataShapes, WgStencilBatchRange& range);
+    void append(WgRenderShape* renderShape);
+    void append(WgRenderPicture* renderPicture);
+    void appendSolidBatch(const Array<WgRenderShape*>& renderShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range);
+    void appendStencilBatch(const Array<WgRenderShape*>& renderShapes, WgStencilBatchRange& range);
     void initialize(WgContext& context){};
     void release(WgContext& context);
     void clear();
@@ -233,67 +243,64 @@ struct WgStageBufferSolidColor
         vbuffer.push(value);
         return vbuffer.count - 1;
     }
+
     void appendRepeated(const RenderColor& value, uint32_t count);
     void release(WgContext& context);
     void clear();
     void flush(WgContext& context);
 };
 
+struct WgStageBufferUniformBase
+{
+    Array<WGPUBindGroup> bbuffer;
+
+    void flush(WgContext& context, WGPUBuffer& buffer, const void* data, uint64_t reserved, uint32_t count, uint64_t stride);
+    void releaseBindGroups(WgContext& context);
+};
+
 // typed uniform stage buffer with related bind groups handling
 template<typename T>
-class WgStageBufferUniform {
-private:
+struct WgStageBufferUniform : WgStageBufferUniformBase
+{
     Array<T> ubuffer;
     WGPUBuffer ubuffer_gpu{};
-    Array<WGPUBindGroup> bbuffer;
-public:
-    // append uniform data to cpu staged buffer and return related bind group index
-    uint32_t append(const T& value) {
+
+    uint32_t append(const T& value)
+    {
         ubuffer.push(value);
         return ubuffer.count - 1;
     }
 
-    void flush(WgContext& context) {
-        // flush data to gpu buffer from cpu memory including reserved data to prevent future gpu buffer reallocations
-        bool bufferChanged = context.allocateBufferUniform(ubuffer_gpu, (void*)ubuffer.data, ubuffer.reserved*sizeof(T));
-        // if gpu buffer handle was changed we must to remove all created binding groups
-        if (bufferChanged) releaseBindGroups(context);
-        // allocate bind groups for all new data items
-        for (uint32_t i = bbuffer.count; i < ubuffer.count; i++)
-            bbuffer.push(context.layouts.createBindGroupBuffer1Un(ubuffer_gpu, i*sizeof(T), sizeof(T)));
-        assert(bbuffer.count >= ubuffer.count);
+    void flush(WgContext& context)
+    {
+        WgStageBufferUniformBase::flush(context, ubuffer_gpu, ubuffer.data, ubuffer.reserved * sizeof(T), ubuffer.count, sizeof(T));
     }
 
-    // please, use index that was returned from append method
-    WGPUBindGroup operator[](const uint32_t index) const {
+    WGPUBindGroup operator[](const uint32_t index) const
+    {
         return bbuffer[index];
     }
 
-    void clear() {
+    void clear()
+    {
         ubuffer.clear();
     }
 
-    void release(WgContext& context) {
+    void release(WgContext& context)
+    {
         context.releaseBuffer(ubuffer_gpu);
         releaseBindGroups(context);
     }
-
-    void releaseBindGroups(WgContext& context) {
-        ARRAY_FOREACH(p, bbuffer)
-            context.layouts.releaseBindGroup(*p);
-        bbuffer.clear();
-    }
 };
-
 
 struct WgIntersector
 {
     bool isPointInTriangle(const Point& p, const Point& a, const Point& b, const Point& c);
     bool isPointInTris(const Point& p, const WgMeshData& mesh);
     bool isPointInMesh(const Point& p, const WgMeshData& mesh);
-    bool intersectClips(const Point& pt, const Array<WgRenderDataPaint*>& clips);
-    bool intersectShape(const RenderRegion region, const WgRenderDataShape* shape);
-    bool intersectImage(const RenderRegion region, const WgRenderDataPicture* image);
+    bool intersectClips(const Point& pt, const Array<WgRenderPaint*>& clips);
+    bool intersectShape(const RenderRegion region, const WgRenderShape* shape);
+    bool intersectImage(const RenderRegion region, const WgRenderPicture* image);
 };
 
 #endif // _TVG_WG_RENDER_DATA_H_

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
@@ -23,7 +23,11 @@
 #include "tvgWgRenderTask.h"
 #include <iostream>
 
-WgBatchTask::WgBatchTask(WgRenderDataShape* first, WgRenderDataShape* second, bool stencilBatch) :
+//***********************************************************************
+// WgBatchTask
+//***********************************************************************
+
+WgBatchTask::WgBatchTask(WgRenderShape* first, WgRenderShape* second, bool stencilBatch) :
     shapes{2}, stencilBatch(stencilBatch)
 {
     shapes.push(first);
@@ -48,17 +52,14 @@ void WgBatchTask::run(WgContext&, WgCompositor& compositor, WGPUCommandEncoder)
 
 void WgPaintTask::stage(WgCompositor& compositor)
 {
-    if (renderData->type() == tvg::Type::Shape) compositor.requestShape((WgRenderDataShape*)renderData);
-    else if (renderData->type() == tvg::Type::Picture) compositor.requestImage((WgRenderDataPicture*)renderData);
+    if (renderPaint->type() == tvg::Type::Shape) compositor.requestShape((WgRenderShape*)renderPaint);
+    if (renderPaint->type() == tvg::Type::Picture) compositor.requestImage((WgRenderPicture*)renderPaint);
 }
 
 void WgPaintTask::run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
 {
-    if (renderData->type() == tvg::Type::Shape)
-        compositor.renderShape(context, (WgRenderDataShape*)renderData, blendMethod);
-    if (renderData->type() == tvg::Type::Picture)
-        compositor.renderImage(context, (WgRenderDataPicture*)renderData, blendMethod);
-    else assert(true);
+    if (renderPaint->type() == tvg::Type::Shape) compositor.renderShape(context, (WgRenderShape*)renderPaint, blendMethod);
+    if (renderPaint->type() == tvg::Type::Picture) compositor.renderImage(context, (WgRenderPicture*)renderPaint, blendMethod);
 }
 
 //***********************************************************************
@@ -111,7 +112,6 @@ void WgSceneTask::runChildren(WgContext& context, WgCompositor& compositor, WGPU
 
 void WgSceneTask::runEffect(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder)
 {
-    assert(effect);
     switch (effect->type) {
         case SceneEffect::GaussianBlur: compositor.gaussianBlur(context, renderTarget, (RenderEffectGaussianBlur*)effect, compose); break;
         case SceneEffect::DropShadow: compositor.dropShadow(context, renderTarget, (RenderEffectDropShadow*)effect, compose); break;

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
@@ -37,11 +37,11 @@ struct WgRenderTask
 struct WgPaintTask : WgRenderTask
 {
     // shape render properties
-    WgRenderDataPaint* renderData{};
+    WgRenderPaint* renderPaint{};
     BlendMethod blendMethod{};
 
-    WgPaintTask(WgRenderDataPaint* renderData, BlendMethod blendMethod) : 
-        renderData(renderData), blendMethod(blendMethod) {}
+    WgPaintTask(WgRenderPaint* renderPaint, BlendMethod blendMethod) :
+        renderPaint(renderPaint), blendMethod(blendMethod) {}
     // stage all resources used by this paint
     void stage(WgCompositor& compositor) override;
     // apply shape execution, including custom blending and clipping
@@ -50,12 +50,12 @@ struct WgPaintTask : WgRenderTask
 
 struct WgBatchTask : WgRenderTask
 {
-    Array<WgRenderDataShape*> shapes;
+    Array<WgRenderShape*> shapes;
     WgSolidBatchRange solidRange;
     WgStencilBatchRange stencilRange;
     bool stencilBatch{};
 
-    WgBatchTask(WgRenderDataShape* first, WgRenderDataShape* second, bool stencilBatch);
+    WgBatchTask(WgRenderShape* first, WgRenderShape* second, bool stencilBatch);
     void stage(WgCompositor& compositor) override;
     void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
 };

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -62,11 +62,11 @@ void WgRenderer::release()
 void WgRenderer::disposeObjects()
 {
     ARRAY_FOREACH(p, mDisposeRenderDatas) {
-        auto renderData = (WgRenderDataPaint*)(*p);
-        if (renderData->type() == Type::Shape) {
-            mRenderDataShapePool.free(mContext, (WgRenderDataShape*)renderData);
+        auto rdata = (WgRenderPaint*)(*p);
+        if (rdata->type() == Type::Shape) {
+            mRenderDataShapePool.free(mContext, (WgRenderShape*)rdata);
         } else {
-            auto rdp = (WgRenderDataPicture*)renderData;
+            auto rdp = (WgRenderPicture*)rdata;
             rdp->releaseTexture(mTextures, mContext);
             mRenderDataPicturePool.free(mContext, rdp);
         }
@@ -145,64 +145,66 @@ void WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint3
 
 RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const Matrix& transform, const Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags, bool clipper)
 {
-    auto rds = data ? (WgRenderDataShape*)data : mRenderDataShapePool.allocate(mContext);
+    auto rds = data ? (WgRenderShape*)data : mRenderDataShapePool.allocate(mContext);
+    if (!data) flags = RenderUpdateFlag::All;
 
     // update geometry
-    if (!data || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path | RenderUpdateFlag::Stroke))) {
+    if (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path | RenderUpdateFlag::Stroke)) {
         rds->updateMeshes(rshape, flags, transform);
     }
 
     // update transform
-    if ((!data) || (flags & RenderUpdateFlag::Transform)) {
+    if (flags & RenderUpdateFlag::Transform) {
         rds->transform = transform;
         rds->updateAABB();
     }
 
     // update paint settings
-    rds->solidShape.opacity = rds->renderSettingsShape.updateOpacity(mTargetSurface.cs, opacity);
-    rds->solidStroke.opacity = rds->renderSettingsStroke.updateOpacity(mTargetSurface.cs, opacity);
+    rds->shape.solid.opacity = rds->shape.setting.update(mTargetSurface.cs, opacity);
+    rds->stroke.solid.opacity = rds->stroke.setting.update(mTargetSurface.cs, opacity);
     rds->fillRule = rshape.rule;
 
     // setup fill settings
     rds->viewport = vport;
     rds->updateVisibility(rshape, opacity);
     // update shape render settings
-    if (!rds->renderSettingsShape.skip) {
-        if (rshape.fill && (!data || (flags & (RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform)))) {
-            bool updateColorRamp = !data || ((flags & RenderUpdateFlag::Gradient) != RenderUpdateFlag::None);
-            rds->renderSettingsShape.update(mContext, rshape.fill, &transform, updateColorRamp);
-        } else if (!data || (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient))) {
-            rds->solidShape.color = rshape.color;
-            rds->renderSettingsShape.fillType = WgRenderSettingsType::Solid;
+    if (rds->shape.setting.valid) {
+        if (rshape.fill && (flags & (RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform))) {
+            auto updateColorRamp = ((flags & RenderUpdateFlag::Gradient) != RenderUpdateFlag::None);
+            rds->shape.setting.update(mContext, rshape.fill, &transform, updateColorRamp);
+        } else if (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient)) {
+            rds->shape.solid.color = rshape.color;
+            rds->shape.setting.fillType = WgRenderSettingsType::Solid;
         }
     }
     // update strokes render settings
-    if (rshape.stroke && !rds->renderSettingsStroke.skip) {
-        if (rshape.stroke->fill && (!data || (flags & (RenderUpdateFlag::GradientStroke | RenderUpdateFlag::Transform)))) {
-            bool updateColorRamp = !data || ((flags & RenderUpdateFlag::GradientStroke) != RenderUpdateFlag::None);
-            rds->renderSettingsStroke.update(mContext, rshape.stroke->fill, nullptr, updateColorRamp);
-        } else if (!data || (flags & (RenderUpdateFlag::Stroke | RenderUpdateFlag::GradientStroke))) {
-            rds->solidStroke.color = rshape.stroke->color;
-            rds->renderSettingsStroke.fillType = WgRenderSettingsType::Solid;
+    if (rds->stroke.setting.valid) {
+        if (rshape.stroke->fill && flags & (RenderUpdateFlag::GradientStroke | RenderUpdateFlag::Transform)) {
+            auto updateColorRamp = ((flags & RenderUpdateFlag::GradientStroke) != RenderUpdateFlag::None);
+            rds->stroke.setting.update(mContext, rshape.stroke->fill, nullptr, updateColorRamp);
+        } else if (flags & (RenderUpdateFlag::Stroke | RenderUpdateFlag::GradientStroke)) {
+            rds->stroke.solid.color = rshape.stroke->color;
+            rds->stroke.setting.fillType = WgRenderSettingsType::Solid;
         }
     }
 
-    if (flags & RenderUpdateFlag::Clip) rds->updateClips(clips);
+    if (flags & RenderUpdateFlag::Clip) rds->update(clips);
 
     return rds;
 }
 
 RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Matrix& transform, const Array<RenderData>& clips, uint8_t opacity, FilterMethod filter, RenderUpdateFlag flags)
 {
-    auto rdp = data ? (WgRenderDataPicture*)data : mRenderDataPicturePool.allocate(mContext);
+    auto rdp = data ? (WgRenderPicture*)data : mRenderDataPicturePool.allocate(mContext);
+    if (!data) flags = RenderUpdateFlag::All;
 
     // update paint settings
     rdp->viewport = vport;
     rdp->transform = transform;
-    rdp->renderSettings.updateOpacity(surface->cs, opacity);
+    rdp->renderSettings.update(surface->cs, opacity);
 
-    auto updateSurface = !data || (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path | RenderUpdateFlag::Image));
-    if (updateSurface) rdp->updateSurface(surface, transform);
+    auto updateSurface = (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path | RenderUpdateFlag::Image));
+    if (updateSurface) rdp->update(surface, transform);
 
     // reload texture
     auto cacheStale = rdp->imageTexture && (rdp->imageStamp != mTextures.stamp);
@@ -214,7 +216,7 @@ RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
         rdp->setImage(entry->texture, entry->bindGroup, surface, filter, mTextures.stamp);
     }
 
-    if (flags & RenderUpdateFlag::Clip) rdp->updateClips(clips);
+    if (flags & RenderUpdateFlag::Clip) rdp->update(clips);
 
     return rdp;
 }
@@ -249,13 +251,13 @@ bool WgRenderer::preRender()
 
 bool WgRenderer::renderShape(RenderData data)
 {
-    auto renderData = (WgRenderDataShape*)data;
+    auto rdata = (WgRenderShape*)data;
     WgSceneTask* sceneTask = mSceneTaskStack.last();
 
-    if (mSolidBatch.draw(sceneTask, renderData, mBlendMethod, mRenderTaskList)) return true;
-    if (mStencilBatch.draw(sceneTask, renderData, mBlendMethod, mRenderTaskList)) return true;
+    if (mSolidBatch.draw(sceneTask, rdata, mBlendMethod, mRenderTaskList)) return true;
+    if (mStencilBatch.draw(sceneTask, rdata, mBlendMethod, mRenderTaskList)) return true;
 
-    WgPaintTask* paintTask = new WgPaintTask(renderData, mBlendMethod);
+    WgPaintTask* paintTask = new WgPaintTask(rdata, mBlendMethod);
     sceneTask->children.push(paintTask);
     mRenderTaskList.push(paintTask);
     return true;
@@ -264,7 +266,7 @@ bool WgRenderer::renderShape(RenderData data)
 
 bool WgRenderer::renderImage(RenderData data)
 {
-    WgPaintTask* paintTask = new WgPaintTask((WgRenderDataPaint*)data, mBlendMethod);
+    WgPaintTask* paintTask = new WgPaintTask((WgRenderPaint*)data, mBlendMethod);
     WgSceneTask* sceneTask = mSceneTaskStack.last();
     sceneTask->children.push(paintTask);
     mRenderTaskList.push(paintTask);
@@ -311,13 +313,13 @@ void WgRenderer::dispose(RenderData data) {
 bool WgRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
 {
     if (data) {
-        auto renderDataPaint = (WgRenderDataPaint*)data;
-        if (renderDataPaint->type() == Type::Shape) {
-            auto renderData = (WgRenderDataShape*)data;
-            if (!renderData->renderSettingsStroke.skip) {
+        auto rdataPaint = (WgRenderPaint*)data;
+        if (rdataPaint->type() == Type::Shape) {
+            auto rdata = (WgRenderShape*)data;
+            if (rdata->stroke.setting.valid) {
                 tvg::BBox bbox;
                 bbox.init();
-                auto& vertexes = renderData->meshStrokes.vbuffer;
+                auto& vertexes = rdata->stroke.mesh.vbuffer;
 
                 for (uint32_t i = 0; i < vertexes.count; i++) {
                     Point vert = vertexes[i] * m;
@@ -339,10 +341,10 @@ bool WgRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
 RenderRegion WgRenderer::region(RenderData data)
 {
     if (!data) return {};
-    auto renderData = (WgRenderDataPaint*)data;
-    if (renderData->type() == Type::Shape) {
-        auto& v1 = renderData->aabb.min;
-        auto& v2 = renderData->aabb.max;
+    auto rdata = (WgRenderPaint*)data;
+    if (rdata->type() == Type::Shape) {
+        auto& v1 = rdata->aabb.min;
+        auto& v2 = rdata->aabb.max;
         return {{int32_t(nearbyint(v1.x)), int32_t(nearbyint(v1.y))}, {int32_t(nearbyint(v2.x)), int32_t(nearbyint(v2.y))}};
     }
     return {{0, 0}, {(int32_t)mTargetSurface.w, (int32_t)mTargetSurface.h}};
@@ -544,18 +546,18 @@ bool WgRenderer::endComposite(RenderCompositor* cmp)
 void WgRenderer::prepare(RenderEffect* effect, const Matrix& transform)
 {
     if (!effect->rd) effect->rd = mRenderDataEffectParamsPool.allocate(mContext);
-    auto renderData = (WgRenderDataEffectParams*)effect->rd;
+    auto effectParams = (WgRenderEffectParams*)effect->rd;
 
     if (effect->type == SceneEffect::GaussianBlur) {
-        renderData->update(mContext, (RenderEffectGaussianBlur*)effect, transform);
+        effectParams->update(mContext, (RenderEffectGaussianBlur*)effect, transform);
     } else if (effect->type == SceneEffect::DropShadow) {
-        renderData->update(mContext, (RenderEffectDropShadow*)effect, transform);
+        effectParams->update(mContext, (RenderEffectDropShadow*)effect, transform);
     } else if (effect->type == SceneEffect::Fill) {
-        renderData->update(mContext, (RenderEffectFill*)effect);
+        effectParams->update(mContext, (RenderEffectFill*)effect);
     } else if (effect->type == SceneEffect::Tint) {
-        renderData->update(mContext, (RenderEffectTint*)effect);
+        effectParams->update(mContext, (RenderEffectTint*)effect);
     } else if (effect->type == SceneEffect::Tritone) {
-        renderData->update(mContext, (RenderEffectTritone*)effect);
+        effectParams->update(mContext, (RenderEffectTritone*)effect);
     } else {
         TVGERR("WG_ENGINE", "Missing effect type? = %d", (int) effect->type);
         return;
@@ -567,23 +569,23 @@ bool WgRenderer::region(RenderEffect* effect)
 {
     if (effect->type == SceneEffect::GaussianBlur) {
         auto gaussian = (RenderEffectGaussianBlur*)effect;
-        auto renderData = (WgRenderDataEffectParams*)gaussian->rd;
+        auto effectParams = (WgRenderEffectParams*)gaussian->rd;
         if (gaussian->direction != 2) {
-            gaussian->extend.min.x = -renderData->extend;
-            gaussian->extend.max.x = +renderData->extend;
+            gaussian->extend.min.x = -effectParams->extend;
+            gaussian->extend.max.x = +effectParams->extend;
         }
         if (gaussian->direction != 1) {
-            gaussian->extend.min.y = -renderData->extend;
-            gaussian->extend.max.y = +renderData->extend;
+            gaussian->extend.min.y = -effectParams->extend;
+            gaussian->extend.max.y = +effectParams->extend;
         }
         return true;
     } else if (effect->type == SceneEffect::DropShadow) {
         auto dropShadow = (RenderEffectDropShadow*)effect;
-        auto renderData = (WgRenderDataEffectParams*)dropShadow->rd;
-        dropShadow->extend.min.x = -std::ceil(renderData->extend + std::abs(renderData->offset.x));
-        dropShadow->extend.min.y = -std::ceil(renderData->extend + std::abs(renderData->offset.y));
-        dropShadow->extend.max.x = +std::floor(renderData->extend + std::abs(renderData->offset.x));
-        dropShadow->extend.max.y = +std::floor(renderData->extend + std::abs(renderData->offset.y));
+        auto effectParams = (WgRenderEffectParams*)dropShadow->rd;
+        dropShadow->extend.min.x = -std::ceil(effectParams->extend + std::abs(effectParams->offset.x));
+        dropShadow->extend.min.y = -std::ceil(effectParams->extend + std::abs(effectParams->offset.y));
+        dropShadow->extend.max.x = +std::floor(effectParams->extend + std::abs(effectParams->offset.x));
+        dropShadow->extend.max.y = +std::floor(effectParams->extend + std::abs(effectParams->offset.y));
         return true;
     }
     return false;
@@ -600,8 +602,8 @@ bool WgRenderer::render(RenderCompositor* cmp, const RenderEffect* effect, TVG_U
 
 void WgRenderer::dispose(RenderEffect* effect)
 {
-    auto renderData = (WgRenderDataEffectParams*)effect->rd;
-    mRenderDataEffectParamsPool.free(mContext, renderData);
+    auto effectParams = (WgRenderEffectParams*)effect->rd;
+    mRenderDataEffectParamsPool.free(mContext, effectParams);
     effect->rd = nullptr;
 };
 
@@ -637,7 +639,7 @@ bool WgRenderer::partial(bool disable)
 bool WgRenderer::intersectsShape(RenderData data, TVG_UNUSED const RenderRegion& region)
 {
     if (!data) return false;
-    auto shape = (WgRenderDataShape*)data;
+    auto shape = (WgRenderShape*)data;
     RenderRegion bbox = {
         {(int32_t)shape->aabb.min.x, (int32_t)shape->aabb.min.y},
         {(int32_t)shape->aabb.max.x, (int32_t)shape->aabb.max.y}
@@ -654,7 +656,7 @@ bool WgRenderer::intersectsShape(RenderData data, TVG_UNUSED const RenderRegion&
 bool WgRenderer::intersectsImage(RenderData data, TVG_UNUSED const RenderRegion& region)
 {
     if (!data) return false;
-    auto picture = (WgRenderDataPicture*)data;
+    auto picture = (WgRenderPicture*)data;
     WgIntersector intersector;
     if (intersector.intersectImage(region, picture)) return true;
     return false;

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.h
@@ -91,9 +91,9 @@ private:
     WgRenderTargetPool mRenderTargetPool;
 
     // render data paint pools
-    WgRenderDataShapePool mRenderDataShapePool;
-    WgRenderDataPicturePool mRenderDataPicturePool;
-    WgRenderDataEffectParamsPool mRenderDataEffectParamsPool;
+    WgRenderShapePool mRenderDataShapePool;
+    WgRenderPicturePool mRenderDataPicturePool;
+    WgRenderEffectParamsPool mRenderDataEffectParamsPool;
     WgTextureMgr mTextures;
 
     // rendering context

--- a/src/renderer/gpu_engine/wg/tvgWgSolidBatch.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgSolidBatch.cpp
@@ -22,38 +22,38 @@
 
 #include "tvgWgSolidBatch.h"
 
-static inline bool eligible(const WgRenderDataShape* renderData, BlendMethod blendMethod)
+static inline bool eligible(const WgRenderShape* rdata, BlendMethod blendMethod)
 {
     if (blendMethod != BlendMethod::Normal) return false;
-    if (renderData->renderSettingsShape.skip || renderData->renderSettingsShape.fillType != WgRenderSettingsType::Solid) return false;
-    if (!renderData->convex || renderData->viewport.invalid() || !renderData->clips.empty()) return false;
-    if (renderData->meshShape.vbuffer.empty() || renderData->meshShape.ibuffer.empty()) return false;
-    if (!renderData->renderSettingsStroke.skip && !renderData->meshStrokes.ibuffer.empty()) return false;
+    if (!rdata->shape.setting.valid || rdata->shape.setting.fillType != WgRenderSettingsType::Solid) return false;
+    if (!rdata->convex || rdata->viewport.invalid() || !rdata->clips.empty()) return false;
+    if (rdata->shape.mesh.vbuffer.empty() || rdata->shape.mesh.ibuffer.empty()) return false;
+    if (rdata->stroke.setting.valid && !rdata->stroke.mesh.ibuffer.empty()) return false;
     return true;
 }
 
-static inline bool appendable(WgSceneTask* batchSceneTask, WgRenderTask* batchTask, const RenderRegion& batchViewport, WgSceneTask* sceneTask, const WgRenderDataShape* renderData, const Array<WgRenderTask*>& renderTaskList)
+static inline bool appendable(WgSceneTask* batchSceneTask, WgRenderTask* batchTask, const RenderRegion& batchViewport, WgSceneTask* sceneTask, const WgRenderShape* rdata, const Array<WgRenderTask*>& renderTaskList)
 {
     // Any task submitted after the candidate is an implicit batch boundary.
     if (batchSceneTask != sceneTask) return false;
     if (sceneTask->children.last() != batchTask) return false;
     if (renderTaskList.last() != batchTask) return false;
-    if (!(batchViewport == renderData->viewport)) return false;
+    if (!(batchViewport == rdata->viewport)) return false;
     return true;
 }
 
-static inline WgRenderTask* emitSingle(WgSceneTask* sceneTask, WgRenderDataShape* renderData, Array<WgRenderTask*>& renderTaskList)
+static inline WgRenderTask* emitSingle(WgSceneTask* sceneTask, WgRenderShape* rdata, Array<WgRenderTask*>& renderTaskList)
 {
-    auto task = new WgPaintTask(renderData, BlendMethod::Normal);
+    auto task = new WgPaintTask(rdata, BlendMethod::Normal);
     sceneTask->children.push(task);
     renderTaskList.push(task);
     return task;
 }
 
-static inline WgRenderTask* promote(WgSceneTask* sceneTask, WgRenderTask* task, WgRenderDataShape* first, WgRenderDataShape* renderData, Array<WgRenderTask*>& renderTaskList)
+static inline WgRenderTask* promote(WgSceneTask* sceneTask, WgRenderTask* task, WgRenderShape* first, WgRenderShape* rdata, Array<WgRenderTask*>& renderTaskList)
 {
     // Tasks are staged only after the tree is complete, so replacing its tail is safe.
-    auto batchTask = new WgBatchTask(first, renderData, false);
+    auto batchTask = new WgBatchTask(first, rdata, false);
     sceneTask->children.last() = batchTask;
     renderTaskList.last() = batchTask;
     delete task;
@@ -61,26 +61,26 @@ static inline WgRenderTask* promote(WgSceneTask* sceneTask, WgRenderTask* task, 
     return batchTask;
 }
 
-static inline void append(WgRenderTask* task, WgRenderDataShape* renderData)
+static inline void append(WgRenderTask* task, WgRenderShape* rdata)
 {
-    static_cast<WgBatchTask*>(task)->shapes.push(renderData);
+    static_cast<WgBatchTask*>(task)->shapes.push(rdata);
 }
 
-bool WgSolidBatch::draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)
+bool WgSolidBatch::draw(WgSceneTask* sceneTask, WgRenderShape* rdata, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)
 {
-    if (!eligible(renderData, blendMethod)) return false;
+    if (!eligible(rdata, blendMethod)) return false;
 
-    if (!appendable(this->sceneTask, task, viewport, sceneTask, renderData, renderTaskList)) {
-        task = emitSingle(sceneTask, renderData, renderTaskList);
+    if (!appendable(this->sceneTask, task, viewport, sceneTask, rdata, renderTaskList)) {
+        task = emitSingle(sceneTask, rdata, renderTaskList);
         this->sceneTask = sceneTask;
-        first = renderData;
-        viewport = renderData->viewport;
+        first = rdata;
+        viewport = rdata->viewport;
         return true;
     }
 
     if (first) {
-        task = promote(this->sceneTask, task, first, renderData, renderTaskList);
+        task = promote(this->sceneTask, task, first, rdata, renderTaskList);
         first = nullptr;
-    } else append(task, renderData);
+    } else append(task, rdata);
     return true;
 }

--- a/src/renderer/gpu_engine/wg/tvgWgSolidBatch.h
+++ b/src/renderer/gpu_engine/wg/tvgWgSolidBatch.h
@@ -27,11 +27,11 @@
 
 struct WgSolidBatch
 {
-    bool draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList);
+    bool draw(WgSceneTask* sceneTask, WgRenderShape* rdata, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList);
 
     WgSceneTask* sceneTask{};
     WgRenderTask* task{};
-    WgRenderDataShape* first{};
+    WgRenderShape* first{};
     RenderRegion viewport{};
 };
 

--- a/src/renderer/gpu_engine/wg/tvgWgStencilBatch.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgStencilBatch.cpp
@@ -23,25 +23,25 @@
 #include "tvgMath.h"
 #include "tvgWgStencilBatch.h"
 
-static bool eligible(const WgRenderDataShape* renderData, BlendMethod blendMethod, RenderRegion& bounds)
+static bool eligible(const WgRenderShape* rdata, BlendMethod blendMethod, RenderRegion& bounds)
 {
-    if (blendMethod != BlendMethod::Normal || renderData->renderSettingsShape.skip) return false;
+    if (blendMethod != BlendMethod::Normal || !rdata->shape.setting.valid) return false;
 
-    const auto fillType = renderData->renderSettingsShape.fillType;
+    const auto fillType = rdata->shape.setting.fillType;
     if (fillType != WgRenderSettingsType::Solid && fillType != WgRenderSettingsType::Linear && fillType != WgRenderSettingsType::Radial) return false;
 
-    if (renderData->convex || renderData->viewport.invalid() || !renderData->clips.empty()) return false;
-    if (renderData->meshShape.vbuffer.empty() || renderData->meshShape.ibuffer.empty() || renderData->meshBBox.vbuffer.empty() || renderData->meshBBox.ibuffer.empty()) return false;
-    if (!renderData->renderSettingsStroke.skip && !renderData->meshStrokes.ibuffer.empty()) return false;
+    if (rdata->convex || rdata->viewport.invalid() || !rdata->clips.empty()) return false;
+    if (rdata->shape.mesh.vbuffer.empty() || rdata->shape.mesh.ibuffer.empty() || rdata->meshBBox.vbuffer.empty() || rdata->meshBBox.ibuffer.empty()) return false;
+    if (rdata->stroke.setting.valid && !rdata->stroke.mesh.ibuffer.empty()) return false;
 
     // Clip finite geometry bounds to the viewport before rounding to the integer overlap region.
-    const auto& aabb = renderData->aabb;
+    const auto& aabb = rdata->aabb;
     if (!std::isfinite(aabb.min.x) || !std::isfinite(aabb.min.y) || !std::isfinite(aabb.max.x) || !std::isfinite(aabb.max.y)) return false;
 
-    const auto minX = tvg::clamp(static_cast<double>(aabb.min.x), static_cast<double>(renderData->viewport.min.x), static_cast<double>(renderData->viewport.max.x));
-    const auto minY = tvg::clamp(static_cast<double>(aabb.min.y), static_cast<double>(renderData->viewport.min.y), static_cast<double>(renderData->viewport.max.y));
-    const auto maxX = tvg::clamp(static_cast<double>(aabb.max.x), static_cast<double>(renderData->viewport.min.x), static_cast<double>(renderData->viewport.max.x));
-    const auto maxY = tvg::clamp(static_cast<double>(aabb.max.y), static_cast<double>(renderData->viewport.min.y), static_cast<double>(renderData->viewport.max.y));
+    const auto minX = tvg::clamp(static_cast<double>(aabb.min.x), static_cast<double>(rdata->viewport.min.x), static_cast<double>(rdata->viewport.max.x));
+    const auto minY = tvg::clamp(static_cast<double>(aabb.min.y), static_cast<double>(rdata->viewport.min.y), static_cast<double>(rdata->viewport.max.y));
+    const auto maxX = tvg::clamp(static_cast<double>(aabb.max.x), static_cast<double>(rdata->viewport.min.x), static_cast<double>(rdata->viewport.max.x));
+    const auto maxY = tvg::clamp(static_cast<double>(aabb.max.y), static_cast<double>(rdata->viewport.min.y), static_cast<double>(rdata->viewport.max.y));
     if (maxX <= minX || maxY <= minY) return false;
 
     bounds = {{static_cast<int32_t>(std::floor(minX)), static_cast<int32_t>(std::floor(minY))}, {static_cast<int32_t>(std::ceil(maxX)), static_cast<int32_t>(std::ceil(maxY))}};
@@ -74,36 +74,36 @@ static void addBounds(WgStencilBatch& batch, const RenderRegion& bounds)
     batch.bounds[p] = bounds;
 }
 
-static bool appendable(const WgStencilBatch& batch, WgSceneTask* sceneTask, WgRenderDataShape* renderData, const RenderRegion& bounds, const Array<WgRenderTask*>& renderTaskList)
+static bool appendable(const WgStencilBatch& batch, WgSceneTask* sceneTask, WgRenderShape* rdata, const RenderRegion& bounds, const Array<WgRenderTask*>& renderTaskList)
 {
     if (batch.sceneTask != sceneTask || sceneTask->children.last() != batch.task || renderTaskList.last() != batch.task) return false;
-    if (!(batch.viewport == renderData->viewport) || batch.fillRule != renderData->fillRule) return false;
+    if (!(batch.viewport == rdata->viewport) || batch.fillRule != rdata->fillRule) return false;
     return !intersects(batch, bounds);
 }
 
-static void emitSingle(WgStencilBatch& batch, WgSceneTask* sceneTask, WgRenderDataShape* renderData, const RenderRegion& bounds, Array<WgRenderTask*>& renderTaskList)
+static void emitSingle(WgStencilBatch& batch, WgSceneTask* sceneTask, WgRenderShape* rdata, const RenderRegion& bounds, Array<WgRenderTask*>& renderTaskList)
 {
-    auto task = new WgPaintTask(renderData, BlendMethod::Normal);
+    auto task = new WgPaintTask(rdata, BlendMethod::Normal);
     sceneTask->children.push(task);
     renderTaskList.push(task);
 
     batch.sceneTask = sceneTask;
     batch.task = task;
-    batch.first = renderData;
-    batch.viewport = renderData->viewport;
-    batch.fillRule = renderData->fillRule;
+    batch.first = rdata;
+    batch.viewport = rdata->viewport;
+    batch.fillRule = rdata->fillRule;
     batch.ySorted = batch.viewport.sh() > batch.viewport.sw();
     batch.bounds.clear();
 
     addBounds(batch, bounds);
 }
 
-static void promote(WgStencilBatch& batch, WgRenderDataShape* renderData, const RenderRegion& bounds, Array<WgRenderTask*>& renderTaskList)
+static void promote(WgStencilBatch& batch, WgRenderShape* rdata, const RenderRegion& bounds, Array<WgRenderTask*>& renderTaskList)
 {
     assert(batch.sceneTask && batch.first && batch.task);
     assert(batch.sceneTask->children.last() == batch.task && renderTaskList.last() == batch.task);
 
-    auto batchTask = new WgBatchTask(batch.first, renderData, true);
+    auto batchTask = new WgBatchTask(batch.first, rdata, true);
     batch.sceneTask->children.last() = batchTask;
     renderTaskList.last() = batchTask;
     delete (batch.task);
@@ -113,24 +113,24 @@ static void promote(WgStencilBatch& batch, WgRenderDataShape* renderData, const 
     addBounds(batch, bounds);
 }
 
-static void append(WgStencilBatch& batch, WgRenderDataShape* renderData, const RenderRegion& bounds)
+static void append(WgStencilBatch& batch, WgRenderShape* rdata, const RenderRegion& bounds)
 {
     assert(batch.sceneTask && !batch.first && batch.task);
-    static_cast<WgBatchTask*>(batch.task)->shapes.push(renderData);
+    static_cast<WgBatchTask*>(batch.task)->shapes.push(rdata);
     addBounds(batch, bounds);
 }
 
-bool WgStencilBatch::draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)
+bool WgStencilBatch::draw(WgSceneTask* sceneTask, WgRenderShape* rdata, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)
 {
     RenderRegion bounds;
-    if (!eligible(renderData, blendMethod, bounds)) return false;
+    if (!eligible(rdata, blendMethod, bounds)) return false;
 
-    if (!appendable(*this, sceneTask, renderData, bounds, renderTaskList)) {
-        emitSingle(*this, sceneTask, renderData, bounds, renderTaskList);
+    if (!appendable(*this, sceneTask, rdata, bounds, renderTaskList)) {
+        emitSingle(*this, sceneTask, rdata, bounds, renderTaskList);
         return true;
     }
 
-    if (first) promote(*this, renderData, bounds, renderTaskList);
-    else append(*this, renderData, bounds);
+    if (first) promote(*this, rdata, bounds, renderTaskList);
+    else append(*this, rdata, bounds);
     return true;
 }

--- a/src/renderer/gpu_engine/wg/tvgWgStencilBatch.h
+++ b/src/renderer/gpu_engine/wg/tvgWgStencilBatch.h
@@ -27,11 +27,11 @@
 
 struct WgStencilBatch
 {
-    bool draw(WgSceneTask* sceneTask, WgRenderDataShape* renderData, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList);
+    bool draw(WgSceneTask* sceneTask, WgRenderShape* rdata, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList);
 
     WgSceneTask* sceneTask{};
     WgRenderTask* task{};
-    WgRenderDataShape* first{};
+    WgRenderShape* first{};
     Array<RenderRegion> bounds;
     RenderRegion viewport{};
     FillRule fillRule{};


### PR DESCRIPTION
- Group fill and stroke settings, colors, and meshes.
- Use update flags as the single condition for render data updates.
- Express shape and stroke visibility with a positive validity flag.
- Simplify color-ramp updates and redundant allocation checks.
- Update rendering, batching, and hit testing for the new layout.
- Simplify WebGPU compositor checks and local declarations.

