### PR TITLE
renderer: make dirty region merging exact and restartable

### DIFF
--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -527,6 +527,7 @@ void rasterPixel32(uint32_t* dst, uint32_t* src, uint32_t len, uint8_t opacity);
 void rasterGrayscale8(uint8_t* dst, uint8_t val, uint32_t offset, int32_t len);
 void rasterXYFlip(uint32_t* src, uint32_t* dst, int32_t stride, int32_t w, int32_t h, const RenderRegion& bbox, bool flipped);
 void rasterUnpremultiply(RenderSurface* surface);
+void rasterUnpremultiply(RenderSurface* surface, const RenderRegion& region);
 void rasterPremultiply(RenderSurface* surface);
 bool rasterConvertCS(RenderSurface* surface, ColorSpace to);
 uint32_t rasterUnpremultiply(uint32_t data);

--- a/src/renderer/cpu_engine/tvgSwRaster.cpp
+++ b/src/renderer/cpu_engine/tvgSwRaster.cpp
@@ -1569,9 +1569,9 @@ bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_
 /* Convert a premultiplied row into the straight-alpha space.
    Fully transparent / fully opaque pixels are left untouched in the buffer,
    sparing the write-back traffic for the regions without semi-transparent content. */
-static inline void _rasterUnpremultiply32(uint32_t* buffer, int32_t len)
+static inline void _rasterUnpremultiply32(uint32_t* buffer, uint32_t len)
 {
-    for (int32_t x = 0; x < len; ++x) {
+    for (uint32_t x = 0; x < len; ++x) {
         auto c = buffer[x];
         auto a = A(c);
         if (a == 255 || a == 0) continue;
@@ -1617,7 +1617,7 @@ void rasterUnpremultiply(RenderSurface* surface, const RenderRegion& region)
     if (clipped.invalid()) return;
 
     for (int32_t y = clipped.min.y; y < clipped.max.y; ++y) {
-        _rasterUnpremultiply32(surface->buf32 + surface->stride * y + clipped.min.x, clipped.max.x - clipped.min.x);
+        _rasterUnpremultiply32(surface->buf32 + surface->stride * y + clipped.min.x, uint32_t(clipped.max.x - clipped.min.x));
     }
 }
 

--- a/src/renderer/cpu_engine/tvgSwRaster.cpp
+++ b/src/renderer/cpu_engine/tvgSwRaster.cpp
@@ -1566,6 +1566,21 @@ bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_
     return true;
 }
 
+/* Convert a premultiplied row into the straight-alpha space.
+   Fully transparent / fully opaque pixels are left untouched in the buffer,
+   sparing the write-back traffic for the regions without semi-transparent content. */
+static inline void _rasterUnpremultiply32(uint32_t* buffer, int32_t len)
+{
+    for (int32_t x = 0; x < len; ++x) {
+        auto c = buffer[x];
+        auto a = A(c);
+        if (a == 255 || a == 0) continue;
+        uint8_t r = std::min(C1(c) * 255u / a, 255u);
+        uint8_t g = std::min(C2(c) * 255u / a, 255u);
+        uint8_t b = std::min(C3(c) * 255u / a, 255u);
+        buffer[x] = JOIN(a, r, g, b);
+    }
+}
 
 uint32_t rasterUnpremultiply(uint32_t data)
 {
@@ -1587,15 +1602,24 @@ void rasterUnpremultiply(RenderSurface* surface)
     TVGLOG("SW_ENGINE", "Unpremultiply [Size: %d x %d]", surface->w, surface->h);
 
     //OPTIMIZE_ME: +SIMD
-    for (uint32_t y = 0; y < surface->h; y++) {
-        auto buffer = surface->buf32 + surface->stride * y;
-        for (uint32_t x = 0; x < surface->w; ++x) {
-            buffer[x] = rasterUnpremultiply(buffer[x]);
-        }
+    auto buffer = surface->buf32;
+    for (uint32_t y = 0; y < surface->h; ++y, buffer += surface->stride) {
+        _rasterUnpremultiply32(buffer, surface->w);
     }
     surface->premultiplied = false;
 }
 
+void rasterUnpremultiply(RenderSurface* surface, const RenderRegion& region)
+{
+    if (surface->channelSize != sizeof(uint32_t)) return;
+
+    auto clipped = RenderRegion::intersect(region, {{0, 0}, {(int32_t)surface->w, (int32_t)surface->h}});
+    if (clipped.invalid()) return;
+
+    for (int32_t y = clipped.min.y; y < clipped.max.y; ++y) {
+        _rasterUnpremultiply32(surface->buf32 + surface->stride * y + clipped.min.x, clipped.max.x - clipped.min.x);
+    }
+}
 
 void rasterPremultiply(RenderSurface* surface)
 {

--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -354,7 +354,22 @@ bool SwRenderer::postRender()
 {
     //Unmultiply alpha if needed
     if (surface->cs == ColorSpace::ABGR8888S || surface->cs == ColorSpace::ARGB8888S) {
-        rasterUnpremultiply(surface);
+        if (fulldraw || dirtyRegion.deactivated()) {
+            rasterUnpremultiply(surface);
+        } else {
+            /* In the partial rendering mode, only the regions rendered in this frame hold
+               premultiplied pixels. The rest of the buffer has been already converted
+               in the previous frames. Each pixel is converted exactly once: commit()
+               merges the dirty regions into a disjoint set. The regions drawn through the
+               intermediate composited surfaces are covered by the dirty regions as well. */
+            for (int idx = 0; idx < RenderDirtyRegion::PARTITIONING; ++idx) {
+                ARRAY_FOREACH(p, dirtyRegion.get(idx))
+                {
+                    rasterUnpremultiply(surface, *p);
+                }
+            }
+            surface->premultiplied = false;
+        }
     }
 
     dirtyRegion.clear();

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -328,17 +328,20 @@ void RenderDirtyRegion::clear()
     }
 }
 
-
 bool RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs)
 {
-    //verify the capacity upfront so that a failure leaves the regions unmodified
-    auto required = targets.count;
+    if (idx >= targets.count) return false;
+
+    // Verify the capacity upfront so that a failure leaves the regions unmodified.
+    // The region at idx is replaced with its fragments, so one required slot is
+    // already available.
+    auto required = uint64_t(targets.count);
     if (rhs.min.y < lhs.min.y) ++required;
     if (rhs.max.y > lhs.max.y) ++required;
     if (rhs.max.x > lhs.max.x) ++required;
 
-    //Please reserve memory enough with targets.reserve()
-    if (required - 1 >= targets.reserved) return false;
+    // Please reserve memory enough with targets.reserve()
+    if (required > uint64_t(targets.reserved) + 1) return false;
 
     RenderRegion temp[3];
     uint32_t cnt = 0;
@@ -375,15 +378,14 @@ bool RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, Re
     return true;
 }
 
-
 bool RenderDirtyRegion::sweepMerge(Array<RenderRegion>& targets, Array<RenderRegion>& output)
 {
-    //sorting by x coord. guarantee the stable performance: O(NlogN)
+    // sorting by x coord. guarantee the stable performance: O(NlogN)
     stable_sort(targets.begin(), targets.end(), [](const RenderRegion& a, const RenderRegion& b) -> bool {
         return a.min.x < b.min.x;
     });
 
-    //Optimized using sweep-line algorithm: O(NlogN)
+    // Optimized using sweep-line algorithm: O(NlogN)
     for (uint32_t i = 0; i < targets.count; ++i) {
         auto& lhs = targets[i];
         if (lhs.invalid()) continue;
@@ -392,28 +394,28 @@ bool RenderDirtyRegion::sweepMerge(Array<RenderRegion>& targets, Array<RenderReg
         for (uint32_t j = i + 1; j < targets.count; ++j) {
             auto& rhs = targets[j];
             if (rhs.invalid()) continue;
-            if (lhs.max.x < rhs.min.x) break;   //line sweeping
+            if (lhs.max.x < rhs.min.x) break;  // line sweeping
 
-            //fully overlapped. drop lhs
+            // fully overlapped. drop lhs
             if (rhs.contained(lhs)) {
                 merged = true;
                 break;
             }
-            //fully overlapped. replace the lhs with rhs
+            // fully overlapped. replace the lhs with rhs
             if (lhs.contained(rhs)) {
                 rhs = {};
                 continue;
             }
-            //just merge & expand on x axis
+            // just merge & expand on x axis
             if (lhs.min.y == rhs.min.y && lhs.max.y == rhs.max.y) {
                 if (lhs.max.x >= rhs.min.x) {
                     lhs.max.x = rhs.max.x;
                     rhs = {};
-                    j = i;   //lhs dirty region has been damaged, try again.
+                    j = i;  // lhs dirty region has been damaged, try again.
                     continue;
                 }
             }
-            //just merge & expand on y axis
+            // just merge & expand on y axis
             if (lhs.min.x == rhs.min.x && lhs.max.x == rhs.max.x) {
                 if (lhs.min.y <= rhs.max.y && rhs.min.y <= lhs.max.y) {
                     rhs.min.y = std::min(lhs.min.y, rhs.min.y);
@@ -422,18 +424,17 @@ bool RenderDirtyRegion::sweepMerge(Array<RenderRegion>& targets, Array<RenderReg
                     break;
                 }
             }
-            //subdivide regions
+            // subdivide regions
             if (lhs.intersected(rhs)) {
-                if (!subdivide(targets, j, lhs, rhs)) return false;  //insufficient capacity, retry required
-                --j; //rhs dirty region has been damaged, try again.
+                if (!subdivide(targets, j, lhs, rhs)) return false;  // insufficient capacity, retry required
+                --j;                                                 // rhs dirty region has been damaged, try again.
             }
         }
-        if (!merged) output.push(lhs);  //this region is complete isolated
+        if (!merged) output.push(lhs);  // this region is complete isolated
         lhs = {};
     }
     return true;
 }
-
 
 void RenderDirtyRegion::commit()
 {
@@ -444,13 +445,12 @@ void RenderDirtyRegion::commit()
         auto& targets = partitions[idx].list[current];
         if (targets.empty()) continue;
 
-        //merge the dirty regions into a disjoint set in the other list.
-        //the output list is cleared in advance, no stale regions can survive a re-commit.
+        // merge the dirty regions into a disjoint set in the other list.
+        // the output list is cleared in advance, no stale regions can survive a re-commit.
         merge(targets, partitions[idx].list[!current]);
         partitions[idx].current = !current;
     }
 }
-
 
 void RenderDirtyRegion::merge(const Array<RenderRegion>& input, Array<RenderRegion>& output)
 {
@@ -459,7 +459,7 @@ void RenderDirtyRegion::merge(const Array<RenderRegion>& input, Array<RenderRegi
         return;
     }
 
-    scratch.reserve(input.count * 10);  //one intersection can be divided up to 3
+    scratch.reserve(input.count * 10);  // one intersection can be divided up to 3
 
     while (true) {
         scratch.clear();
@@ -469,8 +469,8 @@ void RenderDirtyRegion::merge(const Array<RenderRegion>& input, Array<RenderRegi
 
         if (sweepMerge(scratch, output)) return;
 
-        //the region fragments exceeded the working list. enlarge it and restart.
-        TVGLOG("RENDERER", "regions(%d) overflown the reserved(%d) working list. retrying...", input.count, scratch.reserved);
+        // the region fragments exceeded the working list. enlarge it and restart.
+        TVGLOG("RENDERER", "regions(%d) overflowed the reserved(%d) working list. retrying...", input.count, scratch.reserved);
         scratch.reserve(scratch.reserved * 2);
     }
 }

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -329,8 +329,17 @@ void RenderDirtyRegion::clear()
 }
 
 
-void RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs)
+bool RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs)
 {
+    //verify the capacity upfront so that a failure leaves the regions unmodified
+    auto required = targets.count;
+    if (rhs.min.y < lhs.min.y) ++required;
+    if (rhs.max.y > lhs.max.y) ++required;
+    if (rhs.max.x > lhs.max.x) ++required;
+
+    //Please reserve memory enough with targets.reserve()
+    if (required - 1 >= targets.reserved) return false;
+
     RenderRegion temp[3];
     uint32_t cnt = 0;
 
@@ -349,12 +358,6 @@ void RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, Re
         temp[cnt++] = {{lhs.max.x, rhs.min.y}, {rhs.max.x, rhs.max.y}};
     }
 
