### PR TITLE
infra: include PR number in pixel inspector report name

### DIFF
--- a/.github/workflows/pixel_inspector.yml
+++ b/.github/workflows/pixel_inspector.yml
@@ -271,7 +271,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: thorvg-pixel-report
+          name: thorvg-pixel-report-PR-${{ github.event.pull_request.number }}
           path: tvg-pixel-inspector/output/reporter.*.PR-${{ github.event.pull_request.number }}.pdf
           if-no-files-found: warn
 

--- a/.github/workflows/pixel_inspector_report.yml
+++ b/.github/workflows/pixel_inspector_report.yml
@@ -113,7 +113,7 @@ jobs:
             });
 
             const pdfArtifact = artifacts.find(artifact =>
-              artifact.name === 'thorvg-pixel-report' && !artifact.expired
+              artifact.name === `thorvg-pixel-report-PR-${prNumber}` && !artifact.expired
             );
 
             if (pdfArtifact) {


### PR DESCRIPTION
> [!Note]
> This PR is stacked on top of #4739

The report artifact previously used a fixed name.
Include the PR number so downloaded ZIP files are easier to identify.

Issue: https://github.com/thorvg/thorvg.pixel-inspector/issues/25