### PR TITLE
wg: improve image rendering throughput

### DIFF
--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -287,6 +287,14 @@ void WgCompositor::requestSolidBatch(const Array<WgShape*>& renderShapes, WgSoli
     range.viewport = renderShapes[0]->viewport;
 }
 
+void WgCompositor::requestImageBatch(const Array<WgImage*>& renderImages, WgImageBatchRange& range)
+{
+    stageBufferGeometry.appendImageBatch(renderImages, range);
+    auto image = renderImages[0];
+    image->setting.bindGroupIdx = stageBufferPaint.append(image->setting.settings);
+    range.viewport = image->viewport;
+}
+
 void WgCompositor::requestStencilBatch(const Array<WgShape*>& renderShapes, WgStencilBatchRange& range)
 {
     stageBufferGeometry.appendStencilBatch(renderShapes, range);
@@ -364,6 +372,23 @@ void WgCompositor::renderSolidBatch(const WgSolidBatchRange& range)
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_batch);
     wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 0, stageBufferGeometry.vbuffer_gpu, range.vertexOffset, vertexSize);
     wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 1, stageBufferSolidColor.vbuffer_gpu, range.colorOffset, colorSize);
+    wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, stageBufferGeometry.ibuffer_gpu, WGPUIndexFormat_Uint32, range.indexOffset, indexSize);
+    wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.indexCount, 1, 0, 0, 0);
+}
+
+void WgCompositor::renderImageBatch(WgImage* image, const WgImageBatchRange& range)
+{
+    const uint64_t vertexSize = static_cast<uint64_t>(range.vertexCount) * sizeof(Point);
+    const uint64_t indexSize = static_cast<uint64_t>(range.indexCount) * sizeof(uint32_t);
+
+    wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, range.viewport.x(), range.viewport.y(), range.viewport.w(), range.viewport.h());
+    wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[image->setting.bindGroupIdx], 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, image->bindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image_direct);
+    wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 0, stageBufferGeometry.vbuffer_gpu, range.vertexOffset, vertexSize);
+    wgpuRenderPassEncoderSetVertexBuffer(renderPassEncoder, 1, stageBufferGeometry.vbuffer_gpu, range.texCoordOffset, vertexSize);
     wgpuRenderPassEncoderSetIndexBuffer(renderPassEncoder, stageBufferGeometry.ibuffer_gpu, WGPUIndexFormat_Uint32, range.indexOffset, indexSize);
     wgpuRenderPassEncoderDrawIndexed(renderPassEncoder, range.indexCount, 1, 0, 0, 0);
 }
@@ -757,17 +782,12 @@ void WgCompositor::drawImage(WgContext& context, WgImage* rdata)
     if (rdata->viewport.invalid() || !rdata->bindGroup) return;
     WgRenderSettings& settings = rdata->setting;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
-    // draw stencil
-    wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
-    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
-    drawMeshImage(context, &rdata->mesh);
     // draw image
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->bindGroup, 0, nullptr);
-    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image);
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image_direct);
     drawMeshImage(context, &rdata->mesh);
 }
 

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -587,22 +587,21 @@ void WgCompositor::blendShape(WgContext& context, WgShape* rdata, BlendMethod bl
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
-    uint32_t blendMethodInd = (uint32_t)blendMethod;
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_blend[blendMethodInd]);
+        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solidBlend(context, blendMethod));
         drawMeshSolid(context, &rdata->bboxMesh, rdata->shape.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear_blend[blendMethodInd]);
+        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linearBlend(context, blendMethod));
         drawMesh(context, &rdata->bboxMesh);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial_blend[blendMethodInd]);
+        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radialBlend(context, blendMethod));
         drawMesh(context, &rdata->bboxMesh);
     }
 }
@@ -696,22 +695,21 @@ void WgCompositor::blendStrokes(WgContext& context, WgShape* rdata, BlendMethod 
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
-    uint32_t blendMethodInd = (uint32_t)blendMethod;
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_blend[blendMethodInd]);
+        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solidBlend(context, blendMethod));
         drawMeshSolid(context, &rdata->stroke.bboxMesh, rdata->stroke.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear_blend[blendMethodInd]);
+        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linearBlend(context, blendMethod));
         drawMesh(context, &rdata->stroke.bboxMesh);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
-        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial_blend[blendMethodInd]);
+        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radialBlend(context, blendMethod));
         drawMesh(context, &rdata->stroke.bboxMesh);
     }
 };
