### PR TITLE
wg: neat & compactness++

### DIFF
--- a/src/renderer/cpu_engine/tvgSwRenderer.cpp
+++ b/src/renderer/cpu_engine/tvgSwRenderer.cpp
@@ -554,8 +554,7 @@ bool SwRenderer::blend(BlendMethod method)
 
 RenderRegion SwRenderer::region(RenderData data)
 {
-    if (data) return static_cast<SwTask*>(data)->bounds();
-    return {};
+    return data ? static_cast<SwTask*>(data)->bounds() : RenderRegion{};
 }
 
 

--- a/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
+++ b/src/renderer/gpu_engine/gl/tvgGlRenderer.cpp
@@ -1064,9 +1064,7 @@ bool GlRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
 
 RenderRegion GlRenderer::region(RenderData data)
 {
-    if (!data) return {};
-    auto paint = static_cast<GlDrawable*>(data);
-    return paint->geometry.bounds();
+    return data ? static_cast<GlDrawable*>(data)->geometry.bounds() : RenderRegion{};
 }
 
 

--- a/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgCompositor.cpp
@@ -275,7 +275,7 @@ void WgCompositor::requestShape(WgShape* shape)
 void WgCompositor::requestImage(WgImage* image)
 {
     stageBufferGeometry.append(image);
-    image->renderSettings.bindGroupIdx = stageBufferPaint.append(image->renderSettings.settings);
+    image->setting.bindGroupIdx = stageBufferPaint.append(image->setting.settings);
     ARRAY_FOREACH(p, image->clips) {
         requestShape((WgShape*)(*p));
     }
@@ -300,7 +300,7 @@ void WgCompositor::requestStencilBatch(const Array<WgShape*>& renderShapes, WgSt
     ARRAY_FOREACH(p, renderShapes) {
         auto rdata = *p;
         auto& settings = rdata->shape.setting;
-        const auto count = rdata->meshBBox.vbuffer.count;
+        const auto count = rdata->bboxMesh.vbuffer.count;
 
         if (settings.fillType == WgRenderSettingsType::Solid) {
             if (!colorsStarted) {
@@ -407,7 +407,7 @@ void WgCompositor::renderStencilBatch(const Array<WgShape*>& renderShapes, const
         const auto batchFirstIndex = firstIndex;
 
         do {
-            const auto indexCount = rdata->meshBBox.ibuffer.count;
+            const auto indexCount = rdata->bboxMesh.ibuffer.count;
             const uint64_t nextIndex = static_cast<uint64_t>(firstIndex) + indexCount;
             firstIndex = static_cast<uint32_t>(nextIndex);
             if (++p == end || settings.fillType != WgRenderSettingsType::Solid) break;
@@ -532,7 +532,7 @@ void WgCompositor::drawShape(WgContext& context, WgShape* rdata)
     if (!rdata->shape.setting.valid || rdata->shape.mesh.vbuffer.empty() || rdata->viewport.invalid()) return;
     auto& settings = rdata->shape.setting;
     auto convex = rdata->convex;
-    auto mesh = rdata->convex ? &rdata->shape.mesh : &rdata->meshBBox;
+    auto mesh = rdata->convex ? &rdata->shape.mesh : &rdata->bboxMesh;
 
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
 
@@ -591,19 +591,19 @@ void WgCompositor::blendShape(WgContext& context, WgShape* rdata, BlendMethod bl
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_blend[blendMethodInd]);
-        drawMeshSolid(context, &rdata->meshBBox, rdata->shape.solid.colorIdx);
+        drawMeshSolid(context, &rdata->bboxMesh, rdata->shape.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear_blend[blendMethodInd]);
-        drawMesh(context, &rdata->meshBBox);
+        drawMesh(context, &rdata->bboxMesh);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial_blend[blendMethodInd]);
-        drawMesh(context, &rdata->meshBBox);
+        drawMesh(context, &rdata->bboxMesh);
     }
 }
 
@@ -623,23 +623,23 @@ void WgCompositor::clipShape(WgContext& context, WgShape* rdata)
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.merge_depth_stencil);
-    drawMesh(context, &rdata->meshBBox);
+    drawMesh(context, &rdata->bboxMesh);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
-        drawMeshSolid(context, &rdata->meshBBox, rdata->shape.solid.colorIdx);
+        drawMeshSolid(context, &rdata->bboxMesh, rdata->shape.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear);
-        drawMesh(context, &rdata->meshBBox);
+        drawMesh(context, &rdata->bboxMesh);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial);
-        drawMesh(context, &rdata->meshBBox);
+        drawMesh(context, &rdata->bboxMesh);
     }
 }
 
