### PR TITLE
cpu_engine: replace sorted linked-list cells with append + partition + per-row sort

### DIFF
--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -527,6 +527,7 @@ void rasterPixel32(uint32_t* dst, uint32_t* src, uint32_t len, uint8_t opacity);
 void rasterGrayscale8(uint8_t* dst, uint8_t val, uint32_t offset, int32_t len);
 void rasterXYFlip(uint32_t* src, uint32_t* dst, int32_t stride, int32_t w, int32_t h, const RenderRegion& bbox, bool flipped);
 void rasterUnpremultiply(RenderSurface* surface);
+void rasterUnpremultiply(RenderSurface* surface, const RenderRegion& region);
 void rasterPremultiply(RenderSurface* surface);
 bool rasterConvertCS(RenderSurface* surface, ColorSpace to);
 uint32_t rasterUnpremultiply(uint32_t data);

--- a/src/renderer/cpu_engine/tvgSwRaster.cpp
+++ b/src/renderer/cpu_engine/tvgSwRaster.cpp
@@ -1569,9 +1569,9 @@ bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_
 /* Convert a premultiplied row into the straight-alpha space.
    Fully transparent / fully opaque pixels are left untouched in the buffer,
    sparing the write-back traffic for the regions without semi-transparent content. */
-static inline void _rasterUnpremultiply32(uint32_t* buffer, int32_t len)
+static inline void _rasterUnpremultiply32(uint32_t* buffer, uint32_t len)
 {
-    for (int32_t x = 0; x < len; ++x) {
+    for (uint32_t x = 0; x < len; ++x) {
         auto c = buffer[x];
         auto a = A(c);
         if (a == 255 || a == 0) continue;
@@ -1617,7 +1617,7 @@ void rasterUnpremultiply(RenderSurface* surface, const RenderRegion& region)
     if (clipped.invalid()) return;
 
     for (int32_t y = clipped.min.y; y < clipped.max.y; ++y) {
-        _rasterUnpremultiply32(surface->buf32 + surface->stride * y + clipped.min.x, clipped.max.x - clipped.min.x);
+        _rasterUnpremultiply32(surface->buf32 + surface->stride * y + clipped.min.x, uint32_t(clipped.max.x - clipped.min.x));
     }
 }
 

--- a/src/renderer/cpu_engine/tvgSwRaster.cpp
+++ b/src/renderer/cpu_engine/tvgSwRaster.cpp
@@ -1566,6 +1566,21 @@ bool rasterClear(SwSurface* surface, uint32_t x, uint32_t y, uint32_t w, uint32_
     return true;
 }
 
+/* Convert a premultiplied row into the straight-alpha space.
+   Fully transparent / fully opaque pixels are left untouched in the buffer,
+   sparing the write-back traffic for the regions without semi-transparent content. */
+static inline void _rasterUnpremultiply32(uint32_t* buffer, int32_t len)
+{
+    for (int32_t x = 0; x < len; ++x) {
+        auto c = buffer[x];
+        auto a = A(c);
+        if (a == 255 || a == 0) continue;
+        uint8_t r = std::min(C1(c) * 255u / a, 255u);
+        uint8_t g = std::min(C2(c) * 255u / a, 255u);
+        uint8_t b = std::min(C3(c) * 255u / a, 255u);
+        buffer[x] = JOIN(a, r, g, b);
+    }
+}
 
 uint32_t rasterUnpremultiply(uint32_t data)
 {
@@ -1587,15 +1602,24 @@ void rasterUnpremultiply(RenderSurface* surface)
     TVGLOG("SW_ENGINE", "Unpremultiply [Size: %d x %d]", surface->w, surface->h);
 
     //OPTIMIZE_ME: +SIMD
-    for (uint32_t y = 0; y < surface->h; y++) {
-        auto buffer = surface->buf32 + surface->stride * y;
-        for (uint32_t x = 0; x < surface->w; ++x) {
-            buffer[x] = rasterUnpremultiply(buffer[x]);
-        }
+    auto buffer = surface->buf32;
+    for (uint32_t y = 0; y < surface->h; ++y, buffer += surface->stride) {
+        _rasterUnpremultiply32(buffer, surface->w);
     }
     surface->premultiplied = false;
 }
 
+void rasterUnpremultiply(RenderSurface* surface, const RenderRegion& region)
+{
+    if (surface->channelSize != sizeof(uint32_t)) return;
+
+    auto clipped = RenderRegion::intersect(region, {{0, 0}, {(int32_t)surface->w, (int32_t)surface->h}});
+    if (clipped.invalid()) return;
+
+    for (int32_t y = clipped.min.y; y < clipped.max.y; ++y) {
+        _rasterUnpremultiply32(surface->buf32 + surface->stride * y + clipped.min.x, clipped.max.x - clipped.min.x);
+    }
+}
 
 void rasterPremultiply(RenderSurface* surface)
 {

--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -354,7 +354,22 @@ bool SwRenderer::postRender()
 {
     //Unmultiply alpha if needed
     if (surface->cs == ColorSpace::ABGR8888S || surface->cs == ColorSpace::ARGB8888S) {
-        rasterUnpremultiply(surface);
+        if (fulldraw || dirtyRegion.deactivated()) {
+            rasterUnpremultiply(surface);
+        } else {
+            /* In the partial rendering mode, only the regions rendered in this frame hold
+               premultiplied pixels. The rest of the buffer has been already converted
+               in the previous frames. Each pixel is converted exactly once: commit()
+               merges the dirty regions into a disjoint set. The regions drawn through the
+               intermediate composited surfaces are covered by the dirty regions as well. */
+            for (int idx = 0; idx < RenderDirtyRegion::PARTITIONING; ++idx) {
+                ARRAY_FOREACH(p, dirtyRegion.get(idx))
+                {
+                    rasterUnpremultiply(surface, *p);
+                }
+            }
+            surface->premultiplied = false;
+        }
     }
 
     dirtyRegion.clear();

--- a/src/renderer/cpu_engine/tvgSwRle.cpp
+++ b/src/renderer/cpu_engine/tvgSwRle.cpp
@@ -189,6 +189,7 @@
 */
 
 #include <limits.h>
+#include <cstdint>
 #include "tvgSwCommon.h"
 
 /************************************************************************/
@@ -198,9 +199,12 @@
 constexpr auto PIXEL_BITS = 8;   //must be at least 6 bits!
 constexpr auto ONE_PIXEL = (1 << PIXEL_BITS);
 
-struct Band
+struct RawCell
 {
-    int32_t min, max;
+    int32_t x;
+    int32_t y;
+    int32_t cover;
+    long area;
 };
 
 struct RleWorker
@@ -216,9 +220,12 @@ struct RleWorker
     long area;
     int32_t cover;
 
-    SwCell* cells;
-    ptrdiff_t maxCells;
-    ptrdiff_t cellsCnt;
+    RawCell* raw;     // appended cells in the outline order
+    uint32_t rawMax;  // capacity of the raw cells in the scratch buffer
+    uint32_t rawCnt;
+
+    uint32_t* rowTable;  // start offsets of each row in the raw cells, size yCnt + 1
+    uint32_t* rowPos;    // fill positions for the row partitioning, size yCnt + 1
 
     SwPoint pos;
 
@@ -232,12 +239,11 @@ struct RleWorker
     SwOutline* outline;
 
     int bandSize;
-    int bandShoot;
 
-    SwCell* buffer;
+    SwCellPool* pool;  // scratch owner, kept to grow the buffer on demand
+    void* buffer;
     uint32_t bufferSize;
 
-    SwCell** yCells;
     int32_t yCnt;
 
     bool invalid;
@@ -369,66 +375,155 @@ static void _horizLine(RleWorker& rw, int32_t x, int32_t y, int32_t area, int32_
 
 static void _sweep(RleWorker& rw)
 {
-    if (rw.cellsCnt == 0) return;
+    if (rw.rawCnt == 0) return;
 
-    for (int y = 0; y < rw.yCnt; ++y) {
+    for (int32_t y = 0; y < rw.yCnt; ++y) {
         auto cover = 0;
         auto x = 0;
-        auto cell = rw.yCells[y];
 
-        while (cell) {
+        for (auto i = rw.rowTable[y]; i < rw.rowTable[y + 1]; ++i) {
+            auto cell = rw.raw + i;
+
             if (cell->x > x && cover != 0) _horizLine(rw, x, y, cover * (ONE_PIXEL * 2), cell->x - x);
             cover += cell->cover;
             auto area = cover * (ONE_PIXEL * 2) - cell->area;
             if (area != 0 && cell->x >= 0) _horizLine(rw, cell->x, y, area, 1);
             x = cell->x + 1;
-            cell = cell->next;
         }
 
         if (cover != 0) _horizLine(rw, x, y, cover * (ONE_PIXEL * 2), rw.cellXCnt - x);
     }
 }
 
-
-static SwCell* _findCell(RleWorker& rw)
+static uint32_t _tableBytes(int32_t yCnt)
 {
-    auto x = rw.cellPos.x;
-    if (x > rw.cellXCnt) x = rw.cellXCnt;
-
-    auto pcell = &rw.yCells[rw.cellPos.y];
-
-    while(true) {
-        auto cell = *pcell;
-        if (!cell || cell->x > x) break;
-        if (cell->x == x) return cell;
-        pcell = &cell->next;
-    }
-
-    if (rw.cellsCnt >= rw.maxCells) return nullptr;
-
-    auto cell = rw.cells + rw.cellsCnt++;
-    cell->x = x;
-    cell->area = 0;
-    cell->cover = 0;
-    cell->next = *pcell;
-    *pcell = cell;
-
-    return cell;
+    if (yCnt < 0) return ~0u;
+    auto bytes = (uint64_t(yCnt) + 1) * 2 * sizeof(uint32_t);
+    bytes = (bytes + 7) & ~uint64_t(7);
+    if (bytes > ~0u) return ~0u;
+    return uint32_t(bytes);
 }
 
+static bool _layout(RleWorker& rw)
+{
+    // carve the scratch buffer: row tables at the head, the appended cells after.
+    // the raw capacity is computed in integers to avoid a pointer-subtraction UB
+    // that could produce a huge rawMax (the tables and the cells are distinct arrays).
+    auto tableBytes = _tableBytes(rw.yCnt);
+    if (tableBytes >= rw.bufferSize) {
+        rw.rawMax = 0;
+        return false;
+    }
+    auto rawMax = (rw.bufferSize - tableBytes) / sizeof(RawCell);
+    if (rawMax == 0) {
+        rw.rawMax = 0;
+        return false;
+    }
+    rw.rowTable = static_cast<uint32_t*>(rw.buffer);
+    rw.rowPos = rw.rowTable + (rw.yCnt + 1);
+    rw.raw = reinterpret_cast<RawCell*>((char*)rw.buffer + tableBytes);
+    rw.rawMax = rawMax;
+    return true;
+}
+
+static bool _growCells(RleWorker& rw)
+{
+    auto tableBytes = _tableBytes(rw.yCnt);
+    if (tableBytes > ~0u - sizeof(RawCell)) return false;
+    auto minSize = tableBytes + uint32_t(sizeof(RawCell));
+    auto sz = rw.bufferSize + (rw.bufferSize >> 1);  // grow by 1.5x
+    if (sz < rw.bufferSize) return false;            // overflow
+    if (sz < minSize) sz = minSize;
+    sz = ((sz + sizeof(RawCell) - 1) / sizeof(RawCell)) * sizeof(RawCell);
+    auto buffer = tvg::malloc<RawCell>(sz);
+    if (!buffer) return false;
+    if (rw.buffer && rw.bufferSize) memcpy(buffer, rw.buffer, rw.bufferSize);
+    tvg::free(rw.buffer);
+    rw.buffer = buffer;
+    rw.bufferSize = sz;
+    rw.pool->buffer = reinterpret_cast<SwCell*>(buffer);
+    rw.pool->size = sz;
+    return _layout(rw);
+}
 
 static bool _recordCell(RleWorker& rw)
 {
     if (rw.area | rw.cover) {
-        auto cell = _findCell(rw);
-        if (!cell) return false;
-        cell->area += rw.area;
-        cell->cover += rw.cover;
+        while (rw.rawCnt >= rw.rawMax) {
+            if (!_growCells(rw)) return false;
+        }
+        auto cell = rw.raw + rw.rawCnt++;
+        cell->x = rw.cellPos.x;
+        cell->y = rw.cellPos.y;
+        cell->area = rw.area;
+        cell->cover = rw.cover;
     }
 
     return true;
 }
 
+static bool _sortCells(RleWorker& rw)
+{
+    if (rw.rawCnt == 0) return true;
+
+    auto n = rw.rawCnt;
+    auto table = rw.rowTable;
+    auto raw = rw.raw;
+    auto pos = rw.rowPos;
+
+    // counting partition by row. coverage accumulation is a commutative addition,
+    // so the order of the recorded cells is irrelevant for the result.
+    for (int32_t y = 0; y <= rw.yCnt; ++y)
+        table[y] = 0;
+    for (uint32_t i = 0; i < n; ++i) {
+        ++table[rw.raw[i].y + 1];
+    }
+    for (int32_t y = 0; y < rw.yCnt; ++y)
+        table[y + 1] += table[y];
+    memcpy(pos, table, sizeof(uint32_t) * (rw.yCnt + 1));
+
+    // place the cells row by row (in-place cycle permutation). an element whose
+    // slot has already been consumed by its row is in its final position.
+    for (uint32_t i = 0; i < n; ++i) {
+        auto r = rw.raw[i].y;
+        if (table[r] <= i && pos[r] > i) continue;  // already placed
+        while (true) {
+            auto p = pos[r]++;
+            if (p == i) break;
+            std::swap(rw.raw[i], rw.raw[p]);
+            r = rw.raw[i].y;
+        }
+    }
+
+    // sort each row by x and merge the cells of the same x. the write position
+    // lags behind the read position, so the compaction never overwrites unread data.
+    uint32_t w = 0;
+    for (int32_t y = 0; y < rw.yCnt; ++y) {
+        auto rs = table[y];
+        auto re = table[y + 1];
+        table[y] = w;
+        if (rs == re) continue;
+
+        std::sort(rw.raw + rs, rw.raw + re, [](const RawCell& a, const RawCell& b) {
+            return a.x < b.x;
+        });
+
+        raw[w] = raw[rs];
+        for (auto i = rs + 1; i < re; ++i) {
+            if (rw.raw[i].x == raw[w].x) {
+                raw[w].area += rw.raw[i].area;
+                raw[w].cover += rw.raw[i].cover;
+            } else {
+                raw[++w] = rw.raw[i];
+            }
+        }
+        ++w;
+    }
+    table[rw.yCnt] = w;
+    rw.rawCnt = w;
+
+    return true;
+}
 
 static bool _setCell(RleWorker& rw, SwPoint pos)
 {
@@ -746,25 +841,31 @@ static bool _genRle(RleWorker& rw)
 SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox, SwMpool* mpool, unsigned tid, bool antiAlias)
 {
     if (!outline) return nullptr;
-  
+
     RleWorker rw;
     auto cellPool = mpool->cell(tid);
-    auto reqSize = uint32_t(std::max(bbox.w(), bbox.h()) * 0.75f) * sizeof(SwCell);  //experimental decision
+    auto dim = std::max(bbox.w(), bbox.h());
+    uint32_t reqSize = 0;
+    auto reqBytes = uint64_t(dim) * 3 / 4 * sizeof(RawCell);  // experimental: 0.75 of the long side
+    if (reqBytes <= ~0u) reqSize = uint32_t(reqBytes);
 
-    // grow by 1.25x and align to multiple of sizeof(SwCell)
+    // grow by 1.25x and align to multiple of sizeof(RawCell)
     if (reqSize > cellPool->size) {
-        cellPool->size = ((reqSize + (reqSize >> 2)) / sizeof(SwCell)) * sizeof(SwCell);
+        auto newSize = ((reqSize + (reqSize >> 2)) / sizeof(RawCell)) * sizeof(RawCell);
+        auto buffer = tvg::malloc<RawCell>(newSize);
+        if (!buffer) return nullptr;
         tvg::free(cellPool->buffer);
-        cellPool->buffer = tvg::malloc<SwCell>(cellPool->size);
+        cellPool->buffer = reinterpret_cast<SwCell*>(buffer);
+        cellPool->size = newSize;
     }
 
     //Init Cells
+    rw.pool = cellPool;
     rw.buffer = cellPool->buffer;
     rw.bufferSize = cellPool->size;
-    rw.yCells = reinterpret_cast<SwCell**>(cellPool->buffer);
-    rw.cells = nullptr;
-    rw.maxCells = 0;
-    rw.cellsCnt = 0;
+    rw.raw = nullptr;
+    rw.rawMax = 0;
+    rw.rawCnt = 0;
     rw.area = 0;
     rw.cover = 0;
     rw.invalid = true;
@@ -773,9 +874,9 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox,
     rw.cellXCnt = rw.cellMax.x - rw.cellMin.x;
     rw.cellYCnt = rw.cellMax.y - rw.cellMin.y;
     rw.outline = const_cast<SwOutline*>(outline);
-    rw.bandSize = rw.bufferSize / (sizeof(SwCell) * 2);
-    rw.bandShoot = 0;
+    rw.bandSize = rw.bufferSize / (sizeof(RawCell) * 2);
     rw.antiAlias = antiAlias;
+    if (rw.bandSize == 0) return nullptr;
 
     if (!rle) rw.rle = new SwRle;
     else rw.rle = rle;
@@ -783,9 +884,6 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox,
 
     //Generate RLE
     constexpr auto BAND_SIZE = 40;
-
-    Band bands[BAND_SIZE];
-    Band* band;
 
     /* set up vertical bands */
     auto bandCnt = static_cast<int>((rw.cellMax.y - rw.cellMin.y) / rw.bandSize);
@@ -800,66 +898,27 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox,
         max = min + rw.bandSize;
         if (n == bandCnt -1 || max > yMax) max = yMax;
 
-        bands[0].min = min;
-        bands[0].max = max;
-        band = bands;
+        // each band keeps its cells in the shared scratch buffer: the row tables
+        // carve the head of the buffer, the appended raw cells follow them.
+        // the scratch grows on demand, so the band is never re-processed.
+        rw.yCnt = max - min;
+        rw.cellMin.y = min;
+        rw.cellMax.y = max;
+        rw.cellYCnt = max - min;
+        rw.rawCnt = 0;
+        rw.invalid = true;
 
-        while (band >= bands) {
-            rw.yCells = reinterpret_cast<SwCell**>(rw.buffer);
-            rw.yCnt = band->max - band->min;
-
-            int cellStart = sizeof(SwCell*) * (int)rw.yCnt;
-            int cellMod = cellStart % sizeof(SwCell);
-
-            if (cellMod > 0) cellStart += sizeof(SwCell) - cellMod;
-
-            auto cellsMax = reinterpret_cast<SwCell*>((char*)rw.buffer + rw.bufferSize);
-            rw.cells = reinterpret_cast<SwCell*>((char*)rw.buffer + cellStart);
-
-            if (rw.cells >= cellsMax) goto reduce_bands;
-
-            rw.maxCells = cellsMax - rw.cells;
-            if (rw.maxCells < 2) goto reduce_bands;
-
-            for (int y = 0; y < rw.yCnt; ++y)
-                rw.yCells[y] = nullptr;
-
-            rw.cellsCnt = 0;
-            rw.invalid = true;
-            rw.cellMin.y = band->min;
-            rw.cellMax.y = band->max;
-            rw.cellYCnt = band->max - band->min;
-
-            if (_genRle(rw)) {
-                _sweep(rw);
-                --band;
-                continue;
-            }
-
-        reduce_bands:
-            /* render pool overflow: we will reduce the render band by half */
-            auto bottom = band->min;
-            auto top = band->max;
-            auto middle = bottom + ((top - bottom) >> 1);
-
-            /* This is too complex for a single scanline; there must
-               be some problems */
-            if (middle == bottom) {
-                rleFree(rw.rle);
-                return nullptr;
-            }
-
-            if (bottom - top >= rw.bandSize) ++rw.bandShoot;
-
-            band[1].min = bottom;
-            band[1].max = middle;
-            band[0].min = middle;
-            band[0].max = top;
-            ++band;
+        if (!_layout(rw) && !_growCells(rw)) {
+            rleFree(rw.rle);
+            return nullptr;
         }
-    }
-    if (rw.bandShoot > 8 && rw.bandSize > 16) {
-        rw.bandSize = (rw.bandSize >> 1);
+
+        if (!_genRle(rw) || !_sortCells(rw)) {
+            rleFree(rw.rle);
+            return nullptr;
+        }
+
+        _sweep(rw);
     }
     return rw.rle;
 }

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -328,17 +328,20 @@ void RenderDirtyRegion::clear()
     }
 }
 
-
 bool RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs)
 {
-    //verify the capacity upfront so that a failure leaves the regions unmodified
-    auto required = targets.count;
+    if (idx >= targets.count) return false;
+
+    // Verify the capacity upfront so that a failure leaves the regions unmodified.
+    // The region at idx is replaced with its fragments, so one required slot is
+    // already available.
+    auto required = uint64_t(targets.count);
     if (rhs.min.y < lhs.min.y) ++required;
     if (rhs.max.y > lhs.max.y) ++required;
     if (rhs.max.x > lhs.max.x) ++required;
 
-    //Please reserve memory enough with targets.reserve()
-    if (required - 1 >= targets.reserved) return false;
+    // Please reserve memory enough with targets.reserve()
+    if (required > uint64_t(targets.reserved) + 1) return false;
 
     RenderRegion temp[3];
     uint32_t cnt = 0;
@@ -375,15 +378,14 @@ bool RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, Re
     return true;
 }
 
-
 bool RenderDirtyRegion::sweepMerge(Array<RenderRegion>& targets, Array<RenderRegion>& output)
 {
-    //sorting by x coord. guarantee the stable performance: O(NlogN)
+    // sorting by x coord. guarantee the stable performance: O(NlogN)
     stable_sort(targets.begin(), targets.end(), [](const RenderRegion& a, const RenderRegion& b) -> bool {
         return a.min.x < b.min.x;
     });
 
-    //Optimized using sweep-line algorithm: O(NlogN)
+    // Optimized using sweep-line algorithm: O(NlogN)
     for (uint32_t i = 0; i < targets.count; ++i) {
         auto& lhs = targets[i];
         if (lhs.invalid()) continue;
@@ -392,28 +394,28 @@ bool RenderDirtyRegion::sweepMerge(Array<RenderRegion>& targets, Array<RenderReg
         for (uint32_t j = i + 1; j < targets.count; ++j) {
             auto& rhs = targets[j];
             if (rhs.invalid()) continue;
-            if (lhs.max.x < rhs.min.x) break;   //line sweeping
+            if (lhs.max.x < rhs.min.x) break;  // line sweeping
 
-            //fully overlapped. drop lhs
+            // fully overlapped. drop lhs
             if (rhs.contained(lhs)) {
                 merged = true;
                 break;
             }
-            //fully overlapped. replace the lhs with rhs
+            // fully overlapped. replace the lhs with rhs
             if (lhs.contained(rhs)) {
                 rhs = {};
                 continue;
             }
-            //just merge & expand on x axis
+            // just merge & expand on x axis
             if (lhs.min.y == rhs.min.y && lhs.max.y == rhs.max.y) {
                 if (lhs.max.x >= rhs.min.x) {
                     lhs.max.x = rhs.max.x;
                     rhs = {};
-                    j = i;   //lhs dirty region has been damaged, try again.
+                    j = i;  // lhs dirty region has been damaged, try again.
                     continue;
                 }
             }
-            //just merge & expand on y axis
+            // just merge & expand on y axis
             if (lhs.min.x == rhs.min.x && lhs.max.x == rhs.max.x) {
                 if (lhs.min.y <= rhs.max.y && rhs.min.y <= lhs.max.y) {
                     rhs.min.y = std::min(lhs.min.y, rhs.min.y);
@@ -422,18 +424,17 @@ bool RenderDirtyRegion::sweepMerge(Array<RenderRegion>& targets, Array<RenderReg
                     break;
                 }
             }
-            //subdivide regions
+            // subdivide regions
             if (lhs.intersected(rhs)) {
-                if (!subdivide(targets, j, lhs, rhs)) return false;  //insufficient capacity, retry required
-                --j; //rhs dirty region has been damaged, try again.
+                if (!subdivide(targets, j, lhs, rhs)) return false;  // insufficient capacity, retry required
+                --j;                                                 // rhs dirty region has been damaged, try again.
             }
         }
-        if (!merged) output.push(lhs);  //this region is complete isolated
+        if (!merged) output.push(lhs);  // this region is complete isolated
         lhs = {};
     }
     return true;
 }
-
 
 void RenderDirtyRegion::commit()
 {
@@ -444,13 +445,12 @@ void RenderDirtyRegion::commit()
         auto& targets = partitions[idx].list[current];
         if (targets.empty()) continue;
 
-        //merge the dirty regions into a disjoint set in the other list.
-        //the output list is cleared in advance, no stale regions can survive a re-commit.
+        // merge the dirty regions into a disjoint set in the other list.
+        // the output list is cleared in advance, no stale regions can survive a re-commit.
         merge(targets, partitions[idx].list[!current]);
         partitions[idx].current = !current;
     }
 }
-
 
 void RenderDirtyRegion::merge(const Array<RenderRegion>& input, Array<RenderRegion>& output)
 {
@@ -459,7 +459,7 @@ void RenderDirtyRegion::merge(const Array<RenderRegion>& input, Array<RenderRegi
         return;
     }
 
-    scratch.reserve(input.count * 10);  //one intersection can be divided up to 3
+    scratch.reserve(input.count * 10);  // one intersection can be divided up to 3
 
     while (true) {
         scratch.clear();
@@ -469,8 +469,8 @@ void RenderDirtyRegion::merge(const Array<RenderRegion>& input, Array<RenderRegi
 
         if (sweepMerge(scratch, output)) return;
 
-        //the region fragments exceeded the working list. enlarge it and restart.
-        TVGLOG("RENDERER", "regions(%d) overflown the reserved(%d) working list. retrying...", input.count, scratch.reserved);
+        // the region fragments exceeded the working list. enlarge it and restart.
+        TVGLOG("RENDERER", "regions(%d) overflowed the reserved(%d) working list. retrying...", input.count, scratch.reserved);
         scratch.reserve(scratch.reserved * 2);
     }
 }

--- a/src/renderer/tvgRender.cpp
+++ b/src/renderer/tvgRender.cpp
@@ -329,8 +329,17 @@ void RenderDirtyRegion::clear()
 }
 
 
-void RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs)
+bool RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs)
 {
+    //verify the capacity upfront so that a failure leaves the regions unmodified
+    auto required = targets.count;
+    if (rhs.min.y < lhs.min.y) ++required;
+    if (rhs.max.y > lhs.max.y) ++required;
+    if (rhs.max.x > lhs.max.x) ++required;
+
+    //Please reserve memory enough with targets.reserve()
+    if (required - 1 >= targets.reserved) return false;
+
     RenderRegion temp[3];
     uint32_t cnt = 0;
 
@@ -349,12 +358,6 @@ void RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, Re
         temp[cnt++] = {{lhs.max.x, rhs.min.y}, {rhs.max.x, rhs.max.y}};
     }
 
-    //Please reserve memory enough with targets.reserve()
-    if (targets.count + cnt - 1 >= targets.reserved) {
-        TVGERR("RENDERER", "reserved(%d), required(%d)", targets.reserved, targets.count + cnt - 1);
-        return;
-    }
-
     /* Shift data. Considered using a list to avoid memory shifting,
        but ultimately, the array outperformed the list due to better cache locality. */
     auto src = &targets[idx + 1];
@@ -369,6 +372,66 @@ void RenderDirtyRegion::subdivide(Array<RenderRegion>& targets, uint32_t idx, Re
     stable_sort(&targets[idx], dst, [](const RenderRegion& a, const RenderRegion& b) -> bool {
         return a.min.x < b.min.x;
     });
+    return true;
+}
+
+
+bool RenderDirtyRegion::sweepMerge(Array<RenderRegion>& targets, Array<RenderRegion>& output)
+{
+    //sorting by x coord. guarantee the stable performance: O(NlogN)
+    stable_sort(targets.begin(), targets.end(), [](const RenderRegion& a, const RenderRegion& b) -> bool {
+        return a.min.x < b.min.x;
+    });
+
+    //Optimized using sweep-line algorithm: O(NlogN)
+    for (uint32_t i = 0; i < targets.count; ++i) {
+        auto& lhs = targets[i];
+        if (lhs.invalid()) continue;
+        auto merged = false;
+
+        for (uint32_t j = i + 1; j < targets.count; ++j) {
+            auto& rhs = targets[j];
+            if (rhs.invalid()) continue;
+            if (lhs.max.x < rhs.min.x) break;   //line sweeping
+
+            //fully overlapped. drop lhs
+            if (rhs.contained(lhs)) {
+                merged = true;
+                break;
+            }
+            //fully overlapped. replace the lhs with rhs
+            if (lhs.contained(rhs)) {
+                rhs = {};
+                continue;
+            }
+            //just merge & expand on x axis
+            if (lhs.min.y == rhs.min.y && lhs.max.y == rhs.max.y) {
+                if (lhs.max.x >= rhs.min.x) {
+                    lhs.max.x = rhs.max.x;
+                    rhs = {};
+                    j = i;   //lhs dirty region has been damaged, try again.
+                    continue;
+                }
+            }
+            //just merge & expand on y axis
+            if (lhs.min.x == rhs.min.x && lhs.max.x == rhs.max.x) {
+                if (lhs.min.y <= rhs.max.y && rhs.min.y <= lhs.max.y) {
+                    rhs.min.y = std::min(lhs.min.y, rhs.min.y);
+                    rhs.max.y = std::max(lhs.max.y, rhs.max.y);
+                    merged = true;
+                    break;
+                }
+            }
+            //subdivide regions
+            if (lhs.intersected(rhs)) {
+                if (!subdivide(targets, j, lhs, rhs)) return false;  //insufficient capacity, retry required
+                --j; //rhs dirty region has been damaged, try again.
+            }
+        }
+        if (!merged) output.push(lhs);  //this region is complete isolated
+        lhs = {};
+    }
+    return true;
 }
 
 
@@ -381,67 +444,34 @@ void RenderDirtyRegion::commit()
         auto& targets = partitions[idx].list[current];
         if (targets.empty()) continue;
 
-        current = !current; //swapping buffers
-        auto& output = partitions[idx].list[current];
+        //merge the dirty regions into a disjoint set in the other list.
+        //the output list is cleared in advance, no stale regions can survive a re-commit.
+        merge(targets, partitions[idx].list[!current]);
+        partitions[idx].current = !current;
+    }
+}
 
-        targets.reserve(targets.count * 10);  //one intersection can be divided up to 3
-        output.reserve(targets.count);
 
-        partitions[idx].current = current;
+void RenderDirtyRegion::merge(const Array<RenderRegion>& input, Array<RenderRegion>& output)
+{
+    if (input.empty()) {
+        output.clear();
+        return;
+    }
 
-        //sorting by x coord. guarantee the stable performance: O(NlogN)
-        stable_sort(targets.begin(), targets.end(), [](const RenderRegion& a, const RenderRegion& b) -> bool {
-            return a.min.x < b.min.x;
-        });
+    scratch.reserve(input.count * 10);  //one intersection can be divided up to 3
 
-        //Optimized using sweep-line algorithm: O(NlogN)
-        for (uint32_t i = 0; i < targets.count; ++i) {
-            auto& lhs = targets[i];
-            if (lhs.invalid()) continue;
-            auto merged = false;
+    while (true) {
+        scratch.clear();
+        scratch.push(input);
+        output.clear();
+        output.reserve(input.count);
 
-            for (uint32_t j = i + 1; j < targets.count; ++j) {
-                auto& rhs = targets[j];
-                if (rhs.invalid()) continue;
-                if (lhs.max.x < rhs.min.x) break;   //line sweeping
+        if (sweepMerge(scratch, output)) return;
 
-                //fully overlapped. drop lhs
-                if (rhs.contained(lhs)) {
-                    merged = true;
-                    break;
-                }
-                //fully overlapped. replace the lhs with rhs
-                if (lhs.contained(rhs)) {
-                    rhs = {};
-                    continue;
-                }
-                //just merge & expand on x axis
-                if (lhs.min.y == rhs.min.y && lhs.max.y == rhs.max.y) {
-                    if (lhs.max.x >= rhs.min.x) {
-                        lhs.max.x = rhs.max.x;
-                        rhs = {};
-                        j = i;   //lhs dirty region has been damaged, try again.
-                        continue;
-                    }
-                }
-                //just merge & expand on y axis
-                if (lhs.min.x == rhs.min.x && lhs.max.x == rhs.max.x) {
-                    if (lhs.min.y <= rhs.max.y && rhs.min.y <= lhs.max.y) {
-                        rhs.min.y = std::min(lhs.min.y, rhs.min.y);
-                        rhs.max.y = std::max(lhs.max.y, rhs.max.y);
-                        merged = true;
-                        break;
-                    }
-                }
-                //subdivide regions
-                if (lhs.intersected(rhs)) {
-                    subdivide(targets, j, lhs, rhs);
-                    --j; //rhs dirty region has been damaged, try again.
-                }
-            }
-            if (!merged) output.push(lhs);  //this region is complete isolated
-            lhs = {};
-        }
+        //the region fragments exceeded the working list. enlarge it and restart.
+        TVGLOG("RENDERER", "regions(%d) overflown the reserved(%d) working list. retrying...", input.count, scratch.reserved);
+        scratch.reserve(scratch.reserved * 2);
     }
 }
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -218,7 +218,13 @@ struct RenderRegion
         }
 
     private:
-        void subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs);
+        static bool subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs);
+        //Merge the regions in the working list into the disjoint output list.
+        //Returns false if the working list capacity is insufficient, leaving the regions unmodified.
+        static bool sweepMerge(Array<RenderRegion>& targets, Array<RenderRegion>& output);
+        //Merge the input regions into the disjoint output list. The working list is enlarged
+        //and the merge restarted if the produced fragments exceed its capacity.
+        void merge(const Array<RenderRegion>& input, Array<RenderRegion>& output);
 
         struct Partition
         {
@@ -229,6 +235,7 @@ struct RenderRegion
 
         Key key;
         Partition partitions[PARTITIONING];
+        Array<RenderRegion> scratch;  //working list for the merge()
         bool disabled = false;
     };
 #else

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -219,11 +219,11 @@ struct RenderRegion
 
     private:
         static bool subdivide(Array<RenderRegion>& targets, uint32_t idx, RenderRegion& lhs, RenderRegion& rhs);
