### PR TITLE
lottie/slot: slottable properties coverage++

### DIFF
--- a/src/loaders/lottie/tvgLottieModel.h
+++ b/src/loaders/lottie/tvgLottieModel.h
@@ -391,7 +391,8 @@ struct LottieTextRange : LottieObject
     {
         LottieProperty* backup = nullptr;
         OVERRIDE(style.fillColor) || OVERRIDE(style.strokeColor) || OVERRIDE(style.position) || OVERRIDE(style.scale) || OVERRIDE(style.rotation) || OVERRIDE(style.letterSpace) ||
-        OVERRIDE(style.lineSpace) || OVERRIDE(style.strokeWidth) || OVERRIDE(style.fillOpacity) || OVERRIDE(style.strokeOpacity) || OVERRIDE(style.opacity);
+        OVERRIDE(style.lineSpace) || OVERRIDE(style.strokeWidth) || OVERRIDE(style.fillOpacity) || OVERRIDE(style.strokeOpacity) || OVERRIDE(style.opacity) ||
+        OVERRIDE(offset) || OVERRIDE(maxEase) || OVERRIDE(minEase) || OVERRIDE(maxAmount) || OVERRIDE(smoothness) || OVERRIDE(start) || OVERRIDE(end);
         return backup;
     }
 };
@@ -485,7 +486,7 @@ struct LottieText : LottieObject, LottieRenderPooler<tvg::Shape>
     LottieProperty* override(LottieProperty* prop, bool release) override
     {
         LottieProperty* backup = nullptr;
-        OVERRIDE(doc);
+        OVERRIDE(doc) || OVERRIDE(alignOp.anchor);
         return backup;
     }
 
@@ -569,6 +570,13 @@ struct LottieRoundedCorner : LottieObject
         return nullptr;
     }
 
+    LottieProperty* override(LottieProperty* prop, bool release) override
+    {
+        LottieProperty* backup = nullptr;
+        OVERRIDE(radius);
+        return backup;
+    }
+
     LottieFloat radius = 0.0f;
 };
 
@@ -635,6 +643,13 @@ struct LottiePolyStar : LottieShape
         if (rotation.ix == ix) return &rotation;
         if (ptsCnt.ix == ix) return &ptsCnt;
         return nullptr;
+    }
+
+    LottieProperty* override(LottieProperty* prop, bool release) override
+    {
+        LottieProperty* backup = nullptr;
+        OVERRIDE(position) || OVERRIDE(innerRadius) || OVERRIDE(outerRadius) || OVERRIDE(innerRoundness) || OVERRIDE(outerRoundness) || OVERRIDE(rotation) || OVERRIDE(ptsCnt);
+        return backup;
     }
 
     LottieVector position = Point{0.0f, 0.0f};
@@ -717,7 +732,7 @@ struct LottieTransform : LottieObject
     LottieProperty* override(LottieProperty* prop, bool release) override
     {
         LottieProperty* backup = nullptr;
-        OVERRIDE(rotation) || OVERRIDE(scale) || OVERRIDE(position) || OVERRIDE(opacity) || OVERRIDE(skewAngle) || OVERRIDE(skewAxis);
+        OVERRIDE(rotation) || OVERRIDE(scale) || OVERRIDE(position) || OVERRIDE(anchor) || OVERRIDE(opacity) || OVERRIDE(skewAngle) || OVERRIDE(skewAxis);
         return backup;
     }
 
@@ -971,6 +986,13 @@ struct LottieRepeater : LottieObject
         return nullptr;
     }
 
+    LottieProperty* override(LottieProperty* prop, bool release) override
+    {
+        LottieProperty* backup = nullptr;
+        OVERRIDE(copies) || OVERRIDE(offset) || OVERRIDE(position) || OVERRIDE(rotation) || OVERRIDE(scale) || OVERRIDE(anchor) || OVERRIDE(startOpacity) || OVERRIDE(endOpacity);
+        return backup;
+    }
+
     LottieFloat copies = 0.0f;
     LottieFloat offset = 0.0f;
 