@@ -661,17 +661,17 @@ void WgCompositor::drawStrokes(WgContext& context, WgShape* rdata)
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
-        drawMeshSolid(context, &rdata->stroke.bbox, rdata->stroke.solid.colorIdx);
+        drawMeshSolid(context, &rdata->stroke.bboxMesh, rdata->stroke.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear);
-        drawMesh(context, &rdata->stroke.bbox);
+        drawMesh(context, &rdata->stroke.bboxMesh);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial);
-        drawMesh(context, &rdata->stroke.bbox);
+        drawMesh(context, &rdata->stroke.bboxMesh);
     }
 }
 
@@ -700,19 +700,19 @@ void WgCompositor::blendStrokes(WgContext& context, WgShape* rdata, BlendMethod 
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid_blend[blendMethodInd]);
-        drawMeshSolid(context, &rdata->stroke.bbox, rdata->stroke.solid.colorIdx);
+        drawMeshSolid(context, &rdata->stroke.bboxMesh, rdata->stroke.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear_blend[blendMethodInd]);
-        drawMesh(context, &rdata->stroke.bbox);
+        drawMesh(context, &rdata->stroke.bboxMesh);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial_blend[blendMethodInd]);
-        drawMesh(context, &rdata->stroke.bbox);
+        drawMesh(context, &rdata->stroke.bboxMesh);
     }
 };
 
@@ -734,49 +734,49 @@ void WgCompositor::clipStrokes(WgContext& context, WgShape* rdata)
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.merge_depth_stencil);
-    drawMesh(context, &rdata->meshBBox);
+    drawMesh(context, &rdata->bboxMesh);
     // setup fill rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, strokeView, 0, nullptr);
     if (settings.fillType == WgRenderSettingsType::Solid) {
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.solid);
-        drawMeshSolid(context, &rdata->stroke.bbox, rdata->stroke.solid.colorIdx);
+        drawMeshSolid(context, &rdata->stroke.bboxMesh, rdata->stroke.solid.colorIdx);
     } else if (settings.fillType == WgRenderSettingsType::Linear) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.linear);
-        drawMesh(context, &rdata->stroke.bbox);
+        drawMesh(context, &rdata->stroke.bboxMesh);
     } else if (settings.fillType == WgRenderSettingsType::Radial) {
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, settings.gradientData.bindGroup, 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.radial);
-        drawMesh(context, &rdata->stroke.bbox);
+        drawMesh(context, &rdata->stroke.bboxMesh);
     }
 }
 
 void WgCompositor::drawImage(WgContext& context, WgImage* rdata)
 {
-    if (rdata->viewport.invalid() || !rdata->imageBindGroup) return;
-    WgRenderSettings& settings = rdata->renderSettings;
+    if (rdata->viewport.invalid() || !rdata->bindGroup) return;
+    WgRenderSettings& settings = rdata->setting;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // draw stencil
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
-    drawMeshImage(context, &rdata->meshData);
+    drawMeshImage(context, &rdata->mesh);
     // draw image
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->imageBindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->bindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image);
-    drawMeshImage(context, &rdata->meshData);
+    drawMeshImage(context, &rdata->mesh);
 }
 
 void WgCompositor::blendImage(WgContext& context, WgImage* rdata, BlendMethod blendMethod)
 {
-    if (rdata->viewport.invalid() || !rdata->imageBindGroup) return;
-    WgRenderSettings& settings = rdata->renderSettings;
+    if (rdata->viewport.invalid() || !rdata->bindGroup) return;
+    WgRenderSettings& settings = rdata->setting;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // copy current render target data to dst target
     WgRenderTarget *target = currentTarget;
@@ -787,40 +787,40 @@ void WgCompositor::blendImage(WgContext& context, WgImage* rdata, BlendMethod bl
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
-    drawMeshImage(context, &rdata->meshData);
+    drawMeshImage(context, &rdata->mesh);
     // blend image
     uint32_t blendMethodInd = (uint32_t)blendMethod;
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->imageBindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->bindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 3, targetTemp0.bindGroupTexture, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image_blend[blendMethodInd]);
-    drawMeshImage(context, &rdata->meshData);
+    drawMeshImage(context, &rdata->mesh);
 };
 
 void WgCompositor::clipImage(WgContext& context, WgImage* rdata)
 {
-    if (rdata->viewport.invalid() || !rdata->imageBindGroup) return;
-    WgRenderSettings& settings = rdata->renderSettings;
+    if (rdata->viewport.invalid() || !rdata->bindGroup) return;
+    WgRenderSettings& settings = rdata->setting;
     wgpuRenderPassEncoderSetScissorRect(renderPassEncoder, rdata->viewport.x(), rdata->viewport.y(), rdata->viewport.w(), rdata->viewport.h());
     // setup stencil rules
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 255);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.direct);
-    drawMeshImage(context, &rdata->meshData);
+    drawMeshImage(context, &rdata->mesh);
     // merge depth and stencil buffer
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.merge_depth_stencil);
-    drawMeshImage(context, &rdata->meshData);
+    drawMeshImage(context, &rdata->mesh);
     // draw image
     wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, stageBufferPaint[settings.bindGroupIdx], 0, nullptr);
