### PR TITLE
test: remove the generated test.gif file

### DIFF
--- a/test/testSavers.cpp
+++ b/test/testSavers.cpp
@@ -21,7 +21,7 @@
  */
 
 #include <thorvg.h>
-#include <fstream>
+#include <cstdio>
 #include "config.h"
 #include "testFramework.h"
 
@@ -54,6 +54,7 @@ TEST_CASE("Save a lottie into gif", "[tvgSavers]") {
         REQUIRE(saver->background(bg) == Result::Success);
         REQUIRE(saver->save(animation, TEST_DIR"/test.gif") == Result::Success);
         REQUIRE(saver->sync() == Result::Success);
+        REQUIRE(remove(TEST_DIR"/test.gif") == 0);
     }
     REQUIRE(Initializer::term() == Result::Success);
 }


### PR DESCRIPTION
The gif generated by the saver test is a byproduct that is never read back, but it was left in `TEST_DIR` as an untracked file after every run. It's now removed right after `sync()`, and the return value also verifies that the file was actually created.

Also dropped `<fstream>`, unused since 0e45fab