-    //Please reserve memory enough with targets.reserve()
-    if (targets.count + cnt - 1 >= targets.reserved) {
-        TVGERR("RENDERER", "reserved(%d), required(%d)", targets.reserved, targets.count + cnt - 1);
-        return;
-    }
-
     /* Shift data. Considered using a list to avoid memory shifting,
        but ultimately, the array outperformed the list due to better cache locality. */
     auto src = &targets[idx + 1];
@@ -369,6 +372,66 @@ void RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, Re
     stable_sort(&targets[idx], dst, [](const RenderRegion& a, const RenderRegion& b) -> bool {
         return a.min.x < b.min.x;
     });
+    return true;
+}
+
+
+bool RenderDirtyRegion::sweepMerge(Array<RenderRegion>& targets, Array<RenderRegion>& output)
+{
+    //sorting by x coord. guarantee the stable performance: O(NlogN)
+    stable_sort(targets.begin(), targets.end(), [](const RenderRegion& a, const RenderRegion& b) -> bool {
+        return a.min.x < b.min.x;
+    });
+
+    //Optimized using sweep-line algorithm: O(NlogN)
+    for (uint32_t i = 0; i < targets.count; ++i) {
+        auto& lhs = targets[i];
+        if (lhs.invalid()) continue;
+        auto merged = false;
+
+        for (uint32_t j = i + 1; j < targets.count; ++j) {
+            auto& rhs = targets[j];
+            if (rhs.invalid()) continue;
+            if (lhs.max.x < rhs.min.x) break;   //line sweeping
+
+            //fully overlapped. drop lhs
+            if (rhs.contained(lhs)) {
+                merged = true;
+                break;
+            }
+            //fully overlapped. replace the lhs with rhs
+            if (lhs.contained(rhs)) {
+                rhs = {};
+                continue;
+            }
+            //just merge & expand on x axis
+            if (lhs.min.y == rhs.min.y && lhs.max.y == rhs.max.y) {
+                if (lhs.max.x >= rhs.min.x) {
+                    lhs.max.x = rhs.max.x;
+                    rhs = {};
+                    j = i;   //lhs dirty region has been damaged, try again.
+                    continue;
+                }
+            }
+            //just merge & expand on y axis
+            if (lhs.min.x == rhs.min.x && lhs.max.x == rhs.max.x) {
+                if (lhs.min.y <= rhs.max.y && rhs.min.y <= lhs.max.y) {
+                    rhs.min.y = std::min(lhs.min.y, rhs.min.y);
+                    rhs.max.y = std::max(lhs.max.y, rhs.max.y);
+                    merged = true;
+                    break;
+                }
+            }
+            //subdivide regions
+            if (lhs.intersected(rhs)) {
+                if (!subdivide(targets, j, lhs, rhs)) return false;  //insufficient capacity, retry required
+                --j; //rhs dirty region has been damaged, try again.
+            }
+        }
+        if (!merged) output.push(lhs);  //this region is complete isolated
+        lhs = {};
+    }
+    return true;
 }
 
 