-    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->imageBindGroup, 0, nullptr);
+    wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 2, rdata->bindGroup, 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.image);
-    drawMeshImage(context, &rdata->meshData);
+    drawMeshImage(context, &rdata->mesh);
 }
 
 
@@ -886,7 +886,7 @@ void WgCompositor::renderClipPath(WgContext& context, WgPaint* paint)
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
     wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
     wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.copy_stencil_to_depth);
-    drawMesh(context, &rdata0->meshBBox);
+    drawMesh(context, &rdata0->bboxMesh);
     // merge clip paths with AND logic
     for (auto p = paint->clips.begin() + 1; p < paint->clips.end(); ++p) {
         auto rdata = (WgShape*)(*p);
@@ -897,27 +897,27 @@ void WgCompositor::renderClipPath(WgContext& context, WgPaint* paint)
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[190], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.copy_stencil_to_depth_interm);
-        drawMesh(context, &rdata->meshBBox);
+        drawMesh(context, &rdata->bboxMesh);
         // copy depth to stencil
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 1);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[190], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.copy_depth_to_stencil);
-        drawMesh(context, &rdata->meshBBox);
+        drawMesh(context, &rdata->bboxMesh);
         // clear depth current (keep stencil)
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[255], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.clear_depth);
-        drawMesh(context, &rdata->meshBBox);
+        drawMesh(context, &rdata->bboxMesh);
         // clear depth original (keep stencil)
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[255], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.clear_depth);
-        drawMesh(context, &rdata0->meshBBox);
+        drawMesh(context, &rdata0->bboxMesh);
         // copy stencil to depth (clear stencil)
         wgpuRenderPassEncoderSetStencilReference(renderPassEncoder, 0);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[128], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.copy_stencil_to_depth);
-        drawMesh(context, &rdata->meshBBox);
+        drawMesh(context, &rdata->bboxMesh);
     }
 }
 
@@ -933,7 +933,7 @@ void WgCompositor::clearClipPath(WgContext& context, WgPaint* paint)
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 0, bindGroupViewMat, 0, nullptr);
         wgpuRenderPassEncoderSetBindGroup(renderPassEncoder, 1, bindGroupOpacities[255], 0, nullptr);
         wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipelines.clear_depth);
-        drawMesh(context, &rdata->meshBBox);
+        drawMesh(context, &rdata->bboxMesh);
     }
 }
 

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.cpp
@@ -94,10 +94,9 @@ void WgRenderSettings::release(WgContext& context)
 // WgPaint
 //***********************************************************************
 
-void WgPaint::update(const Array<RenderData>& clips)
+void WgPaint::assign(const Array<RenderData>& clips)
 {
-    this->clips.clear();
-    // RenderData == WgPaint*, just copy it.
+    // trick: RenderData == WgPaint*, just copy it.
     this->clips = *((Array<WgPaint*>*)&clips);
 }
 
@@ -105,10 +104,10 @@ void WgPaint::update(const Array<RenderData>& clips)
 // WgShape
 //***********************************************************************
 
-void WgShape::updateBBox(const BBox& bb)
+void WgShape::expand(const BBox& bbox)
 {
-    bbox.min = tvg::min(bbox.min, bb.min);
-    bbox.max = tvg::max(bbox.max, bb.max);
+    this->bbox.min = tvg::min(this->bbox.min, bbox.min);
+    this->bbox.max = tvg::max(this->bbox.max, bbox.max);
 }
 
 void WgShape::update(const RenderShape& rshape, const RenderRegion& vport, uint8_t shapeOpacity, uint8_t strokeOpacity, uint8_t opacity)
