### PR TITLE
renderer/scene: fix dangling parent on a borrowed clipper and mask target

### DIFF
--- a/src/renderer/tvgScene.h
+++ b/src/renderer/tvgScene.h
@@ -297,6 +297,14 @@ struct SceneImpl : Scene
         return scene;
     }
 
+    // insert()/mask()/clip() aim a clipper and mask target at this scene without ref-ing or listing
+    // them, so only this scene can clear a parent it is about to invalidate.
+    void detachBorrowed(Paint::Impl* paint)
+    {
+        if (paint->clipper && PAINT(paint->clipper)->parent == this) PAINT(paint->clipper)->parent = nullptr;
+        if (paint->maskData && PAINT(paint->maskData->target)->parent == this) PAINT(paint->maskData->target)->parent = nullptr;
+    }
+
     Result clearPaints()
     {
         if (paints.empty()) return Result::Success;
@@ -310,6 +318,7 @@ struct SceneImpl : Scene
             auto paint = PAINT((*itr));
             //when the paint is destroyed damage will be triggered
             if (paint->refCnt > 1 && partialDmg) paint->damage();
+            detachBorrowed(paint);
             paint->unref();
             paints.erase(itr++);
         }
@@ -322,10 +331,38 @@ struct SceneImpl : Scene
     Result remove(Paint* paint)
     {
         if (PAINT(paint)->parent != this) return Result::InsufficientCondition;
+
+        auto impl = PAINT(paint);
+        Paint* borrowed[] = {impl->clipper, impl->maskData ? impl->maskData->target : nullptr};
+        bool shared[] = {false, false};
+        auto itr = paints.end();
+
+        if (!borrowed[0] && !borrowed[1]) itr = find(paints.begin(), paints.end(), paint);
+        else {
+            // a borrowed paint may only be detached once nothing left in the list points at it:
+            // clip()/mask() admit a second holder, and a clipper can be pushed as a child too
+            for (auto p = paints.begin(); p != paints.end(); ++p) {
+                if (*p == paint) {
+                    itr = p;
+                    continue;
+                }
+                auto sibling = PAINT((*p));
+                for (int i = 0; i < 2; ++i) {
+                    if (!borrowed[i]) continue;
+                    if (*p == borrowed[i] || sibling->clipper == borrowed[i] || (sibling->maskData && sibling->maskData->target == borrowed[i])) shared[i] = true;
+                }
+            }
+        }
+        // parent alone does not prove ownership: a borrowed clipper or mask target points here too
+        if (itr == paints.end()) return Result::InsufficientCondition;
+
         //when the paint is destroyed damage will be triggered
-        if (PAINT(paint)->refCnt > 1) PAINT(paint)->damage();
-        PAINT(paint)->unref();
-        paints.remove(paint);
+        if (impl->refCnt > 1) impl->damage();
+        for (int i = 0; i < 2; ++i) {
+            if (borrowed[i] && !shared[i] && PAINT(borrowed[i])->parent == this) PAINT(borrowed[i])->parent = nullptr;
+        }
+        impl->unref();
+        paints.erase(itr);
         return Result::Success;
     }
 

--- a/test/testScene.cpp
+++ b/test/testScene.cpp
@@ -125,6 +125,36 @@ TEST_CASE("Scene Clear And Reuse Shape", "[tvgScene]")
     REQUIRE(Initializer::term() == Result::Success);
 }
 