@@ -988,6 +1010,13 @@ struct LottieOffsetPath : LottieObject
 {
     LottieOffsetPath() : LottieObject(LottieObject::OffsetPath) {}
 
+    LottieProperty* override(LottieProperty* prop, bool release) override
+    {
+        LottieProperty* backup = nullptr;
+        OVERRIDE(offset) || OVERRIDE(miterLimit);
+        return backup;
+    }
+
     LottieFloat offset = 0.0f;
     LottieFloat miterLimit = 4.0f;
     StrokeJoin join = StrokeJoin::Miter;
@@ -997,12 +1026,26 @@ struct LottiePuckerBloat : LottieObject
 {
     LottiePuckerBloat() : LottieObject(LottieObject::PuckerBloat) {}
 
+    LottieProperty* override(LottieProperty* prop, bool release) override
+    {
+        LottieProperty* backup = nullptr;
+        OVERRIDE(amount);
+        return backup;
+    }
+
     LottieFloat amount = 0.0f;
 };
 
 struct LottieZigZag : LottieObject
 {
     LottieZigZag() : LottieObject(LottieObject::ZigZag) {}
+
+    LottieProperty* override(LottieProperty* prop, bool release) override
+    {
+        LottieProperty* backup = nullptr;
+        OVERRIDE(amplitude);
+        return backup;
+    }
 
     LottieFloat amplitude = 0.0f;
     LottieInteger frequency = 0;

--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -606,7 +606,7 @@ LottieTransform* LottieParser::parseTransform(bool ddd)
                 else skip();
             }
         }
-        else if (KEY_AS("a")) parseProperty(transform->anchor);
+        else if (KEY_AS("a")) parseProperty(transform->anchor, transform);
         else if (KEY_AS("s")) parseProperty(transform->scale, transform);
         else if (KEY_AS("r")) parseProperty(transform->rotation, transform);
         else if (KEY_AS("o")) parseProperty(transform->opacity, transform);