@@ -179,9 +178,8 @@ void WgShape::update(const RenderShape& rshape, const Matrix& transform, RenderU
             if (shape.mesh.ibuffer.empty()) {
                 shape.mesh.clear();
             } else {
-                shape.bounds = bbox;
-                shape.bbox.bbox(bbox.min, bbox.max);
-                updateBBox(bbox);
+                shape.bbox = bbox;
+                expand(bbox);
             }
         }
     }
@@ -204,31 +202,28 @@ void WgShape::update(const RenderShape& rshape, const Matrix& transform, RenderU
                 stroke.mesh.clear();
             } else {
                 auto bbox = stroker.getBBox();
-                stroke.bounds = bbox;
-                stroke.bbox.bbox(bbox.min, bbox.max);
+                stroke.bbox = bbox;
+                stroke.bboxMesh.bbox(bbox.min, bbox.max);
                 auto strokeBounds = gpuTransformBounds(stroker.bounds(), transform);
-                updateBBox({{(float)strokeBounds.min.x, (float)strokeBounds.min.y}, {(float)strokeBounds.max.x, (float)strokeBounds.max.y}});
+                expand({{(float)strokeBounds.min.x, (float)strokeBounds.min.y}, {(float)strokeBounds.max.x, (float)strokeBounds.max.y}});
             }
         }
     }
     // update shapes bbox (with empty path handling)
-    if (!shape.mesh.vbuffer.empty() || !stroke.mesh.vbuffer.empty()) updateAABB();
-    else bbox = aabb = {{0, 0}, {0, 0}};
-    meshBBox.bbox(bbox.min, bbox.max);
+    if (shape.mesh.vbuffer.empty() && stroke.mesh.vbuffer.empty()) bbox = {{0, 0}, {0, 0}};
+    bboxMesh.bbox(bbox.min, bbox.max);
 }
 
 void WgShape::reset()
 {
     clips.clear();
     stroke.mesh.clear();
-    stroke.bbox.clear();
-    stroke.bounds.init();
+    stroke.bboxMesh.clear();
+    stroke.bbox.init();
     shape.mesh.clear();
-    shape.bbox.clear();
-    shape.bounds.init();
-    meshBBox.clear();
+    shape.bbox.init();
+    bboxMesh.clear();
     bbox.init();
-    aabb.init();
 }
 
 void WgShape::release(WgContext& context)
@@ -244,37 +239,37 @@ void WgShape::release(WgContext& context)
 
 void WgImage::update(const RenderSurface* surface, const Matrix& transform)
 {
-    meshData.imageBox(surface->w, surface->h, transform);
+    mesh.imageBox(surface->w, surface->h, transform);
 }
 
 void WgImage::setup(WGPUTexture texture, WGPUBindGroup bindGroup, const RenderSurface* surface, FilterMethod filter, uint16_t stamp)
 {
-    imageTexture = texture;
-    imageBindGroup = bindGroup;
-    imageSource = texture ? surface : nullptr;
-    imageFilter = filter;
-    imageStamp = texture ? stamp : 0;
+    this->texture = texture;
+    this->bindGroup = bindGroup;
+    this->surface = texture ? surface : nullptr;
+    this->filter = filter;
+    this->stamp = texture ? stamp : 0;
 }
 
 void WgImage::release(WgTextureMgr& textures, WgContext& context)
 {
-    if (imageTexture && imageStamp == textures.stamp) textures.release(context, imageSource, imageFilter, imageTexture);
+    if (texture && stamp == textures.stamp) textures.release(context, surface, filter, texture);
     reset();
 }
 
 void WgImage::reset()
 {
-    imageTexture = nullptr;
-    imageBindGroup = nullptr;
-    imageSource = nullptr;
-    imageFilter = FilterMethod::Bilinear;
-    imageStamp = 0;
+    this->texture = nullptr;
+    this->bindGroup = nullptr;
+    this->surface = nullptr;
+    this->filter = FilterMethod::Bilinear;
+    this->stamp = 0;
 }
 
 void WgImage::release(WgContext& context)
 {
     clips.clear();
-    renderSettings.release(context);
+    setting.release(context);
     reset();
 }
 