+TEST_CASE("Scene Clear And Reuse Mask Target", "[tvgScene]")
+{
+    auto scene = Scene::gen();
+    REQUIRE(scene);
+
+    auto source = Shape::gen();
+    REQUIRE(source);
+    REQUIRE(source->ref() == 1);
+
+    auto target = Shape::gen();
+    REQUIRE(target);
+    REQUIRE(target->ref() == 1);
+
+    REQUIRE(source->mask(target, MaskMethod::Alpha) == Result::Success);
+    REQUIRE(scene->add(source) == Result::Success);
+
+    // No deallocate source. The scene aims a parent at the mask target without ref-ing it.
+    REQUIRE(scene->remove() == Result::Success);
+
+    // Reuse the mask target.
+    auto other = Scene::gen();
+    REQUIRE(other);
+    REQUIRE(other->add(target) == Result::Success);
+
+    Paint::rel(other);
+    REQUIRE(source->unref() == 0);
+    REQUIRE(target->unref() == 0);
+    Paint::rel(scene);
+}
+
 TEST_CASE("Scene Effects", "[tvgScene]")
 {
     REQUIRE(Initializer::init() == Result::Success);


### PR DESCRIPTION
### Problem

`SceneImpl::insert()` writes `parent` on the inserted paint, on its `clipper` and on its
`maskData->target`, but refs and lists only the paint itself. `unref()` clears just the listed
child's `parent`, and `clearPaints()` never visits the other two, so a borrowed clipper or mask
target is left naming a scene that is about to be freed. `Paint::bounds()` then walks it through
`Paint::Impl::ptransform()`.

`Paint::Impl::~Impl()` already cascades to both borrowed paints, so this only shows when the source
paint outlives the scene, which is the normal case for a caller that holds its own reference.

Two distinct symptoms:

1. **Use after free.** `Paint::bounds()` on the borrowed paint dereferences the freed scene. A
   caller that wraps the raw `parent` in an owning handle turns the read into a write followed by an
   extra `unref()`, which can free the block a second time and corrupt the allocator.
2. **A stranded paint, with no crash at all.** `add()`, `clip()` and `mask()` all refuse a paint
   whose `parent` is set, so a borrowed target that keeps a stale parent can never be adopted again.

### The change

`detachBorrowed()` clears a `clipper` or `maskData->target` parent that equals this scene.

- `clearPaints()` calls it unconditionally before each `unref()`. The scene is emptying, so no
  survivor can still need the link.
- `remove()` calls it only for a borrowed paint that nothing left in `paints` points at.

`remove()` also gains the membership check it never had. `parent != this` is satisfied by a borrowed
clipper or mask target too, so the old guard would let `remove()` `unref()` a paint the scene never
ref'd, dropping it below its real count. `paints.remove(paint)` becomes `paints.erase(itr)`, reusing
the iterator the guard already found; this is equivalent because `insert()` refuses a paint that
already has a parent, so the list cannot contain duplicates.

### Why `remove()` needs more than a null check

Two configurations the API permits today would break under a naive detach:

1. `clip()` and `mask()` refuse a target that **already** has a parent. While both sources are
   unparented that guard passes twice, so two paints can share one clipper. Detaching on the removal
   of the first would strip a parent the second still needs.
2. A clipper can also be pushed as a child in its own right, if it is clipped before either paint is
   parented. Detaching it there would let another scene adopt a paint this one still lists, and both
   would eventually `unref()` it.

The single pass in `remove()` covers both, and costs no more asymptotically than the
`paints.remove()` scan it replaces.

### Reproducer

`repro.cpp` (attached) uses only the public API and needs no renderer, no loader and no canvas.
Part A is the invariant break on its own, fully deterministic and touching no freed memory. Part B
is the memory-safety consequence.

```
meson setup build -Dtests=true -Dloaders="all" -Dsavers="all" -Dbindings="capi" -Dlog=true -Db_sanitize="address,undefined"
ninja -C build
c++ -std=c++17 -g -fsanitize=address,undefined -Iinc repro.cpp build/src/libthorvg-1.so.1.2.0 -Wl,-rpath,$PWD/build/src -o repro
```

Before, exit 1:

```
A  after clear source.parent=(nil)  target.parent=0x511000000040
A  FAIL  the scene released the paint but the borrowed target still names it as parent
RENDERER (../src/renderer/tvgScene.h 338): Target paint(0x5110000002c0) is already owned by a parent(0x511000000040)
A  FAIL  Scene::add(target) -> InsufficientCondition, the target is stranded
B  FAIL  this pointer is dangling, the next bounds() call reads freed memory

==4327==ERROR: AddressSanitizer: heap-use-after-free on address 0x511000000540
READ of size 8 at 0x511000000540 thread T0
    #0 in tvg::Paint::Impl::ptransform() ../src/renderer/tvgPaint.h:177
    #1 in tvg::Paint::bounds(float*, float*, float*, float*) ../src/renderer/tvgPaint.cpp:342
    #2 in main repro.cpp:88

0x511000000540 is located 0 bytes inside of 216-byte region
freed by thread T0 here:
    #1 in tvg::Paint::Impl::unrefx(bool) ../src/renderer/tvgPaint.h:119
    #2 in tvg::Paint::unref(bool) ../src/renderer/tvgPaint.cpp:446

previously allocated by thread T0 here:
    #1 in tvg::Scene::gen() ../src/renderer/tvgScene.cpp:31

SUMMARY: AddressSanitizer: heap-use-after-free ../src/renderer/tvgPaint.h:177 in tvg::Paint::Impl::ptransform()
```

The engine's own log line is the non-crashing half of the same defect: the target is refused a new
parent because it never lost the old one.

After, exit 0:

```
A  after clear source.parent=(nil)  target.parent=(nil)
A  ok    the borrowed target was detached with its source
A  ok    the target can be adopted by another scene
B  ok    no dangling parent
B  bounds -> 0.0 0.0 10.0 10.0

RESULT: invariant holds
```

The stale `parent` keeps `ptransform()`'s walk going one level too far, so `PAINT(p->parent)`
reads out of the freed scene. Whether that faults or silently folds a transform from an unrelated
object into the result depends only on whether the freed slot has been reused.

### Tests

A regression test sits next to the existing `Scene Clear And Reuse Shape`, which covers the same
reuse for a plain child:

```
TEST_CASE("Scene Clear And Reuse Mask Target", "[tvgScene]")
```

It holds its own reference to the source, because `Paint::Impl::~Impl()` already cascades to the
borrowed paints and hides the defect whenever the source dies with the scene.

On the current tree it fails at the reuse, with no undefined behaviour and no freed memory
involved, so the failure is a plain assertion rather than a crash:

```
../test/testScene.cpp:150: FATAL ERROR: REQUIRE( other->add(target) == Result::Success ) is NOT correct!
  values: REQUIRE( 2 == 0 )

[doctest] test cases:  1 |  0 passed | 1 failed | 90 skipped
[doctest] Status: FAILURE!
```

`2` is `Result::InsufficientCondition`: `add()` refuses the target because it still carries a
parent. With the change, the same invocation reports `SUCCESS!`.

Self test, exactly as CONTRIBUTING specifies:

```
meson setup build -Dtests=true -Dloaders="all" -Dsavers="all" -Dbindings="capi" -Dlog=true -Db_sanitize="address,undefined"
ninja -C build test
```

```
Ok:                 1
Expected Fail:      0
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0
```

The sanitized run takes about 40s, so it needs `meson test -t` above the 30s default.

Suite totals:

| tree | test cases | assertions |
| -- | -- | -- |
| unmodified | 90 | 13870 |
| with this change | 91 | 13882 |

The twelve added assertions and the one added case are the new test. Note that the unmodified
suite passes, so it does not cover this defect: the existing tests are a no-regression check and
the new one is the evidence.

### Cost

`clearPaints()` gains two pointer comparisons per child.

`remove()` is unchanged asymptotically. Where the paint carries no clipper and no mask it is
cheaper than before, because `find` + `erase` stops at the match while `paints.remove()` always
scanned the whole list. Where it does carry one, the single pass that decides whether the
borrowed paint is still referenced replaces that scan rather than adding to it.

### Memory

The sanitized self test above runs with address and undefined behaviour sanitizers, and
LeakSanitizer with them, across the whole suite. It reports nothing with this change applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgY8baP79jdCpWZPv2EEWh
