### PR TITLE
gl: refine geometry code

### DIFF
--- a/src/renderer/gpu_engine/gl/tvgGlCommon.h
+++ b/src/renderer/gpu_engine/gl/tvgGlCommon.h
@@ -61,14 +61,16 @@ static inline void getMatrix3Std140(const Matrix& mat3, float* matOut)
     matOut[3] = 0.0f;     matOut[7] = 0.0f;     matOut[11] = 0.0f;
 }
 
-enum class GlStencilMode {
+enum class GlStencilMode
+{
     None,
     FillNonZero,
     FillEvenOdd,
     Stroke,
 };
 
-struct GlGeometryBuffer {
+struct GlGeometryBuffer
+{
     Array<float> vertex;
     Array<uint32_t> index;
 
@@ -81,46 +83,50 @@ struct GlGeometryBuffer {
 
 struct GlGeometry
 {
-    const Matrix* inverseMatrix() const
+    const Matrix& itransform() const
     {
-        if (!inverseMatrixDirty) return &cachedInverseMatrix;
-        inverse(&matrix, &cachedInverseMatrix);
-        inverseMatrixDirty = false;
-        return &cachedInverseMatrix;
+        if (!mDirty) return imatrix;
+        inverse(&matrix, &imatrix);
+        mDirty = false;
+        return imatrix;
     }
 
-    void setMatrix(const Matrix& tr) { matrix = tr; inverseMatrixDirty = true;}
+    void transform(const Matrix& m)
+    {
+        matrix = m;
+        mDirty = true;
+    }
+
+    bool drawable(RenderUpdateFlag flag) const
+    {
+        if (flag == RenderUpdateFlag::None) return false;
+        auto& buffer = (flag & (RenderUpdateFlag::Stroke | RenderUpdateFlag::GradientStroke)) ? stroke : fill;
+        return !buffer.index.empty();
+    }
 
     void prepare(const RenderShape& rshape);
     bool tesselateShape(const RenderShape& rshape, float& multiplier);
     bool tesselateStroke(const RenderShape& rshape);
     bool tesselateThinFill(const RenderPath& path);
     void tesselateImage(const RenderSurface* image);
-    bool drawable(RenderUpdateFlag flag) const
-    {
-        if (flag == RenderUpdateFlag::None) return false;
-        auto buffer = ((flag & RenderUpdateFlag::Stroke) || (flag & RenderUpdateFlag::GradientStroke)) ? &stroke : &fill;
-        return !buffer->index.empty();
-    }
     void draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag) const;
-    GlStencilMode getStencilMode(RenderUpdateFlag flag);
-    RenderRegion getBounds() const;
+    GlStencilMode stencilMode(RenderUpdateFlag flag);
+    RenderRegion bounds() const;
 
     GlGeometryBuffer fill, stroke;
-    Matrix matrix = {};
-    RenderRegion viewport = {};
-    RenderRegion fillBounds = {};
-    RenderRegion strokeBounds = {};
-    FillRule fillRule = FillRule::NonZero;
+    Matrix matrix;
+    RenderRegion viewport;
+    RenderRegion fillBBox, strokeBBox;
     RenderPath optPath;        // optimal transformed path
     RenderPath optStrokePath;  // matching local path using transformed-space tolerance
-    float strokeRenderWidth = 0.0f;
-    mutable Matrix cachedInverseMatrix = {};
-    mutable bool inverseMatrixDirty = true;
-    bool fillWorld = false;
-    bool optPathThin = false;
-    bool optPathSkipFill = false;
-    bool convex;
+    float strokeRenderWidth;
+    mutable Matrix imatrix;      // inverse matrix
+    mutable bool mDirty = true;  // matrix dirty
+    FillRule fillRule;
+    bool fillWorld : 1;
+    bool optPathThin : 1;
+    bool optPathSkipFill : 1;
+    bool convex : 1;
 };
 
 struct GlDrawable
@@ -162,9 +168,9 @@ struct GlIntersector
 {
     bool pointInTris(const Point& p, const GlGeometryBuffer& mesh);
     bool pointInMesh(const Point& p, const GlGeometryBuffer& mesh);
-    bool intersect(const Point& pt, const tvg::Array<tvg::RenderData>& clips);
-    bool intersect(const RenderRegion region, const GlShape* shape);
-    bool intersect(const RenderRegion region, const GlImage* image);
+    bool intersect(const tvg::Array<tvg::RenderData>& clips, const Point& pt);
+    bool intersect(const GlShape* shape, const RenderRegion& region);
+    bool intersect(const GlImage* image, const RenderRegion& region);
 };
 
 #define MAX_GRADIENT_STOPS 16

--- a/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlGeometry.cpp
@@ -68,36 +68,35 @@ bool GlIntersector::pointInMesh(const Point& p, const GlGeometryBuffer& mesh)
     return (crossings % 2) == 1;
 }
 
-bool GlIntersector::intersect(const Point& pt, const tvg::Array<tvg::RenderData>& clips)
+bool GlIntersector::intersect(const tvg::Array<tvg::RenderData>& clips, const Point& pt)
 {
     ARRAY_FOREACH(c, clips) {
         auto clip = static_cast<const GlShape*>(*c);
         const auto& geometry = clip->geometry;
         if (clip->valid.fill) {
-            auto p = geometry.fillWorld ? pt : pt * geometry.inverseMatrix();
-            const auto& bounds = geometry.fillBounds;
-            if (p.x < bounds.min.x || p.x > bounds.max.x || p.y < bounds.min.y || p.y > bounds.max.y) return false;
+            auto p = geometry.fillWorld ? pt : pt * geometry.itransform();
+            const auto& bbox = geometry.fillBBox;
+            if (p.x < bbox.min.x || p.x > bbox.max.x || p.y < bbox.min.y || p.y > bbox.max.y) return false;
             if (!pointInMesh(p, geometry.fill)) return false;
         } else if (clip->valid.stroke) {
-            auto p = pt * geometry.inverseMatrix();
-            const auto& bounds = geometry.strokeBounds;
-            if (p.x < bounds.min.x || p.x > bounds.max.x || p.y < bounds.min.y || p.y > bounds.max.y) return false;
+            auto p = pt * geometry.itransform();
+            const auto& bbox = geometry.strokeBBox;
+            if (p.x < bbox.min.x || p.x > bbox.max.x || p.y < bbox.min.y || p.y > bbox.max.y) return false;
             if (!pointInTris(p, geometry.stroke)) return false;
         }
     }
     return true;
 }
 
-bool GlIntersector::intersect(const RenderRegion region, const GlShape* shape)
+bool GlIntersector::intersect(const GlShape* shape, const RenderRegion& region)
 {
-    if (!shape) return false;
     const auto& geometry = shape->geometry;
     auto validFill = shape->valid.fill && !geometry.fill.index.empty();
     auto validStroke = shape->valid.stroke && !geometry.stroke.index.empty();
     if (!validFill && !validStroke) return false;
 
     const Matrix* inverse = nullptr;
-    if ((!geometry.fillWorld && validFill) || validStroke) inverse = geometry.inverseMatrix();
+    if ((!geometry.fillWorld && validFill) || validStroke) inverse = &geometry.itransform();
     auto sizeX = region.sw();
     auto sizeY = region.sh();
 
@@ -109,23 +108,23 @@ bool GlIntersector::intersect(const RenderRegion region, const GlShape* shape)
 
             if (validFill) {
                 auto p = geometry.fillWorld ? pt : pt * *inverse;
-                const auto& bounds = geometry.fillBounds;
-                hit = p.x >= bounds.min.x && p.x <= bounds.max.x && p.y >= bounds.min.y && p.y <= bounds.max.y && pointInMesh(p, geometry.fill);
+                const auto& bbox = geometry.fillBBox;
+                hit = p.x >= bbox.min.x && p.x <= bbox.max.x && p.y >= bbox.min.y && p.y <= bbox.max.y && pointInMesh(p, geometry.fill);
             }
             if (!hit && validStroke) {
                 auto p = pt * *inverse;
-                const auto& bounds = geometry.strokeBounds;
-                hit = p.x >= bounds.min.x && p.x <= bounds.max.x && p.y >= bounds.min.y && p.y <= bounds.max.y && pointInTris(p, geometry.stroke);
+                const auto& bbox = geometry.strokeBBox;
+                hit = p.x >= bbox.min.x && p.x <= bbox.max.x && p.y >= bbox.min.y && p.y <= bbox.max.y && pointInTris(p, geometry.stroke);
             }
-            if (hit && intersect(pt, shape->clips)) return true;
+            if (hit && intersect(shape->clips, pt)) return true;
         }
     }
     return false;
 }
 
