### PR TITLE
cpu_engine: optimize rle for large outlines

### DIFF
--- a/src/renderer/cpu_engine/tvgSwCommon.h
+++ b/src/renderer/cpu_engine/tvgSwCommon.h
@@ -319,6 +319,7 @@ struct SwCompositor : RenderCompositor
 struct SwCellPool
 {
     #define DEFAULT_POOL_SIZE 16368
+    #define MAX_CELL_POOL_SIZE (DEFAULT_POOL_SIZE * 64)   //1 MB per thread, reached only by very complex outlines
 
     uint32_t size;
     SwCell* buffer;

--- a/src/renderer/cpu_engine/tvgSwRle.cpp
+++ b/src/renderer/cpu_engine/tvgSwRle.cpp
@@ -837,7 +837,19 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const RenderRegion& bbox,
             }
 
         reduce_bands:
-            /* render pool overflow: we will reduce the render band by half */
+            /* render pool overflow: grow the cell pool first (bounded), then retry the same band.
+               Halving the band instead re-walks the whole outline once per band. */
+            if (cellPool->size < MAX_CELL_POOL_SIZE) {
+                auto newSize = std::min(cellPool->size * 2, uint32_t(MAX_CELL_POOL_SIZE));
+                if (auto newBuffer = tvg::realloc<SwCell>(cellPool->buffer, newSize)) {
+                    cellPool->size = newSize;
+                    cellPool->buffer = newBuffer;
+                    rw.buffer = cellPool->buffer;
+                    rw.bufferSize = cellPool->size;
+                    continue;
+                }
+            }
+            /* pool is at its cap: reduce the render band by half */
             auto bottom = band->min;
             auto top = band->max;
             auto middle = bottom + ((top - bottom) >> 1);


### PR DESCRIPTION
The rle rasterizer uses a fixed 16 KB cell pool per thread.
When an outline overflows it, rleRender() halves the band and
re-walks the whole outline once per resulting band,
so complex outlines were traversed hundreds of times per frame.

Grow the pool instead: double it on overflow (up to MAX_CELL_POOL_SIZE)
via realloc and retry the same band, falling back to band halving
only at the cap or when the allocation fails.


### Perf Review 

> [!NOTE]
> ` meson setup builddir --wipe  -Dthreads=false -Dloaders=all -Ddefault_library=shared`
> `.\builddir\src\Animation.exe -i .\res\lottie\monkey.json`

>
> `Windows11`, 
> `amd Ryzen 7600`, `64GB`, 
> `msvc 19.50.35728 "Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35728 for x64`
> I couldn’t reproduce the improvement on macOS(M5 pro), wasm. 
> Although I observed a performance improvement in a headless environment, I did not see an FPS increase when rendering to a SDL window.

> For the other assets, I did not observe any significant difference. (big_donut.json, flying.json ... )

| thorvg.example | vs main (fps +%)| 
| - | - |
| Lottie | - |
| Animation/guitar | +15% |
| Animation/monkey  |  +30% | 
| Animation/yarn_loading | +40% |
| Animation/isometric | +140% |
| [Animation/test_20p.json](https://github.com/user-attachments/files/31923747/test_20p.json) | +450% |
| [Animation/test_40p.json](https://github.com/user-attachments/files/31923765/test_40p.json) | +608% |



> [!NOTE]
> thorvg.benchmark: MacOS, thorvg.benchmark main vs pr, threads=true

| thorvg.benchmark | vs main (fps +%) |
| ---|--- |
| stroke / rotation | +3.7 % |
| strokerect / rotation | +3.2 % |