### PR TITLE
wg_engine: support repeated surface reconfiguration

### DIFF
--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -98,6 +98,7 @@ void WgRenderer::clearTargets()
 
 void WgRenderer::surfaceConfigure(WGPUSurface surface, WgContext& context, uint32_t width, uint32_t height, ColorSpace cs)
 {
+    releaseSurfaceTexture();
     this->surface = surface;
 
     // setup surface configuration


### PR DESCRIPTION
## Motivation

Resizing or moving a window between displays may reconfigure its WebGPU
surface while ThorVG retains the previous surface texture. wgpu-native
can reject this lifecycle and abort.

## Change

Release the retained texture before configuring the surface again. This
uses the existing cleanup path and adds no GPU rendering work.

Issue: thorvg/thorvg.example#39