### PR TITLE
loader/jpg: reject duplicate scan components

### DIFF
--- a/src/loaders/jpg/tvgJpgd.cpp
+++ b/src/loaders/jpg/tvgJpgd.cpp
@@ -1015,6 +1015,10 @@ bool jpeg_decoder::read_sos_marker()
 
         if (ci >= m_comps_in_frame) return stop_decoding(JPGD_BAD_SOS_COMP_ID);
 
+        for (auto j = 0; j < i; ++j) {
+            if (m_comp_list[j] == ci) return stop_decoding(JPGD_BAD_SOS_COMP_ID);
+        }
+
         m_comp_list[i]    = ci;
         m_comp_dc_tab[ci] = (c >> 4) & 15;
         m_comp_ac_tab[ci] = (c & 15) + (JPGD_MAX_HUFF_TABLES >> 1);


### PR DESCRIPTION
Duplicate component selectors in an SOS header cause the same component to be counted repeatedly when building MCU blocks. This can exceed buffers sized from the frame components.

Reject duplicate components during SOS parsing before registering them in the scan component list.

issue: https://github.com/thorvg/thorvg/security/advisories/GHSA-mw4c-w54x-248r

---

The following was reproduced using the issue reporter’s tool.

#### before 
- `==9942==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x0001009a0850 at pc 0x00010085224c bp 0x00016f5b9150 sp 0x00016f5b9148`

#### fetch 
- `test/resources/jpgd/gwevil.jpg: 16384x16 rejected`


---

### reference

ITU-T T.81, section B.2.3 (“Scan header syntax”), explicitly requires unique
component selectors within a scan:

> The value of Csⱼ shall be different from the values of Cs₁ to Csⱼ₋₁.

Source: [ITU-T T.81, page 37 (PDF page 41)](https://www.w3.org/Graphics/JPEG/itu-t81.pdf#page=41).

This change rejects duplicate components in `read_sos_marker()` before
adding them to `m_comp_list`.

 The check applies independently to each scan, preserving valid component reuse across progressive scans.
