### PR TITLE
infra: disable Lottie expressions by default

### DIFF
--- a/.github/workflows/binary_size.yml
+++ b/.github/workflows/binary_size.yml
@@ -150,6 +150,7 @@ jobs:
             -Dstatic=true
             -Doptimization=s
             -Derrorlogs=true
+            -Dextra="lottie_exp,openmp"
           )
           [ -n "$C_ARGS" ]        && meson_args+=("-Dc_args=$C_ARGS")
           [ -n "$CPP_ARGS" ]      && meson_args+=("-Dcpp_args=$CPP_ARGS")

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Build
       run: |
-        meson setup build -Dlog=true -Dengines="cpu, gl" -Dloaders=all -Dsavers=all -Dbindings=capi
+        meson setup build -Dlog=true -Dengines="cpu, gl" -Dloaders=all -Dsavers=all -Dbindings=capi -Dextra="lottie_exp,openmp"
         sudo ninja -C build install
 
   compact_test:
@@ -46,7 +46,7 @@ jobs:
 
     - name: Build
       run: |
-        meson setup build -Dlog=true -Dengines="cpu, gl" -Dloaders=all -Dsavers=all -Dstatic=true -Dthreads=false
+        meson setup build -Dlog=true -Dengines="cpu, gl" -Dloaders=all -Dsavers=all -Dstatic=true -Dthreads=false -Dextra="lottie_exp,openmp"
         sudo ninja -C build install
 
   unit_test:
@@ -71,7 +71,7 @@ jobs:
 
     - name: Build
       run: |
-        meson setup build -Dloaders="all" -Dengines="all" -Dsavers="all" -Dbindings="capi" -Dtests=true --errorlogs
+        meson setup build -Dloaders="all" -Dengines="all" -Dsavers="all" -Dbindings="capi" -Dtests=true -Dextra="lottie_exp,openmp" --errorlogs
         sudo ninja -C build install
         env LIBGL_ALWAYS_SOFTWARE=1 meson test -C build --print-errorlogs --timeout 120
 
@@ -91,7 +91,7 @@ jobs:
     - name: Build & Run memcheck Script(ASAN)
       run: |
         sudo rm -rf ./build
-        meson setup build -Db_sanitize="address,undefined" -Dloaders="all" -Dsavers="all" -Dtests="true" -Dbindings="capi"
+        meson setup build -Db_sanitize="address,undefined" -Dloaders="all" -Dsavers="all" -Dtests="true" -Dbindings="capi" -Dextra="lottie_exp,openmp"
         sudo ninja -C build install
         export PATH=$PATH:~/.local/bin/
         chmod +x "${GITHUB_WORKSPACE}/.github/workflows/memcheck_asan.sh"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Build
       run: |
-        meson setup build -Dlog=true -Dloaders=all -Dsavers=all -Dbindings=capi
+        meson setup build -Dlog=true -Dloaders=all -Dsavers=all -Dbindings=capi -Dextra="lottie_exp,openmp"
         where link
         ninja -C build install
 
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build
       run: |
-        meson setup build -Dlog=true -Dloaders=all -Dsavers=all -Dstatic=true -Dthreads=false
+        meson setup build -Dlog=true -Dloaders=all -Dsavers=all -Dstatic=true -Dthreads=false -Dextra="lottie_exp,openmp"
         where link
         ninja -C build install
 
@@ -66,7 +66,7 @@ jobs:
 
     - name: Build
       run: |
-        meson setup build -Dloaders=all -Dsavers=all -Dbindings=capi -Dtests=true --errorlogs
+        meson setup build -Dloaders=all -Dsavers=all -Dbindings=capi -Dtests=true -Dextra="lottie_exp,openmp" --errorlogs
         where link
         ninja -C build install test
 
@@ -74,4 +74,3 @@ jobs:
       with:
         name: UnitTestReport
         path: build/meson-logs/testlog.txt
-

--- a/.github/workflows/memcheck_asan.sh
+++ b/.github/workflows/memcheck_asan.sh
@@ -7,7 +7,7 @@ fi
 
 if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
     echo "Run Address Sanitizer"
