### PR TITLE
 engines: rectify drop shadow offset transforms

### DIFF
--- a/src/renderer/cpu_engine/tvgSwPostEffect.cpp
+++ b/src/renderer/cpu_engine/tvgSwPostEffect.cpp
@@ -159,16 +159,10 @@ void effectGaussianBlurUpdate(RenderEffectGaussianBlur* params, const Matrix& tr
     auto rd = static_cast<SwGaussianBlur*>(params->rd);
 
     //compute box kernel sizes
-    auto scale = sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
-    rd->extends = _gaussianInit(rd, std::pow(params->sigma * scale, 2), params->quality);
+    auto scaleSquared = transform.e11 * transform.e11 + transform.e12 * transform.e12;
+    rd->extends = _gaussianInit(rd, params->sigma * params->sigma * scaleSquared, params->quality);
 
-    //invalid
-    if (rd->extends == 0) {
-        params->valid = false;
-        return;
-    }
-
-    params->valid = true;
+    params->valid = (rd->extends > 0);
 }
 
 
@@ -375,24 +369,17 @@ bool effectDropShadowRegion(RenderEffectDropShadow* params)
 
 void effectDropShadowUpdate(RenderEffectDropShadow* params, const Matrix& transform)
 {
+    Point offset;
+    if (!params->update(transform, offset)) return;
+
     if (!params->rd) params->rd = tvg::malloc<SwDropShadow>(sizeof(SwDropShadow));
     auto rd = static_cast<SwDropShadow*>(params->rd);
 
-    //compute box kernel sizes
-    auto scale = sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
-    rd->extends = _gaussianInit(rd, std::pow(params->sigma * scale, 2), params->quality);
+    // The sum of the box radii covers the full blur support.
+    auto scaleSquared = transform.e11 * transform.e11 + transform.e12 * transform.e12;
+    rd->extends = _gaussianInit(rd, params->sigma * params->sigma * scaleSquared, params->quality);
 
-    //invalid
-    if (params->color[3] == 0) {
-        params->valid = false;
-        return;
-    }
-
-    //offset
-    auto radian = tvg::deg2rad(90.0f - params->angle) - tvg::radian(transform);
-    rd->offset = {(int32_t)((params->distance * scale) * cosf(radian)), (int32_t)(-1.0f * (params->distance * scale) * sinf(radian))};
-
-    params->valid = true;
+    rd->offset = {(int32_t)offset.x, (int32_t)offset.y};
 }
 
 