@@ -381,67 +444,34 @@ void RenderDirtyRegion::commit()
         auto& targets = partitions[idx].list[current];
         if (targets.empty()) continue;
 
-        current = !current; //swapping buffers
-        auto& output = partitions[idx].list[current];
+        //merge the dirty regions into a disjoint set in the other list.
+        //the output list is cleared in advance, no stale regions can survive a re-commit.
+        merge(targets, partitions[idx].list[!current]);
+        partitions[idx].current = !current;
+    }
+}
 
-        targets.reserve(targets.count * 10);  //one intersection can be divided up to 3
-        output.reserve(targets.count);
 
-        partitions[idx].current = current;
+void RenderDirtyRegion::merge(const Array<RenderRegion>& input, Array<RenderRegion>& output)
+{
+    if (input.empty()) {
+        output.clear();
+        return;
+    }
 
-        //sorting by x coord. guarantee the stable performance: O(NlogN)
-        stable_sort(targets.begin(), targets.end(), [](const RenderRegion& a, const RenderRegion& b) -> bool {
-            return a.min.x < b.min.x;
-        });
+    scratch.reserve(input.count * 10);  //one intersection can be divided up to 3
 
-        //Optimized using sweep-line algorithm: O(NlogN)
-        for (uint32_t i = 0; i < targets.count; ++i) {
-            auto& lhs = targets[i];
-            if (lhs.invalid()) continue;
-            auto merged = false;
+    while (true) {
+        scratch.clear();
+        scratch.push(input);
+        output.clear();
+        output.reserve(input.count);
 
-            for (uint32_t j = i + 1; j < targets.count; ++j) {
-                auto& rhs = targets[j];
-                if (rhs.invalid()) continue;
-                if (lhs.max.x < rhs.min.x) break;   //line sweeping
+        if (sweepMerge(scratch, output)) return;
 
-                //fully overlapped. drop lhs
-                if (rhs.contained(lhs)) {
-                    merged = true;
-                    break;
-                }
-                //fully overlapped. replace the lhs with rhs
-                if (lhs.contained(rhs)) {
-                    rhs = {};
-                    continue;
-                }
-                //just merge & expand on x axis
-                if (lhs.min.y == rhs.min.y && lhs.max.y == rhs.max.y) {
-                    if (lhs.max.x >= rhs.min.x) {
-                        lhs.max.x = rhs.max.x;
-                        rhs = {};
-                        j = i;   //lhs dirty region has been damaged, try again.
-                        continue;
-                    }
-                }
-                //just merge & expand on y axis
-                if (lhs.min.x == rhs.min.x && lhs.max.x == rhs.max.x) {
-                    if (lhs.min.y <= rhs.max.y && rhs.min.y <= lhs.max.y) {
-                        rhs.min.y = std::min(lhs.min.y, rhs.min.y);
-                        rhs.max.y = std::max(lhs.max.y, rhs.max.y);
-                        merged = true;
-                        break;
-                    }
-                }
-                //subdivide regions
-                if (lhs.intersected(rhs)) {
-                    subdivide(targets, j, lhs, rhs);
-                    --j; //rhs dirty region has been damaged, try again.
-                }
-            }
-            if (!merged) output.push(lhs);  //this region is complete isolated
-            lhs = {};
-        }
+        //the region fragments exceeded the working list. enlarge it and restart.
+        TVGLOG("RENDERER", "regions(%d) overflown the reserved(%d) working list. retrying...", input.count, scratch.reserved);
+        scratch.reserve(scratch.reserved * 2);
     }
 }
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -218,7 +218,13 @@ struct RenderRegion
         }
 
     private:
-        void subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs);
+        static bool subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs);
+        //Merge the regions in the working list into the disjoint output list.
+        //Returns false if the working list capacity is insufficient, leaving the regions unmodified.
+        static bool sweepMerge(Array<RenderRegion>& targets, Array<RenderRegion>& output);
+        //Merge the input regions into the disjoint output list. The working list is enlarged
+        //and the merge restarted if the produced fragments exceed its capacity.
+        void merge(const Array<RenderRegion>& input, Array<RenderRegion>& output);
 
         struct Partition
         {
@@ -229,6 +235,7 @@ struct RenderRegion
 
         Key key;
         Partition partitions[PARTITIONING];
+        Array<RenderRegion> scratch;  //working list for the merge()
         bool disabled = false;
     };
 #else

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -219,11 +219,11 @@ struct RenderRegion
 
     private:
         static bool subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs);
-        //Merge the regions in the working list into the disjoint output list.
-        //Returns false if the working list capacity is insufficient, leaving the regions unmodified.
+        // Merge the regions in the working list into the disjoint output list.
+        // Returns false if the working list capacity is insufficient, leaving the regions unmodified.
         static bool sweepMerge(Array<RenderRegion>& targets, Array<RenderRegion>& output);
-        //Merge the input regions into the disjoint output list. The working list is enlarged
-        //and the merge restarted if the produced fragments exceed its capacity.
+        // Merge the input regions into the disjoint output list. The working list is enlarged
+        // and the merge restarted if the produced fragments exceed its capacity.
         void merge(const Array<RenderRegion>& input, Array<RenderRegion>& output);
 
         struct Partition