@@ -423,15 +418,14 @@ void WgStageBufferGeometry::append(WgMesh* meshData)
 void WgStageBufferGeometry::append(WgShape* renderShape)
 {
     append(&renderShape->shape.mesh);
-    append(&renderShape->shape.bbox);
     append(&renderShape->stroke.mesh);
-    append(&renderShape->stroke.bbox);
-    append(&renderShape->meshBBox);
+    append(&renderShape->stroke.bboxMesh);
+    append(&renderShape->bboxMesh);
 }
 
 void WgStageBufferGeometry::append(WgImage* renderPicture)
 {
-    append(&renderPicture->meshData);
+    append(&renderPicture->mesh);
 }
 
 void WgStageBufferGeometry::appendSolidBatch(const Array<WgShape*>& renderShapes, WgStageBufferSolidColor& colors, WgSolidBatchRange& range)
@@ -454,7 +448,7 @@ void WgStageBufferGeometry::appendBatch(const Array<WgShape*>& renderShapes, WgG
     uint32_t vertexCount = 0;
     uint32_t indexCount = 0;
     ARRAY_FOREACH(p, renderShapes) {
-        const auto& mesh = cover ? (*p)->meshBBox : (*p)->shape.mesh;
+        const auto& mesh = cover ? (*p)->bboxMesh : (*p)->shape.mesh;
         vertexCount += mesh.vbuffer.count;
         indexCount += mesh.ibuffer.count;
     }
@@ -476,7 +470,7 @@ void WgStageBufferGeometry::appendBatch(const Array<WgShape*>& renderShapes, WgG
     auto vertexDst = vbuffer.data + vbuffer.count;
     auto indexDst = ibuffer.data + ibuffer.count;
     ARRAY_FOREACH(p, renderShapes) {
-        const auto& mesh = cover ? (*p)->meshBBox : (*p)->shape.mesh;
+        const auto& mesh = cover ? (*p)->bboxMesh : (*p)->shape.mesh;
         const uint32_t meshVertexBytes = mesh.vbuffer.count * sizeof(Point);
         memcpy(vertexDst, mesh.vbuffer.data, meshVertexBytes);
         vertexDst += meshVertexBytes;

--- a/src/renderer/gpu_engine/wg/tvgWgRenderData.h
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderData.h
@@ -23,7 +23,6 @@
 #ifndef _TVG_WG_RENDER_DATA_H_
 #define _TVG_WG_RENDER_DATA_H_
 
-#include "tvgWgPipelines.h"
 #include "tvgWgMesh.h"
 #include "tvgWgShaderTypes.h"
 
@@ -72,29 +71,25 @@ struct WgRenderSettings
 
 struct WgPaint
 {
-    BBox aabb{};
     RenderRegion viewport;
     Array<WgPaint*> clips;
     Matrix transform;
 
     virtual ~WgPaint(){};
     virtual void release(WgContext& context) = 0;
+    virtual RenderRegion region() = 0;
     virtual Type type() { return Type::Undefined; };
-
-    void update(const Array<RenderData>& clips);
+    void assign(const Array<RenderData>& clips);
 };
 
 struct WgShape : WgPaint
 {
-    using WgPaint::update;
-
     struct
     {
         WgRenderSettings setting;
         WgSolidFill solid;
         WgMesh mesh;
-        WgMesh bbox;
-        BBox bounds;
+        BBox bbox;
     } shape;
 
     struct
@@ -102,43 +97,51 @@ struct WgShape : WgPaint
         WgRenderSettings setting;
         WgSolidFill solid;
         WgMesh mesh;
-        WgMesh bbox;
-        BBox bounds;
+        WgMesh bboxMesh;
+        BBox bbox;
     } stroke;
 
-    WgMesh meshBBox;
-    FillRule fillRule;
+    WgMesh bboxMesh;
     BBox bbox;
     uint32_t strokeViewMatIdx;
+    FillRule fillRule;
     bool convex;
     bool strokeFirst;
 
-    void updateBBox(const BBox& bb);
-    void updateAABB() { aabb = bbox; }
+    void expand(const BBox& bb);
     void update(const RenderShape& rshape, const RenderRegion& vport, uint8_t shapeOpacity, uint8_t strokeOpacity, uint8_t opacity);
     void update(const RenderShape& rshape, const Matrix& transform, RenderUpdateFlag flag);
     void reset();
     void release(WgContext& context) override;
+
+    RenderRegion region() override
+    {
+        auto& min = bbox.min;
+        auto& max = bbox.max;
+        return {{int32_t(nearbyint(min.x)), int32_t(nearbyint(min.y))}, {int32_t(nearbyint(max.x)), int32_t(nearbyint(max.y))}};
+    }
+
     Type type() override { return Type::Shape; };
 };
 
 struct WgImage : WgPaint
 {
-    using WgPaint::update;
-
-    WgRenderSettings renderSettings;
-    WGPUTexture imageTexture{};
-    WGPUBindGroup imageBindGroup{};
-    const RenderSurface* imageSource = nullptr;
-    FilterMethod imageFilter = FilterMethod::Bilinear;
-    uint16_t imageStamp = 0;
-    WgMesh meshData;
+    const RenderSurface* surface{};
+    WgRenderSettings setting;
+    WGPUTexture texture{};
+    WGPUBindGroup bindGroup{};
+    WgMesh mesh;
+    uint16_t stamp = 0;
+    FilterMethod filter = FilterMethod::Bilinear;
 
     void update(const RenderSurface* surface, const Matrix& transform);
     void setup(WGPUTexture texture, WGPUBindGroup bindGroup, const RenderSurface* surface, FilterMethod filter, uint16_t stamp);
     void release(WgTextureMgr& textures, WgContext& context);
     void reset();
     void release(WgContext& context) override;
+
+    // TODO: return an elaborate bbox
+    RenderRegion region() override { return viewport; }
     Type type() override { return Type::Picture; };
 };
 

--- a/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgRenderer.cpp
@@ -78,7 +78,7 @@ struct WgIntersector
         ARRAY_FOREACH(c, clips) {
             auto clip = static_cast<const WgShape*>(*c);
             const auto& mesh = clip->shape.mesh;
-            if (!clip->shape.bounds.inside(pt) || !gpuPointInEvenOddMesh(pt, mesh.vbuffer.data, mesh.ibuffer.data, mesh.ibuffer.count)) return false;
+            if (!clip->shape.bbox.inside(pt) || !gpuPointInEvenOddMesh(pt, mesh.vbuffer.data, mesh.ibuffer.data, mesh.ibuffer.count)) return false;
         }
         return true;
     }
@@ -99,11 +99,11 @@ struct WgIntersector
             for (int32_t x = 0; x < sizeX; x++) {
                 Point pt{(float)x + region.min.x, (float)py + region.min.y};
                 const auto& mesh = shape->shape.mesh;
-                auto hit = validFill ? shape->shape.bounds.inside(pt) && gpuPointInEvenOddMesh(pt, mesh.vbuffer.data, mesh.ibuffer.data, mesh.ibuffer.count) : false;
+                auto hit = validFill ? shape->shape.bbox.inside(pt) && gpuPointInEvenOddMesh(pt, mesh.vbuffer.data, mesh.ibuffer.data, mesh.ibuffer.count) : false;
                 if (!hit && validStroke) {
                     auto p = pt * itransform;
                     const auto& mesh = shape->stroke.mesh;
-                    hit = shape->stroke.bounds.inside(p) && gpuPointInAnyMesh(p, mesh.vbuffer.data, mesh.ibuffer.data, mesh.ibuffer.count);
+                    hit = shape->stroke.bbox.inside(p) && gpuPointInAnyMesh(p, mesh.vbuffer.data, mesh.ibuffer.data, mesh.ibuffer.count);
                 }
                 if (hit && intersect(shape->clips, pt)) return true;
             }
@@ -113,9 +113,9 @@ struct WgIntersector
 
     bool intersect(const WgImage* image, const RenderRegion& region)
     {
-        if (image->meshData.ibuffer.count < 6) return false;
+        if (image->mesh.ibuffer.count < 6) return false;
 
-        const auto& mesh = image->meshData;
+        const auto& mesh = image->mesh;
         Point triangle[6];
         for (uint32_t i = 0; i < 6; ++i) {
             triangle[i] = mesh.vbuffer[mesh.ibuffer[i]];
@@ -257,10 +257,7 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
     if (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Path | RenderUpdateFlag::Stroke)) shape->update(rshape, transform, flags);
 
     // update transform
-    if (flags & RenderUpdateFlag::Transform) {
-        shape->transform = transform;
-        shape->updateAABB();
-    }
+    if (flags & RenderUpdateFlag::Transform) shape->transform = transform;
 
     // update paint settings
     shape->update(rshape, vport, shape->shape.setting.update(mTargetSurface.cs, opacity), shape->stroke.setting.update(mTargetSurface.cs, opacity), opacity);
@@ -284,7 +281,7 @@ RenderData WgRenderer::prepare(const RenderShape& rshape, RenderData data, const
         }
     }
 
-    if (flags & RenderUpdateFlag::Clip) shape->update(clips);
+    if (flags & RenderUpdateFlag::Clip) shape->assign(clips);
 
     return shape;
 }