-bool GlIntersector::intersect(const RenderRegion region, const GlImage* image)
+bool GlIntersector::intersect(const GlImage* image, const RenderRegion& region)
 {
-    if (!image || image->geometry.fill.index.count < 6) return false;
+    if (image->geometry.fill.index.count < 6) return false;
 
     const auto& geometry = image->geometry;
     const auto& mesh = geometry.fill;
@@ -146,7 +145,7 @@ bool GlIntersector::intersect(const RenderRegion region, const GlImage* image)
         auto py = (y % 2 == 0) ? y : sizeY - y - sizeY % 2;
         for (int32_t x = 0; x < sizeX; x++) {
             Point pt{(float)x + region.min.x, (float)py + region.min.y};
-            if (contains(pt) && intersect(pt, image->clips)) return true;
+            if (contains(pt) && intersect(image->clips, pt)) return true;
         }
     }
     return false;
@@ -165,9 +164,9 @@ void GlGeometry::prepare(const RenderShape& rshape)
     auto strokeWidth = rshape.strokeWidth();
     auto localOut = (std::isfinite(strokeWidth) && !tvg::zero(strokeWidth)) ? &optStrokePath : nullptr;
     auto path = &rshape.path;
-    RenderPath trimmedPath;
 
     if (rshape.trimpath()) {
+        auto& trimmedPath = RenderPath::scratch();
         if (rshape.stroke->trim.trim(rshape.path, trimmedPath)) {
             path = &trimmedPath;
         } else {
@@ -186,7 +185,7 @@ void GlGeometry::prepare(const RenderShape& rshape)
 bool GlGeometry::tesselateShape(const RenderShape& rshape, float& multiplier)
 {
     fill.clear();
-    fillBounds = {};
+    fillBBox = {};
     fillWorld = true;
     convex = false;
     multiplier = 1.0f;
@@ -211,7 +210,7 @@ bool GlGeometry::tesselateShape(const RenderShape& rshape, float& multiplier)
     BWTessellator bwTess{&fill};
     bwTess.tessellate(optPath);
     fillRule = rshape.rule;
-    fillBounds = bwTess.bounds();
+    fillBBox = bwTess.bounds();
     convex = bwTess.convex;
 
     return true;
@@ -221,7 +220,7 @@ bool GlGeometry::tesselateShape(const RenderShape& rshape, float& multiplier)
 bool GlGeometry::tesselateThinFill(const RenderPath& path)
 {
     stroke.clear();
-    strokeBounds = {};
+    strokeBBox = {};
     if (path.pts.count < 2) return false;
 
     // Thin fills borrow stroke tessellation, but the generated stroke buffer is
@@ -230,8 +229,7 @@ bool GlGeometry::tesselateThinFill(const RenderPath& path)
     stroker.run(path); // path is already in world space.
     stroke.index.move(fill.index);
     stroke.vertex.move(fill.vertex);
-    fillBounds = stroker.bounds();
-    strokeBounds = {};
+    fillBBox = stroker.bounds();
     strokeRenderWidth = 0.0f;
     return true;
 }
@@ -240,7 +238,7 @@ bool GlGeometry::tesselateThinFill(const RenderPath& path)
 bool GlGeometry::tesselateStroke(const RenderShape& rshape)
 {
     stroke.clear();
-    strokeBounds = {};
+    strokeBBox = {};
     strokeRenderWidth = 0.0f;
 
     auto strokeWidth = rshape.strokeWidth();
@@ -258,7 +256,7 @@ bool GlGeometry::tesselateStroke(const RenderShape& rshape)
     auto& dashed = RenderPath::scratch();
     if (gpuStrokeDash(rshape, dashed, nullptr)) stroker.run(dashed);
     else stroker.run(optStrokePath);
-    strokeBounds = stroker.bounds();
+    strokeBBox = stroker.bounds();
     return true;
 }
 
@@ -266,7 +264,6 @@ bool GlGeometry::tesselateStroke(const RenderShape& rshape)
 void GlGeometry::tesselateImage(const RenderSurface* image)
 {
     fill.clear();
-    fillBounds = {};
     fillWorld = true;
     strokeRenderWidth = 0.0f;
     fill.vertex.reserve(5 * 4);
@@ -297,7 +294,7 @@ void GlGeometry::tesselateImage(const RenderSurface* image)
     fill.index.push(1);
     fill.index.push(3);
 
-    fillBounds = gpuTransformBounds(RenderRegion{{0, 0}, {int32_t(image->w), int32_t(image->h)}}, matrix);
+    fillBBox = gpuTransformBounds(RenderRegion{{0, 0}, {int32_t(image->w), int32_t(image->h)}}, matrix);
 }
 
 void GlGeometry::draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdateFlag flag) const
@@ -317,7 +314,7 @@ void GlGeometry::draw(GlRenderTask* task, GlStageBuffer* gpuBuffer, RenderUpdate
     task->setDrawRange(indexOffset, buffer->index.count);
 }
 
-GlStencilMode GlGeometry::getStencilMode(RenderUpdateFlag flag)
+GlStencilMode GlGeometry::stencilMode(RenderUpdateFlag flag)
 {
     if (flag & RenderUpdateFlag::Stroke) return GlStencilMode::Stroke;
     if (flag & RenderUpdateFlag::GradientStroke) return GlStencilMode::Stroke;
@@ -330,31 +327,26 @@ GlStencilMode GlGeometry::getStencilMode(RenderUpdateFlag flag)
     return GlStencilMode::None;
 }
 
-
-RenderRegion GlGeometry::getBounds() const
+RenderRegion GlGeometry::bounds() const
 {
-    auto bounds = RenderRegion{};
-    auto hasBounds = false;
+    auto bbox = RenderRegion{};
+    auto valid = false;
 
     if (!fill.index.empty()) {
-        auto fill = fillWorld ? fillBounds : gpuTransformBounds(fillBounds, matrix);
+        auto fill = fillWorld ? fillBBox : gpuTransformBounds(fillBBox, matrix);
         if (fill.valid()) {
-            bounds = fill;
-            hasBounds = true;
+            bbox = fill;
+            valid = true;
         }
     }
 
     if (!stroke.index.empty()) {
-        auto stroke = gpuTransformBounds(strokeBounds, matrix);
+        auto stroke = gpuTransformBounds(strokeBBox, matrix);
         if (stroke.valid()) {
-            if (hasBounds) bounds.add(stroke);
-            else {
-                bounds = stroke;
-                hasBounds = true;
-            }
+            if (valid) bbox.add(stroke);
+            else bbox = stroke;
         }
     }
 
-    if (hasBounds) return bounds;
-    return {};
+    return bbox;
 }

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -299,12 +299,12 @@ void GlRenderer::drawPrimitive(GlShape& shape, const RenderColor& c, RenderUpdat
     if (viewBounds.invalid()) return;
 
     auto stroke = (flag & RenderUpdateFlag::Stroke) || (flag & RenderUpdateFlag::GradientStroke);
-    auto bbox = stroke ? gpuTransformBounds(shape.geometry.strokeBounds, shape.geometry.matrix) : shape.geometry.fillBounds;
+    auto bbox = stroke ? gpuTransformBounds(shape.geometry.strokeBBox, shape.geometry.matrix) : shape.geometry.fillBBox;
     bbox.intersect(viewBounds);
     if (bbox.invalid()) return;
 
     auto viewRegion = viewportRegion(vp, bbox);
-    auto stencilMode = shape.geometry.getStencilMode(flag);
+    auto stencilMode = shape.geometry.stencilMode(flag);
 
     if (!blendShape && stencilMode == GlStencilMode::None && shape.clips.empty()) {
         mSolidBatch.draw(*this, shape, c, depth, viewRegion, viewportRegion(vp, viewBounds));
@@ -358,7 +358,7 @@ void GlRenderer::drawPrimitive(GlShape& shape, const Fill* fill, RenderUpdateFla
     if (viewBounds.invalid()) return;
 
     auto stroke = (flag & RenderUpdateFlag::Stroke) || (flag & RenderUpdateFlag::GradientStroke);
-    auto bbox = stroke ? gpuTransformBounds(shape.geometry.strokeBounds, shape.geometry.matrix) : shape.geometry.fillBounds;
+    auto bbox = stroke ? gpuTransformBounds(shape.geometry.strokeBBox, shape.geometry.matrix) : shape.geometry.fillBBox;
     bbox.intersect(viewBounds);
     if (bbox.invalid()) return;
 
@@ -402,7 +402,7 @@ void GlRenderer::drawPrimitive(GlShape& shape, const Fill* fill, RenderUpdateFla
 
     task->setViewport(viewRegion);
 
-    GlStencilMode stencilMode = shape.geometry.getStencilMode(flag);
+    GlStencilMode stencilMode = shape.geometry.stencilMode(flag);
     RenderRegion stencilBounds{};
     const GlGeometryBuffer* stencilBuffer = nullptr;
     uint32_t* stencilIndices = nullptr;
@@ -561,7 +561,7 @@ void GlRenderer::drawClip(Array<RenderData>& clips, const RenderRegion& viewBoun
         clipTask->setViewMatrix(_viewMatrix(shape->geometry, viewMatrix, flag));
         shape->geometry.draw(clipTask, &mGpuBuffer, flag);
 
-        auto clipBounds = shape->geometry.getBounds();
+        auto clipBounds = shape->geometry.bounds();
         clipBounds.intersect(viewBounds);
         clipTask->setViewport(viewportRegion(passViewport, clipBounds));
 
@@ -1066,7 +1066,7 @@ RenderRegion GlRenderer::region(RenderData data)
 {
     if (!data) return {};
     auto paint = static_cast<GlDrawable*>(data);
-    return paint->geometry.getBounds();
+    return paint->geometry.bounds();
 }
 
 
@@ -1213,7 +1213,7 @@ bool GlRenderer::renderImage(void* data)
     task->setDrawDepth(drawDepth);
     image->geometry.draw(task, &mGpuBuffer, RenderUpdateFlag::Image);
 
-    bool complexBlend = beginComplexBlending(bbox, image->geometry.getBounds());
+    bool complexBlend = beginComplexBlending(bbox, image->geometry.bounds());
     if (complexBlend) vp = currentPass()->getViewport();
     task->setViewMatrix(currentPass()->getViewMatrix());
 
@@ -1326,7 +1326,7 @@ RenderData GlRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
     }
 
     if (flags & (RenderUpdateFlag::Image | RenderUpdateFlag::Transform)) {
-        image->geometry.setMatrix(transform);
+        image->geometry.transform(transform);
         image->geometry.tesselateImage(surface);
     }
 
@@ -1351,7 +1351,7 @@ RenderData GlRenderer::prepare(const RenderShape& rshape, RenderData data, const
 
     if (flags & RenderUpdateFlag::Path) shape->geometry = GlGeometry();
 
-    shape->geometry.setMatrix(transform);
+    shape->geometry.transform(transform);
     shape->geometry.viewport = vport;
 
     auto updateStroke = (flags & RenderUpdateFlag::Stroke) && rshape.stroke && std::isfinite(rshape.strokeWidth()) && !tvg::zero(rshape.strokeWidth()) && shape->geometry.optStrokePath.empty();
@@ -1407,11 +1407,11 @@ bool GlRenderer::intersectsShape(RenderData data, TVG_UNUSED const RenderRegion&
     if (!data) return false;
     auto shape = (GlShape*)data;
     if (shape->opacity == 0) return false;
-    const auto& bbox = shape->geometry.getBounds();
+    const auto& bbox = shape->geometry.bounds();
     if (region.intersected(bbox)) {
         if (region.contained(bbox)) return true;
         GlIntersector intersector;
-        return intersector.intersect(RenderRegion::intersect(region, bbox), shape);
+        return intersector.intersect(shape, RenderRegion::intersect(region, bbox));
     }
     return false;
 }
@@ -1422,11 +1422,11 @@ bool GlRenderer::intersectsImage(RenderData data, TVG_UNUSED const RenderRegion&
     if (!data) return false;
     auto image = static_cast<GlImage*>(data);
     if (image->opacity == 0) return false;
-    const auto& bbox = image->geometry.getBounds();
+    const auto& bbox = image->geometry.bounds();
     if (region.intersected(bbox)) {
         if (region.contained(bbox)) return true;
         GlIntersector intersector;
-        if (intersector.intersect(RenderRegion::intersect(region, bbox), image)) return true;
+        if (intersector.intersect(image, RenderRegion::intersect(region, bbox))) return true;
     }
     return false;
 }

--- a/src/renderer/gpu_engine/gl/tvgGlStencilCoverBatch.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlStencilCoverBatch.cpp
@@ -131,7 +131,7 @@ GlRenderTask* GlStencilCoverBatch::prepare(GlProgram* stencilProgram, GlRenderPa
                                            bool& merge)
 {
     auto stroke = (flag & RenderUpdateFlag::Stroke) || (flag & RenderUpdateFlag::GradientStroke);
-    auto bbox = stroke ? geometry.strokeBounds : geometry.fillBounds;
+    auto bbox = stroke ? geometry.strokeBBox : geometry.fillBBox;
     geometryBounds = stroke ? gpuTransformBounds(bbox, geometry.matrix) : bbox;
     geometryBounds.intersect(viewBounds);
 


### PR DESCRIPTION
- Align geometry helper and field names with project conventions.
- Reorder intersector parameters and simplify local logic.
- Pass regions by reference to avoid unnecessary copies.
- Reuse a scratch path while processing trimmed geometry.