@@ -789,13 +787,12 @@ void WgCompositor::blendImage(WgContext& context, WgImage* rdata, BlendMethod bl
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
     drawMeshImage(context, &rdata->mesh);
     // blend image
-    uint32_t blendMethodInd = (uint32_t)blendMethod;
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->bindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
-    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image_blend[blendMethodInd]);
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.imageBlend(context, blendMethod));
     drawMeshImage(context, &rdata->mesh);
 };
 
@@ -845,14 +842,13 @@ void WgCompositor::blendScene(WgContext& context, WgRenderTarget* scene, WgCompo
     copyTexture(&targetTemp0, target);
     beginRenderPassMS(commandEncoder, target, false);
     // blend scene
-    uint32_t blendMethodInd = (uint32_t)compose->blend;
     RenderRegion rect = shrinkRenderRegion(compose->aabb);
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rect.x(), rect.y(), rect.w(), rect.h());
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, scene->bindGroupTexture, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, bindGroupOpacities[compose->opacity], 0, nullptr);
-    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.scene_blend[blendMethodInd]);
+    wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.sceneBlend(context, compose->blend));
     drawMeshImage(context, &meshDataBlit);
 }
 

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.h
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.h
@@ -125,11 +125,13 @@ public:
     void requestShape(WgShape* shape);
     void requestImage(WgImage* image);
     void requestSolidBatch(const Array<WgShape*>& renderShapes, WgSolidBatchRange& range);
+    void requestImageBatch(const Array<WgImage*>& renderImages, WgImageBatchRange& range);
     void requestStencilBatch(const Array<WgShape*>& renderShapes, WgStencilBatchRange& range);
 
     // render shapes, images and scenes
     void renderShape(WgContext& context, WgShape* rdata, BlendMethod blendMethod);
     void renderSolidBatch(const WgSolidBatchRange& range);
+    void renderImageBatch(WgImage* image, const WgImageBatchRange& range);
     void renderStencilBatch(const Array<WgShape*>& renderShapes, const WgStencilBatchRange& range);
     void renderImage(WgContext& context, WgImage* rdata, BlendMethod blendMethod);
     void renderScene(WgContext& context, WgRenderTarget* scene, WgCompose* compose);

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
@@ -25,6 +25,43 @@
 #include <cstring>
 #include <cassert>
 