@@ -297,21 +294,21 @@ RenderData WgRenderer::prepare(RenderSurface* surface, RenderData data, const Ma
     // update paint settings
     image->viewport = vport;
     image->transform = transform;
-    image->renderSettings.update(surface->cs, opacity);
+    image->setting.update(surface->cs, opacity);
 
     if (flags & (RenderUpdateFlag::Transform | RenderUpdateFlag::Image)) image->update(surface, transform);
 
     // reload texture
-    auto cacheStale = !image->imageTexture || (image->imageStamp != mTextures.stamp);
+    auto cacheStale = !image->texture || (image->stamp != mTextures.stamp);
     auto refreshTex = (flags & RenderUpdateFlag::Image);
-    auto update = cacheStale ||  refreshTex || (image->imageSource != surface) || (image->imageFilter != filter);
+    auto update = cacheStale || refreshTex || (image->surface != surface) || (image->filter != filter);
     if (update) {
         image->release(mTextures, mContext);
         auto* entry = mTextures.retain(mContext, surface, filter, refreshTex);
         image->setup(entry->texture, entry->bindGroup, surface, filter, mTextures.stamp);
     }
 
-    if (flags & RenderUpdateFlag::Clip) image->update(clips);
+    if (flags & RenderUpdateFlag::Clip) image->assign(clips);
 
     return image;
 }
