### PR TITLE
api: expose Lottie expression support query

### DIFF
--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -3262,6 +3262,15 @@ TVG_API Tvg_Result tvg_lottie_animation_tween_go(Tvg_Animation animation, float 
 TVG_API Tvg_Result tvg_lottie_animation_set_quality(Tvg_Animation animation, uint8_t value);
 
 /**
+ * @brief Checks whether Lottie expressions are supported.
+ *
+ * @return @c true if expression support is enabled in this build, otherwise @c false.
+ *
+ * @note Experimental API
+ */
+TVG_API bool tvg_lottie_animation_expressions_supported();
+
+/**
  * @brief Describes the current state of a Lottie audio layer.
  *
  * This structure is provided to the audio resolver callback and contains

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -1318,6 +1318,15 @@ TVG_API Tvg_Result tvg_lottie_animation_set_quality(Tvg_Animation animation, uin
 }
 
 
+TVG_API bool tvg_lottie_animation_expressions_supported()
+{
+#ifdef THORVG_LOTTIE_LOADER_SUPPORT
+    return LottieAnimation::expressions();
+#endif
+    return false;
+}
+
+
 TVG_API Tvg_Result tvg_lottie_animation_set_audio_resolver(Tvg_Animation animation, Tvg_Audio_Resolver resolver, void* data)
 {
 #ifdef THORVG_LOTTIE_LOADER_SUPPORT

--- a/src/loaders/lottie/thorvg_lottie.h
+++ b/src/loaders/lottie/thorvg_lottie.h
@@ -243,6 +243,15 @@ struct TVG_API LottieAnimation final : Animation
     Result resolver(std::function<void(const LottieAudioResolver& info, void* data)> func, void* data) noexcept;
 
     /**
+     * @brief Checks whether Lottie expressions are supported.
+     *
+     * @return @c true if expression support is enabled in this build, otherwise @c false.
+     *
+     * @note Experimental API
+     */
+    static bool expressions() noexcept;
+
+    /**
      * @brief Creates a new LottieAnimation object.
      *
      * @return A new LottieAnimation object.

--- a/src/loaders/lottie/tvgLottieAnimation.cpp
+++ b/src/loaders/lottie/tvgLottieAnimation.cpp
@@ -138,6 +138,14 @@ Result LottieAnimation::resolver(std::function<void(const LottieAudioResolver&, 
     return Result::Success;
 }
 
+bool LottieAnimation::expressions() noexcept
+{
+#ifdef THORVG_LOTTIE_EXPRESSIONS_SUPPORT
+    return true;
+#else
+    return false;
+#endif
+}
 
 LottieAnimation* LottieAnimation::gen() noexcept
 {


### PR DESCRIPTION
- Add a build-time capability query for Lottie expression support.
- Expose the same capability through the C API.

C++
+ static bool LottieAnimation::expressions()

CAPI
+ bool tvg_lottie_animation_expressions_supported()