-    echo "meson -Db_sanitize=\"address,undefined\" -Dloaders=\"all\" -Dsavers=\"all\" -Dtests=\"true\" -Dbindings=\"capi\" . build"
+    echo "meson -Db_sanitize=\"address,undefined\" -Dloaders=\"all\" -Dsavers=\"all\" -Dtests=\"true\" -Dbindings=\"capi\" -Dextra=\"lottie_exp,openmp\" . build"
     pwd
     cd ${GITHUB_WORKSPACE}/build/test
     ./tvgUnitTests > memcheck_asan.txt 2>&1
@@ -23,7 +23,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
     if [[ $PAYLOAD_MEMCHECK == *"runtime error:"* || $PAYLOAD_MEMCHECK == *"ERROR: AddressSanitizer:"* ]]; then
         OUTPUT+=$'\n**MEMCHECK(ASAN) RESULT**:\n'
 
-        OUTPUT+=$'\n`meson -Db_sanitize="address,undefined" -Dloaders="all" -Dsavers="all" -Dtests="true" -Dbindings="capi" . build`\n'
+        OUTPUT+=$'\n`meson -Db_sanitize="address,undefined" -Dloaders="all" -Dsavers="all" -Dtests="true" -Dbindings="capi" -Dextra="lottie_exp,openmp" . build`\n'
         OUTPUT+=$'\n```\n'
         OUTPUT+="$PAYLOAD_MEMCHECK"
         OUTPUT+=$'\n```\n' 
@@ -41,4 +41,3 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
         curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.github.VERSION.text+json" --data "$PAYLOAD" "$COMMENTS_URL"
     fi
 fi
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install meson ninja-build
       - name: Create source archive
         run: |
-          meson setup builddir thorvg
+          meson setup builddir thorvg -Dextra="lottie_exp,openmp"
           meson dist -C builddir
       - name: Upload to release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -353,19 +353,19 @@ ThorVG supports the most powerful [Lottie Animation features](https://github.com
 ThorVG offers great flexibility in building its binary. Besides serving as a general graphics engine, it can be configured as a compact Lottie animation playback library with specific build options:
 
 ```
-$meson setup builddir -Dloaders="lottie"
+$meson setup builddir -Dloaders="lottie, ..."
 ```
 
-Alternatively, to support additional bitmap image formats:
+Alternatively, to enable all loaders available for Lottie:
 
 ```
-$meson setup builddir -Dloaders="lottie, png, jpg, webp"
+$meson setup builddir -Dloaders="all"
 ```
 
-Please note that ThorVG supports Lottie Expressions by default. Lottie Expressions are small JavaScript code snippets that can be applied to animated properties in your Lottie animations, evaluating to a single value. This is an advanced feature in the Lottie specification and may impact binary size and performance, especially when targeting small devices such as MCUs. If this feature is not essential for your requirements, you can disable it using the `extra` build option in ThorVG:
+Lottie Expressions are small JavaScript code snippets that can be applied to animated properties and evaluated to a single value. Expressions are an advanced feature that is not currently part of the official Lottie specification and may increase binary size or affect performance, especially on small devices such as MCUs. ThorVG disables expression support by default; enable it explicitly with the `extra` build option when required:
 
 ```
-$meson setup builddir -Dloaders="lottie" -Dextra=""
+$meson setup builddir -Dloaders="lottie" -Dextra="lottie_exp, ..."
 ```
 
 The following code snippet demonstrates how to use ThorVG to play a Lottie animation.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -60,5 +60,5 @@ option('file',
 option('extra',
    type: 'array',
    choices: ['', 'opengl_es', 'lottie_exp', 'openmp'],
-   value: ['lottie_exp', 'openmp'],
+   value: ['openmp'],
    description: 'Enable support for extra options')

--- a/src/loaders/lottie/jerryscript/jerry-core/LICENSE
+++ b/src/loaders/lottie/jerryscript/jerry-core/LICENSE
@@ -1,5 +1,5 @@
 # JerryScript
-# Included with the ThorVG build options -Dloaders="lottie" (default) and -Dextra="lottie_exp" (default).
+# Included with the ThorVG build options -Dloaders="lottie" and -Dextra="lottie_exp".
 # This component is enabled when THORVG_LOTTIE_EXPRESSIONS_SUPPORT is set to 1.
 
 Copyright JS Foundation and other contributors, http://js.foundation


### PR DESCRIPTION
Lottie expressions are an advanced feature and are not currently part of the official Lottie specification.

Disable them by default to reduce binary size while allowing users who need expression support to enable it explicitly.