@@ -408,26 +405,21 @@ void WgRenderer::dispose(RenderData data) {
 bool WgRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
 {
     if (data) {
-        auto rdataPaint = (WgPaint*)data;
-        if (rdataPaint->type() == Type::Shape) {
-            auto rdata = (WgShape*)data;
-            if (rdata->stroke.setting.valid) {
-                tvg::BBox bbox;
-                bbox.init();
-                auto& vertexes = rdata->stroke.mesh.vbuffer;
-
-                for (uint32_t i = 0; i < vertexes.count; i++) {
-                    Point vert = vertexes[i] * m;
-                    bbox.min = min(bbox.min, vert);
-                    bbox.max = max(bbox.max, vert);
-                }
-
-                pt4[0] = bbox.min;
-                pt4[1] = {bbox.max.x, bbox.min.y};
-                pt4[2] = bbox.max;
-                pt4[3] = {bbox.min.x, bbox.max.y};
-                return true;
+        auto shape = static_cast<WgShape*>(data);
+        if (shape->stroke.setting.valid) {
+            tvg::BBox bbox;
+            bbox.init();
+            auto& vertexes = shape->stroke.mesh.vbuffer;
+            for (uint32_t i = 0; i < vertexes.count; i++) {
+                auto pt = vertexes[i] * m;
+                bbox.min = min(bbox.min, pt);
+                bbox.max = max(bbox.max, pt);
             }
+            pt4[0] = bbox.min;
+            pt4[1] = {bbox.max.x, bbox.min.y};
+            pt4[2] = bbox.max;
+            pt4[3] = {bbox.min.x, bbox.max.y};
+            return true;
         }
     }
     return false;
@@ -435,21 +427,12 @@ bool WgRenderer::bounds(RenderData data, Point* pt4, const Matrix& m)
 
 RenderRegion WgRenderer::region(RenderData data)
 {
-    if (!data) return {};
-    auto rdata = (WgPaint*)data;
-    if (rdata->type() == Type::Shape) {
-        auto& v1 = rdata->aabb.min;
-        auto& v2 = rdata->aabb.max;
-        return {{int32_t(nearbyint(v1.x)), int32_t(nearbyint(v1.y))}, {int32_t(nearbyint(v2.x)), int32_t(nearbyint(v2.y))}};
-    }
-    return {{0, 0}, {(int32_t)mTargetSurface.w, (int32_t)mTargetSurface.h}};
+    return data ? static_cast<WgPaint*>(data)->region() : RenderRegion{};
 }
-
 
 bool WgRenderer::blend(BlendMethod method)
 {
     mBlendMethod = (method == BlendMethod::Composition ? BlendMethod::Normal : method);
-
     return true;
 }
 
@@ -736,9 +719,8 @@ bool WgRenderer::intersectsShape(RenderData data, TVG_UNUSED const RenderRegion&
     if (!data) return false;
     auto shape = (WgShape*)data;
     RenderRegion bbox = {
-        {(int32_t)shape->aabb.min.x, (int32_t)shape->aabb.min.y},
-        {(int32_t)shape->aabb.max.x, (int32_t)shape->aabb.max.y}
-    };
+        {(int32_t)shape->bbox.min.x, (int32_t)shape->bbox.min.y},
+        {(int32_t)shape->bbox.max.x, (int32_t)shape->bbox.max.y}};
     if (region.intersected(bbox)) {
         if (region.contained(bbox)) return true;
         WgIntersector intersector;

--- a/src/renderer/gpu_engine/wg/tvgWgStencilBatch.cpp
+++ b/src/renderer/gpu_engine/wg/tvgWgStencilBatch.cpp
@@ -32,17 +32,17 @@ static bool eligible(const WgShape* rdata, BlendMethod blendMethod, RenderRegion
     if (fillType != WgRenderSettingsType::Solid && fillType != WgRenderSettingsType::Linear && fillType != WgRenderSettingsType::Radial) return false;
 
     if (rdata->convex || rdata->viewport.invalid() || !rdata->clips.empty()) return false;
-    if (rdata->shape.mesh.vbuffer.empty() || rdata->shape.mesh.ibuffer.empty() || rdata->meshBBox.vbuffer.empty() || rdata->meshBBox.ibuffer.empty()) return false;
+    if (rdata->shape.mesh.vbuffer.empty() || rdata->shape.mesh.ibuffer.empty() || rdata->bboxMesh.vbuffer.empty() || rdata->bboxMesh.ibuffer.empty()) return false;
     if (rdata->stroke.setting.valid && !rdata->stroke.mesh.ibuffer.empty()) return false;
 
     // Clip finite geometry bounds to the viewport before rounding to the integer overlap region.
-    const auto& aabb = rdata->aabb;
-    if (!std::isfinite(aabb.min.x) || !std::isfinite(aabb.min.y) || !std::isfinite(aabb.max.x) || !std::isfinite(aabb.max.y)) return false;
+    const auto& bbox = rdata->bbox;
+    if (!std::isfinite(bbox.min.x) || !std::isfinite(bbox.min.y) || !std::isfinite(bbox.max.x) || !std::isfinite(bbox.max.y)) return false;
 
-    const auto minX = tvg::clamp(static_cast<double>(aabb.min.x), static_cast<double>(rdata->viewport.min.x), static_cast<double>(rdata->viewport.max.x));
-    const auto minY = tvg::clamp(static_cast<double>(aabb.min.y), static_cast<double>(rdata->viewport.min.y), static_cast<double>(rdata->viewport.max.y));
-    const auto maxX = tvg::clamp(static_cast<double>(aabb.max.x), static_cast<double>(rdata->viewport.min.x), static_cast<double>(rdata->viewport.max.x));
-    const auto maxY = tvg::clamp(static_cast<double>(aabb.max.y), static_cast<double>(rdata->viewport.min.y), static_cast<double>(rdata->viewport.max.y));
+    const auto minX = tvg::clamp(static_cast<double>(bbox.min.x), static_cast<double>(rdata->viewport.min.x), static_cast<double>(rdata->viewport.max.x));
+    const auto minY = tvg::clamp(static_cast<double>(bbox.min.y), static_cast<double>(rdata->viewport.min.y), static_cast<double>(rdata->viewport.max.y));
+    const auto maxX = tvg::clamp(static_cast<double>(bbox.max.x), static_cast<double>(rdata->viewport.min.x), static_cast<double>(rdata->viewport.max.x));
+    const auto maxY = tvg::clamp(static_cast<double>(bbox.max.y), static_cast<double>(rdata->viewport.min.y), static_cast<double>(rdata->viewport.max.y));
     if (maxX <= minX || maxY <= minY) return false;
 
     bounds = {{static_cast<int32_t>(std::floor(minX)), static_cast<int32_t>(std::floor(minY))}, {static_cast<int32_t>(std::ceil(maxX)), static_cast<int32_t>(std::ceil(maxY))}};


### PR DESCRIPTION
- Remove redundant AABB storage and use shape bounds directly for
  region queries, hit testing, and stencil batching.
- Removed unnecessary shape bbox mesh.
- Rename the bounds helper to expand() and clip assignment to assign().
- Properly casting the render region from the WgPaint.