### PR TITLE
api: add paint user data

### DIFF
--- a/inc/thorvg.h
+++ b/inc/thorvg.h
@@ -768,6 +768,15 @@ struct TVG_API Paint
     uint32_t id = 0;
 
     /**
+     * @brief User-defined data associated with this instance.
+     *
+     * ThorVG does not interpret or manage the lifetime of this data.
+     *
+     * @note Experimental API
+     */
+    void* data = nullptr;
+
+    /**
      * @brief Safely releases a Paint object.
      *
      * This is the counterpart to the `gen()` API, and releases the given Paint object safely, 

--- a/src/bindings/capi/thorvg_capi.h
+++ b/src/bindings/capi/thorvg_capi.h
@@ -998,6 +998,33 @@ TVG_API uint32_t tvg_paint_get_id(const Tvg_Paint paint);
 TVG_API Tvg_Result tvg_paint_set_id(Tvg_Paint paint, uint32_t id);
 
 /**
+ * @brief Gets the user-defined data associated with the Paint object.
+ *
+ * @param[in] paint The paint object whose user-defined data will be returned.
+ *
+ * @return The user-defined data, or @c NULL if none is set or @p paint is invalid.
+ *
+ * @see tvg_paint_set_data()
+ *
+ * @note Experimental API
+ */
+TVG_API void* tvg_paint_get_data(const Tvg_Paint paint);
+
+/**
+ * @brief Associates user-defined data with the Paint object.
+ *
+ * ThorVG does not interpret or manage the lifetime of this data.
+ *
+ * @param[in] paint The paint object whose user-defined data will be set.
+ * @param[in] data The user-defined data to associate with the paint object.
+ *
+ * @see tvg_paint_get_data()
+ *
+ * @note Experimental API
+ */
+TVG_API Tvg_Result tvg_paint_set_data(Tvg_Paint paint, void* data);
+
+/**
  * @brief Scales the given Tvg_Paint object by the given factor.
  *
  * @param[in] paint The paint object to be scaled.

--- a/src/bindings/capi/tvgCapi.cpp
+++ b/src/bindings/capi/tvgCapi.cpp
@@ -216,6 +216,21 @@ TVG_API Tvg_Result tvg_paint_set_id(Tvg_Paint paint, uint32_t id)
     return TVG_RESULT_INVALID_ARGUMENT;
 }
 
+TVG_API void* tvg_paint_get_data(const Tvg_Paint paint)
+{
+    if (paint) return reinterpret_cast<const Paint*>(paint)->data;
+    return nullptr;
+}
+
+TVG_API Tvg_Result tvg_paint_set_data(Tvg_Paint paint, void* data)
+{
+    if (paint) {
+        reinterpret_cast<Paint*>(paint)->data = data;
+        return TVG_RESULT_SUCCESS;
+    }
+    return TVG_RESULT_INVALID_ARGUMENT;
+}
+
 TVG_API uint16_t tvg_paint_ref(Tvg_Paint paint)
 {
     if (paint) return reinterpret_cast<Paint*>(paint)->ref();


### PR DESCRIPTION
Applications need a direct way to associate their own context with a paint without maintaining a separate paint-to-data lookup.

- Add opaque user data storage to Paint.
- Expose experimental getter and setter APIs for C clients.

C++:
+ void* Paint::data

C API:
+ Result tvg_paint_set_data(Tvg_Paint* paint, void *data);
+ void* tvg_paint_get_data(const Tvg_Paint* paint);

Usages:
- paint->data = user_data;
- video->picture()->data = user_data;
- animation->picture()->data = user_data;

Issue: #4769