### PR TITLE
gl: finetune geometry updates

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlCommon.h
+++ b/src/renderer/gpu_engine/gl/tvgGlCommon.h
@@ -92,7 +92,7 @@ struct GlGeometry
     void setMatrix(const Matrix& tr) { matrix = tr; inverseMatrixDirty = true;}
 
     void prepare(const RenderShape& rshape);
-    bool tesselateShape(const RenderShape& rshape, float* opacityMultiplier = nullptr);
+    bool tesselateShape(const RenderShape& rshape, float& multiplier);
     bool tesselateStroke(const RenderShape& rshape);
     bool tesselateThinFill(const RenderPath& path);
     void tesselateImage(const RenderSurface* image);
@@ -141,6 +141,7 @@ struct GlShape : GlDrawable
     void destroy(GlRenderer& renderer) override {}
 
     const RenderShape* rshape;
+    float multiplier = 1.0f;
     struct {
         bool fill = false;
         bool stroke = false;

--- a/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
@@ -183,12 +183,13 @@ void GlGeometry::prepare(const RenderShape& rshape)
 }
 
 
-bool GlGeometry::tesselateShape(const RenderShape& rshape, float* opacityMultiplier)
+bool GlGeometry::tesselateShape(const RenderShape& rshape, float& multiplier)
 {
     fill.clear();
     fillBounds = {};
     fillWorld = true;
     convex = false;
+    multiplier = 1.0f;
 
     // `skipFill` means the path stayed thin enough that even thin fallback should not draw a fill.
     if (optPathSkipFill) return false;
@@ -199,7 +200,7 @@ bool GlGeometry::tesselateShape(const RenderShape& rshape, float* opacityMultipl
     // Visible thin fills use stroke tessellation; sub-quantum fills are skipped earlier.
     if (optPathThin && tvg::zero(rshape.strokeWidth())) {
         if (tesselateThinFill(optPath)) {
-            if (opacityMultiplier) *opacityMultiplier = MIN_GL_STROKE_ALPHA;
+            multiplier = MIN_GL_STROKE_ALPHA;
             fillRule = rshape.rule;
             return true;
         }
@@ -212,7 +213,7 @@ bool GlGeometry::tesselateShape(const RenderShape& rshape, float* opacityMultipl
     fillRule = rshape.rule;
     fillBounds = bwTess.bounds();
     convex = bwTess.convex;
-    if (opacityMultiplier) *opacityMultiplier = 1.0f;
+
     return true;
 }
 

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -50,13 +50,10 @@ bool GlDrawable::prepare(RenderUpdateFlag& updateFlags, const Point& viewSize, u
         flags |= updateFlags;
         return true;
     }
-
     updateFlags |= flags;
     flags = RenderUpdateFlag::None;
     if (updateFlags == RenderUpdateFlag::None) return true;
-
     size = viewSize;
-    this->opacity = opacity;
     return false;
 }
 
@@ -1328,11 +1325,15 @@ RenderData GlRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
         textures.upload(mStateCache, image->texId, surface, filter);
     }
 
-    image->geometry.setMatrix(transform);
-    image->geometry.viewport = vport;
-    image->geometry.tesselateImage(surface);
+    if (flags & (RenderUpdateFlag::Image | RenderUpdateFlag::Transform)) {
+        image->geometry.setMatrix(transform);
+        image->geometry.tesselateImage(surface);
+    }
 
     if (flags & RenderUpdateFlag::Clip) image->clips = clips;
+
+    image->geometry.viewport = vport;
+    image->opacity = opacity;
 
     return image;
 }
@@ -1352,24 +1353,20 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
     shape->geometry.setMatrix(transform);
     shape->geometry.viewport = vport;
-    auto strokePathMissing = (flags & RenderUpdateFlag::Stroke) && rshape.stroke && std::isfinite(rshape.strokeWidth()) && !tvg::zero(rshape.strokeWidth()) && shape->geometry.optStrokePath.empty();
-    if ((flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform)) || strokePathMissing) shape->geometry.prepare(rshape);
 
-    //TODO: Please precisely update tessellation not to update only if the color is changed.
-    if (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Gradient | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
+    auto updateStroke = (flags & RenderUpdateFlag::Stroke) && rshape.stroke && std::isfinite(rshape.strokeWidth()) && !tvg::zero(rshape.strokeWidth()) && shape->geometry.optStrokePath.empty();
+    auto updatePath = (flags & (RenderUpdateFlag::Path | RenderUpdateFlag::Transform)) || updateStroke;
+
+    if (updatePath) {
+        shape->geometry.prepare(rshape);
         shape->valid.fill = false;
-        float opacityMultiplier = 1.0f;
-        if (shape->geometry.tesselateShape(*(shape->rshape), &opacityMultiplier)) {
-            shape->opacity *= opacityMultiplier;
+        if (shape->geometry.tesselateShape(*(shape->rshape), shape->multiplier)) {
             shape->valid.fill = true;
         }
+        shape->valid.stroke = shape->geometry.tesselateStroke(*(shape->rshape));
     }
 
-    //TODO: Please precisely update tessellation not to update only if the color is changed.
-    if (flags & (RenderUpdateFlag::Color | RenderUpdateFlag::Stroke | RenderUpdateFlag::GradientStroke | RenderUpdateFlag::Transform | RenderUpdateFlag::Path)) {
-        shape->valid.stroke = false;
-        if (shape->geometry.tesselateStroke(*(shape->rshape))) shape->valid.stroke = true;
-    }
+    shape->opacity = float(opacity) * shape->multiplier;
 
     if (flags & RenderUpdateFlag::Clip) shape->clips = clips;
 


### PR DESCRIPTION
- Retessellate shape fills and strokes only when geometry changes.
- Rebuild image meshes only for image or transform updates.
- Preserve thin-fill opacity across non-geometry updates.
- Require fill tessellation to return its opacity multiplier.