@@ -235,7 +235,7 @@ struct RenderRegion
 
         Key key;
         Partition partitions[PARTITIONING];
-        Array<RenderRegion> scratch;  //working list for the merge()
+        Array<RenderRegion> scratch;  // working list for the merge()
         bool disabled = false;
     };
 #else

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -412,6 +412,7 @@ TEST_CASE("Intersection", "[tvgSwEngine]")
 // hundreds of thousands of values under --success and slow the test.
 static void requireBuffersEqual(const vector<uint32_t>& a, const vector<uint32_t>& b, uint32_t w)
 {
+    REQUIRE(a.size() == b.size());
     for (size_t i = 0; i < a.size(); ++i) {
         if (a[i] != b[i]) {
             FAIL("first mismatch at (" << i % w << ", " << i / w << "): "

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -22,6 +22,7 @@
 
 #include <thorvg.h>
 #include <fstream>
+#include <cmath>
 #include "config.h"
 #include "catch.hpp"
 
@@ -407,4 +408,190 @@ TEST_CASE("Intersection", "[tvgSwEngine]")
     REQUIRE(Initializer::term() == Result::Success);
 }
 
+// Compares the buffers per pixel: a whole-vector REQUIRE would expand
+// hundreds of thousands of values under --success and slow the test.
+static void requireBuffersEqual(const vector<uint32_t>& a, const vector<uint32_t>& b, uint32_t w)
+{
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (a[i] != b[i]) {
+            FAIL("first mismatch at (" << i % w << ", " << i / w << "): "
+                                       << "a=0x" << hex << a[i] << " b=0x" << b[i]);
+        }
+    }
+    REQUIRE(true);
+}
+
+#ifdef THORVG_PARTIAL_RENDER_SUPPORT
+
+TEST_CASE("Partial Rendering. Composited scene consistency", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        const uint32_t W = 400, H = 200;
+
+        // a still half-transparent group and a recolored opaque shape aside
+        auto makeScene = [](uint8_t moverFill, Shape** moverOut) {
+            auto root = Scene::gen();
+            auto group = Scene::gen();
+            auto r1 = Shape::gen();
+            REQUIRE(r1->appendRect(20, 20, 30, 40) == Result::Success);
+            REQUIRE(r1->fill(120, 40, 200) == Result::Success);
+            auto r2 = Shape::gen();
+            REQUIRE(r2->appendRect(70, 20, 30, 40) == Result::Success);
+            REQUIRE(r2->fill(120, 40, 200) == Result::Success);
+            REQUIRE(group->add(r1) == Result::Success);
+            REQUIRE(group->add(r2) == Result::Success);
+            REQUIRE(group->opacity(128) == Result::Success);
+            REQUIRE(root->add(group) == Result::Success);
+
+            auto mover = Shape::gen();
+            REQUIRE(mover->appendRect(300, 20, 20, 20) == Result::Success);
+            REQUIRE(mover->fill(moverFill, 200, 40) == Result::Success);
+            REQUIRE(root->add(mover) == Result::Success);
+            if (moverOut) *moverOut = mover;
+            return root;
+        };
+
+        vector<uint32_t> incremental(W * H, 0), fresh(W * H, 0);
+        const int FRAMES = 4;
+
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(incremental.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            Shape* mover = nullptr;
+            REQUIRE(canvas->add(makeScene(20, &mover)) == Result::Success);
+            for (int f = 0; f <= FRAMES; ++f) {
+                if (f > 0) REQUIRE(mover->fill(uint8_t(20 + f), 200, 40) == Result::Success);
+                REQUIRE(canvas->update() == Result::Success);
+                REQUIRE(canvas->draw() == Result::Success);
+                REQUIRE(canvas->sync() == Result::Success);
+            }
+        }
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(fresh.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            REQUIRE(canvas->add(makeScene(20 + FRAMES, nullptr)) == Result::Success);
+            REQUIRE(canvas->draw(true) == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        requireBuffersEqual(incremental, fresh, W);
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
+TEST_CASE("Partial Rendering. Fragmented regions consistency", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        const uint32_t W = 800, H = 600;
+
+        // a still translucent background with a large number of tiny updated shapes
+        auto makeScene = [](uint8_t fill, vector<Shape*>* rectsOut) {
+            auto scene = Scene::gen();
+            auto bg = Shape::gen();
+            REQUIRE(bg->appendRect(0, 0, W, H) == Result::Success);
+            REQUIRE(bg->fill(120, 40, 200, 128) == Result::Success);
+            REQUIRE(scene->add(bg) == Result::Success);
+            for (int i = 0; i < 65; ++i) {
+                auto x = 20 + (i % 13) * 10, y = 20 + (i / 13) * 10;
+                auto rect = Shape::gen();
+                REQUIRE(rect->appendRect(float(x), float(y), 2, 2) == Result::Success);
+                REQUIRE(rect->fill(fill, 220, 40) == Result::Success);
+                REQUIRE(scene->add(rect) == Result::Success);
+                if (rectsOut) rectsOut->push_back(rect);
+            }
+            return scene;
+        };
+
+        vector<uint32_t> incremental(W * H, 0), fresh(W * H, 0);
+
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(incremental.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            vector<Shape*> rects;
+            REQUIRE(canvas->add(makeScene(20, &rects)) == Result::Success);
+            REQUIRE(canvas->update() == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+
+            for (auto rect : rects)
+                REQUIRE(rect->fill(21, 220, 40) == Result::Success);
+            REQUIRE(canvas->update() == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(fresh.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            REQUIRE(canvas->add(makeScene(21, nullptr)) == Result::Success);
+            REQUIRE(canvas->draw(true) == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        requireBuffersEqual(incremental, fresh, W);
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
+TEST_CASE("Partial Rendering. Heavy region fragmentation consistency", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        const uint32_t W = 800, H = 600;
+
+        // still composited bands crossed by recolored strips: the region union
+        // fragments beyond the initial working list capacity
+        auto makeScene = [](uint8_t stripFill, vector<Shape*>* stripsOut) {
+            auto root = Scene::gen();
+            for (int i = 0; i < 30; ++i) {
+                auto group = Scene::gen();
+                auto r1 = Shape::gen();
+                REQUIRE(r1->appendRect(0, float(i * 4), 30, 2) == Result::Success);
+                REQUIRE(r1->fill(30, 180, 60) == Result::Success);
+                auto r2 = Shape::gen();
+                REQUIRE(r2->appendRect(30, float(i * 4), 30, 2) == Result::Success);
+                REQUIRE(r2->fill(30, 180, 60) == Result::Success);
+                REQUIRE(group->add(r1) == Result::Success);
+                REQUIRE(group->add(r2) == Result::Success);
+                REQUIRE(group->opacity(128) == Result::Success);
+                REQUIRE(root->add(group) == Result::Success);
+            }
+            for (int i = 0; i < 15; ++i) {
+                auto strip = Shape::gen();
+                REQUIRE(strip->appendRect(float(i * 4), 0, 2, 120) == Result::Success);
+                REQUIRE(strip->fill(stripFill, 40, 200, 128) == Result::Success);
+                REQUIRE(root->add(strip) == Result::Success);
+                if (stripsOut) stripsOut->push_back(strip);
+            }
+            return root;
+        };
+
+        vector<uint32_t> incremental(W * H, 0), fresh(W * H, 0);
+
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(incremental.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            vector<Shape*> strips;
+            REQUIRE(canvas->add(makeScene(100, &strips)) == Result::Success);
+            REQUIRE(canvas->update() == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+
+            for (auto strip : strips)
+                REQUIRE(strip->fill(101, 40, 200, 128) == Result::Success);
+            REQUIRE(canvas->update() == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(fresh.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            REQUIRE(canvas->add(makeScene(101, nullptr)) == Result::Success);
+            REQUIRE(canvas->draw(true) == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        requireBuffersEqual(incremental, fresh, W);
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+#endif
 #endif


### PR DESCRIPTION
In the partial rendering mode the dirty regions of a frame are merged into a disjoint set of rectangles, which is then used both to clear the buffer (preRender) and to post-process the rendered regions. Three defects in the current merge make the set unreliable:

1. **Silent region loss.** When the sweep merge subdivided intersecting regions and ran out of working-list capacity, `subdivide()` left the list half-mutated and only logged the error -- the dropped fragments were never converted (or cleared), leaving stale pixels.
2. **Stale regions across frames.** The merged output was written over the other buffer without clearing it first, so regions from older commits could survive a re-commit and be processed again.
3. **Composite drift on straight-alpha targets.** Consequences of 1+2: in incremental rendering on straight-alpha targets, unpremultiply is not idempotent, so any region that is converted twice (or skipped) drifts from the fresh rendering. A static semi-transparent group next to a moving shape drifted `0x807727c7 -> 0x80ffffff` within a few frames.

This makes the merge exact and restartable:

- `subdivide()` verifies the capacity upfront and fails without mutating the list;
- `merge()` runs the sweep in a separate scratch list and restarts with a doubled capacity if the fragments exceeded it -- the consolidation is exact under any fragmentation;
- `commit()` fills a pre-cleared output list, so no stale regions can survive a re-commit.

The post-render stage can then rely on the committed set directly. Converting only the rendered regions (each exactly once) also removes the whole-surface unpremultiply pass from partial updates: incremental renders of huge static scenes get ~20% faster, and the store is skipped for fully transparent/opaque pixels.

**Reproducible example:**
- [`PartialRenderDrift.cpp`](https://github.com/artemkulyk/thorvg.example/blob/348ab54c25f8f8f2fdaa88e7e619fa75679d8fb5/src/PartialRenderDrift.cpp) renders the same composited scene incrementally on an `ARGB8888S` canvas and compares it pixel-by-pixel with a fresh full rendering.
- `main` (`e43bc8ba`): `Composite drift after 4 frames, first mismatch at pixel (30, 30): partial=0x80ffffff fresh=0x807727c7`
- This PR (`29efa5b8`): `PartialRenderDrift: 4 frames verified, no drift.`

**Verification** (macOS arm64, `-O3`):
- New regression tests cover composite drift, capacity-exceeding region unions and stale re-commits; all fail on `main`, pass with this patch.
- Byte-identical outputs vs the unpatched build on a 32-file SVG corpus (including the 79 MB Koppen-Geiger case and 4K renders) in premultiplied and straight-alpha targets, plus 200/200 Lottie frames of incremental playback.
- Unit tests: 14,978 assertions / 81 cases in scalar and SIMD configurations; 13,849 assertions / 78 cases with partial rendering disabled.
- The canonical example builds successfully against pristine and patched ThorVG; ASan and UBSan runs are clean.
- ThreadSanitizer clean.
- clang-format 18 and whitespace checks pass.