@@ -720,13 +720,13 @@ LottiePolyStar* LottieParser::parsePolyStar()
 
     while (auto key = nextObjectKey()) {
         if (parseCommon(star, key)) continue;
-        else if (KEY_AS("p")) parseProperty(star->position);
-        else if (KEY_AS("pt")) parseProperty(star->ptsCnt);
-        else if (KEY_AS("ir")) parseProperty(star->innerRadius);
-        else if (KEY_AS("is")) parseProperty(star->innerRoundness);
-        else if (KEY_AS("or")) parseProperty(star->outerRadius);
-        else if (KEY_AS("os")) parseProperty(star->outerRoundness);
-        else if (KEY_AS("r")) parseProperty(star->rotation);
+        else if (KEY_AS("p")) parseProperty(star->position, star);
+        else if (KEY_AS("pt")) parseProperty(star->ptsCnt, star);
+        else if (KEY_AS("ir")) parseProperty(star->innerRadius, star);
+        else if (KEY_AS("is")) parseProperty(star->innerRoundness, star);
+        else if (KEY_AS("or")) parseProperty(star->outerRadius, star);
+        else if (KEY_AS("os")) parseProperty(star->outerRoundness, star);
+        else if (KEY_AS("r")) parseProperty(star->rotation, star);
         else if (KEY_AS("sy")) star->type = (LottiePolyStar::Type) getInt();
         else if (parseDirection(star, key)) continue;
         else skip();
@@ -743,7 +743,7 @@ LottieRoundedCorner* LottieParser::parseRoundedCorner()
 
     while (auto key = nextObjectKey()) {
         if (parseCommon(corner, key)) continue;
-        else if (KEY_AS("r")) parseProperty(corner->radius);
+        else if (KEY_AS("r")) parseProperty(corner->radius, corner);
         else skip();
     }
     return corner;
@@ -840,19 +840,19 @@ LottieRepeater* LottieParser::parseRepeater()
 
     while (auto key = nextObjectKey()) {
         if (parseCommon(repeater, key)) continue;
-        else if (KEY_AS("c")) parseProperty(repeater->copies);
-        else if (KEY_AS("o")) parseProperty(repeater->offset);
+        else if (KEY_AS("c")) parseProperty(repeater->copies, repeater);
+        else if (KEY_AS("o")) parseProperty(repeater->offset, repeater);
         else if (KEY_AS("m")) repeater->inorder = getInt() == 2;
         else if (KEY_AS("tr"))
         {
             enterObject();
             while (auto key = nextObjectKey()) {
-                if (KEY_AS("a")) parseProperty(repeater->anchor);
-                else if (KEY_AS("p")) parseProperty(repeater->position);
-                else if (KEY_AS("r")) parseProperty(repeater->rotation);
-                else if (KEY_AS("s")) parseProperty(repeater->scale);
-                else if (KEY_AS("so")) parseProperty(repeater->startOpacity);
-                else if (KEY_AS("eo")) parseProperty(repeater->endOpacity);
+                if (KEY_AS("a")) parseProperty(repeater->anchor, repeater);
+                else if (KEY_AS("p")) parseProperty(repeater->position, repeater);
+                else if (KEY_AS("r")) parseProperty(repeater->rotation, repeater);
+                else if (KEY_AS("s")) parseProperty(repeater->scale, repeater);
+                else if (KEY_AS("so")) parseProperty(repeater->startOpacity, repeater);
+                else if (KEY_AS("eo")) parseProperty(repeater->endOpacity, repeater);
                 else skip();
             }
         }
@@ -870,9 +870,9 @@ LottieOffsetPath* LottieParser::parseOffsetPath()
 
     while (auto key = nextObjectKey()) {
         if (parseCommon(offsetPath, key)) continue;
-        else if (KEY_AS("a")) parseProperty(offsetPath->offset);
+        else if (KEY_AS("a")) parseProperty(offsetPath->offset, offsetPath);
         else if (KEY_AS("lj")) offsetPath->join = (StrokeJoin) (getInt() - 1);
-        else if (KEY_AS("ml")) parseProperty(offsetPath->miterLimit);
+        else if (KEY_AS("ml")) parseProperty(offsetPath->miterLimit, offsetPath);
         else skip();
     }
     return offsetPath;
@@ -886,7 +886,7 @@ LottiePuckerBloat* LottieParser::parsePuckerBloat()
 
     while (auto key = nextObjectKey()) {
         if (parseCommon(puckerBloat, key)) continue;
-        else if (KEY_AS("a")) parseProperty(puckerBloat->amount);
+        else if (KEY_AS("a")) parseProperty(puckerBloat->amount, puckerBloat);
         else skip();
     }
     return puckerBloat;
@@ -900,7 +900,7 @@ LottieZigZag* LottieParser::parseZigZag()
 
     while (auto key = nextObjectKey()) {
         if (parseCommon(zigzag, key)) continue;
-        else if (KEY_AS("s")) parseProperty(zigzag->amplitude);
+        else if (KEY_AS("s")) parseProperty(zigzag->amplitude, zigzag);
         else if (KEY_AS("r")) parseProperty(zigzag->frequency);
         else if (KEY_AS("pt")) parseProperty(zigzag->point);
         else skip();
@@ -1246,7 +1246,7 @@ void LottieParser::parseTextAlignmentOption(LottieText* text)
     enterObject();
     while (auto key = nextObjectKey()) {
         if (KEY_AS("g")) text->alignOp.group = (LottieText::AlignOption::Group) getInt();
-        else if (KEY_AS("a")) parseProperty(text->alignOp.anchor);
+        else if (KEY_AS("a")) parseProperty(text->alignOp.anchor, text);
         else skip();
     }
 }
@@ -1268,19 +1268,19 @@ void LottieParser::parseTextRange(LottieText* text)
                     if (KEY_AS("t")) selector->expressible = (bool) getInt();
                     else if (KEY_AS("xe"))
                     {
-                        parseProperty(selector->maxEase);
+                        parseProperty(selector->maxEase, selector);
                         selector->interpolator = tvg::malloc<LottieInterpolator>(sizeof(LottieInterpolator));
                     }
-                    else if (KEY_AS("ne")) parseProperty(selector->minEase);
-                    else if (KEY_AS("a")) parseProperty(selector->maxAmount);
+                    else if (KEY_AS("ne")) parseProperty(selector->minEase, selector);
+                    else if (KEY_AS("a")) parseProperty(selector->maxAmount, selector);
                     else if (KEY_AS("b")) selector->based = (LottieTextRange::Based) getInt();
                     else if (KEY_AS("rn")) selector->random = getInt() ? rand() : 0;
                     else if (KEY_AS("sh")) selector->shape = (LottieTextRange::Shape) getInt();
-                    else if (KEY_AS("o")) parseProperty(selector->offset);
+                    else if (KEY_AS("o")) parseProperty(selector->offset, selector);
                     else if (KEY_AS("r")) selector->rangeUnit = (LottieTextRange::Unit) getInt();
-                    else if (KEY_AS("sm")) parseProperty(selector->smoothness);
-                    else if (KEY_AS("s")) parseProperty(selector->start);
-                    else if (KEY_AS("e")) parseProperty(selector->end);
+                    else if (KEY_AS("sm")) parseProperty(selector->smoothness, selector);
+                    else if (KEY_AS("s")) parseProperty(selector->start, selector);
+                    else if (KEY_AS("e")) parseProperty(selector->end, selector);
                     else skip();
                 }
             } else if (KEY_AS("a")) { // text style


### PR DESCRIPTION
Any Lottie property can be a slot target. Some can be added mechanically without touching the existing structure, so this adds them in bulk for API convenience.

### Newly slottable:

| Object | Property | Sample | Slot JSON | Before | After |
|---|---|---|---|---|---|
| `LottieTransform` | `anchor` | [transform-anchor.json](https://github.com/user-attachments/files/31713950/transform-anchor.json) | <code>{"tr_anchor": {"p": {"a": 0, "k": [35, 20]}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/4d8845ce-adf7-43c1-8249-2670cffb2003"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/14638734-f97e-4849-a13f-47e4175694e3"> |
| `LottiePolyStar` | `position` | [polystar-position.json](https://github.com/user-attachments/files/31713927/polystar-position.json) | <code>{"star_position": {"p": {"a": 0, "k": [-30, -20]}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/7dc4985a-ea06-476b-92a6-84acd54e1cdd"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/2b9b8393-b4d3-4798-95a4-69fbb7682eeb"> |
| `LottiePolyStar` | `ptsCnt` | [polystar-ptsCnt.json](https://github.com/user-attachments/files/31713928/polystar-ptsCnt.json) | <code>{"star_ptsCnt": {"p": {"a": 0, "k": 9}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/7dc4985a-ea06-476b-92a6-84acd54e1cdd"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/fe968a63-8d1b-441c-ac7a-4abe939849b9"> |
| `LottiePolyStar` | `rotation` | [polystar-rotation.json](https://github.com/user-attachments/files/31713929/polystar-rotation.json) | <code>{"star_rotation": {"p": {"a": 0, "k": 36}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/7dc4985a-ea06-476b-92a6-84acd54e1cdd"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/010e7bdd-d696-441b-8362-6986a1c2488f"> |
| `LottiePolyStar` | `innerRadius` | [polystar-innerRadius.json](https://github.com/user-attachments/files/31713923/polystar-innerRadius.json) | <code>{"star_innerRadius": {"p": {"a": 0, "k": 58}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/7dc4985a-ea06-476b-92a6-84acd54e1cdd"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/8c97f0d2-c81c-411e-a5f2-eedec6de0d17"> |
| `LottiePolyStar` | `innerRoundness` | [polystar-innerRoundness.json](https://github.com/user-attachments/files/31713924/polystar-innerRoundness.json) | <code>{"star_innerRoundness": {"p": {"a": 0, "k": 100}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/7dc4985a-ea06-476b-92a6-84acd54e1cdd"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/b18d9ac4-ac1b-4213-b95f-1827b6178bf6"> |
| `LottiePolyStar` | `outerRadius` | [polystar-outerRadius.json](https://github.com/user-attachments/files/31713925/polystar-outerRadius.json) | <code>{"star_outerRadius": {"p": {"a": 0, "k": 45}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/7dc4985a-ea06-476b-92a6-84acd54e1cdd"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/6b08ccfa-6a5c-4986-bf73-40d79108bc18"> |
| `LottiePolyStar` | `outerRoundness` | [polystar-outerRoundness.json](https://github.com/user-attachments/files/31713926/polystar-outerRoundness.json) | <code>{"star_outerRoundness": {"p": {"a": 0, "k": 100}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/7dc4985a-ea06-476b-92a6-84acd54e1cdd"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/551be36a-4b6a-4400-84a6-7b0572b702bd"> |
| `LottieRepeater` | `copies` | [repeater-copies.json](https://github.com/user-attachments/files/31713933/repeater-copies.json) | <code>{"rep_copies": {"p": {"a": 0, "k": 5}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/0351dcbb-3276-4743-863f-304d2fc068a0"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/41438f5a-a79f-4dfe-8c14-cb16b1082884"> |
| `LottieRepeater` | `offset` | [repeater-offset.json](https://github.com/user-attachments/files/31713935/repeater-offset.json) | <code>{"rep_offset": {"p": {"a": 0, "k": 2}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/0351dcbb-3276-4743-863f-304d2fc068a0"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/77017773-049a-4ad7-b4f2-fbeda48faeb9"> |
| `LottieRepeater` | `position` | [repeater-position.json](https://github.com/user-attachments/files/31713936/repeater-position.json) | <code>{"rep_position": {"p": {"a": 0, "k": [50, 0]}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/0351dcbb-3276-4743-863f-304d2fc068a0"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/67521246-ac77-42ad-9355-c573185344ea"> |
| `LottieRepeater` | `rotation` | [repeater-rotation.json](https://github.com/user-attachments/files/31713937/repeater-rotation.json) | <code>{"rep_rotation": {"p": {"a": 0, "k": 55}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/0351dcbb-3276-4743-863f-304d2fc068a0"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/48a85c80-c5bd-4c89-896a-c2af3b8b011e"> |
| `LottieRepeater` | `scale` | [repeater-scale.json](https://github.com/user-attachments/files/31713938/repeater-scale.json) | <code>{"rep_scale": {"p": {"a": 0, "k": [60, 60]}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/0351dcbb-3276-4743-863f-304d2fc068a0"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/5bc06ffc-c816-4d10-839f-cec066c3dbb6"> |
| `LottieRepeater` | `anchor` | [repeater-anchor.json](https://github.com/user-attachments/files/31713932/repeater-anchor.json) | <code>{"rep_anchor": {"p": {"a": 0, "k": [25, 25]}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/0351dcbb-3276-4743-863f-304d2fc068a0"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/4ee40e58-198f-42e4-9670-a40e247be135"> |
| `LottieRepeater` | `startOpacity` | [repeater-startOpacity.json](https://github.com/user-attachments/files/31713940/repeater-startOpacity.json) | <code>{"rep_startOpacity": {"p": {"a": 0, "k": 20}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/0351dcbb-3276-4743-863f-304d2fc068a0"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/07bbc3bb-a8da-4a0b-ac06-25d52888f0d1"> |
| `LottieRepeater` | `endOpacity` | [repeater-endOpacity.json](https://github.com/user-attachments/files/31713934/repeater-endOpacity.json) | <code>{"rep_endOpacity": {"p": {"a": 0, "k": 15}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/0351dcbb-3276-4743-863f-304d2fc068a0"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/88880ac5-999b-41e8-956b-0c373d9e6cd5"> |
| `LottieRoundedCorner` | `radius` | [roundedcorner-radius.json](https://github.com/user-attachments/files/31713941/roundedcorner-radius.json) | <code>{"corner_radius": {"p": {"a": 0, "k": 45}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/648a522d-a872-4817-88a8-10f031b08891"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/a2faab9d-a16a-4f60-bbe1-390dcb0d1165"> |
| `LottieOffsetPath` | `offset` | [offsetpath-offset.json](https://github.com/user-attachments/files/31713922/offsetpath-offset.json) | <code>{"offset_amount": {"p": {"a": 0, "k": 12}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/df4cd6f2-f794-4ca4-bc27-4a27b2eee5fe"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/9c27055c-dea5-44c1-8e36-f8c8e1db82f8"> |
| `LottieOffsetPath` | `miterLimit` | [offsetpath-miterLimit.json](https://github.com/user-attachments/files/31713921/offsetpath-miterLimit.json) | <code>{"offset_amount": {"p": {"a": 0, "k": 12}}, "offset_miterLimit": {"p": {"a": 0, "k": 1}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/df4cd6f2-f794-4ca4-bc27-4a27b2eee5fe"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/7b88d6bb-b8cc-42ff-83e4-5228f3ed05f2"> |
| `LottiePuckerBloat` | `amount` | [puckerbloat-amount.json](https://github.com/user-attachments/files/31713931/puckerbloat-amount.json) | <code>{"pucker_amount": {"p": {"a": 0, "k": 60}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/93998bbf-a9b0-4405-9ba3-39758b544fcf"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/c3d28859-767e-4eed-995c-0a345df6fe72"> |
| `LottieZigZag` | `amplitude` | [zigzag-amplitude.json](https://github.com/user-attachments/files/31713951/zigzag-amplitude.json) | <code>{"zigzag_amplitude": {"p": {"a": 0, "k": 10}}}</code> | <img width="200" height="200" src="https://github.com/user-attachments/assets/3eb3b703-7638-4b2a-9ebd-eae64563b926"> | <img width="200" height="200" src="https://github.com/user-attachments/assets/77f29aa1-5b70-4146-91f0-6c32abe0cc07"> |
| `LottieTextRange` | `start` | [textrange-start.json](https://github.com/user-attachments/files/31713949/textrange-start.json) | <code>{"range_start": {"p": {"a": 0, "k": 2}}}</code> | <img width="400" height="140" src="https://github.com/user-attachments/assets/a2614342-deff-4efa-8b5c-69399b6eec83"> | <img width="400" height="140" src="https://github.com/user-attachments/assets/a107ac68-c506-48b2-bc39-bb690025081a"> |
| `LottieTextRange` | `end` | [textrange-end.json](https://github.com/user-attachments/files/31713943/textrange-end.json) | <code>{"range_end": {"p": {"a": 0, "k": 7.3}}}</code> | <img width="400" height="140" src="https://github.com/user-attachments/assets/a2614342-deff-4efa-8b5c-69399b6eec83"> | <img width="400" height="140" src="https://github.com/user-attachments/assets/3dff0992-79c5-4aff-bc54-b173893f607a"> |
| `LottieTextRange` | `offset` | [textrange-offset.json](https://github.com/user-attachments/files/31713947/textrange-offset.json) | <code>{"range_offset": {"p": {"a": 0, "k": -2}}}</code> | <img width="400" height="140" src="https://github.com/user-attachments/assets/a2614342-deff-4efa-8b5c-69399b6eec83"> | <img width="400" height="140" src="https://github.com/user-attachments/assets/68d53b5b-a761-415c-82d0-9c30c399ebc5"> |
| `LottieTextRange` | `maxAmount` | [textrange-maxAmount.json](https://github.com/user-attachments/files/31713944/textrange-maxAmount.json) | <code>{"range_maxAmount": {"p": {"a": 0, "k": 40}}}</code> | <img width="400" height="140" src="https://github.com/user-attachments/assets/a2614342-deff-4efa-8b5c-69399b6eec83"> | <img width="400" height="140" src="https://github.com/user-attachments/assets/f6bca73d-14ed-497d-97f3-58009b21b1bf"> |
| `LottieTextRange` | `smoothness` | [textrange-smoothness.json](https://github.com/user-attachments/files/31713948/textrange-smoothness.json) | <code>{"range_smoothness": {"p": {"a": 0, "k": 10}}}</code> | <img width="400" height="140" src="https://github.com/user-attachments/assets/a2614342-deff-4efa-8b5c-69399b6eec83"> | <img width="400" height="140" src="https://github.com/user-attachments/assets/1d889d16-c769-48d6-bb0a-4770c75937b8"> |
| `LottieTextRange` | `maxEase` | [textrange-maxEase.json](https://github.com/user-attachments/files/31713945/textrange-maxEase.json) | <code>{"range_maxEase": {"p": {"a": 0, "k": 90}}}</code> | <img width="400" height="140" src="https://github.com/user-attachments/assets/a2614342-deff-4efa-8b5c-69399b6eec83"> | <img width="400" height="140" src="https://github.com/user-attachments/assets/cb12ec3e-1e27-416e-b1f8-8f620c057383"> |
| `LottieTextRange` | `minEase` | [textrange-minEase.json](https://github.com/user-attachments/files/31713946/textrange-minEase.json) | <code>{"range_minEase": {"p": {"a": 0, "k": 90}}}</code> | <img width="400" height="140" src="https://github.com/user-attachments/assets/a2614342-deff-4efa-8b5c-69399b6eec83"> | <img width="400" height="140" src="https://github.com/user-attachments/assets/9fa3ebd2-0967-4d38-b966-ed71c4bb21a9"> |
| `LottieText` | `alignOp.anchor` | [text-alignAnchor.json](https://github.com/user-attachments/files/31713942/text-alignAnchor.json) | <code>{"text_alignAnchor": {"p": {"a": 0, "k": [25, 15]}}}</code> | <img width="400" height="140" src="https://github.com/user-attachments/assets/a2614342-deff-4efa-8b5c-69399b6eec83"> | <img width="400" height="140" src="https://github.com/user-attachments/assets/ec6d18fa-0bf0-423e-b162-0f474e5e619c"> |



### Binary Size Increasement
Measured with `--buildtype=minsize -Db_lto=true -Dengines=cpu -Dloaders=lottie,ttf`, shared, stripped:


| Section                        |  Before |   After |           Delta |
|--------------------------------|---------|---------|-----------------|
| __TEXT.__text                  | 200,656 | 201,136 | +480 B (+0.24%) |
| __DATA_CONST.__const (vtables) |   5,712 |   5,712 |               0 |