--- a/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlEffect.cpp
@@ -34,15 +34,15 @@
 
 struct GlGaussianBlur
 {
-    float sigma{};
-    float scale{};
-    float extend{};
-    float quality{};
+    float sigma;
+    float scale;
+    float extend;
+    float quality;
 };
 
 static float _blurQuality(uint8_t quality, float extend)
 {
-    float step = 1.0f;
+    auto step = 1.0f;
     if (quality <= 33) step = 3.0f;
     else if (quality <= 66) step = 2.0f;
     return std::min(step, float(std::max(int(extend), 1)));
@@ -65,14 +65,18 @@ bool GlEffect::region(RenderEffectGaussianBlur* effect)
 
 void GlEffect::update(RenderEffectGaussianBlur* effect, const Matrix& transform)
 {
-    GlGaussianBlur* blur = (GlGaussianBlur*)effect->rd;
+    const auto scale = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
+    const auto extend = 2 * effect->sigma * scale;
+    effect->valid = !tvg::zero(extend);
+    if (!effect->valid) return;
+
+    auto blur = (GlGaussianBlur*)effect->rd;
     if (!blur) blur = tvg::malloc<GlGaussianBlur>(sizeof(GlGaussianBlur));
     blur->sigma = effect->sigma;
-    blur->scale = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
-    blur->extend = 2 * blur->sigma * blur->scale;
+    blur->scale = scale;
+    blur->extend = extend;
     blur->quality = _blurQuality(effect->quality, blur->extend);
     effect->rd = blur;
-    effect->valid = (blur->extend > 0);
 }
 
 
@@ -135,25 +139,28 @@ bool GlEffect::region(RenderEffectDropShadow* effect)
 
 void GlEffect::update(RenderEffectDropShadow* effect, const Matrix& transform)
 {
+    Point offset;
+    if (!effect->update(transform, offset)) return;
+
     GlDropShadow* dropShadow = (GlDropShadow*)effect->rd;
     if (!dropShadow) dropShadow = tvg::malloc<GlDropShadow>(sizeof(GlDropShadow));
     const auto scale = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
-    const auto radian = tvg::deg2rad(90.0f - effect->angle) - tvg::radian(transform);
-    const Point offset = {-effect->distance * cosf(radian) * scale, -effect->distance * sinf(radian) * scale};
 
     dropShadow->sigma = effect->sigma;
     dropShadow->scale = scale;
-    dropShadow->color[3] = effect->color[3] / 255.0f;
+
     //Drop shadow effect applies blending in the shader (GL_BLEND disabled), so the color should be premultiplied:
+    dropShadow->color[3] = effect->color[3] / 255.0f;
     dropShadow->color[0] = effect->color[0] / 255.0f * dropShadow->color[3];
     dropShadow->color[1] = effect->color[1] / 255.0f * dropShadow->color[3];
     dropShadow->color[2] = effect->color[2] / 255.0f * dropShadow->color[3];
-    dropShadow->offset[0] = offset.x;
+
+    dropShadow->offset[0] = -offset.x;
     dropShadow->offset[1] = offset.y;
     dropShadow->extend = 2 * std::max(effect->sigma * scale + std::abs(offset.x), effect->sigma * scale + std::abs(offset.y));
     dropShadow->quality = _blurQuality(effect->quality, dropShadow->extend);
+
     effect->rd = dropShadow;
-    effect->valid = (dropShadow->extend >= 0);
 }
 
 

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -292,7 +292,6 @@ void WgRenderEffectParams::update(WgContext& context, WgShaderTypeEffectParams& 
 
 void WgRenderEffectParams::update(WgContext& context, RenderEffectGaussianBlur* gaussian, const Matrix& transform)
 {
-    assert(gaussian);
     WgShaderTypeEffectParams effectParams;
     if (!effectParams.update(gaussian, transform)) return;
     update(context, effectParams);
@@ -301,7 +300,6 @@ void WgRenderEffectParams::update(WgContext& context, RenderEffectGaussianBlur* 
 
 void WgRenderEffectParams::update(WgContext& context, RenderEffectDropShadow* dropShadow, const Matrix& transform)
 {
-    assert(dropShadow);
     WgShaderTypeEffectParams effectParams;
     if (!effectParams.update(dropShadow, transform)) return;
     update(context, effectParams);

--- a/src/renderer/gpu_engine/wg/tvgWgShaderTypes.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgShaderTypes.cpp
@@ -197,38 +197,35 @@ void WgShaderTypeGradientData::update(const Fill* fill)
 
 bool WgShaderTypeEffectParams::update(RenderEffectGaussianBlur* gaussian, const Matrix& transform)
 {
-    assert(gaussian);
     params[0] = gaussian->sigma;
     params[1] = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
-    params[2] = 2 * gaussian->sigma * params[1];
-    extend = params[2] * 2; // kernel
-    gaussian->valid = (extend > 0);
+    params[2] = 2.0f * gaussian->sigma * params[1];
+    extend = params[2] * 2.0f; // kernel
+    gaussian->valid = !tvg::zero(extend);
     return gaussian->valid;
 }
 
 
 bool WgShaderTypeEffectParams::update(RenderEffectDropShadow* dropShadow, const Matrix& transform)
 {
-    assert(dropShadow);
+    if (!dropShadow->update(transform, offset)) return false;
+
     const auto scale = std::sqrt(transform.e11 * transform.e11 + transform.e12 * transform.e12);
-    const auto kernel = 2 * dropShadow->sigma * scale;
-    const auto radian = tvg::deg2rad(90.0f - dropShadow->angle) - tvg::radian(transform);
-    const Point offset = {dropShadow->distance * cosf(radian) * scale, -dropShadow->distance * sinf(radian) * scale};
+    extend = 2 * std::max(dropShadow->sigma * scale + std::abs(offset.x), dropShadow->sigma * scale + std::abs(offset.y));
+
     params[0] = dropShadow->sigma;
     params[1] = scale;
-    params[2] = kernel;
+    params[2] = 2 * dropShadow->sigma * scale;
     params[3] = 0.0f;
     params[7] = dropShadow->color[3] / 255.0f; // alpha
+
     //Color is premultiplied to avoid multiplication in the fragment shader:
     params[4] = dropShadow->color[0] / 255.0f * params[7]; // red
     params[5] = dropShadow->color[1] / 255.0f * params[7]; // green
     params[6] = dropShadow->color[2] / 255.0f * params[7]; // blue
     params[8] = offset.x;
     params[9] = offset.y;
-    extend = 2 * std::max(dropShadow->sigma * scale + std::abs(offset.x), dropShadow->sigma * scale + std::abs(offset.y));
-
-    dropShadow->valid = (extend >= 0);
-    return dropShadow->valid;
+    return true;
 }
 
 

--- a/src/renderer/tvgRender.h
+++ b/src/renderer/tvgRender.h
@@ -536,6 +536,19 @@ struct RenderEffectDropShadow : RenderEffect
     float sigma;
     uint8_t quality;   //0 ~ 100  (optional)
 
+    bool update(const Matrix& transform, Point& offset)
+    {
+        valid = (color[3] != 0);
+        if (!valid) return false;
+
+        // Transform the offset as a direction, without translation.
+        const auto radian = tvg::deg2rad(90.0f - angle);
+        const auto x = distance * cosf(radian);
+        const auto y = -distance * sinf(radian);
+        offset = {transform.e11 * x + transform.e12 * y, transform.e21 * x + transform.e22 * y};
+        return true;
+    }
+
     static RenderEffectDropShadow* gen(va_list& args)
     {
         auto inst = new RenderEffectDropShadow;


### PR DESCRIPTION
Apply the linear transform to shadow offsets across CPU, GL, and
WebGPU to handle nonuniform scaling, skew, and reflection.