### PR TITLE
lottie: enhanced solid color hex conversion

### DIFF
--- a/src/loaders/lottie/tvgLottieParser.cpp
+++ b/src/loaders/lottie/tvgLottieParser.cpp
@@ -100,32 +100,16 @@ MaskMethod LottieParser::getMaskMethod(bool inversed)
     }
 }
 
-
+// expected: #rrggbb or #rrggbbaa
+// lottie spec does not define an alpha channel, but we handle it defensively.
 RGB32 LottieParser::getColor(const char *str)
 {
-    RGB32 color = {0, 0, 0};
-
-    if (!str) return color;
-
+    if (!str) return {};
     auto len = strlen(str);
-
-    // some resource has empty color string, return a default color for those cases.
-    if (len != 7 || str[0] != '#') return color;
-
-    char tmp[3] = {'\0', '\0', '\0'};
-    tmp[0] = str[1];
-    tmp[1] = str[2];
-    color.r = uint8_t(strtol(tmp, nullptr, 16));
-
-    tmp[0] = str[3];
-    tmp[1] = str[4];
-    color.g = uint8_t(strtol(tmp, nullptr, 16));
-
-    tmp[0] = str[5];
-    tmp[1] = str[6];
-    color.b = uint8_t(strtol(tmp, nullptr, 16));
-
-    return color;
+    if (str[0] == '#') ++str;
+    auto hex = strtoul(str, nullptr, 16);
+    if (len > 7) hex >>= 8;  // ignore the alpha channel
+    return {int32_t((hex >> 16) & 0xff), int32_t((hex >> 8) & 0xff), int32_t(hex & 0xff)};
 }
 
 


### PR DESCRIPTION
this allows alpha channel handling from user wrong input.

Co-Authored-By: Hermet Park <hermetpark@gmail.com>

> Some Lottie assets use color hex codes longer than six characters. While lottie-web parses them as RGBA without issues, ThorVG previously skipped parsing and fell back to black. This update keeps the six-character standard but allows such codes to be parsed by ignoring the alpha channel.

sample : [sample.json](https://github.com/user-attachments/files/32032731/5036829.1.json)

| Before | After |
|---|---|
| <img width="2052" height="1834" alt="Before" src="https://github.com/user-attachments/assets/8e17cd2b-a043-4a83-9c87-94ac24ce1dca" /> | <img width="2052" height="1834" alt="CleanShot 2026-09-10 at 9 36 29 AM@2x" src="https://github.com/user-attachments/assets/c0077b3c-4616-40a8-a3ea-66ebd84435e2" /> |