+static const char* shaderBlendNames[]{
+    "fs_main_Normal",
+    "fs_main_Multiply",
+    "fs_main_Screen",
+    "fs_main_Overlay",
+    "fs_main_Darken",
+    "fs_main_Lighten",
+    "fs_main_ColorDodge",
+    "fs_main_ColorBurn",
+    "fs_main_HardLight",
+    "fs_main_SoftLight",
+    "fs_main_Difference",
+    "fs_main_Exclusion",
+    "fs_main_Hue",
+    "fs_main_Saturation",
+    "fs_main_Color",
+    "fs_main_Luminosity",
+    "fs_main_Add",
+    "fs_main_Normal"  // TODO: a padding for reserved Hardmix.
+};
+
+static const WGPUVertexAttribute vertexAttributePos{.format = WGPUVertexFormat_Float32x2, .offset = 0, .shaderLocation = 0};
+static const WGPUVertexAttribute vertexAttributeColor{.format = WGPUVertexFormat_Unorm8x4, .offset = 0, .shaderLocation = 1};
+static const WGPUVertexAttribute vertexAttributeTex{.format = WGPUVertexFormat_Float32x2, .offset = 0, .shaderLocation = 1};
+static const WGPUVertexAttribute vertexAttributesPos[]{vertexAttributePos};
+static const WGPUVertexAttribute vertexAttributesColor[]{vertexAttributeColor};
+static const WGPUVertexAttribute vertexAttributesTex[]{vertexAttributeTex};
+static const WGPUVertexBufferLayout vertexBufferLayoutPos{.stepMode = WGPUVertexStepMode_Vertex, .arrayStride = 8, .attributeCount = 1, .attributes = vertexAttributesPos};
+// Solid colors advance per instance for single draws and per vertex for batches.
+static const WGPUVertexBufferLayout vertexBufferLayoutColor{.stepMode = WGPUVertexStepMode_Instance, .arrayStride = sizeof(RenderColor), .attributeCount = 1, .attributes = vertexAttributesColor};
+static const WGPUVertexBufferLayout vertexBufferLayoutColorBatch{.stepMode = WGPUVertexStepMode_Vertex, .arrayStride = sizeof(RenderColor), .attributeCount = 1, .attributes = vertexAttributesColor};
+static const WGPUVertexBufferLayout vertexBufferLayoutTex{.stepMode = WGPUVertexStepMode_Vertex, .arrayStride = 8, .attributeCount = 1, .attributes = vertexAttributesTex};
+static const WGPUVertexBufferLayout vertexBufferLayoutsSolid[]{vertexBufferLayoutPos, vertexBufferLayoutColor};
+static const WGPUVertexBufferLayout vertexBufferLayoutsSolidBatch[]{vertexBufferLayoutPos, vertexBufferLayoutColorBatch};
+static const WGPUVertexBufferLayout vertexBufferLayoutsShape[]{vertexBufferLayoutPos};
+static const WGPUVertexBufferLayout vertexBufferLayoutsImage[]{vertexBufferLayoutPos, vertexBufferLayoutTex};
+
 WGPUShaderModule WgPipelines::createShaderModule(WGPUDevice device, const char* label, const char* code)
 {
     WGPUShaderSourceWGSL shaderSourceWGSL {
@@ -71,6 +108,62 @@ WGPURenderPipeline WgPipelines::createRenderPipeline(
     return wgpuDeviceCreateRenderPipeline(device, &renderPipelineDesc);
 }
 
+WGPURenderPipeline WgPipelines::createBlendPipeline(
+    WgContext& context, const char* pipelineLabel, const WGPUShaderModule shaderModule,
+    const char* fsEntryPoint, const WGPUPipelineLayout pipelineLayout,
+    const WGPUVertexBufferLayout* vertexBufferLayouts, const uint32_t vertexBufferLayoutsCount,
+    const WGPUCompareFunction stencilCompare)
+{
+    WGPUBlendComponent blendComponentSrc{.operation = WGPUBlendOperation_Add, .srcFactor = WGPUBlendFactor_One, .dstFactor = WGPUBlendFactor_Zero};
+    const WGPUBlendState blendStateSrc{.color = blendComponentSrc, .alpha = blendComponentSrc};
+    const WGPUDepthStencilState depthStencilState = makeDepthStencilState(
+        WGPUCompareFunction_Always, WGPUOptionalBool_False,
+        stencilCompare,
+        WGPUStencilOperation_Zero);
+    const WGPUMultisampleState multisampleState{.count = 4, .mask = 0xFFFFFFFF, .alphaToCoverageEnabled = false};
+
+    return createRenderPipeline(
+        context.device, pipelineLabel,
+        shaderModule, "vs_main", fsEntryPoint,
+        pipelineLayout, vertexBufferLayouts, vertexBufferLayoutsCount,
+        WGPUColorWriteMask_All, WGPUTextureFormat_RGBA8Unorm, blendStateSrc,
+        depthStencilState, multisampleState);
+}
+
+WGPURenderPipeline WgPipelines::solidBlend(WgContext& context, BlendMethod method)
+{
+    auto index = (uint32_t)method;
+    if (!solid_blend[index]) solid_blend[index] = createBlendPipeline(context, "The render pipeline solid blend", shader_solid_blend, shaderBlendNames[index], layout_solid_blend, vertexBufferLayoutsSolid, 2, WGPUCompareFunction_NotEqual);
+    return solid_blend[index];
+}
+
+WGPURenderPipeline WgPipelines::radialBlend(WgContext& context, BlendMethod method)
+{
+    auto index = (uint32_t)method;
+    if (!radial_blend[index]) radial_blend[index] = createBlendPipeline(context, "The render pipeline radial blend", shader_radial_blend, shaderBlendNames[index], layout_gradient_blend, vertexBufferLayoutsShape, 1, WGPUCompareFunction_NotEqual);
+    return radial_blend[index];
+}
+
+WGPURenderPipeline WgPipelines::linearBlend(WgContext& context, BlendMethod method)
+{
+    auto index = (uint32_t)method;
+    if (!linear_blend[index]) linear_blend[index] = createBlendPipeline(context, "The render pipeline linear blend", shader_linear_blend, shaderBlendNames[index], layout_gradient_blend, vertexBufferLayoutsShape, 1, WGPUCompareFunction_NotEqual);
+    return linear_blend[index];
+}
+
+WGPURenderPipeline WgPipelines::imageBlend(WgContext& context, BlendMethod method)
+{
+    auto index = (uint32_t)method;
+    if (!image_blend[index]) image_blend[index] = createBlendPipeline(context, "The render pipeline image blend", shader_image_blend, shaderBlendNames[index], layout_image_blend, vertexBufferLayoutsImage, 2, WGPUCompareFunction_NotEqual);
+    return image_blend[index];
+}
+
+WGPURenderPipeline WgPipelines::sceneBlend(WgContext& context, BlendMethod method)
+{
+    auto index = (uint32_t)method;
+    if (!scene_blend[index]) scene_blend[index] = createBlendPipeline(context, "The render pipeline scene blend", shader_scene_blend, shaderBlendNames[index], layout_scene_blend, vertexBufferLayoutsImage, 2, WGPUCompareFunction_Always);
+    return scene_blend[index];
+}
 
 void WgPipelines::releaseRenderPipeline(WGPURenderPipeline& renderPipeline)
 {
@@ -125,21 +218,6 @@ WGPUDepthStencilState WgPipelines::makeDepthStencilState(
 void WgPipelines::initialize(WgContext& context)
 {
     // common pipeline settings
-    const WGPUVertexAttribute vertexAttributePos { .format = WGPUVertexFormat_Float32x2, .offset = 0, .shaderLocation = 0 };
-    const WGPUVertexAttribute vertexAttributeColor{.format = WGPUVertexFormat_Unorm8x4, .offset = 0, .shaderLocation = 1};
-    const WGPUVertexAttribute vertexAttributeTex { .format = WGPUVertexFormat_Float32x2, .offset = 0, .shaderLocation = 1 };
-    const WGPUVertexAttribute vertexAttributesPos[] { vertexAttributePos };
-    const WGPUVertexAttribute vertexAttributesColor[] { vertexAttributeColor };
-    const WGPUVertexAttribute vertexAttributesTex[] { vertexAttributeTex };
-    const WGPUVertexBufferLayout vertexBufferLayoutPos { .stepMode = WGPUVertexStepMode_Vertex, .arrayStride = 8, .attributeCount = 1, .attributes = vertexAttributesPos };
-    // Solid colors advance per instance for single draws and per vertex for batches.
-    const WGPUVertexBufferLayout vertexBufferLayoutColor{.stepMode = WGPUVertexStepMode_Instance, .arrayStride = sizeof(RenderColor), .attributeCount = 1, .attributes = vertexAttributesColor};
-    const WGPUVertexBufferLayout vertexBufferLayoutColorBatch{.stepMode = WGPUVertexStepMode_Vertex, .arrayStride = sizeof(RenderColor), .attributeCount = 1, .attributes = vertexAttributesColor};
-    const WGPUVertexBufferLayout vertexBufferLayoutTex { .stepMode = WGPUVertexStepMode_Vertex, .arrayStride = 8, .attributeCount = 1, .attributes = vertexAttributesTex };
-    const WGPUVertexBufferLayout vertexBufferLayoutsSolid[] { vertexBufferLayoutPos, vertexBufferLayoutColor };
-    const WGPUVertexBufferLayout vertexBufferLayoutsSolidBatch[]{vertexBufferLayoutPos, vertexBufferLayoutColorBatch};
-    const WGPUVertexBufferLayout vertexBufferLayoutsShape[] { vertexBufferLayoutPos };
-    const WGPUVertexBufferLayout vertexBufferLayoutsImage[] { vertexBufferLayoutPos, vertexBufferLayoutTex };
     const WGPUMultisampleState multisampleState   { .count = 4, .mask = 0xFFFFFFFF, .alphaToCoverageEnabled = false };
     const WGPUMultisampleState multisampleStateX1 { .count = 1, .mask = 0xFFFFFFFF, .alphaToCoverageEnabled = false };
     const WGPUTextureFormat offscreenTargetFormat = WGPUTextureFormat_RGBA8Unorm;
@@ -356,67 +434,6 @@ void WgPipelines::initialize(WgContext& context)
         layout_scene, vertexBufferLayoutsImage, 2,
         WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
         depthStencilStateScene, multisampleState);
-
-    // blend shader names
-    const char* shaderBlendNames[] {
-        "fs_main_Normal",
-        "fs_main_Multiply",
-        "fs_main_Screen",
-        "fs_main_Overlay",
-        "fs_main_Darken",
-        "fs_main_Lighten",
-        "fs_main_ColorDodge",
-        "fs_main_ColorBurn",
-        "fs_main_HardLight",
-        "fs_main_SoftLight",
-        "fs_main_Difference",
-        "fs_main_Exclusion",
-        "fs_main_Hue",
-        "fs_main_Saturation",
-        "fs_main_Color",
-        "fs_main_Luminosity",
-        "fs_main_Add",
-        "fs_main_Normal"  //TODO: a padding for reserved Hardmix.
-    };
-
-    // render pipeline shape blend
-    for (uint32_t i = 0; i < 18; i++) {
-        // blend solid
-        solid_blend[i] = createRenderPipeline(
-            context.device, "The render pipeline solid blend",
-            shader_solid_blend, "vs_main", shaderBlendNames[i],
-            layout_solid_blend, vertexBufferLayoutsSolid, 2,
-            WGPUColorWriteMask_All, offscreenTargetFormat, blendStateSrc,
-            depthStencilStateShape, multisampleState);
-        // blend radial
-        radial_blend[i] = createRenderPipeline(
-            context.device, "The render pipeline radial blend",
-            shader_radial_blend, "vs_main", shaderBlendNames[i],
-            layout_gradient_blend, vertexBufferLayoutsShape, 1,
-            WGPUColorWriteMask_All, offscreenTargetFormat, blendStateSrc,
-            depthStencilStateShape, multisampleState);
-        // blend linear
-        linear_blend[i] = createRenderPipeline(
-            context.device, "The render pipeline linear blend",
-            shader_linear_blend, "vs_main", shaderBlendNames[i],
-            layout_gradient_blend, vertexBufferLayoutsShape, 1,
-            WGPUColorWriteMask_All, offscreenTargetFormat, blendStateSrc,
-            depthStencilStateShape, multisampleState);
-        // blend image
-        image_blend[i] = createRenderPipeline(
-            context.device, "The render pipeline image blend",
-            shader_image_blend, "vs_main", shaderBlendNames[i],
-            layout_image_blend, vertexBufferLayoutsImage, 2,
-            WGPUColorWriteMask_All, offscreenTargetFormat, blendStateSrc,
-            depthStencilStateShape, multisampleState);
-        // blend scene
-        scene_blend[i] = createRenderPipeline(
-            context.device, "The render pipeline scene blend",
-            shader_scene_blend, "vs_main", shaderBlendNames[i],
-            layout_scene_blend, vertexBufferLayoutsImage, 2,
-            WGPUColorWriteMask_All, offscreenTargetFormat, blendStateSrc,
-            depthStencilStateScene, multisampleState);
-    }
 
     // compose shader names
     const char* shaderComposeNames[] {

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.cpp
@@ -427,6 +427,13 @@ void WgPipelines::initialize(WgContext& context)
         layout_image, vertexBufferLayoutsImage, 2,
         WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
         depthStencilStateShape, multisampleState);
+    // render pipeline image (no stencil)
+    image_direct = createRenderPipeline(
+        context.device, "The render pipeline image direct",
+        shader_image, "vs_main", "fs_main",
+        layout_image, vertexBufferLayoutsImage, 2,
+        WGPUColorWriteMask_All, offscreenTargetFormat, blendStateNrm,
+        depthStencilStateScene, multisampleState);
     // render pipeline scene
     scene = createRenderPipeline(
         context.device, "The render pipeline scene",
@@ -562,6 +569,7 @@ void WgPipelines::releaseGraphicHandles(WgContext& context)
     // pipelines normal blend
     releaseRenderPipeline(scene);
     releaseRenderPipeline(image);
+    releaseRenderPipeline(image_direct);
     releaseRenderPipeline(linear_conv);
     releaseRenderPipeline(radial_conv);
     releaseRenderPipeline(solid_stencil_batch);

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.h
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.h
@@ -121,6 +121,11 @@ private:
         const WGPUVertexBufferLayout *vertexBufferLayouts, const uint32_t vertexBufferLayoutsCount,
         const WGPUColorWriteMask writeMask, const WGPUTextureFormat colorTargetFormat, const WGPUBlendState blendState,
         const WGPUDepthStencilState depthStencilState, const WGPUMultisampleState multisampleState);
+    WGPURenderPipeline createBlendPipeline(
+        WgContext& context, const char* pipelineLabel, const WGPUShaderModule shaderModule,
+        const char* fsEntryPoint, const WGPUPipelineLayout pipelineLayout,
+        const WGPUVertexBufferLayout* vertexBufferLayouts, const uint32_t vertexBufferLayoutsCount,
+        const WGPUCompareFunction stencilCompare);
     void releaseRenderPipeline(WGPURenderPipeline& renderPipeline);
     void releasePipelineLayout(WGPUPipelineLayout& pipelineLayout);
     void releaseShaderModule(WGPUShaderModule& shaderModule);
@@ -133,6 +138,12 @@ private:
         const WGPUCompareFunction stencilFunctionFrnt, const WGPUStencilOperation stencilOperationFrnt,
         const WGPUCompareFunction stencilFunctionBack, const WGPUStencilOperation stencilOperationBack);
 public:
+    WGPURenderPipeline solidBlend(WgContext& context, BlendMethod method);
+    WGPURenderPipeline radialBlend(WgContext& context, BlendMethod method);
+    WGPURenderPipeline linearBlend(WgContext& context, BlendMethod method);
+    WGPURenderPipeline imageBlend(WgContext& context, BlendMethod method);
+    WGPURenderPipeline sceneBlend(WgContext& context, BlendMethod method);
+
     void initialize(WgContext& context);
     void release(WgContext& context);
 };

--- a/src/renderer/gpu_engine/wg/tvgWgPipelines.h
+++ b/src/renderer/gpu_engine/wg/tvgWgPipelines.h
@@ -91,6 +91,7 @@ public:
     WGPURenderPipeline radial_conv{}; // convex geometry (no stencil)
     WGPURenderPipeline linear_conv{}; // convex geometry (no stencil)
     WGPURenderPipeline image{};
+    WGPURenderPipeline image_direct{}; // image geometry (no stencil)
     WGPURenderPipeline scene{};
     // pipelines custom blend
     WGPURenderPipeline solid_blend[18]{};

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -493,6 +493,57 @@ void WgStageBufferGeometry::appendStencilBatch(const Array<WgShape*>& renderShap
     appendBatch(renderShapes, range.cover, true);
 }
 
+void WgStageBufferGeometry::appendImageBatch(const Array<WgImage*>& renderImages, WgImageBatchRange& range)
+{
+    assert(renderImages.count > 1);
+
+    uint32_t vertexCount = 0;
+    uint32_t indexCount = 0;
+    ARRAY_FOREACH(p, renderImages) {
+        const auto& mesh = (*p)->mesh;
+        assert(mesh.vbuffer.count == mesh.tbuffer.count);
+        vertexCount += mesh.vbuffer.count;
+        indexCount += mesh.ibuffer.count;
+    }
+
+    const uint32_t vertexBytes = vertexCount * sizeof(Point);
+    const uint32_t indexBytes = indexCount * sizeof(uint32_t);
+
+    if (vbuffer.reserved < vbuffer.count + vertexBytes * 2)
+        vbuffer.grow(std::max(vertexBytes * 2, vbuffer.reserved));
+    if (ibuffer.reserved < ibuffer.count + indexBytes)
+        ibuffer.grow(std::max(indexBytes, ibuffer.reserved));
+
+    range.vertexOffset = vbuffer.count;
+    range.texCoordOffset = vbuffer.count + vertexBytes;
+    range.indexOffset = ibuffer.count;
+    range.vertexCount = vertexCount;
+    range.indexCount = indexCount;
+
+    uint32_t baseVertex = 0;
+    auto vertexDst = vbuffer.data + range.vertexOffset;
+    auto texCoordDst = vbuffer.data + range.texCoordOffset;
+    auto indexDst = ibuffer.data + range.indexOffset;
+    ARRAY_FOREACH(p, renderImages) {
+        const auto& mesh = (*p)->mesh;
+        const uint32_t meshVertexBytes = mesh.vbuffer.count * sizeof(Point);
+        memcpy(vertexDst, mesh.vbuffer.data, meshVertexBytes);
+        memcpy(texCoordDst, mesh.tbuffer.data, meshVertexBytes);
+        vertexDst += meshVertexBytes;
+        texCoordDst += meshVertexBytes;
+
+        for (uint32_t i = 0; i < mesh.ibuffer.count; ++i) {
+            const auto index = mesh.ibuffer[i] + baseVertex;
+            memcpy(indexDst, &index, sizeof(index));
+            indexDst += sizeof(index);
+        }
+
+        baseVertex += mesh.vbuffer.count;
+    }
+    vbuffer.count += vertexBytes * 2;
+    ibuffer.count += indexBytes;
+}
+
 void WgStageBufferGeometry::release(WgContext& context)
 {
     context.releaseBuffer(vbuffer_gpu);

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.h
@@ -159,6 +159,12 @@ struct WgSolidBatchRange : WgGeometryRange
     RenderRegion viewport;
 };
 
+struct WgImageBatchRange : WgGeometryRange
+{
+    size_t texCoordOffset{};
+    RenderRegion viewport;
+};
+
 struct WgStencilBatchRange
 {
     WgGeometryRange stencil;
@@ -213,6 +219,7 @@ struct WgStageBufferGeometry
     void append(WgShape* renderShape);
     void append(WgImage* renderPicture);
     void appendSolidBatch(const Array<WgShape*>& renderShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range);
+    void appendImageBatch(const Array<WgImage*>& renderImages, WgImageBatchRange& range);
     void appendStencilBatch(const Array<WgShape*>& renderShapes, WgStencilBatchRange& range);
     void initialize(WgContext& context){};
     void release(WgContext& context);

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.cpp
@@ -47,6 +47,26 @@ void WgBatchTask::run(WgContext&, WgCompositor& compositor, WGPUCommandEncoder)
 }
 
 //***********************************************************************
+// WgImageBatchTask
+//***********************************************************************
+
+WgImageBatchTask::WgImageBatchTask(WgImage* first, WgImage* second) : images{2}
+{
+    images.push(first);
+    images.push(second);
+}
+
+void WgImageBatchTask::stage(WgCompositor& compositor)
+{
+    compositor.requestImageBatch(images, range);
+}
+
+void WgImageBatchTask::run(WgContext&, WgCompositor& compositor, WGPUCommandEncoder)
+{
+    compositor.renderImageBatch(images[0], range);
+}
+
+//***********************************************************************
 // WgPaintTask
 //***********************************************************************
 

--- a/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderTask.h
@@ -60,6 +60,16 @@ struct WgBatchTask : WgRenderTask
     void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
 };
 
+struct WgImageBatchTask : WgRenderTask
+{
+    Array<WgImage*> images;
+    WgImageBatchRange range;
+
+    WgImageBatchTask(WgImage* first, WgImage* second);
+    void stage(WgCompositor& compositor) override;
+    void run(WgContext& context, WgCompositor& compositor, WGPUCommandEncoder encoder) override;
+};
+
 // task for scene rendering with blending, composition and effect
 struct WgSceneTask : WgRenderTask
 {

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -358,8 +358,11 @@ bool WgRenderer::renderShape(RenderData data)
 
 bool WgRenderer::renderImage(RenderData data)
 {
-    WgPaintTask* paintTask = new WgPaintTask((WgPaint*)data, mBlendMethod);
+    auto rdata = (WgImage*)data;
     WgSceneTask* sceneTask = mSceneTaskStack.last();
+    if (mSolidBatch.draw(sceneTask, rdata, mBlendMethod, mRenderTaskList)) return true;
+
+    WgPaintTask* paintTask = new WgPaintTask(rdata, mBlendMethod);
     sceneTask->children.push(paintTask);
     mRenderTaskList.push(paintTask);
     return true;

--- a/src/renderer/gpu_engine/wg/tvgWgSolidBatch.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgSolidBatch.cpp
@@ -32,7 +32,15 @@ static inline bool eligible(const WgShape* rdata, BlendMethod blendMethod)
     return true;
 }
 
-static inline bool appendable(WgSceneTask* batchSceneTask, WgRenderTask* batchTask, const RenderRegion& batchViewport, WgSceneTask* sceneTask, const WgShape* rdata, const Array<WgRenderTask*>& renderTaskList)
+static inline bool eligible(const WgImage* rdata, BlendMethod blendMethod)
+{
+    if (blendMethod != BlendMethod::Normal) return false;
+    if (rdata->viewport.invalid() || !rdata->clips.empty() || !rdata->bindGroup) return false;
+    if (rdata->mesh.vbuffer.empty() || rdata->mesh.ibuffer.empty()) return false;
+    return true;
+}
+
+static inline bool appendable(WgSceneTask* batchSceneTask, WgRenderTask* batchTask, const RenderRegion& batchViewport, WgSceneTask* sceneTask, const WgPaint* rdata, const Array<WgRenderTask*>& renderTaskList)
 {
     // Any task submitted after the candidate is an implicit batch boundary.
     if (batchSceneTask != sceneTask) return false;
@@ -42,7 +50,7 @@ static inline bool appendable(WgSceneTask* batchSceneTask, WgRenderTask* batchTa
     return true;
 }
 
-static inline WgRenderTask* emitSingle(WgSceneTask* sceneTask, WgShape* rdata, Array<WgRenderTask*>& renderTaskList)
+static inline WgRenderTask* emitSingle(WgSceneTask* sceneTask, WgPaint* rdata, Array<WgRenderTask*>& renderTaskList)
 {
     auto task = new WgPaintTask(rdata, BlendMethod::Normal);
     sceneTask->children.push(task);
@@ -50,10 +58,9 @@ static inline WgRenderTask* emitSingle(WgSceneTask* sceneTask, WgShape* rdata, A
     return task;
 }
 
-static inline WgRenderTask* promote(WgSceneTask* sceneTask, WgRenderTask* task, WgShape* first, WgShape* rdata, Array<WgRenderTask*>& renderTaskList)
+static inline WgRenderTask* promote(WgSceneTask* sceneTask, WgRenderTask* task, WgRenderTask* batchTask, Array<WgRenderTask*>& renderTaskList)
 {
     // Tasks are staged only after the tree is complete, so replacing its tail is safe.
-    auto batchTask = new WgBatchTask(first, rdata, false);
     sceneTask->children.last() = batchTask;
     renderTaskList.last() = batchTask;
     delete task;
@@ -61,26 +68,46 @@ static inline WgRenderTask* promote(WgSceneTask* sceneTask, WgRenderTask* task, 
     return batchTask;
 }
 
-static inline void append(WgRenderTask* task, WgShape* rdata)
-{
-    static_cast<WgBatchTask*>(task)->shapes.push(rdata);
-}
-
 bool WgSolidBatch::draw(WgSceneTask* sceneTask, WgShape* rdata, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)
 {
     if (!eligible(rdata, blendMethod)) return false;
 
-    if (!appendable(this->sceneTask, task, viewport, sceneTask, rdata, renderTaskList)) {
+    if (type != Type::Shape || !appendable(this->sceneTask, task, viewport, sceneTask, rdata, renderTaskList)) {
         task = emitSingle(sceneTask, rdata, renderTaskList);
         this->sceneTask = sceneTask;
         first = rdata;
         viewport = rdata->viewport;
+        type = Type::Shape;
+        batched = false;
         return true;
     }
 
-    if (first) {
-        task = promote(this->sceneTask, task, first, rdata, renderTaskList);
-        first = nullptr;
-    } else append(task, rdata);
+    if (!batched) {
+        task = promote(sceneTask, task, new WgBatchTask(static_cast<WgShape*>(first), rdata, false), renderTaskList);
+        batched = true;
+    } else static_cast<WgBatchTask*>(task)->shapes.push(rdata);
+    return true;
+}
+
+bool WgSolidBatch::draw(WgSceneTask* sceneTask, WgImage* rdata, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList)
+{
+    if (!eligible(rdata, blendMethod)) return false;
+
+    if (type != Type::Picture || !appendable(this->sceneTask, task, viewport, sceneTask, rdata, renderTaskList) ||
+        static_cast<WgImage*>(first)->bindGroup != rdata->bindGroup ||
+        static_cast<WgImage*>(first)->setting.settings.options.vec[3] != rdata->setting.settings.options.vec[3]) {
+        task = emitSingle(sceneTask, rdata, renderTaskList);
+        this->sceneTask = sceneTask;
+        first = rdata;
+        viewport = rdata->viewport;
+        type = Type::Picture;
+        batched = false;
+        return true;
+    }
+
+    if (!batched) {
+        task = promote(sceneTask, task, new WgImageBatchTask(static_cast<WgImage*>(first), rdata), renderTaskList);
+        batched = true;
+    } else static_cast<WgImageBatchTask*>(task)->images.push(rdata);
     return true;
 }

--- a/src/renderer/gpu_engine/wg/tvgWgSolidBatch.h
+++ b/src/renderer/gpu_engine/wg/tvgWgSolidBatch.h
@@ -28,11 +28,14 @@
 struct WgSolidBatch
 {
     bool draw(WgSceneTask* sceneTask, WgShape* rdata, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList);
+    bool draw(WgSceneTask* sceneTask, WgImage* rdata, BlendMethod blendMethod, Array<WgRenderTask*>& renderTaskList);
 
     WgSceneTask* sceneTask{};
     WgRenderTask* task{};
-    WgShape* first{};
+    WgPaint* first{};
     RenderRegion viewport{};
+    Type type = Type::Undefined;
+    bool batched{};
 };
 
 #endif  // _TVG_WG_SOLID_BATCH_H_


### PR DESCRIPTION
Reduce WebGPU image rendering overhead by batching consecutive compatible images and skipping the stencil prepass for normal, unclipped images. 
Create custom blend pipelines on demand to avoid initializing unused variants.
Compared with main, five paired runs with 5,000 PNG images at 2560×1440 and VSync disabled show:
- Default: +23.0%.
- Rotation: +23.0%.
- Mean frame time decreases by 18.7% in both scenes.