-        //Merge the regions in the working list into the disjoint output list.
-        //Returns false if the working list capacity is insufficient, leaving the regions unmodified.
+        // Merge the regions in the working list into the disjoint output list.
+        // Returns false if the working list capacity is insufficient, leaving the regions unmodified.
         static bool sweepMerge(Array<RenderRegion>& targets, Array<RenderRegion>& output);
-        //Merge the input regions into the disjoint output list. The working list is enlarged
-        //and the merge restarted if the produced fragments exceed its capacity.
+        // Merge the input regions into the disjoint output list. The working list is enlarged
+        // and the merge restarted if the produced fragments exceed its capacity.
         void merge(const Array<RenderRegion>& input, Array<RenderRegion>& output);
 
         struct Partition
@@ -235,7 +235,7 @@ struct RenderRegion
 
         Key key;
         Partition partitions[PARTITIONING];
-        Array<RenderRegion> scratch;  //working list for the merge()
+        Array<RenderRegion> scratch;  // working list for the merge()
         bool disabled = false;
     };
 #else

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -422,6 +422,80 @@ static void requireBuffersEqual(const vector<uint32_t>& a, const vector<uint32_t
     REQUIRE(true);
 }
 
+TEST_CASE("RLE dense and tall fill consistency", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        // solid rect: interior is covered, a far corner stays clear (sweep / clip)
+        {
+            const uint32_t W = 64, H = 64;
+            vector<uint32_t> buffer(W * H, 0);
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(buffer.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            auto rect = Shape::gen();
+            REQUIRE(rect->appendRect(10, 10, 20, 20) == Result::Success);
+            REQUIRE(rect->fill(200, 40, 80) == Result::Success);
+            REQUIRE(canvas->add(rect) == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+            REQUIRE(buffer[20 + 20 * W] != 0);
+            REQUIRE(buffer[0] == 0);
+            REQUIRE(buffer[(W - 1) + (H - 1) * W] == 0);
+        }
+
+        // tall sawtooth plus a dense star: many rows / cells, including pool growth
+        const uint32_t W = 64, H = 2048;
+        auto makeScene = []() {
+            const uint32_t TW = 64, TH = 2048;
+            auto scene = Scene::gen();
+            auto saw = Shape::gen();
+            REQUIRE(saw->moveTo(0, 0) == Result::Success);
+            for (int y = 0; y < int(TH); y += 8) {
+                REQUIRE(saw->lineTo(40, float(y + 4)) == Result::Success);
+                REQUIRE(saw->lineTo(8, float(y + 8)) == Result::Success);
+            }
+            REQUIRE(saw->lineTo(float(TW - 1), float(TH)) == Result::Success);
+            REQUIRE(saw->lineTo(float(TW - 1), 0) == Result::Success);
+            REQUIRE(saw->close() == Result::Success);
+            REQUIRE(saw->fill(120, 40, 200) == Result::Success);
+            REQUIRE(scene->add(saw) == Result::Success);
+
+            auto star = Shape::gen();
+            const int N = 200;
+            const float cx = 32.0f, cy = 32.0f, r = 28.0f;
+            REQUIRE(star->moveTo(cx + r, cy) == Result::Success);
+            for (int i = 1; i <= N; ++i) {
+                auto a = float(i) * 6.2831853f / float(N);
+                auto rad = (i % 2) ? r * 0.35f : r;
+                REQUIRE(star->lineTo(cx + rad * std::cos(a), cy + rad * std::sin(a)) == Result::Success);
+            }
+            REQUIRE(star->close() == Result::Success);
+            REQUIRE(star->fill(30, 180, 60) == Result::Success);
+            REQUIRE(scene->add(star) == Result::Success);
+            return scene;
+        };
+
+        vector<uint32_t> first(W * H, 0), second(W * H, 0);
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(first.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            REQUIRE(canvas->add(makeScene()) == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(second.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            REQUIRE(canvas->add(makeScene()) == Result::Success);
+            REQUIRE(canvas->draw(true) == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        REQUIRE(first[32 + 32 * W] != 0);
+        requireBuffersEqual(first, second, W);
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
 #ifdef THORVG_PARTIAL_RENDER_SUPPORT
 
 TEST_CASE("Partial Rendering. Composited scene consistency", "[tvgSwEngine]")

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -412,6 +412,7 @@ TEST_CASE("Intersection", "[tvgSwEngine]")
 // hundreds of thousands of values under --success and slow the test.
 static void requireBuffersEqual(const vector<uint32_t>& a, const vector<uint32_t>& b, uint32_t w)
 {
+    REQUIRE(a.size() == b.size());
     for (size_t i = 0; i < a.size(); ++i) {
         if (a[i] != b[i]) {
             FAIL("first mismatch at (" << i % w << ", " << i / w << "): "

--- a/test/testSwEngine.cpp
+++ b/test/testSwEngine.cpp
@@ -22,6 +22,7 @@
 
 #include <thorvg.h>
 #include <fstream>
+#include <cmath>
 #include "config.h"
 #include "catch.hpp"
 
@@ -407,4 +408,190 @@ TEST_CASE("Intersection", "[tvgSwEngine]")
     REQUIRE(Initializer::term() == Result::Success);
 }
 
+// Compares the buffers per pixel: a whole-vector REQUIRE would expand
+// hundreds of thousands of values under --success and slow the test.
+static void requireBuffersEqual(const vector<uint32_t>& a, const vector<uint32_t>& b, uint32_t w)
+{
+    for (size_t i = 0; i < a.size(); ++i) {
+        if (a[i] != b[i]) {
+            FAIL("first mismatch at (" << i % w << ", " << i / w << "): "
+                                       << "a=0x" << hex << a[i] << " b=0x" << b[i]);
+        }
+    }
+    REQUIRE(true);
+}
+
+#ifdef THORVG_PARTIAL_RENDER_SUPPORT
+
+TEST_CASE("Partial Rendering. Composited scene consistency", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        const uint32_t W = 400, H = 200;
+
+        // a still half-transparent group and a recolored opaque shape aside
+        auto makeScene = [](uint8_t moverFill, Shape** moverOut) {
+            auto root = Scene::gen();
+            auto group = Scene::gen();
+            auto r1 = Shape::gen();
+            REQUIRE(r1->appendRect(20, 20, 30, 40) == Result::Success);
+            REQUIRE(r1->fill(120, 40, 200) == Result::Success);
+            auto r2 = Shape::gen();
+            REQUIRE(r2->appendRect(70, 20, 30, 40) == Result::Success);
+            REQUIRE(r2->fill(120, 40, 200) == Result::Success);
+            REQUIRE(group->add(r1) == Result::Success);
+            REQUIRE(group->add(r2) == Result::Success);
+            REQUIRE(group->opacity(128) == Result::Success);
+            REQUIRE(root->add(group) == Result::Success);
+
+            auto mover = Shape::gen();
+            REQUIRE(mover->appendRect(300, 20, 20, 20) == Result::Success);
+            REQUIRE(mover->fill(moverFill, 200, 40) == Result::Success);
+            REQUIRE(root->add(mover) == Result::Success);
+            if (moverOut) *moverOut = mover;
+            return root;
+        };
+
+        vector<uint32_t> incremental(W * H, 0), fresh(W * H, 0);
+        const int FRAMES = 4;
+
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(incremental.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            Shape* mover = nullptr;
+            REQUIRE(canvas->add(makeScene(20, &mover)) == Result::Success);
+            for (int f = 0; f <= FRAMES; ++f) {
+                if (f > 0) REQUIRE(mover->fill(uint8_t(20 + f), 200, 40) == Result::Success);
+                REQUIRE(canvas->update() == Result::Success);
+                REQUIRE(canvas->draw() == Result::Success);
+                REQUIRE(canvas->sync() == Result::Success);
+            }
+        }
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(fresh.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            REQUIRE(canvas->add(makeScene(20 + FRAMES, nullptr)) == Result::Success);
+            REQUIRE(canvas->draw(true) == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        requireBuffersEqual(incremental, fresh, W);
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
+TEST_CASE("Partial Rendering. Fragmented regions consistency", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        const uint32_t W = 800, H = 600;
+
+        // a still translucent background with a large number of tiny updated shapes
+        auto makeScene = [](uint8_t fill, vector<Shape*>* rectsOut) {
+            auto scene = Scene::gen();
+            auto bg = Shape::gen();
+            REQUIRE(bg->appendRect(0, 0, W, H) == Result::Success);
+            REQUIRE(bg->fill(120, 40, 200, 128) == Result::Success);
+            REQUIRE(scene->add(bg) == Result::Success);
+            for (int i = 0; i < 65; ++i) {
+                auto x = 20 + (i % 13) * 10, y = 20 + (i / 13) * 10;
+                auto rect = Shape::gen();
+                REQUIRE(rect->appendRect(float(x), float(y), 2, 2) == Result::Success);
+                REQUIRE(rect->fill(fill, 220, 40) == Result::Success);
+                REQUIRE(scene->add(rect) == Result::Success);
+                if (rectsOut) rectsOut->push_back(rect);
+            }
+            return scene;
+        };
+
+        vector<uint32_t> incremental(W * H, 0), fresh(W * H, 0);
+
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(incremental.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            vector<Shape*> rects;
+            REQUIRE(canvas->add(makeScene(20, &rects)) == Result::Success);
+            REQUIRE(canvas->update() == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+
+            for (auto rect : rects)
+                REQUIRE(rect->fill(21, 220, 40) == Result::Success);
+            REQUIRE(canvas->update() == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(fresh.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            REQUIRE(canvas->add(makeScene(21, nullptr)) == Result::Success);
+            REQUIRE(canvas->draw(true) == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        requireBuffersEqual(incremental, fresh, W);
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+
+TEST_CASE("Partial Rendering. Heavy region fragmentation consistency", "[tvgSwEngine]")
+{
+    REQUIRE(Initializer::init() == Result::Success);
+    {
+        const uint32_t W = 800, H = 600;
+
+        // still composited bands crossed by recolored strips: the region union
+        // fragments beyond the initial working list capacity
+        auto makeScene = [](uint8_t stripFill, vector<Shape*>* stripsOut) {
+            auto root = Scene::gen();
+            for (int i = 0; i < 30; ++i) {
+                auto group = Scene::gen();
+                auto r1 = Shape::gen();
+                REQUIRE(r1->appendRect(0, float(i * 4), 30, 2) == Result::Success);
+                REQUIRE(r1->fill(30, 180, 60) == Result::Success);
+                auto r2 = Shape::gen();
+                REQUIRE(r2->appendRect(30, float(i * 4), 30, 2) == Result::Success);
+                REQUIRE(r2->fill(30, 180, 60) == Result::Success);
+                REQUIRE(group->add(r1) == Result::Success);
+                REQUIRE(group->add(r2) == Result::Success);
+                REQUIRE(group->opacity(128) == Result::Success);
+                REQUIRE(root->add(group) == Result::Success);
+            }
+            for (int i = 0; i < 15; ++i) {
+                auto strip = Shape::gen();
+                REQUIRE(strip->appendRect(float(i * 4), 0, 2, 120) == Result::Success);
+                REQUIRE(strip->fill(stripFill, 40, 200, 128) == Result::Success);
+                REQUIRE(root->add(strip) == Result::Success);
+                if (stripsOut) stripsOut->push_back(strip);
+            }
+            return root;
+        };
+
+        vector<uint32_t> incremental(W * H, 0), fresh(W * H, 0);
+
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(incremental.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            vector<Shape*> strips;
+            REQUIRE(canvas->add(makeScene(100, &strips)) == Result::Success);
+            REQUIRE(canvas->update() == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+
+            for (auto strip : strips)
+                REQUIRE(strip->fill(101, 40, 200, 128) == Result::Success);
+            REQUIRE(canvas->update() == Result::Success);
+            REQUIRE(canvas->draw() == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        {
+            auto canvas = unique_ptr<SwCanvas>(SwCanvas::gen());
+            REQUIRE(canvas->target(fresh.data(), W, W, H, ColorSpace::ARGB8888S) == Result::Success);
+            REQUIRE(canvas->add(makeScene(101, nullptr)) == Result::Success);
+            REQUIRE(canvas->draw(true) == Result::Success);
+            REQUIRE(canvas->sync() == Result::Success);
+        }
+        requireBuffersEqual(incremental, fresh, W);
+    }
+    REQUIRE(Initializer::term() == Result::Success);
+}
+#endif
 #endif


### PR DESCRIPTION
Coverage cells were accumulated in a sorted singly-linked list per scanline: for every cell transition `_findCell()` walked the row from its head to find the insertion point, each hop touching a separate 24-byte list node. For dense shapes a row holds hundreds of cells, so the insertion cost is O(cells²) per row — quadratic pointer chasing that dominates profiles on fill-heavy workloads (in a dense-fill sample ~98% of the engine time is inside the cell worker, mostly `_findCell`/`_setCell`). The design comes from FreeType glyph rasterization, where cells per row are small; ThorVG runs it on full-canvas paths.

Replace the sorted lists with the AGG-style layout:

1. **Append** cells in outline order into a contiguous array — O(1), no scan.
2. **Partition by row** with a counting pass; sort each row by x; merge equal-x cells (coverage accumulation is a commutative integer addition, so the recording order is irrelevant — the sweep consumes the identical set of merged cells in identical (y, x) order and the span output is byte-identical).
3. **Sweep** walks contiguous row ranges instead of chasing `next` pointers.

Banding is kept to bound the scratch; the scratch grows on demand instead of re-processing the band on pool overflow (the retry path becomes unreachable and is removed). The layout arithmetic is done in integers — the previous pointer-subtraction produced a huge `rawMax` under `-O3` and could overflow the heap. The rework also removes a data race on the shared cell-pool buffer (after a grow freed the old block, another thread's malloc could reuse the same address for a different slot), which made multi-threaded renders nondeterministic; ThreadSanitizer is clean now.

**Performance** (Apple M1, render-only, byte-identical A/B builds): dense fill +25%, wide stroke +14%, self-overlapping spiral +25%; synthetic suite totals +8.4% (4 threads) / +9.5–11% (8 threads); Ghostscript Tiger +28%; Germany municipalities map (25 MB) +13%. Tiny shapes with only a few cells per row pay a small single-thread overhead (the counting pass dominates when the old O(k²) was already cheap); it is hidden by shape-level parallelism at 4–8 threads.

**Verification:** byte-identical rendering on 68 SVG cases (17 files × 2 resolutions × 2 color spaces), 12 large-SVG cases (up to 79 MB), 2 × 4K renders and 200/200 Lottie frames of incremental playback; a 200k-case fuzz of the partition/sort/merge against a reference sort; ThreadSanitizer clean over multi-threaded renders (previously 11–44 races per run); the new RLE consistency test renders a 2048-row sawtooth plus a dense star through both draw paths.

Depends on #4743 (stacked on top of it).
